### PR TITLE
feat(frontend): refine knowledge workspace navigation

### DIFF
--- a/frontend/DESIGN_SYSTEM.md
+++ b/frontend/DESIGN_SYSTEM.md
@@ -236,7 +236,13 @@ an `sr-only` summary, never the only signal.
 - **Application shell**: the global app header always spans the full viewport.
   Its 13rem brand slot keeps the complete AKB lockup visible and the global
   Search entry stable even when the persistent desktop app sidebar changes
-  density. The sidebar is a 13rem labelled entry rail on ordinary routes and
+  density. From `lg`, a fixed 11rem status slot immediately left of Search
+  surfaces active indexing or failed work across only the Vaults the current
+  user can read. The slot remains reserved when caught up so polling never
+  shifts Search, while its single atomic live-status announces complete phrases
+  without competing badge regions. Partial Vault-health responses render
+  lower-bound counts with a `+`; the system-wide `/health` total must never be
+  presented as the user's workspace state. The sidebar is a 13rem labelled entry rail on ordinary routes and
   can be collapsed to a persistent 3.5rem icon rail with an explicitly labelled
   toggle. The user's choice is remembered locally. Vault routes always use the same 3.5rem icon
   rail beside the existing Vault/Collections navigator;
@@ -267,7 +273,9 @@ an `sr-only` summary, never the only signal.
   Vault cards; narrower desktop widths stack context below the primary ledger.
   It opens with a cardless masthead anchored by a
   neutral hairline: one `brand-gradient` word in the title, a plain-language
-  description, and labelled Vault/index facts rather than floating badges. A
+  description, and labelled Vault/index facts rather than floating badges. The
+  Home index fact consumes the same reader-scoped aggregate as the app-header
+  status, not the system-wide operational counter. A
   32px dashboard gutter separates the primary ledger from its context rail and
   carries through the vertical section rhythm; section anchors keep 16px before
   their first bounded content surface so neighbouring information does not read
@@ -325,6 +333,25 @@ an `sr-only` summary, never the only signal.
   `rail-scroll` treatment rather than platform-default gray scrollbar slabs.
   Narrow layouts return to one document flow and restore card spacing for
   separation.
+  The expanded Vaults and Collections rails use the same two-tier control
+  grammar: an `h-10` labelled header with refresh/create/collapse actions, then
+  an `h-8` icon-led filter field. Root creation belongs in that header rather
+  than at the end of a scrollable tree. Its single create menu and every
+  Collection overflow menu share the same document / upload / table /
+  Collection vocabulary, with the target Collection preselected in each modal.
+  Collection rows keep the human name and one overflow trigger only—never a
+  second line of icon counts or sibling action icons that squeeze the name.
+  When a Collection mixes resource kinds, or one kind exceeds the 20-row
+  preview, Documents / Tables / Files become peer disclosure rows with a quiet
+  tabular count. Each open group renders 20 rows initially and reveals 50 more
+  per request; a resource-type filter bypasses unrelated kinds, so a large
+  document set can never bury tables or files at the end of the tree. A final
+  300-row progressive guard prevents one action from mounting a multi-thousand
+  node Vault. Small single-kind Collections stay flat and compact. The details
+  action is the stable place to review the complete typed counts and Collection
+  summary and, when supported by the connected backend, edit it.
+  Older backends keep the current summary readable
+  and surface an explicit compatibility notice instead of failing silently.
   A read-only permission notice is a flush, full-width policy bar directly above
   the three panes, with a bottom hairline and no card margin or rounded shell.
   In the primary form column, each governance section uses a cardless section
@@ -421,22 +448,38 @@ commits` control and `Full commit log` route. Below `xl`, the work area stacks
   document location and technical metadata. The
   main column is a Git-style framed file viewer with Rendered / Raw / Edit modes
   and only an 8–12px outer gutter in read mode. Details is closed by default and
-  opens as a 20–22rem right overlay inspector: it never reserves canvas width or
+  opens as a 24rem right overlay inspector: it never reserves canvas width or
   reflows the document. On narrow screens it gains a dismissible backdrop;
   backdrop click, Close, and Escape dismiss it and return focus to the Details
-  trigger. The inspector owns properties, outline, relations, version history,
-  publish state, and destructive actions. Retrieval metadata does not interrupt
+  trigger. The inspector treats Info, Outline, Relations, and History as four
+  peer views below one fixed header; the selected view owns all remaining panel
+  height instead of sitting beneath a permanently expanded Properties block.
+  Publish state and destructive actions stay inside Info, so they do not tax the
+  reading height of Outline, Relations, or History. Retrieval metadata does not interrupt
   the reading flow. Rendered headings, paragraphs, lists, and quotes share one
   centered 64rem measure so their left and right edges stay aligned regardless
   of font size; Korean-heavy technical documents still use most of the file
   frame without creating a one-sided void. Code, tables, and media may use the
   full workspace. The
-  file toolbar keeps logical line count and UTF-8 byte size at the left, exposes
-  Copy in both Rendered and Raw views, and keeps the Rendered / Raw / Edit mode
-  control right-aligned. The
+  file toolbar keeps logical line count and UTF-8 byte size at the left, uses
+  its flexible middle slot for a labelled single-line document summary when
+  metadata and horizontal space are available, exposes Copy in both Rendered
+  and Raw views, and keeps the Rendered / Raw / Edit mode control right-aligned.
+  Bound and disclose summary overflow through the shared tooltip text primitive;
+  hide the compact summary when horizontal space is constrained, while Details /
+  Info remains the complete metadata view at every breakpoint. The
   document title is the compact workspace-header H1 and is not repeated as a
   page hero; path, author, commit, age, and History share one dense file-context
-  row immediately above the content surface.
+  row immediately above the content surface. Never add another vertical summary
+  band before the file viewer, and omit the compact summary entirely when older
+  backends return no value.
+  Composer images use a 10 MB transfer ceiling and the asset service's 12 MP /
+  8,192px decode boundary. The client automatically fits oversized still PNG,
+  JPEG, and WebP images to that resolution before upload so a highly compressed
+  camera photo is not rejected based on decoded size alone; animated GIFs are
+  never flattened silently. Upload errors stay inside the editor with an
+  announced reason and explicit recovery: Retry appears only for transient
+  failures, while Choose another and Dismiss are always available.
   A document opened from Search uses this same reader inside a route-backed
   preview dialog rather than replacing the result ledger. The dialog leaves the
   persistent Vault navigation visible on wide screens, becomes full-screen on

--- a/frontend/src/components/__tests__/collection-details-dialog.test.tsx
+++ b/frontend/src/components/__tests__/collection-details-dialog.test.tsx
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CollectionDetailsDialog } from "@/components/collection-details-dialog";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    updateCollection: vi.fn(),
+  };
+});
+
+import { ApiError, updateCollection } from "@/lib/api";
+
+const updateMock = updateCollection as unknown as ReturnType<typeof vi.fn>;
+
+const baseProps = {
+  open: true,
+  onOpenChange: vi.fn(),
+  vault: "v",
+  path: "architecture",
+  summary: "System boundaries.",
+  counts: { documents: 2, tables: 1, files: 1 },
+  editable: true,
+  onUpdated: vi.fn(),
+};
+
+beforeEach(() => {
+  updateMock.mockReset();
+  baseProps.onOpenChange.mockReset();
+  baseProps.onUpdated.mockReset();
+});
+
+afterEach(() => cleanup());
+
+describe("CollectionDetailsDialog", () => {
+  it("keeps the current summary readable for read-only members", () => {
+    render(<CollectionDetailsDialog {...baseProps} editable={false} />);
+    expect(screen.getByText("System boundaries.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /save summary/i })).not.toBeInTheDocument();
+  });
+
+  it("surfaces a compatibility notice when the connected server has no PATCH contract", async () => {
+    updateMock.mockRejectedValue(
+      new ApiError("Method Not Allowed", 405, { detail: "Method Not Allowed" }),
+    );
+    const user = userEvent.setup();
+    render(<CollectionDetailsDialog {...baseProps} />);
+
+    const summary = screen.getByLabelText("Summary");
+    await user.clear(summary);
+    await user.type(summary, "Updated system boundaries.");
+    await user.click(screen.getByRole("button", { name: /save summary/i }));
+
+    expect(
+      await screen.findByText(/summary editing is coming soon on this server/i),
+    ).toBeInTheDocument();
+    expect(baseProps.onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("refreshes and closes after a supported server saves the summary", async () => {
+    updateMock.mockResolvedValue({ ok: true });
+    const user = userEvent.setup();
+    render(<CollectionDetailsDialog {...baseProps} />);
+
+    const summary = screen.getByLabelText("Summary");
+    await user.clear(summary);
+    await user.type(summary, "Updated system boundaries.");
+    await user.click(screen.getByRole("button", { name: /save summary/i }));
+
+    await waitFor(() =>
+      expect(updateMock).toHaveBeenCalledWith(
+        "v",
+        "architecture",
+        "Updated system boundaries.",
+      ),
+    );
+    expect(baseProps.onUpdated).toHaveBeenCalledTimes(1);
+    expect(baseProps.onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/frontend/src/components/__tests__/delete-collection-dialog.test.tsx
+++ b/frontend/src/components/__tests__/delete-collection-dialog.test.tsx
@@ -102,12 +102,13 @@ describe("DeleteCollectionDialog", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
-  it("cascade mode body text displays doc and file counts", () => {
+  it("cascade mode body text displays document, table, and file counts", () => {
     render(
       <DeleteCollectionDialog
         vault="v"
         path="x"
         docCount={3}
+        tableCount={2}
         fileCount={1}
         subCollectionCount={0}
         open
@@ -119,6 +120,7 @@ describe("DeleteCollectionDialog", () => {
     // Search the dialog content for "3 document" and "1 file" substrings.
     const dialog = screen.getByRole("dialog");
     expect(dialog.textContent?.toLowerCase()).toContain("3 document");
+    expect(dialog.textContent?.toLowerCase()).toContain("2 table");
     expect(dialog.textContent?.toLowerCase()).toContain("1 file");
   });
 

--- a/frontend/src/components/__tests__/header-indexing-status.test.tsx
+++ b/frontend/src/components/__tests__/header-indexing-status.test.tsx
@@ -1,0 +1,65 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { HeaderIndexingStatus } from "../header-indexing-status";
+
+afterEach(() => cleanup());
+
+describe("HeaderIndexingStatus", () => {
+  it("keeps a quiet reserved slot after every accessible Vault catches up", () => {
+    render(
+      <HeaderIndexingStatus
+        status={{
+          vaultCount: 4,
+          checkedVaultCount: 4,
+          pending: 0,
+          abandoned: 0,
+          indexed: 120,
+          incomplete: false,
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Knowledge indexing is caught up across 4 accessible Vaults",
+    );
+    expect(screen.queryByText("120 indexed")).toBeNull();
+  });
+
+  it("shows an active lower-bound count without wrapping the badge", () => {
+    render(
+      <HeaderIndexingStatus
+        status={{
+          vaultCount: 4,
+          checkedVaultCount: 3,
+          pending: 12,
+          abandoned: 0,
+          indexed: 80,
+          incomplete: true,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("12+ indexing")).toBeTruthy();
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "12+ items are indexing across accessible Vaults",
+    );
+  });
+
+  it("prioritizes failed work over active work in the compact slot", () => {
+    render(
+      <HeaderIndexingStatus
+        status={{
+          vaultCount: 2,
+          checkedVaultCount: 2,
+          pending: 8,
+          abandoned: 3,
+          indexed: 40,
+          incomplete: false,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("3 need attention")).toBeTruthy();
+    expect(screen.queryByText("8 indexing")).toBeNull();
+  });
+});

--- a/frontend/src/components/__tests__/layout-auth-gate.test.tsx
+++ b/frontend/src/components/__tests__/layout-auth-gate.test.tsx
@@ -11,6 +11,7 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Layout } from "../layout";
 import * as api from "@/lib/api";
+import { useAccessibleIndexingHealth } from "@/hooks/use-accessible-indexing-health";
 
 // Mock api so getToken() can be flipped between tests, and the health
 // hook's network call never fires. UserMenu (rendered by Layout) calls
@@ -27,6 +28,10 @@ vi.mock("@/lib/api", () => ({
 
 vi.mock("@/hooks/use-health", () => ({
   useHealth: () => ({ data: undefined, isLoading: false, error: null }),
+}));
+
+vi.mock("@/hooks/use-accessible-indexing-health", () => ({
+  useAccessibleIndexingHealth: vi.fn(),
 }));
 
 vi.mock("@/hooks/use-measured-height", () => ({
@@ -58,6 +63,10 @@ describe("Layout — auth gate", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    vi.mocked(useAccessibleIndexingHealth).mockReturnValue({
+      data: null,
+      error: null,
+    });
     vi.mocked(api.getAuthConfig).mockResolvedValue({
       available: true,
       schema_version: 2,
@@ -126,6 +135,31 @@ describe("Layout — auth gate", () => {
     expect(headerRow).toHaveClass("w-full");
     expect(headerRow).not.toHaveClass("px-3");
     expect(headerRow).not.toHaveClass("xl:px-12", "2xl:px-16");
+  });
+
+  it("keeps accessible indexing status immediately before global search", async () => {
+    vi.mocked(useAccessibleIndexingHealth).mockReturnValue({
+      data: {
+        vaultCount: 2,
+        checkedVaultCount: 2,
+        pending: 7,
+        abandoned: 0,
+        indexed: 42,
+        incomplete: false,
+      },
+      error: null,
+    });
+    vi.mocked(api.getToken).mockReturnValue("fake-jwt");
+
+    renderAt("/");
+
+    expect(await screen.findByTestId("home")).toBeTruthy();
+    const status = screen.getByTestId("header-indexing-status");
+    const search = screen.getByRole("button", { name: "Search knowledge" });
+    expect(status).toHaveTextContent("7 indexing");
+    expect(
+      status.compareDocumentPosition(search) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it("moves desktop entry points into an expanded workspace sidebar", async () => {

--- a/frontend/src/components/__tests__/markdown-editor-image.test.tsx
+++ b/frontend/src/components/__tests__/markdown-editor-image.test.tsx
@@ -317,6 +317,8 @@ describe("MarkdownEditor image insertion", () => {
     expect(apiMocks.uploadAsset).toHaveBeenCalledTimes(2);
 
     expect(screen.getByText("Image upload failed")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Choose another" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Dismiss" })).toBeVisible();
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
     await waitFor(() => expect(apiMocks.uploadAsset).toHaveBeenCalledTimes(4));
     expect(apiMocks.uploadAsset.mock.calls.map((call) => call[1])).toEqual([
@@ -325,6 +327,27 @@ describe("MarkdownEditor image insertion", () => {
       files[1],
       files[2],
     ]);
+  });
+
+  it("does not offer a futile retry for a server size rejection", async () => {
+    apiMocks.uploadAsset.mockRejectedValue(
+      Object.assign(new Error("Image dimensions are too large"), { status: 413 }),
+    );
+    const { container } = render(
+      <MarkdownEditor value="Draft" vault="team" onChange={vi.fn()} />,
+    );
+
+    fireEvent.change(container.querySelector('input[type="file"]')!, {
+      target: {
+        files: [new File(["small compressed image"], "phone.jpg", { type: "image/jpeg" })],
+      },
+    });
+
+    expect(await screen.findByText(/10 MB, 12 MP, or 8,192 pixels/)).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Choose another" })).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(screen.queryByText(/10 MB, 12 MP, or 8,192 pixels/)).toBeNull();
   });
 
   it("prevents default file-drop navigation and retains a batch dropped during upload", async () => {

--- a/frontend/src/components/__tests__/vault-explorer.test.tsx
+++ b/frontend/src/components/__tests__/vault-explorer.test.tsx
@@ -11,24 +11,48 @@ vi.mock("@/lib/api", () => ({
   // them transitively via the dialog components.
   createCollection: vi.fn(),
   deleteCollection: vi.fn(),
+  updateCollection: vi.fn(),
+  uploadVaultFile: vi.fn(),
+  createVaultTable: vi.fn(),
   ApiError: class ApiError extends Error {
     status?: number;
   },
 }));
 
 // Pull the mock references after declaration so we can set per-test responses.
-import { browseVault, getVaultInfo } from "@/lib/api";
+import {
+  browseVault,
+  createVaultTable,
+  getVaultInfo,
+  uploadVaultFile,
+} from "@/lib/api";
 const browseMock = browseVault as unknown as ReturnType<typeof vi.fn>;
 const vaultInfoMock = getVaultInfo as unknown as ReturnType<typeof vi.fn>;
+const uploadMock = uploadVaultFile as unknown as ReturnType<typeof vi.fn>;
+const tableCreateMock = createVaultTable as unknown as ReturnType<typeof vi.fn>;
 
 const sample = {
   vault: "v",
   path: "",
   items: [
-    { type: "collection", name: "architecture", path: "architecture", doc_count: 2 },
+    {
+      type: "collection",
+      name: "architecture",
+      path: "architecture",
+      summary: "System boundaries and ownership.",
+      doc_count: 2,
+    },
     { type: "collection", name: "guides", path: "guides", doc_count: 1 },
     { type: "document", name: "Schema", path: "architecture/schema.md" },
     { type: "document", name: "System", path: "architecture/system.md" },
+    { type: "table", name: "owners", path: "owners", collection: "architecture" },
+    {
+      type: "file",
+      name: "diagram.png",
+      path: "diagram.png",
+      uri: "akb://v/coll/architecture/file/file-1",
+      collection: "architecture",
+    },
     { type: "document", name: "Start", path: "guides/start.md" },
     { type: "table", name: "audit_log", path: "audit_log" },
   ],
@@ -49,6 +73,13 @@ beforeEach(() => {
   // Default to reader so the existing tests don't accidentally render
   // the mutation affordances. Tests that need writer+ override this.
   vaultInfoMock.mockResolvedValue({ role: "reader" });
+  uploadMock.mockReset();
+  uploadMock.mockResolvedValue({
+    uri: "akb://v/coll/architecture/file/file-1",
+    name: "diagram.png",
+  });
+  tableCreateMock.mockReset();
+  tableCreateMock.mockResolvedValue({ name: "owners_new" });
   localStorage.clear();
 });
 
@@ -57,8 +88,8 @@ afterEach(() => cleanup());
 describe("VaultExplorer — rendering", () => {
   it("renders collections from browse response", async () => {
     renderAt("/vault/v");
-    expect(await screen.findByRole("button", { name: /architecture/ })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /guides/ })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: /^architecture/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^guides/i })).toBeInTheDocument();
     expect(screen.getByRole("treeitem", { name: /audit_log/ })).toBeInTheDocument();
   });
 
@@ -66,7 +97,10 @@ describe("VaultExplorer — rendering", () => {
     renderAt("/vault/v");
     // Collection row: the name span carries title=name for the CSS-truncated label.
     const collectionName = await screen.findByText("architecture");
-    expect(collectionName).toHaveAttribute("title", "architecture");
+    expect(collectionName).toHaveAttribute(
+      "title",
+      "architecture — System boundaries and ownership.",
+    );
     // Leaf row (root-level table is visible without expanding any collection).
     expect(screen.getByText("audit_log")).toHaveAttribute("title", "audit_log");
   });
@@ -77,8 +111,43 @@ describe("VaultExplorer — rendering", () => {
     expect(tree).toBeInTheDocument();
     const items = within(tree).getAllByRole("treeitem");
     expect(items.length).toBeGreaterThan(0);
-    const collection = within(tree).getByRole("button", { name: /architecture/ });
+    const collection = within(tree).getByRole("button", { name: /^architecture/i });
     expect(collection.parentElement).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("keeps the collection row clean and exposes counts on kind groups", async () => {
+    const user = userEvent.setup();
+    renderAt("/vault/v");
+    const architecture = await screen.findByRole("button", { name: /^architecture/i });
+    expect(within(architecture).queryByText(/2 documents/i)).not.toBeInTheDocument();
+    await user.click(architecture);
+    expect(screen.getByRole("treeitem", { name: "Documents, 2 items" })).toBeInTheDocument();
+    expect(screen.getByRole("treeitem", { name: "Tables, 1 item" })).toBeInTheDocument();
+    expect(screen.getByRole("treeitem", { name: "Files, 1 item" })).toBeInTheDocument();
+  });
+
+  it("opens a stable details view for the collection summary", async () => {
+    const user = userEvent.setup();
+    renderAt("/vault/v");
+    await user.click(
+      await screen.findByRole("button", {
+        name: /collection actions for architecture/i,
+      }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: /view details/i }));
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText("System boundaries and ownership.")).toBeInTheDocument();
+    expect(within(dialog).getByText("Documents")).toBeInTheDocument();
+    expect(within(dialog).getByText("Tables")).toBeInTheDocument();
+    expect(within(dialog).getByText("Files")).toBeInTheDocument();
+  });
+
+  it("keeps one compact actions trigger beside the collection name", async () => {
+    renderAt("/vault/v");
+    const name = await screen.findByText("architecture");
+    const row = name.closest('[role="treeitem"]');
+    expect(row).not.toBeNull();
+    expect(within(row as HTMLElement).getAllByRole("button")).toHaveLength(2);
   });
 
   it("auto-reveals ancestors of the active document", async () => {
@@ -92,7 +161,7 @@ describe("VaultExplorer — interaction", () => {
   it("toggles a collection on click", async () => {
     const user = userEvent.setup();
     renderAt("/vault/v");
-    const btn = await screen.findByRole("button", { name: /architecture/ });
+    const btn = await screen.findByRole("button", { name: /^architecture/i });
     expect(btn.parentElement).toHaveAttribute("aria-expanded", "false");
     await user.click(btn);
     expect(btn.parentElement).toHaveAttribute("aria-expanded", "true");
@@ -102,26 +171,73 @@ describe("VaultExplorer — interaction", () => {
   it("filters the tree by name", async () => {
     const user = userEvent.setup();
     renderAt("/vault/v");
-    await screen.findByRole("button", { name: /architecture/ });
-    const filter = screen.getByLabelText(/filter tree/i);
+    await screen.findByRole("button", { name: /^architecture/i });
+    const filter = screen.getByLabelText(/filter resources/i);
     await user.type(filter, "schema");
     expect(screen.getByRole("treeitem", { name: /Schema/ })).toBeInTheDocument();
     expect(screen.queryByRole("treeitem", { name: /Start/ })).not.toBeInTheDocument();
   });
 
+  it("filters by resource kind without making users traverse unrelated rows", async () => {
+    const user = userEvent.setup();
+    renderAt("/vault/v");
+    await user.click(await screen.findByRole("button", { name: /resource type/i }));
+    await user.click(screen.getByRole("menuitemradio", { name: /Tables/i }));
+    await user.click(screen.getByRole("button", { name: /^architecture/i }));
+    expect(screen.getByRole("treeitem", { name: /owners/i })).toBeInTheDocument();
+    expect(screen.getByRole("treeitem", { name: /audit_log/i })).toBeInTheDocument();
+    expect(screen.queryByRole("treeitem", { name: /Schema/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("treeitem", { name: /diagram.png/i })).not.toBeInTheDocument();
+  });
+
+  it("keeps tables and files reachable beside a large document set", async () => {
+    const user = userEvent.setup();
+    browseMock.mockResolvedValueOnce({
+      vault: "v",
+      path: "",
+      items: [
+        { type: "collection", name: "large", path: "large" },
+        ...Array.from({ length: 75 }, (_, index) => ({
+          type: "document",
+          name: `Doc ${String(index + 1).padStart(4, "0")}`,
+          path: `large/${String(index + 1).padStart(4, "0")}.md`,
+        })),
+        { type: "table", name: "owners", path: "owners", collection: "large" },
+        {
+          type: "file",
+          name: "diagram.png",
+          path: "diagram.png",
+          uri: "akb://v/coll/large/file/file-1",
+          collection: "large",
+        },
+      ],
+    });
+    renderAt("/vault/v");
+    await user.click(await screen.findByRole("button", { name: /^large/i }));
+    expect(screen.getByRole("treeitem", { name: "Documents, 75 items" })).toBeInTheDocument();
+    expect(screen.getByRole("treeitem", { name: "Tables, 1 item" })).toBeInTheDocument();
+    expect(screen.getByRole("treeitem", { name: "Files, 1 item" })).toBeInTheDocument();
+    expect(screen.getByRole("treeitem", { name: /owners/i })).toBeInTheDocument();
+    expect(screen.getByRole("treeitem", { name: /diagram.png/i })).toBeInTheDocument();
+    expect(screen.queryByRole("treeitem", { name: /Doc 0021/i })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("treeitem", { name: /Show 50 more documents/i }));
+    expect(screen.getByRole("treeitem", { name: /Doc 0070/i })).toBeInTheDocument();
+    expect(screen.queryByRole("treeitem", { name: /Doc 0071/i })).not.toBeInTheDocument();
+  });
+
   it("ArrowDown moves focus through the visible list", async () => {
     const user = userEvent.setup();
     renderAt("/vault/v");
-    const first = await screen.findByRole("button", { name: /architecture/ });
+    const first = await screen.findByRole("button", { name: /^architecture/i });
     first.focus();
     await user.keyboard("{ArrowDown}");
-    expect(document.activeElement).toBe(screen.getByRole("button", { name: /guides/ }));
+    expect(document.activeElement).toBe(screen.getByRole("button", { name: /^guides/i }));
   });
 
   it("End jumps to last visible row", async () => {
     const user = userEvent.setup();
     renderAt("/vault/v");
-    const first = await screen.findByRole("button", { name: /architecture/ });
+    const first = await screen.findByRole("button", { name: /^architecture/i });
     first.focus();
     await user.keyboard("{End}");
     expect(document.activeElement).toBe(screen.getByRole("treeitem", { name: /audit_log/ }));
@@ -130,16 +246,16 @@ describe("VaultExplorer — interaction", () => {
   it("typeahead jumps to a row starting with the typed prefix", async () => {
     const user = userEvent.setup();
     renderAt("/vault/v");
-    const first = await screen.findByRole("button", { name: /architecture/ });
+    const first = await screen.findByRole("button", { name: /^architecture/i });
     first.focus();
     await user.keyboard("g");
-    expect(document.activeElement).toBe(screen.getByRole("button", { name: /guides/ }));
+    expect(document.activeElement).toBe(screen.getByRole("button", { name: /^guides/i }));
   });
 
   it("ArrowRight expands a collapsed collection; ArrowLeft collapses it", async () => {
     const user = userEvent.setup();
     renderAt("/vault/v");
-    const btn = await screen.findByRole("button", { name: /architecture/ });
+    const btn = await screen.findByRole("button", { name: /^architecture/i });
     btn.focus();
     await user.keyboard("{ArrowRight}");
     expect(btn.parentElement).toHaveAttribute("aria-expanded", "true");
@@ -149,37 +265,110 @@ describe("VaultExplorer — interaction", () => {
 });
 
 describe("VaultExplorer — role gating", () => {
-  it("renders the bottom-of-section '+ NEW COLLECTION' for writer role", async () => {
+  it("puts all root creation actions in one header menu for writer role", async () => {
+    const user = userEvent.setup();
     vaultInfoMock.mockResolvedValue({ role: "writer" });
     renderAt("/vault/v");
-    expect(await screen.findByText(/\+ New collection/i)).toBeInTheDocument();
+    await user.click(await screen.findByRole("button", { name: /create in vault/i }));
+    expect(screen.getByRole("menuitem", { name: /new document/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /upload file/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /new table/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /new collection/i })).toBeInTheDocument();
   });
 
-  it("hides the bottom-of-section '+ NEW COLLECTION' for reader role", async () => {
+  it("hides root collection creation for reader role", async () => {
     vaultInfoMock.mockResolvedValue({ role: "reader" });
     renderAt("/vault/v");
-    await screen.findByRole("button", { name: /architecture/ });
-    expect(screen.queryByText(/\+ New collection/i)).not.toBeInTheDocument();
-  });
-
-  it("renders the per-collection-row '+ sub-collection' button for writer role", async () => {
-    vaultInfoMock.mockResolvedValue({ role: "writer" });
-    renderAt("/vault/v");
+    await screen.findByRole("button", { name: /^architecture/i });
     expect(
-      await screen.findByRole("button", { name: /create sub-collection in architecture/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /create sub-collection in guides/i }),
-    ).toBeInTheDocument();
-  });
-
-  it("hides the per-collection-row '+ sub-collection' button for reader role", async () => {
-    vaultInfoMock.mockResolvedValue({ role: "reader" });
-    renderAt("/vault/v");
-    await screen.findByRole("button", { name: /architecture/ });
-    expect(
-      screen.queryByRole("button", { name: /create sub-collection/i }),
+      screen.queryByRole("button", { name: /create in vault/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it("groups collection write actions into one overflow menu for writer role", async () => {
+    const user = userEvent.setup();
+    vaultInfoMock.mockResolvedValue({ role: "writer" });
+    renderAt("/vault/v");
+    await user.click(
+      await screen.findByRole("button", { name: /collection actions for architecture/i }),
+    );
+    expect(screen.getByRole("menuitem", { name: /new document/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /upload file/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /new table/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /new sub-collection/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /delete collection/i })).toBeInTheDocument();
+  });
+
+  it("prefills the target collection for file and table creation", async () => {
+    const user = userEvent.setup();
+    vaultInfoMock.mockResolvedValue({ role: "writer" });
+    renderAt("/vault/v");
+
+    await user.click(
+      await screen.findByRole("button", { name: /collection actions for architecture/i }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: /upload file/i }));
+    let dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByLabelText(/Collection/i)).toHaveValue("architecture");
+    await user.click(within(dialog).getByRole("button", { name: /Cancel/i }));
+
+    await user.click(
+      screen.getByRole("button", { name: /collection actions for architecture/i }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: /new table/i }));
+    dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByLabelText(/Collection/i)).toHaveValue("architecture");
+  });
+
+  it("uploads a file into the collection selected from the overflow menu", async () => {
+    const user = userEvent.setup();
+    vaultInfoMock.mockResolvedValue({ role: "writer" });
+    renderAt("/vault/v");
+    await user.click(
+      await screen.findByRole("button", { name: /collection actions for architecture/i }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: /upload file/i }));
+    const dialog = screen.getByRole("dialog");
+    const file = new File(["image"], "diagram.png", { type: "image/png" });
+    await user.upload(within(dialog).getByLabelText(/^File/i), file);
+    await user.click(within(dialog).getByRole("button", { name: /^Upload file$/i }));
+    expect(uploadMock).toHaveBeenCalledWith(
+      "v",
+      file,
+      expect.objectContaining({ collection: "architecture" }),
+    );
+  });
+
+  it("creates a table in the collection selected from the overflow menu", async () => {
+    const user = userEvent.setup();
+    vaultInfoMock.mockResolvedValue({ role: "writer" });
+    renderAt("/vault/v");
+    await user.click(
+      await screen.findByRole("button", { name: /collection actions for architecture/i }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: /new table/i }));
+    const dialog = screen.getByRole("dialog");
+    await user.type(within(dialog).getByLabelText(/Table name/i), "owners_new");
+    await user.type(within(dialog).getByLabelText(/^Name$/i), "owner_name");
+    await user.click(within(dialog).getByRole("button", { name: /^Create table$/i }));
+    expect(tableCreateMock).toHaveBeenCalledWith(
+      "v",
+      expect.objectContaining({
+        name: "owners_new",
+        collection: "architecture",
+      }),
+    );
+  });
+
+  it("keeps reader collection menus read-only", async () => {
+    const user = userEvent.setup();
+    vaultInfoMock.mockResolvedValue({ role: "reader" });
+    renderAt("/vault/v");
+    await user.click(
+      await screen.findByRole("button", { name: /collection actions for architecture/i }),
+    );
+    expect(screen.getByRole("menuitem", { name: /view details/i })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: /new sub-collection/i })).not.toBeInTheDocument();
   });
 });
 
@@ -199,28 +388,26 @@ describe("VaultExplorer — reserved system collection", () => {
   });
 
   it("suppresses the row actions on `overview` while keeping them on normal collections", async () => {
+    const user = userEvent.setup();
     vaultInfoMock.mockResolvedValue({ role: "writer" });
     renderAt("/vault/v");
-    // A normal collection keeps all three affordances.
-    expect(
-      await screen.findByRole("button", { name: /create document in architecture/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /create sub-collection in architecture/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /delete collection architecture/i }),
-    ).toBeInTheDocument();
-    // The system collection is managed from vault settings, not the tree.
-    expect(
-      screen.queryByRole("button", { name: /create document in overview/i }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: /create sub-collection in overview/i }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: /delete collection overview/i }),
-    ).not.toBeInTheDocument();
+    // A normal collection keeps all write actions behind one trigger.
+    await user.click(
+      await screen.findByRole("button", { name: /collection actions for architecture/i }),
+    );
+    expect(screen.getByRole("menuitem", { name: /new document/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /new sub-collection/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /delete collection/i })).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+
+    // The system collection keeps only its read-only details action.
+    await user.click(
+      screen.getByRole("button", { name: /collection actions for overview/i }),
+    );
+    expect(screen.getByRole("menuitem", { name: /view details/i })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: /new document/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: /new sub-collection/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: /delete collection/i })).not.toBeInTheDocument();
   });
 
   it("renders `overview` first, marked as a system collection", async () => {

--- a/frontend/src/components/collection-details-dialog.tsx
+++ b/frontend/src/components/collection-details-dialog.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState } from "react";
+import { FileText, Folder, Paperclip, Table2 } from "lucide-react";
+import { ApiError, updateCollection } from "@/lib/api";
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+export interface CollectionResourceCounts {
+  documents: number;
+  tables: number;
+  files: number;
+}
+
+interface CollectionDetailsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  vault: string;
+  path: string;
+  summary?: string | null;
+  counts: CollectionResourceCounts;
+  editable: boolean;
+  onUpdated: () => void;
+}
+
+export function CollectionDetailsDialog({
+  open,
+  onOpenChange,
+  vault,
+  path,
+  summary,
+  counts,
+  editable,
+  onUpdated,
+}: CollectionDetailsDialogProps) {
+  const [draft, setDraft] = useState(summary ?? "");
+  const [working, setWorking] = useState(false);
+  const [error, setError] = useState("");
+  const [compatibilityNotice, setCompatibilityNotice] = useState("");
+
+  useEffect(() => {
+    if (open) {
+      setDraft(summary ?? "");
+      setError("");
+      setCompatibilityNotice("");
+    }
+  }, [open, path, summary]);
+
+  const normalizedDraft = draft.trim();
+  const normalizedSummary = (summary ?? "").trim();
+  const changed = normalizedDraft !== normalizedSummary;
+
+  async function handleSave() {
+    if (!editable || !changed) return;
+    setWorking(true);
+    setError("");
+    setCompatibilityNotice("");
+    try {
+      await updateCollection(vault, path, normalizedDraft || null);
+      onUpdated();
+      onOpenChange(false);
+    } catch (e) {
+      if (e instanceof ApiError && (e.status === 404 || e.status === 405)) {
+        setCompatibilityNotice(
+          "Collection summary editing is coming soon on this server. You can still review the current summary and contents here.",
+        );
+      } else {
+        setError(e instanceof Error ? e.message : "Couldn't update the collection summary.");
+      }
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  const name = path.split("/").filter(Boolean).pop() || path;
+  const metrics = [
+    { label: "Documents", value: counts.documents, icon: FileText },
+    { label: "Tables", value: counts.tables, icon: Table2 },
+    { label: "Files", value: counts.files, icon: Paperclip },
+  ];
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !working && onOpenChange(next)}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <div className="flex min-w-0 items-center gap-2">
+            <span
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-md)] bg-surface-selected text-surface-selected-foreground"
+              aria-hidden
+            >
+              <Folder className="h-4 w-4" aria-hidden />
+            </span>
+            <div className="min-w-0">
+              <DialogTitle className="truncate">{name}</DialogTitle>
+              <DialogDescription className="truncate font-mono">
+                {path}
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <div className="grid grid-cols-3 divide-x divide-border border-y border-border bg-surface-2/45">
+          {metrics.map(({ label, value, icon: Icon }) => (
+            <div key={label} className="min-w-0 px-3 py-2.5">
+              <div className="flex items-center gap-1.5 text-xs text-foreground-muted">
+                <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden />
+                <span className="truncate">{label}</span>
+              </div>
+              <p className="mt-1 text-sm font-semibold tabular-nums text-foreground">
+                {value}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        <div>
+          {editable ? (
+            <>
+              <Label htmlFor="collection-details-summary" className="coord-ink mb-1.5 block">
+                Summary
+              </Label>
+              <Textarea
+                id="collection-details-summary"
+                value={draft}
+                onChange={(event) => setDraft(event.target.value)}
+                placeholder="What belongs in this collection?"
+                rows={4}
+                disabled={working}
+              />
+              <p className="mt-1.5 text-xs leading-relaxed text-foreground-muted">
+                Help people understand what belongs here before they open individual resources.
+              </p>
+            </>
+          ) : (
+            <>
+              <p className="coord-ink mb-1.5">Summary</p>
+              <p className="min-h-20 rounded-[var(--radius-md)] border border-border bg-surface-2/45 px-3 py-2.5 text-sm leading-relaxed text-foreground-muted">
+                {normalizedSummary || "No summary has been added yet."}
+              </p>
+            </>
+          )}
+        </div>
+
+        {compatibilityNotice && <Alert variant="info">{compatibilityNotice}</Alert>}
+        {error && <Alert variant="destructive">{error}</Alert>}
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={working}
+          >
+            {editable ? "Cancel" : "Close"}
+          </Button>
+          {editable && (
+            <Button
+              type="button"
+              onClick={handleSave}
+              loading={working}
+              disabled={!changed}
+            >
+              {working ? "Saving…" : "Save summary"}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/delete-collection-dialog.tsx
+++ b/frontend/src/components/delete-collection-dialog.tsx
@@ -20,6 +20,7 @@ interface DeleteCollectionDialogProps {
   vault: string;
   path: string;
   docCount: number;
+  tableCount?: number;
   fileCount: number;
   /**
    * Number of descendant collection rows under this path. Surfaces the
@@ -35,7 +36,7 @@ interface DeleteCollectionDialogProps {
 
 /** Two-mode delete dialog for collections.
  *
- *  - Empty mode (`docCount + fileCount + subCollectionCount === 0`):
+ *  - Empty mode (`docCount + tableCount + fileCount + subCollectionCount === 0`):
  *    one-click confirm.
  *  - Cascade mode (any count > 0): requires the user to type the collection
  *    path exactly before the destructive button enables, and shows a
@@ -53,11 +54,12 @@ export function DeleteCollectionDialog({
   vault,
   path,
   docCount,
+  tableCount = 0,
   fileCount,
   subCollectionCount,
   onDeleted,
 }: DeleteCollectionDialogProps) {
-  const isCascade = docCount + fileCount + subCollectionCount > 0;
+  const isCascade = docCount + tableCount + fileCount + subCollectionCount > 0;
   const [typed, setTyped] = useState("");
   const [working, setWorking] = useState(false);
   const [error, setError] = useState("");
@@ -110,6 +112,9 @@ export function DeleteCollectionDialog({
   const items: string[] = [];
   if (docCount > 0) {
     items.push(`${docCount} document${docCount === 1 ? "" : "s"}`);
+  }
+  if (tableCount > 0) {
+    items.push(`${tableCount} table${tableCount === 1 ? "" : "s"}`);
   }
   if (fileCount > 0) {
     items.push(`${fileCount} file${fileCount === 1 ? "" : "s"}`);

--- a/frontend/src/components/doc-outline.tsx
+++ b/frontend/src/components/doc-outline.tsx
@@ -9,7 +9,13 @@ export function DocumentOutline({
   articleEl: HTMLElement | null;
 }) {
   const { headings, activeSlug } = useDocOutline(markdown, { root: articleEl });
-  if (headings.length === 0) return null;
+  if (headings.length === 0) {
+    return (
+      <p className="text-sm leading-relaxed text-foreground-muted">
+        No headings in this document yet.
+      </p>
+    );
+  }
 
   // Normalize so the shallowest level sits flush-left, even if the doc starts
   // at H2 or uses only H3/H4.

--- a/frontend/src/components/document-view.tsx
+++ b/frontend/src/components/document-view.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { getDocument } from "@/lib/api";
 import { MarkdownRender } from "@/components/markdown-render";
 import { Alert } from "@/components/ui/alert";
+import { TooltipText } from "@/components/ui/tooltip-text";
 import { cn } from "@/lib/utils";
 
 type ViewMode = "rendered" | "raw";
@@ -136,6 +137,7 @@ export function DocumentView({
         onCopyRaw={copyRaw}
         lineCount={contentStats.lineCount}
         byteCount={contentStats.byteCount}
+        summary={doc.summary}
       />
 
       {/* ── Doc body ──────────────────────────────────────────────── */}
@@ -208,6 +210,7 @@ interface TabStripProps {
   onCopyRaw: () => void;
   lineCount: number;
   byteCount: number;
+  summary?: string | null;
 }
 
 function TabStrip({
@@ -219,6 +222,7 @@ function TabStrip({
   onCopyRaw,
   lineCount,
   byteCount,
+  summary,
 }: TabStripProps) {
   const tabs: Array<{
     key: ViewMode | "extra";
@@ -259,13 +263,33 @@ function TabStrip({
     >
       {fileAppearance && (
         <>
-          <div
-            aria-label={`Document statistics: ${formatLineCount(lineCount)}, ${formatByteSize(byteCount)}`}
-            className="mr-auto inline-flex min-h-8 shrink-0 items-center gap-2 text-xs tabular-nums text-foreground-muted"
-          >
-            <span>{formatLineCount(lineCount)}</span>
-            <span aria-hidden>·</span>
-            <span>{formatByteSize(byteCount)}</span>
+          <div className="mr-auto flex min-w-0 flex-1 items-center gap-3">
+            <div
+              aria-label={`Document statistics: ${formatLineCount(lineCount)}, ${formatByteSize(byteCount)}`}
+              className="inline-flex min-h-8 shrink-0 items-center gap-2 text-xs tabular-nums text-foreground-muted"
+            >
+              <span>{formatLineCount(lineCount)}</span>
+              <span aria-hidden>·</span>
+              <span>{formatByteSize(byteCount)}</span>
+            </div>
+            {summary && (
+              <div
+                role="note"
+                aria-label="Document summary"
+                className="hidden min-w-0 flex-1 items-center gap-2 border-l border-border pl-3 lg:flex"
+              >
+                <span className="coord shrink-0 font-medium text-foreground-muted">
+                  Summary
+                </span>
+                <TooltipText
+                  as="p"
+                  tip={summary}
+                  className="truncate text-xs leading-relaxed text-foreground-muted"
+                >
+                  {summary}
+                </TooltipText>
+              </div>
+            )}
           </div>
           <button
             type="button"

--- a/frontend/src/components/file-upload-dialog.tsx
+++ b/frontend/src/components/file-upload-dialog.tsx
@@ -36,12 +36,14 @@ export function FileUploadDialog({
   open,
   onOpenChange,
   vault,
+  initialCollection = "",
   onUploaded,
   returnFocusRef,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   vault: string;
+  initialCollection?: string;
   onUploaded: (file: VaultFileUploadResult) => void;
   returnFocusRef?: RefObject<HTMLElement | null>;
 }) {
@@ -55,14 +57,17 @@ export function FileUploadDialog({
   const [error, setError] = useState("");
 
   useEffect(() => {
-    if (open) return;
+    if (open) {
+      setCollection(initialCollection.trim());
+      return;
+    }
     setFile(null);
     setCollection("");
     setDescription("");
     setDragging(false);
     setStage("preparing");
     setError("");
-  }, [open]);
+  }, [open, initialCollection]);
 
   function choose(next: File | null) {
     if (!next) return;

--- a/frontend/src/components/header-indexing-status.tsx
+++ b/frontend/src/components/header-indexing-status.tsx
@@ -1,0 +1,56 @@
+import { AlertTriangle, CircleDashed } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import type { AccessibleIndexingStatus } from "@/hooks/use-accessible-indexing-health";
+
+export function HeaderIndexingStatus({
+  status,
+}: {
+  status: AccessibleIndexingStatus | null;
+}) {
+  const suffix = status?.incomplete ? "+" : "";
+  const abandoned = status?.abandoned ?? 0;
+  const pending = status?.pending ?? 0;
+  const hasAbandoned = abandoned > 0;
+  const hasPending = pending > 0;
+  const visibleLabel = hasAbandoned
+    ? `${abandoned.toLocaleString()}${suffix} need attention`
+    : hasPending
+      ? `${pending.toLocaleString()}${suffix} indexing`
+      : null;
+  const announcement = !status
+    ? "Checking indexing across accessible Vaults"
+    : hasAbandoned
+      ? `${status.abandoned.toLocaleString()}${suffix} items need indexing attention across accessible Vaults`
+      : hasPending
+        ? `${status.pending.toLocaleString()}${suffix} items are indexing across accessible Vaults`
+        : status.incomplete
+          ? "Indexing status is temporarily unavailable for some accessible Vaults"
+          : `Knowledge indexing is caught up across ${status.vaultCount.toLocaleString()} accessible Vaults`;
+
+  return (
+    <div
+      className="hidden w-44 shrink-0 items-center justify-end lg:flex"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      data-testid="header-indexing-status"
+    >
+      <span className="sr-only">{announcement}</span>
+      {visibleLabel && (
+        <Badge
+          aria-hidden="true"
+          variant={hasAbandoned ? "error" : "pending"}
+          className="max-w-full tabular-nums"
+          title={announcement}
+        >
+          {hasAbandoned ? (
+            <AlertTriangle className="h-3 w-3 shrink-0" aria-hidden />
+          ) : (
+            <CircleDashed className="h-3 w-3 shrink-0 animate-spin" aria-hidden />
+          )}
+          <span className="min-w-0 truncate">{visibleLabel}</span>
+        </Badge>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/layout.tsx
+++ b/frontend/src/components/layout.tsx
@@ -9,14 +9,15 @@ import {
   getToken,
   type CurrentUser,
 } from "@/lib/api";
-import { useHealth } from "@/hooks/use-health";
 import { UserMenu } from "@/components/user-menu";
 import { Logo } from "@/components/logo";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { GlobalSearchDialog } from "@/components/global-search-dialog";
+import { HeaderIndexingStatus } from "@/components/header-indexing-status";
 import { AppSidebar } from "@/components/app-sidebar";
 import { appRouteBoundaryForPath } from "@/app-route-contract";
 import { CurrentUserProvider } from "@/contexts/current-user-context";
+import { useAccessibleIndexingHealth } from "@/hooks/use-accessible-indexing-health";
 
 const APP_SIDEBAR_COMPACT_KEY = "akb_app_sidebar_compact";
 
@@ -137,7 +138,10 @@ export function Layout() {
   const isSearchWorkspace = location.pathname === "/search";
   const viewportLocked = wide || isSearchWorkspace;
   const sidebarCompact = wide || sidebarCollapsed;
-  const { data: health } = useHealth(session.status === "authenticated");
+  const { data: indexingStatus } = useAccessibleIndexingHealth(
+    session.status === "authenticated",
+    activeUser?.user_id,
+  );
 
   function setSidebarCompact(compact: boolean) {
     setSidebarCollapsed(compact);
@@ -219,11 +223,14 @@ export function Layout() {
           </div>
 
           <div className="flex min-w-0 flex-1 items-center pr-3">
-            {/* This is a real global-search surface, not a shortcut to /search.
-                Advanced mode and vault/type filters remain on the full page. */}
-            <CurrentUserProvider user={session.user}>
-              <GlobalSearchDialog />
-            </CurrentUserProvider>
+            <div className="ml-auto flex min-w-0 items-center gap-2">
+              <HeaderIndexingStatus status={indexingStatus} />
+              {/* This is a real global-search surface, not a shortcut to /search.
+                  Advanced mode and vault/type filters remain on the full page. */}
+              <CurrentUserProvider user={session.user}>
+                <GlobalSearchDialog />
+              </CurrentUserProvider>
+            </div>
 
             {/* The persistent sidebar owns desktop entry points. Compact icon
                 links remain in the header only where that rail is hidden. */}
@@ -279,7 +286,7 @@ export function Layout() {
             {viewportLocked ? (
               <CurrentUserProvider user={session.user}>
                 <ErrorBoundary resetKeys={[location.pathname, location.search]}>
-                  <Outlet context={{ health }} />
+                  <Outlet context={{ indexingStatus }} />
                 </ErrorBoundary>
               </CurrentUserProvider>
             ) : (
@@ -288,7 +295,7 @@ export function Layout() {
                   <ErrorBoundary
                     resetKeys={[location.pathname, location.search]}
                   >
-                    <Outlet context={{ health }} />
+                    <Outlet context={{ indexingStatus }} />
                   </ErrorBoundary>
                 </CurrentUserProvider>
               </div>

--- a/frontend/src/components/markdown-editor.tsx
+++ b/frontend/src/components/markdown-editor.tsx
@@ -71,10 +71,12 @@ import remarkGfm from "remark-gfm";
 import { AssetImage } from "@/components/asset-image";
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { ApiError, discardAsset, uploadAsset } from "@/lib/api";
+import { discardAsset, uploadAsset } from "@/lib/api";
 import {
   assetIdFromUrl,
+  classifyEditorImageUploadFailure,
   EDITOR_IMAGE_MIME_TYPES,
+  prepareEditorImage,
   validateEditorImage,
 } from "@/lib/image-assets";
 import { cn, sanitizeLinkUrl } from "@/lib/utils";
@@ -440,15 +442,19 @@ interface EditorToolbarProps {
   uploadingImage: boolean;
   onChooseImages: (files: File[]) => void;
   appearance: "framed" | "canvas" | "workspace";
+  imageInputRef: React.RefObject<HTMLInputElement | null>;
 }
 
-function EditorToolbar({ uploadingImage, onChooseImages, appearance }: EditorToolbarProps) {
+function EditorToolbar({
+  uploadingImage,
+  onChooseImages,
+  appearance,
+  imageInputRef,
+}: EditorToolbarProps) {
   // useEditorState re-renders on editor changes so active states stay in sync;
   // useEditorRef gives a stable handle for the mutating callbacks.
   const editor = useEditorRef();
   const state = useEditorState();
-  const imageInputRef = React.useRef<HTMLInputElement>(null);
-
   // Active mark lookup — editor.api.marks() returns the marks that would apply
   // at the current selection (null when none).
   const marks = (state.api.marks() ?? {}) as Record<string, unknown>;
@@ -693,6 +699,7 @@ export function MarkdownEditor({
     kind: "error" | "queued";
   } | null>(null);
   const uploadControllerRef = React.useRef<AbortController | null>(null);
+  const imageInputRef = React.useRef<HTMLInputElement>(null);
   const uploadInFlightRef = React.useRef(false);
   const deferredImageFilesRef = React.useRef<File[]>([]);
   const unclaimedAssetIdsRef = React.useRef(new Set<string>());
@@ -816,8 +823,12 @@ export function MarkdownEditor({
       try {
         for (const [index, file] of files.entries()) {
           currentFileIndex = index;
-          setUploadingName(file.name);
-          const asset = await uploadAsset(vault, file, controller.signal);
+          setUploadingName(`Checking ${file.name}`);
+          const prepared = await prepareEditorImage(file);
+          setUploadingName(
+            prepared.optimized ? `Uploading optimized ${file.name}` : file.name,
+          );
+          const asset = await uploadAsset(vault, prepared.file, controller.signal);
           const assetId = assetIdFromUrl(asset.url);
           if (!assetId || assetId !== asset.id) {
             throw new Error("The image upload returned an invalid asset URL.");
@@ -850,15 +861,17 @@ export function MarkdownEditor({
           (error instanceof DOMException && error.name === "AbortError");
         failed = true;
         if (!aborted && mountedRef.current) {
-          const message =
-            error instanceof ApiError || error instanceof Error
-              ? error.message
-              : "The image could not be uploaded.";
+          const failure = classifyEditorImageUploadFailure(
+            error,
+            files[currentFileIndex],
+          );
           const deferred = deferredImageFilesRef.current.splice(0);
           setUploadFailure({
-            files: [...files.slice(currentFileIndex), ...deferred],
-            message,
-            retryable: true,
+            files: failure.retryable
+              ? [...files.slice(currentFileIndex), ...deferred]
+              : [],
+            message: failure.message,
+            retryable: failure.retryable,
             kind: "error",
           });
         } else if (mountedRef.current && deferredImageFilesRef.current.length > 0) {
@@ -984,6 +997,7 @@ export function MarkdownEditor({
           uploadingImage={uploadingImage}
           onChooseImages={(files) => void uploadImages(files)}
           appearance={appearance}
+          imageInputRef={imageInputRef}
         />
       )}
       {uploadingImage && (
@@ -1008,33 +1022,43 @@ export function MarkdownEditor({
           title={uploadFailure.kind === "queued" ? "Images waiting to upload" : "Image upload failed"}
           className="border-x border-t-0"
         >
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <span>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <span className="min-w-0 flex-1">
               {uploadFailure.message}
               {uploadFailure.files.length > 1
                 ? ` ${uploadFailure.files.length} images remain in this batch.`
                 : ""}
             </span>
-            {uploadFailure.retryable ? (
+            <div className="flex flex-wrap items-center gap-1.5">
+              {uploadFailure.retryable && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void uploadImages(uploadFailure.files)}
+                >
+                  <RotateCcw className="h-3.5 w-3.5" aria-hidden />
+                  {uploadFailure.kind === "queued" ? "Upload" : "Retry"}
+                </Button>
+              )}
               <Button
                 type="button"
                 variant="outline"
                 size="sm"
-                onClick={() => void uploadImages(uploadFailure.files)}
+                onClick={() => imageInputRef.current?.click()}
               >
-                <RotateCcw className="h-3.5 w-3.5" aria-hidden />
-                {uploadFailure.kind === "queued" ? "Upload" : "Retry"}
+                <ImagePlus className="h-3.5 w-3.5" aria-hidden />
+                Choose another
               </Button>
-            ) : (
               <Button
                 type="button"
-                variant="outline"
+                variant="ghost"
                 size="sm"
                 onClick={() => setUploadFailure(null)}
               >
                 Dismiss
               </Button>
-            )}
+            </div>
           </div>
         </Alert>
       )}

--- a/frontend/src/components/table-create-dialog.tsx
+++ b/frontend/src/components/table-create-dialog.tsx
@@ -48,12 +48,14 @@ export function TableCreateDialog({
   open,
   onOpenChange,
   vault,
+  initialCollection = "",
   onCreated,
   returnFocusRef,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   vault: string;
+  initialCollection?: string;
   onCreated: (tableName: string) => void;
   returnFocusRef?: RefObject<HTMLElement | null>;
 }) {
@@ -68,7 +70,10 @@ export function TableCreateDialog({
   const [error, setError] = useState("");
 
   useEffect(() => {
-    if (open) return;
+    if (open) {
+      setCollection(initialCollection.trim());
+      return;
+    }
     setName("");
     setDescription("");
     setCollection("");
@@ -76,7 +81,7 @@ export function TableCreateDialog({
     nextColumnKey.current = 2;
     setSubmitted(false);
     setError("");
-  }, [open]);
+  }, [open, initialCollection]);
 
   const tableNameError = identifierError(name, "Table name");
   const columnErrors = columns.map((column, index) =>

--- a/frontend/src/components/vault-explorer.tsx
+++ b/frontend/src/components/vault-explorer.tsx
@@ -1,17 +1,24 @@
-import { Link, useLocation } from "react-router-dom";
-import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import {
   ChevronDown,
   ChevronRight,
   FilePlus,
   FileText,
   FolderPlus,
+  Info,
   Lock,
+  MoreHorizontal,
   Paperclip,
-  RotateCw,
+  PanelLeftClose,
+  Plus,
+  RefreshCw,
+  Search,
   Sparkles,
   Table,
   Trash2,
+  Upload,
 } from "lucide-react";
 import { Alert } from "@/components/ui/alert";
 import { SkillBadge } from "@/components/ui/skill-badge";
@@ -20,23 +27,35 @@ import { useVaultRefresh } from "@/contexts/vault-refresh-context";
 import { useOpenDocumentCreateDialog } from "@/contexts/document-create-dialog-context";
 import {
   activePathFromRoute,
-  countDocs,
   filterTree,
+  filterTreeByKind,
   flattenVisible,
+  kindGroupKey,
   leafHref,
+  RESOURCE_PREVIEW_SIZE,
+  type ResourceKind,
+  type FlatKindGroupRow,
+  type FlatMoreRow,
   type FlatRow,
 } from "@/lib/tree-route";
 import { getVaultInfo } from "@/lib/api";
 import { recentTone } from "@/lib/recent";
 import { isReservedCollection } from "@/lib/skill";
 import { CreateCollectionDialog } from "@/components/create-collection-dialog";
+import {
+  CollectionDetailsDialog,
+  type CollectionResourceCounts,
+} from "@/components/collection-details-dialog";
 import { DeleteCollectionDialog } from "@/components/delete-collection-dialog";
+import { FileUploadDialog } from "@/components/file-upload-dialog";
+import { TableCreateDialog } from "@/components/table-create-dialog";
+import { SelectMenu } from "@/components/ui/select-menu";
+import { parseFileUri } from "@/lib/uri";
 
 const PAGE_SIZE = 10;
 const TYPEAHEAD_TIMEOUT_MS = 500;
-/** Soft cap on rendered rows to keep first paint fast on very large
- *  vaults. Users can opt into rendering all rows. */
-const TREE_RENDER_CAP = 300;
+const TREE_RENDER_PAGE = 300;
+const RESOURCE_PAGE_SIZE = 50;
 
 /**
  * Left-rail explorer — single collection-rooted tree. Documents, tables,
@@ -64,12 +83,15 @@ export interface VaultExplorerProps {
    * the parent needs the handle to share it with siblings.
    */
   onRefetchReady?: (refetch: () => void) => void;
+  /** Collapse the collection column from the shared sidebar header. */
+  onCollapse?: () => void;
 }
 
 export function VaultExplorer({
   vault,
   onMutation,
   onRefetchReady,
+  onCollapse,
 }: VaultExplorerProps) {
   const { tree, loading, error, refetch } = useVaultTree(vault);
   const openCreateDocument = useOpenDocumentCreateDialog();
@@ -88,8 +110,16 @@ export function VaultExplorer({
   }, [onRefetchReady, refetch]);
   const { expanded, toggle, revealAncestorsOf } = useExpandedPaths(vault);
   const { pathname } = useLocation();
+  const navigate = useNavigate();
   const [filter, setFilter] = useState("");
-  const [uncapped, setUncapped] = useState(false);
+  const [kindFilter, setKindFilter] = useState<ResourceKind | "all">("all");
+  const [collapsedKindGroups, setCollapsedKindGroups] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [kindLimits, setKindLimits] = useState<Map<string, number>>(
+    () => new Map(),
+  );
+  const [renderLimit, setRenderLimit] = useState(TREE_RENDER_PAGE);
   const listRef = useRef<HTMLDivElement | null>(null);
 
   // Role-gated affordances. We fetch the role on mount/vault-change rather
@@ -127,9 +157,35 @@ export function VaultExplorer({
   const [deleteTarget, setDeleteTarget] = useState<{
     path: string;
     docCount: number;
+    tableCount: number;
     fileCount: number;
     subCollectionCount: number;
   } | null>(null);
+  const [detailsTarget, setDetailsTarget] = useState<{
+    path: string;
+    summary?: string | null;
+    counts: CollectionResourceCounts;
+    editable: boolean;
+  } | null>(null);
+  const [uploadCollection, setUploadCollection] = useState<string | null>(null);
+  const [tableCollection, setTableCollection] = useState<string | null>(null);
+  const mutationTriggerRef = useRef<HTMLElement | null>(null);
+
+  const rememberMutationTrigger = useCallback(() => {
+    if (document.activeElement instanceof HTMLElement) {
+      mutationTriggerRef.current = document.activeElement;
+    }
+  }, []);
+
+  const openUpload = useCallback((collection: string) => {
+    rememberMutationTrigger();
+    setUploadCollection(collection);
+  }, [rememberMutationTrigger]);
+
+  const openTableCreate = useCallback((collection: string) => {
+    rememberMutationTrigger();
+    setTableCollection(collection);
+  }, [rememberMutationTrigger]);
 
   const activeSig = useMemo(() => activePathFromRoute(pathname, tree), [pathname, tree]);
 
@@ -140,40 +196,106 @@ export function VaultExplorer({
     }
   }, [activeSig, revealAncestorsOf]);
 
-  const filtered = useMemo(() => {
+  const kindFiltered = useMemo(() => {
     if (!tree) return tree;
+    return filterTreeByKind(tree, kindFilter);
+  }, [tree, kindFilter]);
+
+  const filtered = useMemo(() => {
+    if (!kindFiltered) return kindFiltered;
     const q = filter.trim().toLowerCase();
-    return q ? filterTree(tree, q) : tree;
-  }, [tree, filter]);
+    return q ? filterTree(kindFiltered, q) : kindFiltered;
+  }, [kindFiltered, filter]);
 
   const forceOpen = filter.length > 0;
 
   /** Total row count (unfiltered) for the empty-state check. */
   const total = useMemo<number>(() => {
-    if (!tree) return 0;
-    let c = 0;
-    for (const n of tree) {
-      if (n.kind === "collection") c += countDocs(n);
-      else c += 1;
-    }
-    return c;
+    return tree ? countTreeNodes(tree) : 0;
   }, [tree]);
+
+  const resourceCounts = useMemo(
+    () => countResourceKinds(tree ?? []),
+    [tree],
+  );
+  const resourceTotal =
+    resourceCounts.document + resourceCounts.table + resourceCounts.file;
+  const kindOptions = useMemo(
+    () => [
+      {
+        value: "all",
+        label: "All",
+        hint: `${resourceTotal.toLocaleString()} resources`,
+      },
+      {
+        value: "document",
+        label: "Documents",
+        hint: `${resourceCounts.document.toLocaleString()} documents`,
+      },
+      {
+        value: "table",
+        label: "Tables",
+        hint: `${resourceCounts.table.toLocaleString()} tables`,
+      },
+      {
+        value: "file",
+        label: "Files",
+        hint: `${resourceCounts.file.toLocaleString()} files`,
+      },
+    ],
+    [resourceCounts, resourceTotal],
+  );
 
   /** Full flattened row list (without cap). */
   const fullRows = useMemo<FlatRow[]>(
-    () => (filtered ? flattenVisible(filtered, expanded, forceOpen) : []),
-    [filtered, expanded, forceOpen],
+    () =>
+      filtered
+          ? flattenVisible(filtered, expanded, forceOpen, {
+            collapsedKindGroups,
+            kindLimits,
+            activeSig,
+          })
+        : [],
+    [filtered, expanded, forceOpen, collapsedKindGroups, kindLimits, activeSig],
   );
 
-  /** Capped rows — soft cap applied unless the user opts in, or unless
-   *  a filter is active (the user is hunting for a specific match and a
-   *  cap could hide it). */
+  /** Progressive global cap prevents a single interaction from mounting an
+   * entire multi-thousand-row tree. Per-kind previews handle the common case;
+   * this is the final guard for vaults with many expanded collections. */
   const visibleRows = useMemo<FlatRow[]>(() => {
-    if (filter || uncapped) return fullRows;
-    return fullRows.length > TREE_RENDER_CAP
-      ? fullRows.slice(0, TREE_RENDER_CAP)
-      : fullRows;
-  }, [fullRows, uncapped, filter]);
+    return fullRows.slice(0, renderLimit);
+  }, [fullRows, renderLimit]);
+
+  useEffect(() => {
+    setRenderLimit(TREE_RENDER_PAGE);
+    setKindLimits(new Map());
+  }, [filter, kindFilter, vault]);
+
+  useEffect(() => {
+    setCollapsedKindGroups(new Set());
+  }, [vault]);
+
+  const toggleKindGroup = useCallback((parentPath: string, kind: ResourceKind) => {
+    const key = kindGroupKey(parentPath, kind);
+    setCollapsedKindGroups((current) => {
+      const next = new Set(current);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  const showMoreKind = useCallback((parentPath: string, kind: ResourceKind) => {
+    const key = kindGroupKey(parentPath, kind);
+    setKindLimits((current) => {
+      const next = new Map(current);
+      next.set(
+        key,
+        (current.get(key) ?? RESOURCE_PREVIEW_SIZE) + RESOURCE_PAGE_SIZE,
+      );
+      return next;
+    });
+  }, []);
 
   const focusAt = useCallback((i: number) => {
     const clamped = Math.max(0, Math.min(i, visibleRows.length - 1));
@@ -203,7 +325,17 @@ export function VaultExplorer({
         case "ArrowLeft": {
           if (idx < 0) return;
           const row = visibleRows[idx];
-          if (row.node.kind !== "collection") return;
+          if (row.type === "kind-group") {
+            if (e.key === "ArrowRight" && !row.isOpen) {
+              toggleKindGroup(row.parentPath, row.kind);
+            }
+            if (e.key === "ArrowLeft" && row.isOpen) {
+              toggleKindGroup(row.parentPath, row.kind);
+            }
+            e.preventDefault();
+            return;
+          }
+          if (row.type !== "node" || row.node.kind !== "collection") return;
           const isOpen = forceOpen || expanded.has(row.node.path);
           if (e.key === "ArrowRight" && !isOpen) toggle(row.node.path);
           if (e.key === "ArrowLeft" && isOpen) toggle(row.node.path);
@@ -227,33 +359,90 @@ export function VaultExplorer({
         }
       }
     },
-    [visibleRows, focusAt, forceOpen, expanded, toggle],
+    [
+      visibleRows,
+      focusAt,
+      forceOpen,
+      expanded,
+      toggle,
+      toggleKindGroup,
+    ],
   );
+
+  const headBtn =
+    "inline-flex h-7 w-7 items-center justify-center rounded-[var(--radius-sm)] text-foreground-muted hover:bg-surface-hover hover:text-link transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:cursor-default disabled:opacity-50";
 
   return (
     <aside
-      className="flex flex-col h-full overflow-hidden text-sm bg-background"
+      className="flex flex-col h-full overflow-hidden text-sm bg-surface"
       aria-label={`${vault} collections`}
     >
-      <div className="border-b border-border px-2 py-1.5 shrink-0 flex items-center gap-1.5">
-        <input
-          type="search"
-          placeholder="Filter in vault…"
-          value={filter}
-          onChange={(e) => setFilter(e.target.value)}
-          className="flex-1 min-w-0 h-9 px-2.5 rounded-[var(--radius-md)] bg-surface border border-border text-xs text-foreground placeholder:text-foreground-muted focus:outline-none focus:border-primary focus-visible:ring-2 focus-visible:ring-ring transition-colors"
-          aria-label="Filter tree"
-        />
-        <button
-          type="button"
-          onClick={() => refetch()}
-          aria-label="Refresh"
-          title="Refresh"
-          className="shrink-0 inline-flex h-9 w-9 items-center justify-center rounded-[var(--radius-md)] border border-border bg-surface text-foreground-muted hover:text-foreground hover:bg-surface-hover transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-        >
-          <RotateCw className="h-3.5 w-3.5" aria-hidden />
-        </button>
+      <div className="flex h-10 shrink-0 items-center justify-between border-b border-border px-3">
+        <span className="coord-ink">Collections</span>
+        <div className="flex items-center gap-0.5">
+          <button
+            type="button"
+            onClick={() => refetch()}
+            disabled={loading}
+            aria-label="Refresh collections"
+            title="Refresh collections"
+            className={headBtn}
+          >
+            <RefreshCw className={loading ? "h-3 w-3 animate-spin" : "h-3 w-3"} aria-hidden />
+          </button>
+          {canWrite && (
+            <RootCreateMenu
+              triggerClassName={headBtn}
+              onCreateDocument={() => openCreateDocument()}
+              onUploadFile={() => openUpload("")}
+              onCreateTable={() => openTableCreate("")}
+              onCreateCollection={() => openCreate(null)}
+            />
+          )}
+          {onCollapse && (
+            <button
+              type="button"
+              onClick={onCollapse}
+              title="Collapse tree (⌘\\)"
+              aria-label="Collapse collection tree"
+              aria-expanded={true}
+              className={headBtn}
+            >
+              <PanelLeftClose className="h-4 w-4" aria-hidden />
+            </button>
+          )}
+        </div>
       </div>
+
+      {total > 0 && (
+        <div className="shrink-0 border-b border-border px-2 py-1.5">
+          <div className="grid grid-cols-[minmax(0,1fr)_6.5rem] gap-1.5">
+            <div className="relative min-w-0">
+              <Search
+                className="pointer-events-none absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-foreground-muted"
+                aria-hidden
+              />
+              <input
+                type="search"
+                placeholder="Filter resources"
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                className="h-8 w-full rounded-[var(--radius-md)] border border-border bg-background pl-6 pr-2 text-xs text-foreground placeholder:text-foreground-muted transition-colors focus:border-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                aria-label="Filter resources"
+              />
+            </div>
+            <SelectMenu
+              value={kindFilter}
+              onValueChange={(value) =>
+                setKindFilter(value as ResourceKind | "all")
+              }
+              options={kindOptions}
+              aria-label="Resource type"
+              className="h-8 bg-background px-2 text-xs"
+            />
+          </div>
+        </div>
+      )}
 
       <div
         ref={listRef}
@@ -269,75 +458,86 @@ export function VaultExplorer({
             No collections yet — the tree fills in with your first document.
           </div>
         )}
-        {!loading && !error && total > 0 && visibleRows.length === 0 && filter && (
-          <div className="coord px-3 py-1.5" role="status">— No matches —</div>
+        {!loading && !error && total > 0 && visibleRows.length === 0 && (
+          <div className="coord px-3 py-2" role="status">
+            No resources match these filters.
+          </div>
         )}
 
         {!loading && !error &&
-          visibleRows.map((r) => (
-            <Fragment key={r.sig}>
-              {r.kindHeader && <KindGroupLabel kind={r.kindHeader} depth={r.depth} />}
+          visibleRows.map((row) => {
+            if (row.type === "kind-group") {
+              return (
+                <KindGroupRow
+                  key={row.sig}
+                  row={row}
+                  onToggle={() => toggleKindGroup(row.parentPath, row.kind)}
+                />
+              );
+            }
+            if (row.type === "more") {
+              return (
+                <KindMoreRow
+                  key={row.sig}
+                  row={row}
+                  onShowMore={() => showMoreKind(row.parentPath, row.kind)}
+                />
+              );
+            }
+            return (
               <TreeRow
-              node={r.node}
-              depth={r.depth}
-              sig={r.sig}
-              isOpen={r.isOpen}
-              isActive={r.sig === activeSig}
-              vault={vault}
-              onToggle={toggle}
-              canWrite={canWrite}
-              onCreateDoc={(node) =>
-                openCreateDocument({ collection: node.path })
-              }
-              onCreateSubCollection={(node) => openCreate(node.path)}
-              onDeleteCollection={(node) =>
-                setDeleteTarget({
-                  path: node.path,
-                  docCount: countDocs(node),
-                  // TODO: the in-memory tree currently flattens files
-                  // to vault root (see use-vault-tree.ts buildTree),
-                  // so a collection's true file count isn't available
-                  // client-side. The server's 409 response will
-                  // surface the real count if the user picks
-                  // empty-mode on a collection that secretly has files.
-                  fileCount: 0,
-                  // The tree already nests sub-collections under their
-                  // parent, so this is a pure local walk. Critical for
-                  // the nested-parent case: when the user clicks trash
-                  // on a synthesized parent, this drives the dialog into
-                  // cascade mode and shows the strengthened banner.
-                  subCollectionCount: countSubCollections(node),
-                })
-              }
+                key={row.sig}
+                node={row.node}
+                depth={row.depth}
+                sig={row.sig}
+                isOpen={row.isOpen}
+                isActive={row.sig === activeSig}
+                vault={vault}
+                onToggle={toggle}
+                canWrite={canWrite}
+                onCreateDoc={(node) =>
+                  openCreateDocument({ collection: node.path })
+                }
+                onUploadFile={(node) => openUpload(node.path)}
+                onCreateTable={(node) => openTableCreate(node.path)}
+                onCreateSubCollection={(node) => openCreate(node.path)}
+                onOpenDetails={(node) => {
+                  const counts = countCollectionResources(node);
+                  setDetailsTarget({
+                    path: node.path,
+                    summary: node.raw?.summary,
+                    counts,
+                    editable: canWrite && !isReservedCollection(node.path),
+                  });
+                }}
+                onDeleteCollection={(node) => {
+                  const counts = countCollectionResources(node);
+                  setDeleteTarget({
+                    path: node.path,
+                    docCount: counts.documents,
+                    tableCount: counts.tables,
+                    fileCount: counts.files,
+                    subCollectionCount: countSubCollections(node),
+                  });
+                }}
               />
-            </Fragment>
-          ))}
+            );
+          })}
 
-        {!loading && !error && !filter && !uncapped &&
+        {!loading && !error &&
           fullRows.length > visibleRows.length && (
             <button
               type="button"
-              onClick={() => setUncapped(true)}
+              onClick={() =>
+                setRenderLimit((current) => current + TREE_RENDER_PAGE)
+              }
               className="w-full coord px-3 py-2 text-left hover:bg-surface-hover hover:text-link transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background cursor-pointer"
             >
-              ↓ Show {fullRows.length - visibleRows.length} more
+              Show next {Math.min(TREE_RENDER_PAGE, fullRows.length - visibleRows.length)} of{" "}
+              {(fullRows.length - visibleRows.length).toLocaleString()}
             </button>
           )}
 
-        {/* Once real knowledge exists, keep a discoverable root-collection
-            action at the bottom of the tree. In the empty state the main
-            onboarding already owns the next action, matching the quiet mockup
-            rather than showing two competing ways to begin. */}
-        {!loading && !error && total > 0 && canWrite && (
-          <button
-            type="button"
-            onClick={() => openCreate(null)}
-            className="w-full inline-flex items-center gap-1.5 px-3 py-1.5 text-left text-foreground-muted hover:bg-surface-hover hover:text-link transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-          >
-            <FolderPlus className="h-3 w-3" aria-hidden />
-            <span className="coord">+ New collection</span>
-          </button>
-        )}
       </div>
 
       {/* Mutation dialogs. Mounted unconditionally so portals stay
@@ -362,6 +562,7 @@ export function VaultExplorer({
         vault={vault}
         path={deleteTarget?.path ?? ""}
         docCount={deleteTarget?.docCount ?? 0}
+        tableCount={deleteTarget?.tableCount ?? 0}
         fileCount={deleteTarget?.fileCount ?? 0}
         subCollectionCount={deleteTarget?.subCollectionCount ?? 0}
         open={deleteTarget !== null}
@@ -370,6 +571,49 @@ export function VaultExplorer({
         }}
         onDeleted={() => {
           handleMutation();
+        }}
+      />
+      <CollectionDetailsDialog
+        vault={vault}
+        path={detailsTarget?.path ?? ""}
+        summary={detailsTarget?.summary}
+        counts={detailsTarget?.counts ?? { documents: 0, tables: 0, files: 0 }}
+        editable={detailsTarget?.editable ?? false}
+        open={detailsTarget !== null}
+        onOpenChange={(next) => {
+          if (!next) setDetailsTarget(null);
+        }}
+        onUpdated={() => {
+          handleMutation();
+        }}
+      />
+      <FileUploadDialog
+        open={uploadCollection !== null}
+        onOpenChange={(next) => {
+          if (!next) setUploadCollection(null);
+        }}
+        vault={vault}
+        initialCollection={uploadCollection ?? ""}
+        returnFocusRef={mutationTriggerRef}
+        onUploaded={(file) => {
+          handleMutation();
+          const parsed = parseFileUri(file.uri);
+          if (parsed) {
+            navigate(`/vault/${vault}/file/${encodeURIComponent(parsed.id)}`);
+          }
+        }}
+      />
+      <TableCreateDialog
+        open={tableCollection !== null}
+        onOpenChange={(next) => {
+          if (!next) setTableCollection(null);
+        }}
+        vault={vault}
+        initialCollection={tableCollection ?? ""}
+        returnFocusRef={mutationTriggerRef}
+        onCreated={(tableName) => {
+          handleMutation();
+          navigate(`/vault/${vault}/table/${encodeURIComponent(tableName)}`);
         }}
       />
     </aside>
@@ -392,6 +636,8 @@ interface RowProps {
   /** Fired when the user clicks the trash icon on a collection row.
    *  Parent decides which dialog to open and seeds it with counts. */
   onDeleteCollection?: (node: TreeNode) => void;
+  /** Open the collection metadata and resource-count inspector. */
+  onOpenDetails?: (node: TreeNode) => void;
   /** Fired when the user clicks the `+` (new sub-collection) icon on a
    *  collection row. Parent opens the create dialog with this node's
    *  path prefilled as the parent. */
@@ -399,15 +645,18 @@ interface RowProps {
   /** Fired when the user clicks the doc icon on a collection row. Parent
    *  routes to the new-document page with this collection prefilled. */
   onCreateDoc?: (node: TreeNode) => void;
+  /** Open the file uploader with this collection preselected. */
+  onUploadFile?: (node: TreeNode) => void;
+  /** Open the table builder with this collection preselected. */
+  onCreateTable?: (node: TreeNode) => void;
 }
 
 const TreeRow = memo(function TreeRow({
-  node, depth, sig, isOpen, isActive, vault, onToggle, canWrite, onDeleteCollection, onCreateSubCollection, onCreateDoc,
+  node, depth, sig, isOpen, isActive, vault, onToggle, canWrite, onDeleteCollection, onOpenDetails, onCreateSubCollection, onCreateDoc, onUploadFile, onCreateTable,
 }: RowProps) {
   const indent = { paddingLeft: `${depth * 12 + 12}px` };
 
   if (node.kind === "collection") {
-    const count = countDocs(node);
     const ChevronIcon = isOpen ? ChevronDown : ChevronRight;
     // The reserved `overview` collection holds the vault guide. The backend
     // rejects writes into it, so the tree shows it read-only (locked, no row
@@ -426,7 +675,7 @@ const TreeRow = memo(function TreeRow({
           data-sig={sig}
           onClick={() => onToggle(node.path)}
           style={indent}
-          className={`flex-1 min-w-0 flex items-center gap-1.5 pr-2 py-1.5 min-h-9 text-left transition-colors hover:bg-surface-hover focus:bg-surface-hover focus:outline-none cursor-pointer ${
+          className={`flex min-h-11 min-w-0 flex-1 items-center gap-1.5 py-1.5 pr-1 text-left transition-colors hover:bg-surface-hover focus:bg-surface-hover focus:outline-none cursor-pointer ${
             isActive ? "bg-surface-selected text-surface-selected-foreground" : ""
           }`}
         >
@@ -434,68 +683,58 @@ const TreeRow = memo(function TreeRow({
             className="h-3 w-3 shrink-0 text-foreground-muted group-hover:text-link transition-colors"
             aria-hidden
           />
-          <span
-            title={node.raw?.summary ? `${node.name} — ${node.raw.summary}` : node.name}
-            className="truncate font-medium tracking-tight text-[13px]"
-          >
-            {node.name}
-          </span>
-          {isReserved && (
-            <span
-              title="System collection — managed via vault settings"
-              className="inline-flex shrink-0 items-center"
-              style={{ color: "var(--color-primary)" }}
-            >
-              <Lock className="h-3 w-3" aria-hidden />
-              <span className="sr-only">System collection</span>
+          <span className="min-w-0 flex-1">
+            <span className="flex min-w-0 items-center gap-1">
+              <span
+                title={node.raw?.summary ? `${node.name} — ${node.raw.summary}` : node.name}
+                className="block min-w-0 flex-1 truncate font-medium tracking-tight text-[13px]"
+              >
+                {node.name}
+              </span>
+              {isReserved && (
+                <span
+                  title="System collection — managed via vault settings"
+                  className="inline-flex shrink-0 items-center"
+                  style={{ color: "var(--color-primary)" }}
+                >
+                  <Lock className="h-3 w-3" aria-hidden />
+                  <span className="sr-only">System collection</span>
+                </span>
+              )}
             </span>
-          )}
-          {count > 0 && <span className="coord ml-auto shrink-0 tabular-nums">{count}</span>}
+          </span>
         </button>
-        {!isReserved && canWrite && onCreateDoc && (
-          <button
-            type="button"
-            onClick={(e) => {
-              // Stop the row's expand-toggle from also firing.
-              e.stopPropagation();
-              onCreateDoc(node);
-            }}
-            title={`New document in ${node.path}`}
-            aria-label={`Create document in ${node.path}`}
-            className="shrink-0 px-2 inline-flex items-center justify-center text-foreground-muted hover:text-link transition-colors cursor-pointer opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-          >
-            <FilePlus className="h-3 w-3" aria-hidden />
-          </button>
-        )}
-        {!isReserved && canWrite && onCreateSubCollection && (
-          <button
-            type="button"
-            onClick={(e) => {
-              // Stop the row's expand-toggle from also firing.
-              e.stopPropagation();
-              onCreateSubCollection(node);
-            }}
-            title={`New sub-collection in ${node.path}`}
-            aria-label={`Create sub-collection in ${node.path}`}
-            className="shrink-0 px-2 inline-flex items-center justify-center text-foreground-muted hover:text-link transition-colors cursor-pointer opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-          >
-            <FolderPlus className="h-3 w-3" aria-hidden />
-          </button>
-        )}
-        {!isReserved && canWrite && onDeleteCollection && (
-          <button
-            type="button"
-            onClick={(e) => {
-              // Stop the row's expand-toggle from also firing.
-              e.stopPropagation();
-              onDeleteCollection(node);
-            }}
-            title={`Delete ${node.path}`}
-            aria-label={`Delete collection ${node.path}`}
-            className="shrink-0 px-2 inline-flex items-center justify-center text-foreground-muted hover:text-destructive transition-colors cursor-pointer opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-          >
-            <Trash2 className="h-3 w-3" aria-hidden />
-          </button>
+        {onOpenDetails && (
+          <CollectionActionsMenu
+            node={node}
+            editable={Boolean(canWrite && !isReserved)}
+            onOpenDetails={() => onOpenDetails(node)}
+            onCreateDoc={
+              !isReserved && canWrite && onCreateDoc
+                ? () => onCreateDoc(node)
+                : undefined
+            }
+            onUploadFile={
+              !isReserved && canWrite && onUploadFile
+                ? () => onUploadFile(node)
+                : undefined
+            }
+            onCreateTable={
+              !isReserved && canWrite && onCreateTable
+                ? () => onCreateTable(node)
+                : undefined
+            }
+            onCreateSubCollection={
+              !isReserved && canWrite && onCreateSubCollection
+                ? () => onCreateSubCollection(node)
+                : undefined
+            }
+            onDelete={
+              !isReserved && canWrite && onDeleteCollection
+                ? () => onDeleteCollection(node)
+                : undefined
+            }
+          />
         )}
       </div>
     );
@@ -554,7 +793,7 @@ const TreeRow = memo(function TreeRow({
   );
 });
 
-/* ── Kind-group label (Documents / Tables / Files) ────────────────────────── */
+/* ── Resource-kind disclosure rows ───────────────────────────────────────── */
 
 const KIND_LABEL: Partial<Record<NodeKind, string>> = {
   document: "Documents",
@@ -562,23 +801,64 @@ const KIND_LABEL: Partial<Record<NodeKind, string>> = {
   file: "Files",
 };
 
-/**
- * A muted, non-interactive group heading rendered above the first row of each
- * leaf-kind run when a collection mixes kinds (Sentence case per the design
- * system). `role="presentation"` + no `data-sig` keeps it out of the tree's
- * roving keyboard nav and the aria-tree row set — it's purely a visual divider.
- */
-function KindGroupLabel({ kind, depth }: { kind: NodeKind; depth: number }) {
-  const label = KIND_LABEL[kind];
-  if (!label) return null;
+function KindGroupRow({
+  row,
+  onToggle,
+}: {
+  row: FlatKindGroupRow;
+  onToggle: () => void;
+}) {
+  const label = KIND_LABEL[row.kind] ?? "Resources";
+  const ChevronIcon = row.isOpen ? ChevronDown : ChevronRight;
   return (
-    <div
-      role="presentation"
-      style={{ paddingLeft: `${depth * 12 + 12}px` }}
-      className="coord px-2 pt-2 pb-0.5 select-none"
+    <button
+      type="button"
+      role="treeitem"
+      aria-level={row.depth + 1}
+      aria-expanded={row.isOpen}
+      aria-label={`${label}, ${row.count.toLocaleString()} ${row.count === 1 ? "item" : "items"}`}
+      data-sig={row.sig}
+      onClick={onToggle}
+      style={{ paddingLeft: `${row.depth * 12 + 12}px` }}
+      className="group flex min-h-8 w-full items-center gap-1.5 border-y border-border bg-surface-2 px-2 py-1 text-left text-xs font-medium text-foreground transition-colors hover:bg-surface-hover hover:text-link focus:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
     >
-      {label}
-    </div>
+      <ChevronIcon
+        className="h-3 w-3 shrink-0 text-foreground-muted transition-colors group-hover:text-link"
+        aria-hidden
+      />
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+      <span className="shrink-0 tabular-nums text-foreground-muted">
+        {row.count.toLocaleString()}
+      </span>
+    </button>
+  );
+}
+
+function KindMoreRow({
+  row,
+  onShowMore,
+}: {
+  row: FlatMoreRow;
+  onShowMore: () => void;
+}) {
+  const remaining = row.totalCount - row.visibleCount;
+  const next = Math.min(RESOURCE_PAGE_SIZE, remaining);
+  const label = KIND_LABEL[row.kind]?.toLowerCase() ?? "resources";
+  return (
+    <button
+      type="button"
+      role="treeitem"
+      aria-level={row.depth + 1}
+      data-sig={row.sig}
+      onClick={onShowMore}
+      style={{ paddingLeft: `${row.depth * 12 + 12}px` }}
+      className="flex min-h-9 w-full items-center pr-2 py-1.5 text-left text-xs font-medium text-link transition-colors hover:bg-surface-hover hover:text-link-hover focus:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+    >
+      Show {next.toLocaleString()} more {label}
+      <span className="ml-auto pl-2 tabular-nums text-foreground-muted">
+        {remaining.toLocaleString()} left
+      </span>
+    </button>
   );
 }
 
@@ -600,13 +880,209 @@ function countSubCollections(node: TreeNode): number {
   return n;
 }
 
+function countCollectionResources(node: TreeNode): CollectionResourceCounts {
+  const counts: CollectionResourceCounts = { documents: 0, tables: 0, files: 0 };
+  const visit = (current: TreeNode) => {
+    if (current.kind === "document") counts.documents += 1;
+    else if (current.kind === "table") counts.tables += 1;
+    else if (current.kind === "file") counts.files += 1;
+    current.children?.forEach(visit);
+  };
+  node.children?.forEach(visit);
+  return counts;
+}
+
+function countTreeNodes(nodes: TreeNode[]): number {
+  let total = 0;
+  const visit = (node: TreeNode) => {
+    total += 1;
+    node.children?.forEach(visit);
+  };
+  nodes.forEach(visit);
+  return total;
+}
+
+function countResourceKinds(nodes: TreeNode[]): Record<ResourceKind, number> {
+  const counts: Record<ResourceKind, number> = {
+    document: 0,
+    table: 0,
+    file: 0,
+  };
+  const visit = (node: TreeNode) => {
+    if (node.kind !== "collection") counts[node.kind] += 1;
+    node.children?.forEach(visit);
+  };
+  nodes.forEach(visit);
+  return counts;
+}
+
+function CollectionActionsMenu({
+  node,
+  editable,
+  onOpenDetails,
+  onCreateDoc,
+  onUploadFile,
+  onCreateTable,
+  onCreateSubCollection,
+  onDelete,
+}: {
+  node: TreeNode;
+  editable: boolean;
+  onOpenDetails: () => void;
+  onCreateDoc?: () => void;
+  onUploadFile?: () => void;
+  onCreateTable?: () => void;
+  onCreateSubCollection?: () => void;
+  onDelete?: () => void;
+}) {
+  const hasWriteActions = Boolean(
+    onCreateDoc || onUploadFile || onCreateTable || onCreateSubCollection || onDelete,
+  );
+  const itemClass =
+    "flex cursor-pointer select-none items-center gap-2 rounded-[var(--radius-sm)] px-2.5 py-2 text-sm text-foreground outline-none data-[highlighted]:bg-surface-hover";
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <button
+          type="button"
+          title={`Collection actions for ${node.path}`}
+          aria-label={`Collection actions for ${node.path}`}
+          className="inline-flex min-h-11 w-8 shrink-0 items-center justify-center text-foreground-muted transition-colors hover:bg-surface-hover hover:text-link focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        >
+          <MoreHorizontal className="h-4 w-4" aria-hidden />
+        </button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          align="start"
+          side="right"
+          sideOffset={4}
+          className="z-[var(--z-popover)] min-w-48 overflow-hidden rounded-[var(--radius-md)] border border-border bg-surface p-1 shadow-md"
+        >
+          {hasWriteActions && (
+            <DropdownMenu.Label className="px-2.5 pb-1 pt-1 text-xs font-medium text-foreground-muted">
+              Add to collection
+            </DropdownMenu.Label>
+          )}
+          {onCreateDoc && (
+            <DropdownMenu.Item onSelect={onCreateDoc} className={itemClass}>
+              <FilePlus className="h-4 w-4 text-foreground-muted" aria-hidden />
+              New document
+            </DropdownMenu.Item>
+          )}
+          {onUploadFile && (
+            <DropdownMenu.Item onSelect={onUploadFile} className={itemClass}>
+              <Upload className="h-4 w-4 text-foreground-muted" aria-hidden />
+              Upload file
+            </DropdownMenu.Item>
+          )}
+          {onCreateTable && (
+            <DropdownMenu.Item onSelect={onCreateTable} className={itemClass}>
+              <Table className="h-4 w-4 text-foreground-muted" aria-hidden />
+              New table
+            </DropdownMenu.Item>
+          )}
+          {onCreateSubCollection && (
+            <DropdownMenu.Item onSelect={onCreateSubCollection} className={itemClass}>
+              <FolderPlus className="h-4 w-4 text-foreground-muted" aria-hidden />
+              New sub-collection
+            </DropdownMenu.Item>
+          )}
+          {hasWriteActions && <DropdownMenu.Separator className="my-1 h-px bg-border" />}
+          <DropdownMenu.Item onSelect={onOpenDetails} className={itemClass}>
+            <Info className="h-4 w-4 text-foreground-muted" aria-hidden />
+            {editable ? "View or edit summary" : "View details"}
+          </DropdownMenu.Item>
+          {onDelete && (
+            <>
+              <DropdownMenu.Separator className="my-1 h-px bg-border" />
+              <DropdownMenu.Item
+                onSelect={onDelete}
+                className={`${itemClass} text-destructive data-[highlighted]:bg-destructive-soft`}
+              >
+                <Trash2 className="h-4 w-4" aria-hidden />
+                Delete collection
+              </DropdownMenu.Item>
+            </>
+          )}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+}
+
+function RootCreateMenu({
+  triggerClassName,
+  onCreateDocument,
+  onUploadFile,
+  onCreateTable,
+  onCreateCollection,
+}: {
+  triggerClassName: string;
+  onCreateDocument: () => void;
+  onUploadFile: () => void;
+  onCreateTable: () => void;
+  onCreateCollection: () => void;
+}) {
+  const itemClass =
+    "flex cursor-pointer select-none items-center gap-2 rounded-[var(--radius-sm)] px-2.5 py-2 text-sm text-foreground outline-none data-[highlighted]:bg-surface-hover";
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <button
+          type="button"
+          aria-label="Create in vault"
+          title="Create in vault"
+          className={triggerClassName}
+        >
+          <Plus className="h-3.5 w-3.5" aria-hidden />
+        </button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          align="end"
+          sideOffset={4}
+          className="z-[var(--z-popover)] min-w-48 overflow-hidden rounded-[var(--radius-md)] border border-border bg-surface p-1 shadow-md"
+        >
+          <DropdownMenu.Label className="px-2.5 pb-1 pt-1 text-xs font-medium text-foreground-muted">
+            Create at Vault root
+          </DropdownMenu.Label>
+          <DropdownMenu.Item onSelect={onCreateDocument} className={itemClass}>
+            <FilePlus className="h-4 w-4 text-foreground-muted" aria-hidden />
+            New document
+          </DropdownMenu.Item>
+          <DropdownMenu.Item onSelect={onUploadFile} className={itemClass}>
+            <Upload className="h-4 w-4 text-foreground-muted" aria-hidden />
+            Upload file
+          </DropdownMenu.Item>
+          <DropdownMenu.Item onSelect={onCreateTable} className={itemClass}>
+            <Table className="h-4 w-4 text-foreground-muted" aria-hidden />
+            New table
+          </DropdownMenu.Item>
+          <DropdownMenu.Item onSelect={onCreateCollection} className={itemClass}>
+            <FolderPlus className="h-4 w-4 text-foreground-muted" aria-hidden />
+            New collection
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+}
+
 function findNextByPrefix(rows: FlatRow[], start: number, prefix: string): number {
   const n = rows.length;
   for (let i = 0; i < n; i++) {
     const k = (start + i) % n;
-    if (rows[k].node.name.toLowerCase().startsWith(prefix)) return k;
+    if (rowLabel(rows[k]).toLowerCase().startsWith(prefix)) return k;
   }
   return -1;
+}
+
+function rowLabel(row: FlatRow): string {
+  if (row.type === "node") return row.node.name;
+  if (row.type === "kind-group") return KIND_LABEL[row.kind] ?? "Resources";
+  return `Show more ${KIND_LABEL[row.kind] ?? "resources"}`;
 }
 
 function cssEscape(s: string): string {

--- a/frontend/src/components/vault-shell.tsx
+++ b/frontend/src/components/vault-shell.tsx
@@ -348,23 +348,11 @@ export function VaultShell() {
                 className="shrink-0 h-full flex flex-col min-h-0"
                 style={{ width: desktopNav ? tree.width : mobileTreeWidth }}
               >
-                <div className="flex h-10 shrink-0 items-center justify-between border-b border-border px-3">
-                  <span className="coord-ink">Collections</span>
-                  <button
-                    type="button"
-                    onClick={() => setEffectiveTreeVisible(false)}
-                    title="Collapse tree (⌘\\)"
-                    aria-label="Collapse collection tree"
-                    aria-expanded={true}
-                    className="text-foreground-muted hover:text-link transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
-                  >
-                    <PanelLeftClose className="h-4 w-4" aria-hidden />
-                  </button>
-                </div>
                 <div className="flex-1 min-h-0">
                   <VaultExplorer
                     vault={name}
                     onRefetchReady={onTreeRefetchReady}
+                    onCollapse={() => setEffectiveTreeVisible(false)}
                   />
                 </div>
               </div>

--- a/frontend/src/hooks/__tests__/use-accessible-indexing-health.test.ts
+++ b/frontend/src/hooks/__tests__/use-accessible-indexing-health.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { authenticatedFetch, listVaults } from "@/lib/api";
+import { loadAccessibleIndexingHealth } from "../use-accessible-indexing-health";
+
+vi.mock("@/lib/api", () => ({
+  authenticatedFetch: vi.fn(),
+  listVaults: vi.fn(),
+}));
+
+const listVaultsMock = vi.mocked(listVaults);
+const authenticatedFetchMock = vi.mocked(authenticatedFetch);
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("loadAccessibleIndexingHealth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("aggregates only reader-visible Vault health and includes metadata work", async () => {
+    listVaultsMock.mockResolvedValue({
+      vaults: [
+        { name: "platform" },
+        { name: "shared research" },
+        { name: "platform" },
+      ],
+    });
+    authenticatedFetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("platform")) {
+        return jsonResponse({
+          vector_store: {
+            backfill: { upsert: { pending: 3, abandoned: 1, indexed: 20 } },
+          },
+          metadata_backfill: { pending: 2, abandoned: 0 },
+        });
+      }
+      return jsonResponse({
+        vector_store: {
+          backfill: { upsert: { pending: 4, abandoned: 0, indexed: 10 } },
+        },
+        metadata_backfill: { pending: 1, abandoned: 2 },
+      });
+    });
+
+    await expect(loadAccessibleIndexingHealth()).resolves.toEqual({
+      vaultCount: 2,
+      checkedVaultCount: 2,
+      pending: 10,
+      abandoned: 3,
+      indexed: 30,
+      incomplete: false,
+    });
+    expect(authenticatedFetchMock).toHaveBeenCalledWith(
+      "/health/vault/shared%20research",
+    );
+  });
+
+  it("marks totals as a lower bound when one Vault status is unavailable", async () => {
+    listVaultsMock.mockResolvedValue({
+      vaults: [{ name: "available" }, { name: "temporarily-offline" }],
+    });
+    authenticatedFetchMock.mockImplementation(async (input) => {
+      if (String(input).endsWith("temporarily-offline")) {
+        return jsonResponse({ detail: "Unavailable" }, 503);
+      }
+      return jsonResponse({
+        vector_store: {
+          backfill: { upsert: { pending: 5, abandoned: 0, indexed: 12 } },
+        },
+      });
+    });
+
+    await expect(loadAccessibleIndexingHealth()).resolves.toEqual({
+      vaultCount: 2,
+      checkedVaultCount: 1,
+      pending: 5,
+      abandoned: 0,
+      indexed: 12,
+      incomplete: true,
+    });
+  });
+
+  it("returns a complete quiet snapshot for an account with no Vaults", async () => {
+    listVaultsMock.mockResolvedValue({ vaults: [] });
+
+    await expect(loadAccessibleIndexingHealth()).resolves.toEqual({
+      vaultCount: 0,
+      checkedVaultCount: 0,
+      pending: 0,
+      abandoned: 0,
+      indexed: 0,
+      incomplete: false,
+    });
+    expect(authenticatedFetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/use-accessible-indexing-health.ts
+++ b/frontend/src/hooks/use-accessible-indexing-health.ts
@@ -1,0 +1,148 @@
+import { useEffect, useState } from "react";
+import { authenticatedFetch, listVaults } from "@/lib/api";
+
+interface PipelineStats {
+  pending?: number;
+  abandoned?: number;
+  indexed?: number;
+}
+
+interface VaultHealthResponse {
+  metadata_backfill?: PipelineStats;
+  vector_store?: {
+    backfill?: {
+      upsert?: PipelineStats;
+    };
+  };
+}
+
+export interface AccessibleIndexingStatus {
+  vaultCount: number;
+  checkedVaultCount: number;
+  pending: number;
+  abandoned: number;
+  indexed: number;
+  incomplete: boolean;
+}
+
+const HEALTH_CONCURRENCY = 5;
+const ACTIVE_INTERVAL = 15_000;
+const IDLE_INTERVAL = 60_000;
+
+function count(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.max(0, value)
+    : 0;
+}
+
+async function fetchVaultHealth(name: string): Promise<VaultHealthResponse> {
+  const response = await authenticatedFetch(
+    `/health/vault/${encodeURIComponent(name)}`,
+  );
+  if (!response.ok) {
+    throw new Error(`Vault health request failed: ${response.status}`);
+  }
+  return (await response.json()) as VaultHealthResponse;
+}
+
+/**
+ * Builds a user-scoped indexing snapshot from the reader-gated Vault health
+ * surface. The generic `/health` endpoint is intentionally not used: its
+ * counters are system-wide and would misrepresent another tenant's work as the
+ * current user's status.
+ *
+ * Requests are capped in small batches because one account can access many
+ * Vaults. A partial response remains useful, but is explicitly marked
+ * `incomplete` so consumers render lower-bound counts rather than exact totals.
+ */
+export async function loadAccessibleIndexingHealth(): Promise<AccessibleIndexingStatus> {
+  const response = await listVaults();
+  const names = Array.from(
+    new Set(
+      (response.vaults || [])
+        .map((vault) => (typeof vault?.name === "string" ? vault.name : ""))
+        .filter(Boolean),
+    ),
+  );
+
+  const status: AccessibleIndexingStatus = {
+    vaultCount: names.length,
+    checkedVaultCount: 0,
+    pending: 0,
+    abandoned: 0,
+    indexed: 0,
+    incomplete: false,
+  };
+
+  for (let index = 0; index < names.length; index += HEALTH_CONCURRENCY) {
+    const batch = names.slice(index, index + HEALTH_CONCURRENCY);
+    const results = await Promise.allSettled(batch.map(fetchVaultHealth));
+    results.forEach((result) => {
+      if (result.status !== "fulfilled") return;
+      const upsert = result.value.vector_store?.backfill?.upsert;
+      const metadata = result.value.metadata_backfill;
+      status.checkedVaultCount += 1;
+      status.pending += count(upsert?.pending) + count(metadata?.pending);
+      status.abandoned += count(upsert?.abandoned) + count(metadata?.abandoned);
+      status.indexed += count(upsert?.indexed);
+    });
+  }
+
+  status.incomplete = status.checkedVaultCount !== status.vaultCount;
+  return status;
+}
+
+export function useAccessibleIndexingHealth(
+  enabled: boolean,
+  userId: string | undefined,
+) {
+  const [data, setData] = useState<AccessibleIndexingStatus | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !userId) {
+      setData(null);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    let timer: number | undefined;
+    setData(null);
+    setError(null);
+
+    const schedule = (delay: number) => {
+      if (!cancelled) timer = window.setTimeout(tick, delay);
+    };
+
+    const tick = async () => {
+      try {
+        const next = await loadAccessibleIndexingHealth();
+        if (cancelled) return;
+        setData(next);
+        setError(null);
+        schedule(
+          next.pending > 0 || next.abandoned > 0 || next.incomplete
+            ? ACTIVE_INTERVAL
+            : IDLE_INTERVAL,
+        );
+      } catch (caught) {
+        if (cancelled) return;
+        setError(
+          caught instanceof Error
+            ? caught
+            : new Error("Index status unavailable"),
+        );
+        schedule(ACTIVE_INTERVAL);
+      }
+    };
+
+    void tick();
+    return () => {
+      cancelled = true;
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
+  }, [enabled, userId]);
+
+  return { data, error };
+}

--- a/frontend/src/hooks/use-vault-tree.ts
+++ b/frontend/src/hooks/use-vault-tree.ts
@@ -41,11 +41,10 @@ interface BrowseItem {
  * misnomer "depth=2" (= "include documents"); this code requests the
  * unbounded subtree explicitly so the tree builder sees every node.
  *
- * Scaling note: assumes the vault fits in a single browse response
- * comfortably. The largest real vault today holds ~30 items; when (if) a
- * vault grows past a few thousand, switch the initial call to `depth=1`
- * and add a per-collection lazy-load on expand. Not implemented now
- * because it would be unreachable code under current sizes.
+ * Compatibility note: older backends expose no cursor or kind filter, so the
+ * client still requests the full subtree. VaultExplorer limits DOM work with
+ * kind disclosures and progressive pages. True network/memory scaling will
+ * require a future browse contract with collection + kind + cursor inputs.
  */
 export function useVaultTree(vault: string | undefined) {
   const [items, setItems] = useState<BrowseItem[] | null>(null);

--- a/frontend/src/lib/__tests__/image-assets.test.ts
+++ b/frontend/src/lib/__tests__/image-assets.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  EDITOR_IMAGE_MAX_BYTES,
+  EDITOR_IMAGE_MAX_PIXELS,
+  classifyEditorImageUploadFailure,
+  fitEditorImageDimensions,
+  prepareEditorImage,
+} from "@/lib/image-assets";
+
+describe("editor image preparation", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("fits high-resolution images within both server decode boundaries", () => {
+    const fitted = fitEditorImageDimensions(4_000, 4_000);
+
+    expect(fitted.width).toBeLessThan(4_000);
+    expect(fitted.height).toBeLessThan(4_000);
+    expect(fitted.width * fitted.height).toBeLessThanOrEqual(EDITOR_IMAGE_MAX_PIXELS);
+    expect(fitEditorImageDimensions(4_000, 3_000)).toEqual({
+      width: 4_000,
+      height: 3_000,
+    });
+    expect(fitEditorImageDimensions(10_000, 1_000)).toEqual({
+      width: 8_192,
+      height: 819,
+    });
+  });
+
+  it("optimizes a sub-1 MB image whose decoded resolution exceeds 12 MP", async () => {
+    const original = new File(
+      [new Uint8Array(750 * 1024)],
+      "camera.jpg",
+      { type: "image/jpeg", lastModified: 123 },
+    );
+    const close = vi.fn();
+    const drawImage = vi.fn();
+    vi.stubGlobal("createImageBitmap", vi.fn().mockResolvedValue({
+      width: 4_000,
+      height: 4_000,
+      close,
+    }));
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({
+      drawImage,
+    } as unknown as CanvasRenderingContext2D);
+    vi.spyOn(HTMLCanvasElement.prototype, "toBlob").mockImplementation(
+      (callback, type) => callback(new Blob([new Uint8Array(600 * 1024)], { type: type || "" })),
+    );
+
+    const prepared = await prepareEditorImage(original);
+
+    expect(original.size).toBeLessThan(1024 * 1024);
+    expect(prepared.optimized).toBe(true);
+    expect(prepared.file).not.toBe(original);
+    expect(prepared.file.name).toBe("camera.jpg");
+    expect(prepared.file.type).toBe("image/jpeg");
+    expect(prepared.file.size).toBeLessThan(EDITOR_IMAGE_MAX_BYTES);
+    expect((prepared.width || 0) * (prepared.height || 0)).toBeLessThanOrEqual(
+      EDITOR_IMAGE_MAX_PIXELS,
+    );
+    expect(drawImage).toHaveBeenCalledWith(
+      expect.objectContaining({ width: 4_000, height: 4_000 }),
+      0,
+      0,
+      prepared.width,
+      prepared.height,
+    );
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("does not silently flatten an oversized animated image", async () => {
+    const close = vi.fn();
+    vi.stubGlobal("createImageBitmap", vi.fn().mockResolvedValue({
+      width: 4_000,
+      height: 4_000,
+      close,
+    }));
+
+    await expect(
+      prepareEditorImage(new File(["gif"], "motion.gif", { type: "image/gif" })),
+    ).rejects.toThrow(/preserve its animation/);
+    expect(close).toHaveBeenCalledOnce();
+  });
+});
+
+describe("editor image upload error recovery", () => {
+  it("marks size and format failures as non-retryable with a recovery path", () => {
+    const tooLarge = classifyEditorImageUploadFailure(
+      Object.assign(new Error("Image dimensions are too large"), { status: 413 }),
+      new File(["image"], "phone.jpg", { type: "image/jpeg" }),
+    );
+    const invalid = classifyEditorImageUploadFailure(
+      Object.assign(new Error("Invalid encoding"), { status: 415 }),
+    );
+
+    expect(tooLarge).toEqual({
+      message: expect.stringMatching(/phone\.jpg.*10 MB, 12 MP.*8,192.*Choose another/),
+      retryable: false,
+    });
+    expect(invalid.retryable).toBe(false);
+    expect(invalid.message).toMatch(/PNG, JPEG, GIF, or WebP/);
+  });
+
+  it("keeps transient server failures retryable", () => {
+    expect(
+      classifyEditorImageUploadFailure(
+        Object.assign(new Error("Storage temporarily unavailable"), { status: 503 }),
+      ),
+    ).toEqual({
+      message: "the server could not store the image right now. Try again.",
+      retryable: true,
+    });
+  });
+});

--- a/frontend/src/lib/__tests__/tree-route.test.ts
+++ b/frontend/src/lib/__tests__/tree-route.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { activePathFromRoute, filterTree, findDoc, flattenVisible, leafHref } from "@/lib/tree-route";
+import {
+  activePathFromRoute,
+  filterTree,
+  filterTreeByKind,
+  findDoc,
+  flattenVisible,
+  kindGroupKey,
+  leafHref,
+} from "@/lib/tree-route";
 import type { TreeNode } from "@/hooks/use-vault-tree";
 
 const t: TreeNode[] = [
@@ -67,8 +75,27 @@ describe("filterTree", () => {
   });
 });
 
-describe("flattenVisible — kind-group headers", () => {
-  it("labels each leaf-kind group only when a parent mixes ≥2 kinds", () => {
+describe("filterTreeByKind", () => {
+  it("keeps collection ancestry while removing unrelated resource kinds", () => {
+    const mixed: TreeNode[] = [
+      {
+        kind: "collection",
+        name: "mixed",
+        path: "mixed",
+        children: [
+          { kind: "document", name: "Doc", path: "mixed/doc.md" },
+          { kind: "table", name: "Data", path: "data" },
+        ],
+      },
+    ];
+    const tables = filterTreeByKind(mixed, "table");
+    expect(tables).toHaveLength(1);
+    expect(tables[0].children?.map((node) => node.kind)).toEqual(["table"]);
+  });
+});
+
+describe("flattenVisible — resource-kind groups", () => {
+  it("promotes mixed resource kinds into independent disclosure rows", () => {
     const tree: TreeNode[] = [
       {
         kind: "collection", name: "mixed", path: "mixed", children: [
@@ -86,29 +113,127 @@ describe("flattenVisible — kind-group headers", () => {
       },
     ];
     const rows = flattenVisible(tree, new Set(["mixed", "docsonly"]), false);
-    expect(rows.map((r) => [r.node.name, r.kindHeader])).toEqual([
-      ["mixed", undefined],
-      ["a", "document"], // first doc of a mixed parent → header
-      ["b", undefined],
-      ["t1", "table"], // kind transition → header
-      ["f1", "file"],
-      ["docsonly", undefined],
-      ["c", undefined], // single-kind collection → no headers
-      ["d", undefined],
+    expect(rows.map((row) =>
+      row.type === "node"
+        ? [row.type, row.node.name]
+        : [row.type, row.kind],
+    )).toEqual([
+      ["node", "mixed"],
+      ["kind-group", "document"],
+      ["node", "a"],
+      ["node", "b"],
+      ["kind-group", "table"],
+      ["node", "t1"],
+      ["kind-group", "file"],
+      ["node", "f1"],
+      ["node", "docsonly"],
+      ["node", "c"],
+      ["node", "d"],
     ]);
   });
 
-  it("groups loose leaf kinds at the vault root too; collections never get a header", () => {
+  it("groups loose mixed resource kinds at the vault root too", () => {
     const tree: TreeNode[] = [
       { kind: "collection", name: "col", path: "col", children: [] },
       { kind: "document", name: "rdoc", path: "rdoc.md" },
       { kind: "table", name: "rtab", path: "rtab" },
     ];
     const rows = flattenVisible(tree, new Set(), false);
-    expect(rows.map((r) => [r.node.name, r.kindHeader])).toEqual([
-      ["col", undefined],
-      ["rdoc", "document"],
-      ["rtab", "table"],
+    expect(rows.map((row) =>
+      row.type === "node"
+        ? [row.type, row.node.name]
+        : [row.type, row.kind],
+    )).toEqual([
+      ["node", "col"],
+      ["kind-group", "document"],
+      ["node", "rdoc"],
+      ["kind-group", "table"],
+      ["node", "rtab"],
     ]);
+  });
+
+  it("limits a large kind preview and exposes an incremental more row", () => {
+    const documents: TreeNode[] = Array.from({ length: 25 }, (_, index) => ({
+      kind: "document",
+      name: `Document ${index + 1}`,
+      path: `large/${index + 1}.md`,
+    }));
+    const tree: TreeNode[] = [
+      {
+        kind: "collection",
+        name: "large",
+        path: "large",
+        children: documents,
+      },
+    ];
+    const rows = flattenVisible(tree, new Set(["large"]), false);
+    expect(rows.filter((row) => row.type === "node")).toHaveLength(21);
+    expect(rows.find((row) => row.type === "kind-group")).toMatchObject({
+      kind: "document",
+      count: 25,
+      isOpen: true,
+    });
+    expect(rows.find((row) => row.type === "more")).toMatchObject({
+      visibleCount: 20,
+      totalCount: 25,
+    });
+  });
+
+  it("keeps a collapsed kind visible while removing its leaves", () => {
+    const tree: TreeNode[] = [
+      {
+        kind: "collection",
+        name: "mixed",
+        path: "mixed",
+        children: [
+          { kind: "document", name: "Doc", path: "mixed/doc.md" },
+          { kind: "table", name: "Table", path: "table" },
+        ],
+      },
+    ];
+    const rows = flattenVisible(tree, new Set(["mixed"]), false, {
+      collapsedKindGroups: new Set([kindGroupKey("mixed", "document")]),
+    });
+    const documentGroup = rows.find(
+      (row) => row.type === "kind-group" && row.kind === "document",
+    );
+    expect(documentGroup).toMatchObject({ isOpen: false });
+    expect(
+      rows.some((row) => row.type === "node" && row.node.name === "Doc"),
+    ).toBe(false);
+    expect(
+      rows.some((row) => row.type === "node" && row.node.name === "Table"),
+    ).toBe(true);
+  });
+
+  it("pins the current route into a limited preview without rendering the gap", () => {
+    const documents: TreeNode[] = Array.from({ length: 80 }, (_, index) => ({
+      kind: "document",
+      name: `Document ${index + 1}`,
+      path: `large/${index + 1}.md`,
+    }));
+    const rows = flattenVisible(
+      [
+        {
+          kind: "collection",
+          name: "large",
+          path: "large",
+          children: documents,
+        },
+      ],
+      new Set(["large"]),
+      false,
+      { activeSig: "document:large/80.md" },
+    );
+    expect(
+      rows.some(
+        (row) => row.type === "node" && row.node.path === "large/80.md",
+      ),
+    ).toBe(true);
+    expect(
+      rows.some(
+        (row) => row.type === "node" && row.node.path === "large/21.md",
+      ),
+    ).toBe(false);
   });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1131,6 +1131,7 @@ export interface CollectionDeleteResult {
   deleted_docs: number;
   deleted_files: number;
   deleted_sub_collections: number;
+  deleted_tables?: number;
 }
 
 export interface CollectionNotEmptyDetail {
@@ -1138,6 +1139,7 @@ export interface CollectionNotEmptyDetail {
   doc_count: number;
   file_count: number;
   sub_collection_count: number;
+  table_count?: number;
 }
 
 export const createCollection = (vault: string, path: string, summary?: string) =>
@@ -1145,6 +1147,23 @@ export const createCollection = (vault: string, path: string, summary?: string) 
     method: "POST",
     body: JSON.stringify({ path, summary }),
   });
+
+/**
+ * Update collection metadata on backends that implement the collection PATCH
+ * contract. Older AKB servers only expose POST + DELETE and answer 404/405;
+ * callers must keep their view usable and surface an upgrade hint instead of
+ * treating that compatibility response as a generic failure.
+ */
+export const updateCollection = (vault: string, path: string, summary: string | null) => {
+  const segs = path.split("/").map(encodeURIComponent).join("/");
+  return api<CollectionCreateResult>(
+    `/collections/${encodeURIComponent(vault)}/${segs}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify({ summary }),
+    },
+  );
+};
 
 export const deleteCollection = (vault: string, path: string, recursive: boolean) => {
   // Path may contain '/' — backend uses {path:path} catch-all. Encode segments

--- a/frontend/src/lib/image-assets.ts
+++ b/frontend/src/lib/image-assets.ts
@@ -1,12 +1,43 @@
 const ASSET_URL = /^\/api\/assets\/([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\/?$/i;
 
 export const EDITOR_IMAGE_MAX_BYTES = 10 * 1024 * 1024;
+/**
+ * The current asset API decodes at most 12 MP and 8,192 px per side. Keep
+ * these values in the client as a compatibility target: high-resolution
+ * camera images can be resized before they reach both current and older AKB
+ * backends instead of failing even when their compressed file is under 1 MB.
+ */
+export const EDITOR_IMAGE_MAX_PIXELS = 12_000_000;
+export const EDITOR_IMAGE_MAX_DIMENSION = 8_192;
 export const EDITOR_IMAGE_MIME_TYPES = [
   "image/png",
   "image/jpeg",
   "image/gif",
   "image/webp",
 ] as const;
+
+export interface PreparedEditorImage {
+  file: File;
+  optimized: boolean;
+  originalWidth?: number;
+  originalHeight?: number;
+  width?: number;
+  height?: number;
+}
+
+export interface EditorImageUploadFailure {
+  message: string;
+  retryable: boolean;
+}
+
+export class EditorImagePreparationError extends Error {
+  readonly retryable = false;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "EditorImagePreparationError";
+  }
+}
 
 export function assetIdFromUrl(src: string | null | undefined): string | null {
   if (!src) return null;
@@ -18,7 +49,183 @@ export function validateEditorImage(file: File): string | null {
     return "Choose a PNG, JPEG, GIF, or WebP image.";
   }
   if (file.size > EDITOR_IMAGE_MAX_BYTES) {
-    return "Images must be 10 MB or smaller.";
+    return `${formatBytes(file.size)} selected — ${formatBytes(file.size - EDITOR_IMAGE_MAX_BYTES)} over the 10 MB limit.`;
   }
   return null;
+}
+
+export function fitEditorImageDimensions(
+  width: number,
+  height: number,
+): { width: number; height: number } {
+  const pixelScale = Math.sqrt(EDITOR_IMAGE_MAX_PIXELS / (width * height));
+  const dimensionScale = EDITOR_IMAGE_MAX_DIMENSION / Math.max(width, height);
+  const scale = Math.min(1, pixelScale, dimensionScale);
+  return {
+    width: Math.max(1, Math.floor(width * scale)),
+    height: Math.max(1, Math.floor(height * scale)),
+  };
+}
+
+function canvasBlob(
+  canvas: HTMLCanvasElement,
+  type: string,
+  quality?: number,
+): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (blob) resolve(blob);
+        else reject(new EditorImagePreparationError("The optimized image could not be encoded."));
+      },
+      type,
+      quality,
+    );
+  });
+}
+
+/**
+ * Resize compressed high-resolution still images to the asset API's decode
+ * boundary. A 16 MP JPEG can be well below 1 MB, so byte validation alone is
+ * not enough. GIFs remain untouched to avoid silently dropping animation.
+ * Browsers without createImageBitmap fall back to server-side validation.
+ */
+export async function prepareEditorImage(file: File): Promise<PreparedEditorImage> {
+  const validationMessage = validateEditorImage(file);
+  if (validationMessage) throw new EditorImagePreparationError(validationMessage);
+  if (typeof createImageBitmap !== "function") return { file, optimized: false };
+
+  let bitmap: ImageBitmap;
+  try {
+    bitmap = await createImageBitmap(file);
+  } catch {
+    throw new EditorImagePreparationError(
+      "This image could not be read. Choose a valid PNG, JPEG, GIF, or WebP file.",
+    );
+  }
+
+  try {
+    const originalWidth = bitmap.width;
+    const originalHeight = bitmap.height;
+    const fitted = fitEditorImageDimensions(originalWidth, originalHeight);
+    if (fitted.width === originalWidth && fitted.height === originalHeight) {
+      return {
+        file,
+        optimized: false,
+        originalWidth,
+        originalHeight,
+        width: originalWidth,
+        height: originalHeight,
+      };
+    }
+
+    const resolution = `${originalWidth.toLocaleString()}×${originalHeight.toLocaleString()}`;
+    if (file.type === "image/gif") {
+      throw new EditorImagePreparationError(
+        `${resolution} animated image exceeds the 12 MP limit. Resize it before uploading to preserve its animation.`,
+      );
+    }
+
+    const canvas = document.createElement("canvas");
+    canvas.width = fitted.width;
+    canvas.height = fitted.height;
+    const context = canvas.getContext("2d");
+    if (!context) {
+      throw new EditorImagePreparationError(
+        "This browser could not optimize the high-resolution image. Resize it below 12 MP and try again.",
+      );
+    }
+    context.drawImage(bitmap, 0, 0, fitted.width, fitted.height);
+    const blob = await canvasBlob(
+      canvas,
+      file.type,
+      file.type === "image/jpeg" || file.type === "image/webp" ? 0.9 : undefined,
+    );
+    if (blob.size > EDITOR_IMAGE_MAX_BYTES) {
+      throw new EditorImagePreparationError(
+        `The optimized image is ${formatBytes(blob.size)}. Resize it below 10 MB and try again.`,
+      );
+    }
+
+    return {
+      file: new File([blob], file.name, {
+        type: file.type,
+        lastModified: file.lastModified,
+      }),
+      optimized: true,
+      originalWidth,
+      originalHeight,
+      width: fitted.width,
+      height: fitted.height,
+    };
+  } finally {
+    bitmap.close();
+  }
+}
+
+export function classifyEditorImageUploadFailure(
+  error: unknown,
+  file?: File,
+): EditorImageUploadFailure {
+  if (error instanceof EditorImagePreparationError) {
+    return { message: error.message, retryable: false };
+  }
+
+  const status =
+    typeof error === "object" && error !== null && "status" in error
+      ? Number((error as { status?: unknown }).status)
+      : 0;
+  const serverMessage = error instanceof Error ? error.message : "The image could not be uploaded.";
+  const name = file?.name ? `${file.name}: ` : "";
+
+  if (status === 413) {
+    return {
+      message: `${name}the server rejected this image because it exceeds 10 MB, 12 MP, or 8,192 pixels per side. Choose another image or resize it and try again.`,
+      retryable: false,
+    };
+  }
+  if (status === 415) {
+    return {
+      message: `${name}the file is not a valid supported image. Choose a PNG, JPEG, GIF, or WebP image.`,
+      retryable: false,
+    };
+  }
+  if (status === 403) {
+    return {
+      message: `${name}you do not have permission to add images to this Vault.`,
+      retryable: false,
+    };
+  }
+  if (status === 409) {
+    return { message: `${name}${serverMessage}`, retryable: false };
+  }
+  if (status === 408) {
+    return {
+      message: `${name}the upload timed out before it finished. Try again.`,
+      retryable: true,
+    };
+  }
+  if (status === 429) {
+    return {
+      message: `${name}image uploads are busy right now. Wait a moment and try again.`,
+      retryable: true,
+    };
+  }
+  if (status >= 500) {
+    return {
+      message: `${name}the server could not store the image right now. Try again.`,
+      retryable: true,
+    };
+  }
+
+  return {
+    message: `${name}${serverMessage}`,
+    retryable: status === 0,
+  };
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
 }

--- a/frontend/src/lib/tree-route.ts
+++ b/frontend/src/lib/tree-route.ts
@@ -87,17 +87,71 @@ export function filterTree(nodes: TreeNode[], q: string): TreeNode[] {
   return out;
 }
 
-export interface FlatRow {
+export type ResourceKind = Exclude<NodeKind, "collection">;
+
+export interface FlatNodeRow {
+  type: "node";
   node: TreeNode;
   depth: number;
   sig: string;
   /** True iff this collection is currently expanded. `false` for leaves. */
   isOpen: boolean;
-  /** When set, render a kind-group label ("Documents"/"Tables"/"Files") just
-   *  above this row. Populated only on the first row of each leaf-kind group,
-   *  and only inside a parent that actually mixes ≥2 leaf kinds — a doc-only
-   *  collection stays unlabeled. Purely visual; not a focusable tree row. */
-  kindHeader?: NodeKind;
+}
+
+export interface FlatKindGroupRow {
+  type: "kind-group";
+  kind: ResourceKind;
+  parentPath: string;
+  depth: number;
+  sig: string;
+  count: number;
+  isOpen: boolean;
+}
+
+export interface FlatMoreRow {
+  type: "more";
+  kind: ResourceKind;
+  parentPath: string;
+  depth: number;
+  sig: string;
+  visibleCount: number;
+  totalCount: number;
+}
+
+export type FlatRow = FlatNodeRow | FlatKindGroupRow | FlatMoreRow;
+
+export const RESOURCE_PREVIEW_SIZE = 20;
+
+const RESOURCE_KIND_ORDER: ResourceKind[] = ["document", "table", "file"];
+
+export function kindGroupKey(parentPath: string, kind: ResourceKind): string {
+  return `${parentPath || "$root"}:${kind}`;
+}
+
+export function filterTreeByKind(
+  nodes: TreeNode[],
+  kind: ResourceKind | "all",
+): TreeNode[] {
+  if (kind === "all") return nodes;
+  const out: TreeNode[] = [];
+  for (const node of nodes) {
+    if (node.kind === "collection") {
+      const children = filterTreeByKind(node.children ?? [], kind);
+      if (children.length > 0) out.push({ ...node, children });
+    } else if (node.kind === kind) {
+      out.push(node);
+    }
+  }
+  return out;
+}
+
+interface FlattenVisibleOptions {
+  /** Groups are open by default. Keys in this set are explicitly collapsed. */
+  collapsedKindGroups?: ReadonlySet<string>;
+  /** Per-group visible leaf limits; absent groups use RESOURCE_PREVIEW_SIZE. */
+  kindLimits?: ReadonlyMap<string, number>;
+  /** Keep the current route visible even when it falls beyond a preview. */
+  activeSig?: string | null;
 }
 
 /**
@@ -113,28 +167,91 @@ export function flattenVisible(
   nodes: TreeNode[],
   expanded: Set<string>,
   forceOpen: boolean,
+  options: FlattenVisibleOptions = {},
 ): FlatRow[] {
   const out: FlatRow[] = [];
-  const visit = (list: TreeNode[], depth: number) => {
-    // Label kind groups only when this sibling list mixes ≥2 leaf kinds
-    // (sub-collections don't count) — a doc-only collection stays unlabeled so
-    // the common case carries no extra chrome. The list is already sorted
-    // collection→document→table→file, so each kind arrives in one contiguous run.
-    const leafKinds = new Set<NodeKind>();
-    for (const n of list) if (n.kind !== "collection") leafKinds.add(n.kind);
-    const grouped = leafKinds.size >= 2;
-    let prevLeafKind: NodeKind | null = null;
-    for (const n of list) {
+  const collapsed = options.collapsedKindGroups ?? new Set<string>();
+  const limits = options.kindLimits ?? new Map<string, number>();
+
+  const pushNode = (node: TreeNode, depth: number, isOpen = false) => {
+    out.push({
+      type: "node",
+      node,
+      depth,
+      sig: signatureOf(node),
+      isOpen,
+    });
+  };
+
+  const visit = (list: TreeNode[], depth: number, parentPath: string) => {
+    // Collections keep their natural hierarchy. Resource kinds become peer
+    // disclosure rows only when the sibling set mixes kinds or is too large to
+    // scan safely. A small single-kind collection stays compact.
+    const collections = list.filter((node) => node.kind === "collection");
+    const leaves = list.filter((node) => node.kind !== "collection");
+
+    for (const n of collections) {
       const isOpen = n.kind === "collection" && (forceOpen || expanded.has(n.path));
-      let kindHeader: NodeKind | undefined;
-      if (grouped && n.kind !== "collection" && n.kind !== prevLeafKind) {
-        kindHeader = n.kind;
+      pushNode(n, depth, isOpen);
+      if (isOpen && n.children) visit(n.children, depth + 1, n.path);
+    }
+
+    const presentKinds = RESOURCE_KIND_ORDER.filter((kind) =>
+      leaves.some((leaf) => leaf.kind === kind),
+    );
+    const shouldGroup =
+      presentKinds.length > 1 || leaves.length > RESOURCE_PREVIEW_SIZE;
+
+    if (!shouldGroup) {
+      for (const leaf of leaves) pushNode(leaf, depth);
+      return;
+    }
+
+    for (const kind of presentKinds) {
+      const kindLeaves = leaves.filter((leaf) => leaf.kind === kind);
+      const key = kindGroupKey(parentPath, kind);
+      const activeLeaf = options.activeSig
+        ? kindLeaves.find((leaf) => signatureOf(leaf) === options.activeSig)
+        : undefined;
+      const isOpen = forceOpen || Boolean(activeLeaf) || !collapsed.has(key);
+      out.push({
+        type: "kind-group",
+        kind,
+        parentPath,
+        depth,
+        sig: `kind-group:${key}`,
+        count: kindLeaves.length,
+        isOpen,
+      });
+      if (!isOpen) continue;
+
+      const previewCount = Math.min(
+        Math.max(limits.get(key) ?? RESOURCE_PREVIEW_SIZE, RESOURCE_PREVIEW_SIZE),
+        kindLeaves.length,
+      );
+      const visibleLeaves = kindLeaves.slice(0, previewCount);
+      if (
+        activeLeaf &&
+        !visibleLeaves.some((leaf) => signatureOf(leaf) === options.activeSig)
+      ) {
+        visibleLeaves.push(activeLeaf);
       }
-      if (n.kind !== "collection") prevLeafKind = n.kind;
-      out.push({ node: n, depth, sig: signatureOf(n), isOpen, kindHeader });
-      if (isOpen && n.children) visit(n.children, depth + 1);
+      for (const leaf of visibleLeaves) {
+        pushNode(leaf, depth + 1);
+      }
+      if (visibleLeaves.length < kindLeaves.length) {
+        out.push({
+          type: "more",
+          kind,
+          parentPath,
+          depth: depth + 1,
+          sig: `kind-more:${key}`,
+          visibleCount: visibleLeaves.length,
+          totalCount: kindLeaves.length,
+        });
+      }
     }
   };
-  visit(nodes, 0);
+  visit(nodes, 0, "");
   return out;
 }

--- a/frontend/src/pages/__tests__/document-view-toggle.test.tsx
+++ b/frontend/src/pages/__tests__/document-view-toggle.test.tsx
@@ -282,6 +282,22 @@ describe("DocumentPage view toggle", () => {
     expect(details).toHaveAttribute("aria-hidden", "false");
     expect(details).toHaveClass("translate-x-0");
     expect(detailsToggle).toHaveAttribute("aria-expanded", "true");
+    expect(details).toHaveClass("lg:w-96");
+
+    const detailViews = screen.getByRole("tablist", { name: "Document detail views" });
+    const infoTab = screen.getByRole("tab", { name: "Info" });
+    expect(detailViews).toContainElement(infoTab);
+    expect(infoTab).toHaveAttribute("aria-selected", "true");
+    const infoPanel = screen.getByRole("tabpanel", { name: "Info" });
+    expect(infoPanel).toHaveClass("min-h-0", "flex-1", "overflow-y-auto");
+
+    await user.click(screen.getByRole("tab", { name: /^Outline/ }));
+    expect(screen.getByRole("heading", { level: 3, name: "On this page" })).toBeVisible();
+    expect(screen.getByRole("tabpanel", { name: /^Outline/ })).toHaveClass(
+      "min-h-0",
+      "flex-1",
+      "overflow-y-auto",
+    );
 
     await user.click(screen.getByRole("button", { name: "Hide document details" }));
     expect(details).toHaveAttribute("aria-hidden", "true");
@@ -310,6 +326,36 @@ describe("DocumentPage view toggle", () => {
     );
     // The raw <pre> should NOT be present.
     expect(screen.queryByTestId("doc-raw")).not.toBeInTheDocument();
+  });
+
+  it("merges a compact summary into the document viewer toolbar without opening Details", async () => {
+    getDocumentMock.mockResolvedValue(
+      makeDoc({ summary: "A concise orientation to the document before the full body begins." }),
+    );
+    renderAt("/vault/v/doc/notes%2Fhello.md");
+
+    const summary = await screen.findByRole("note", { name: "Document summary" });
+    expect(summary).toHaveClass("hidden", "lg:flex", "flex-1", "border-l");
+    expect(summary).toHaveTextContent("Summary");
+    expect(summary).toHaveTextContent(
+      "A concise orientation to the document before the full body begins.",
+    );
+    const statistics = screen.getByLabelText("Document statistics: 3 lines, 20 Bytes");
+    const copyMarkdown = screen.getByRole("button", { name: "Copy markdown" });
+    expect(summary.parentElement).toContainElement(statistics);
+    expect(summary.parentElement?.nextElementSibling).toBe(copyMarkdown);
+    expect(screen.queryByRole("region", { name: "Document summary" })).not.toBeInTheDocument();
+    expect(document.getElementById("document-details-panel")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+  });
+
+  it("omits the reading summary when the backend does not provide one", async () => {
+    renderAt("/vault/v/doc/notes%2Fhello.md");
+
+    await screen.findByRole("heading", { level: 2, name: "BodyHeading" });
+    expect(screen.queryByRole("note", { name: "Document summary" })).not.toBeInTheDocument();
   });
 
   it("counts logical lines and UTF-8 bytes", async () => {

--- a/frontend/src/pages/__tests__/home-working-set.test.tsx
+++ b/frontend/src/pages/__tests__/home-working-set.test.tsx
@@ -61,7 +61,7 @@ const CURRENT_USER = {
 function TestLayout() {
   return (
     <CurrentUserProvider user={CURRENT_USER}>
-      <Outlet context={{ health: null }} />
+      <Outlet context={{ indexingStatus: null }} />
     </CurrentUserProvider>
   );
 }

--- a/frontend/src/pages/document.tsx
+++ b/frontend/src/pages/document.tsx
@@ -108,7 +108,7 @@ export default function DocumentPage({
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [publishOpen, setPublishOpen] = useState(false);
   const [detailsOpen, setDetailsOpen] = useState(false);
-  const [detailsTab, setDetailsTab] = useState<"outline" | "relations" | "history">("outline");
+  const [detailsTab, setDetailsTab] = useState<"info" | "outline" | "relations" | "history">("info");
   const detailsToggleRef = useRef<HTMLButtonElement | null>(null);
   const detailsCloseRef = useRef<HTMLButtonElement | null>(null);
   // Plate manages its own state; we remount via `editorKey` when hydrating
@@ -892,7 +892,7 @@ export default function DocumentPage({
                 aria-hidden={!detailsOpen}
                 inert={!detailsOpen}
                 className={cn(
-                  "absolute inset-y-0 right-0 z-[var(--z-overlay)] flex w-full max-w-md flex-col overflow-hidden border-l border-border bg-surface shadow-xl transition-transform duration-[var(--duration-base)] ease-[var(--ease-out)] lg:w-80 xl:w-88",
+                  "absolute inset-y-0 right-0 z-[var(--z-overlay)] flex w-full max-w-lg flex-col overflow-hidden border-l border-border bg-surface shadow-xl transition-transform duration-[var(--duration-base)] ease-[var(--ease-out)] lg:w-96",
                   detailsOpen
                     ? "translate-x-0"
                     : "pointer-events-none translate-x-full",
@@ -915,7 +915,38 @@ export default function DocumentPage({
                 </Button>
               </div>
 
-              <section aria-labelledby="document-properties-heading" className="shrink-0 border-b border-border px-4 py-4">
+              <Tabs
+                value={detailsTab}
+                onValueChange={(value) => setDetailsTab(value as typeof detailsTab)}
+                className="flex min-h-0 flex-1 flex-col"
+              >
+                <TabsList
+                  aria-label="Document detail views"
+                  className="mx-4 mt-3 w-[calc(100%-2rem)] shrink-0"
+                >
+                  <TabsTrigger value="info" className="min-w-0 flex-1 gap-1 px-2 text-xs">
+                    <Info className="h-3.5 w-3.5" aria-hidden />
+                    Info
+                  </TabsTrigger>
+                  <TabsTrigger value="outline" className="min-w-0 flex-1 gap-1 px-2 text-xs">
+                    <ListTree className="h-3.5 w-3.5" aria-hidden />
+                    Outline
+                    <span className="coord tabular-nums">{headingSlugs.length}</span>
+                  </TabsTrigger>
+                  <TabsTrigger value="relations" className="min-w-0 flex-1 gap-1 px-2 text-xs">
+                    <Link2 className="h-3.5 w-3.5" aria-hidden />
+                    Relations
+                    {visibleRelationCount > 0 && <span className="coord tabular-nums">{visibleRelationCount}</span>}
+                  </TabsTrigger>
+                  <TabsTrigger value="history" className="min-w-0 flex-1 gap-1 px-2 text-xs">
+                    <History className="h-3.5 w-3.5" aria-hidden />
+                    History
+                    {provenance.length > 0 && <span className="coord tabular-nums">{provenance.length}</span>}
+                  </TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="info" className="min-h-0 flex-1 overflow-y-auto px-4 pb-4 pt-3 rail-scroll">
+              <section aria-labelledby="document-properties-heading">
                 <div className="mb-3 flex items-center justify-between gap-3">
                   <h3 id="document-properties-heading" className="flex items-center gap-2 text-sm font-semibold text-foreground">
                     <Info className="h-4 w-4 text-link" aria-hidden />
@@ -1000,30 +1031,27 @@ export default function DocumentPage({
                 )}
               </section>
 
-              <Tabs
-                value={detailsTab}
-                onValueChange={(value) => setDetailsTab(value as typeof detailsTab)}
-                className="flex min-h-0 flex-1 flex-col"
-              >
-                <TabsList className="mx-4 mt-4 w-[calc(100%-2rem)] shrink-0">
-                  <TabsTrigger value="outline" className="min-w-0 flex-1 gap-1 px-2 text-xs">
-                    <ListTree className="h-3.5 w-3.5" aria-hidden />
-                    Outline
-                    <span className="coord tabular-nums">{headingSlugs.length}</span>
-                  </TabsTrigger>
-                  <TabsTrigger value="relations" className="min-w-0 flex-1 gap-1 px-2 text-xs">
-                    <Link2 className="h-3.5 w-3.5" aria-hidden />
-                    Relations
-                    {visibleRelationCount > 0 && <span className="coord tabular-nums">{visibleRelationCount}</span>}
-                  </TabsTrigger>
-                  <TabsTrigger value="history" className="min-w-0 flex-1 gap-1 px-2 text-xs">
-                    <History className="h-3.5 w-3.5" aria-hidden />
-                    History
-                    {provenance.length > 0 && <span className="coord tabular-nums">{provenance.length}</span>}
-                  </TabsTrigger>
-                </TabsList>
+                  {canWrite && !isHistorical && (
+                    <div className="mt-4 border-t border-border pt-3">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="w-full justify-start text-destructive hover:bg-destructive-soft hover:text-destructive-soft-foreground"
+                        onClick={() => setDeleteOpen(true)}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" aria-hidden />
+                        Delete document
+                      </Button>
+                    </div>
+                  )}
+                </TabsContent>
 
                 <TabsContent value="outline" className="min-h-0 flex-1 overflow-y-auto px-4 pb-4 pt-3 rail-scroll">
+                  <div className="mb-3 border-b border-border pb-3">
+                    <h3 className="text-sm font-semibold text-foreground">On this page</h3>
+                    <p className="mt-0.5 text-xs text-foreground-muted">Jump to a heading without leaving the document.</p>
+                  </div>
                   <DocumentOutline markdown={doc.content || ""} articleEl={articleEl} />
                 </TabsContent>
                 <TabsContent value="relations" className="min-h-0 flex-1 overflow-y-auto px-4 pb-4 pt-3 rail-scroll">
@@ -1038,6 +1066,10 @@ export default function DocumentPage({
                   />
                 </TabsContent>
                 <TabsContent value="history" className="min-h-0 flex-1 overflow-y-auto px-4 pb-4 pt-3 rail-scroll">
+                  <div className="mb-3 border-b border-border pb-3">
+                    <h3 className="text-sm font-semibold text-foreground">Version history</h3>
+                    <p className="mt-0.5 text-xs text-foreground-muted">Select a commit to inspect that version.</p>
+                  </div>
                   {historyError ? (
                     <Alert variant="destructive">Failed to load history.</Alert>
                   ) : (
@@ -1054,21 +1086,6 @@ export default function DocumentPage({
                   )}
                 </TabsContent>
               </Tabs>
-
-              {canWrite && !isHistorical && (
-                <div className="shrink-0 border-t border-border p-3">
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="w-full justify-start text-destructive hover:bg-destructive-soft hover:text-destructive-soft-foreground"
-                    onClick={() => setDeleteOpen(true)}
-                  >
-                    <Trash2 className="h-3.5 w-3.5" aria-hidden />
-                    Delete document
-                  </Button>
-                </div>
-              )}
               </aside>
             </>
           )}

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -35,7 +35,7 @@ import {
   getAuthConfig,
 } from "@/lib/api";
 import { recentIcon, recentTone } from "@/lib/recent";
-import type { HealthSnapshot } from "@/hooks/use-health";
+import type { AccessibleIndexingStatus } from "@/hooks/use-accessible-indexing-health";
 import { useCurrentUser } from "@/contexts/current-user-context";
 import {
   readRecentDocumentViews,
@@ -85,7 +85,9 @@ interface VaultMetrics {
 }
 
 export default function HomePage() {
-  const { health } = useOutletContext<{ health: HealthSnapshot | null }>();
+  const { indexingStatus } = useOutletContext<{
+    indexingStatus: AccessibleIndexingStatus | null;
+  }>();
   const currentUser = useCurrentUser();
   const [vaults, setVaults] = useState<VaultRow[]>([]);
   const [vaultsLoading, setVaultsLoading] = useState(true);
@@ -330,12 +332,10 @@ export default function HomePage() {
     toggleFavorite(v.id);
   }
 
-  const indexUpsert = health?.vector_store?.backfill?.upsert;
-  const indexedCount = indexUpsert?.indexed ?? null;
-  const indexingAbandoned = indexUpsert?.abandoned ?? 0;
-  const indexingPending = indexUpsert
-    ? Math.max(0, (indexUpsert.pending ?? 0) - indexingAbandoned)
-    : 0;
+  const indexedCount = indexingStatus?.indexed ?? null;
+  const indexingAbandoned = indexingStatus?.abandoned ?? 0;
+  const indexingPending = indexingStatus?.pending ?? 0;
+  const indexingIncomplete = indexingStatus?.incomplete ?? false;
   const hasVault = vaults.length > 0;
   const writableVault = vaults.find(
     (vault) => vault.status !== "archived" && vault.role !== "reader",
@@ -378,6 +378,7 @@ export default function HomePage() {
         indexedCount={indexedCount}
         indexingPending={indexingPending}
         indexingAbandoned={indexingAbandoned}
+        indexingIncomplete={indexingIncomplete}
       />
 
       <div className="grid grid-cols-1 items-start gap-x-8 gap-y-8 2xl:grid-cols-[minmax(0,1fr)_320px]">
@@ -517,6 +518,7 @@ export default function HomePage() {
             indexedCount={indexedCount}
             indexingPending={indexingPending}
             indexingAbandoned={indexingAbandoned}
+            indexingIncomplete={indexingIncomplete}
             showSetupLink={!setupComplete && setupDismissed}
             onShowSetup={showSetup}
           />
@@ -765,21 +767,26 @@ function HomeWorkspaceHeader({
   indexedCount,
   indexingPending,
   indexingAbandoned,
+  indexingIncomplete,
 }: {
   vaultCount: number;
   loading: boolean;
   indexedCount: number | null;
   indexingPending: number;
   indexingAbandoned: number;
+  indexingIncomplete: boolean;
 }) {
+  const suffix = indexingIncomplete ? "+" : "";
   const indexLabel = indexingAbandoned > 0
-    ? `${indexingAbandoned.toLocaleString()} need attention`
+    ? `${indexingAbandoned.toLocaleString()}${suffix} need attention`
     : indexingPending > 0
-      ? `${indexingPending.toLocaleString()} indexing`
-      : indexedCount !== null
+      ? `${indexingPending.toLocaleString()}${suffix} indexing`
+      : indexedCount !== null && !indexingIncomplete
         ? `${indexedCount.toLocaleString()} indexed`
-        : null;
-  const indexTone = indexingAbandoned > 0
+        : indexingIncomplete
+          ? "Status unavailable"
+          : null;
+  const indexTone = indexingAbandoned > 0 || indexingIncomplete
     ? "bg-warning"
     : indexingPending > 0
       ? "bg-info"
@@ -1087,6 +1094,7 @@ function WorkspaceSummary({
   indexedCount,
   indexingPending,
   indexingAbandoned,
+  indexingIncomplete,
   showSetupLink,
   onShowSetup,
 }: {
@@ -1103,15 +1111,17 @@ function WorkspaceSummary({
   indexedCount: number | null;
   indexingPending: number;
   indexingAbandoned: number;
+  indexingIncomplete: boolean;
   showSetupLink: boolean;
   onShowSetup: () => void;
 }) {
   const value = (count: number) => loading ? "—" : count.toLocaleString();
+  const suffix = indexingIncomplete ? "+" : "";
   const indexText = indexingAbandoned > 0
-    ? `${indexingAbandoned.toLocaleString()} items need attention`
+    ? `${indexingAbandoned.toLocaleString()}${suffix} items need attention`
     : indexingPending > 0
-      ? `${indexingPending.toLocaleString()} items are indexing`
-      : indexedCount !== null
+      ? `${indexingPending.toLocaleString()}${suffix} items are indexing`
+      : indexedCount !== null && !indexingIncomplete
         ? `${indexedCount.toLocaleString()} chunks indexed`
         : "Index status unavailable";
   const agentText = hasConnectedAgent
@@ -1146,7 +1156,13 @@ function WorkspaceSummary({
       <div className="divide-y divide-border">
         <StatusLine
           icon={<Database aria-hidden />}
-          tone={indexingAbandoned > 0 ? "warning" : indexingPending > 0 ? "info" : "success"}
+          tone={indexingAbandoned > 0 || indexingIncomplete
+            ? "warning"
+            : indexingPending > 0
+              ? "info"
+              : indexedCount === null
+                ? "neutral"
+                : "success"}
           label="Knowledge index"
           value={indexText}
         />


### PR DESCRIPTION
## Summary

- surface accessible indexing status in the global header and Vault context while preserving legacy backend compatibility
- harden document image insertion and recovery, improve the document viewer details/summary layout, and keep editor drafts stable across file selection
- redesign the Collections explorer with editable summaries, collection-scoped create/upload actions, resource-type groups, keyboard navigation, and progressive rendering for large Vaults

## User experience

- documents, tables, and files remain directly reachable even when a collection contains thousands of documents
- collection actions now prefill the selected collection for new documents, file uploads, and tables
- unsupported or unavailable backend fields degrade to neutral UI instead of blocking the frontend

## Compatibility

- frontend-only change
- no backend schema or API contract changes
- compatible with both the current and legacy hybrid-auth/indexing responses

## Testing

- `npm run design:check`
- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings only)
- `npm run test` (87 files, 623 tests)
- local Docker frontend rebuild and browser verification
