### PR TITLE
fix(backend): install image application package

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,10 +18,9 @@ RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/* \
 
 WORKDIR /app
 
-COPY pyproject.toml .
-RUN pip install --no-cache-dir .
-
 COPY . .
+RUN pip install --no-cache-dir .
+RUN /usr/local/bin/python -I -B -c "import app.cli; import mcp_server"
 
 # Create vault storage directory
 RUN mkdir -p /data/vaults

--- a/backend/tests/test_backend_image_unit.py
+++ b/backend/tests/test_backend_image_unit.py
@@ -1,0 +1,19 @@
+"""Regression guard for the backend image's installed Python packages."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+_DOCKERFILE = Path(__file__).resolve().parents[1] / "Dockerfile"
+
+
+def test_backend_image_installs_and_imports_declared_packages() -> None:
+    lines = [line.strip() for line in _DOCKERFILE.read_text().splitlines()]
+    source_copy = lines.index("COPY . .")
+    install = lines.index("RUN pip install --no-cache-dir .")
+    import_check = lines.index(
+        'RUN /usr/local/bin/python -I -B -c "import app.cli; import mcp_server"'
+    )
+
+    assert source_copy < install < import_check


### PR DESCRIPTION
Closes #422.

The backend image previously installed the project before copying `app` and `mcp_server`, leaving those packages absent from site-packages. Runtime happened to work from `/app`, but isolated management CLI imports failed.

This change copies the backend source before installation and adds a build-time isolated import smoke for `app.cli` and `mcp_server`. A deterministic unit test guards the Dockerfile ordering and smoke command.

Validation:

- `pytest backend/tests/test_backend_image_unit.py`: 1 passed
- Ruff: passed
- local isolated import check: passed
- `git diff --check`: passed
