### PR TITLE
fix(files): reject malformed download file ids

### DIFF
--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -22,7 +22,7 @@ from urllib.parse import quote
 
 from app.config import settings
 from app.db.postgres import get_pool
-from app.exceptions import AKBError, ConflictError, NotFoundError
+from app.exceptions import AKBError, ConflictError, NotFoundError, ValidationError
 from app.repositories import vault_files_repo
 from app.repositories.document_repo import CollectionRepository
 from app.repositories.events_repo import emit_event
@@ -926,10 +926,14 @@ class FileService:
         """Return a presigned GET URL for direct download from S3."""
         if self._measurement is not None:
             return await self._measurement.get_download_url(vault_id, file_id)
+        try:
+            fid = uuid.UUID(file_id)
+        except (ValueError, AttributeError):
+            raise ValidationError("file_id must be a UUID") from None
         pool = await get_pool()
         async with pool.acquire() as conn:
             row = await vault_files_repo.find_by_id(
-                conn, vault_id, uuid.UUID(file_id),
+                conn, vault_id, fid,
             )
             if (
                 not row

--- a/backend/app/services/m1_file_measurement.py
+++ b/backend/app/services/m1_file_measurement.py
@@ -457,7 +457,10 @@ class MeasurementFileService:
             await conn.execute("DELETE FROM m1_file_transfer_intents WHERE id = $1", intent_id)
 
     async def get_download_url(self, vault_id: uuid.UUID, file_id: str) -> dict:
-        fid = uuid.UUID(file_id)
+        try:
+            fid = uuid.UUID(file_id)
+        except (ValueError, AttributeError):
+            raise ValidationError("file_id must be a UUID") from None
         token = _new_token()
         pool = await get_pool()
         async with pool.acquire() as conn:

--- a/backend/tests/test_file_download_id_validation_unit.py
+++ b/backend/tests/test_file_download_id_validation_unit.py
@@ -1,0 +1,48 @@
+"""Malformed file ids are client errors at the download boundary."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.exceptions import ValidationError
+from app.services import file_service as fs
+from app.services import m1_file_measurement as m1
+
+
+@pytest.mark.asyncio
+async def test_direct_s3_download_rejects_malformed_file_id_before_database_access(
+    monkeypatch,
+):
+    monkeypatch.setattr(fs, "measurement_enabled", lambda: False)
+    service = fs.FileService()
+
+    async def unexpected_pool():
+        raise AssertionError("malformed file ids must be rejected before database access")
+
+    monkeypatch.setattr(fs, "get_pool", unexpected_pool)
+
+    with pytest.raises(ValidationError, match="file_id must be a UUID") as error:
+        await service.get_download_url(uuid.uuid4(), "not-a-uuid")
+
+    assert error.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_measurement_download_rejects_malformed_file_id_before_database_access(
+    monkeypatch,
+):
+    monkeypatch.setattr(m1, "measurement_enabled", lambda: True)
+    monkeypatch.setattr(m1.settings, "public_base_url", "https://akb.test")
+    service = m1.MeasurementFileService()
+
+    async def unexpected_pool():
+        raise AssertionError("malformed file ids must be rejected before database access")
+
+    monkeypatch.setattr(m1, "get_pool", unexpected_pool)
+
+    with pytest.raises(ValidationError, match="file_id must be a UUID") as error:
+        await service.get_download_url(uuid.uuid4(), "not-a-uuid")
+
+    assert error.value.status_code == 422


### PR DESCRIPTION
Fixes #421

## Summary

- Validate `file_id` before database access in both direct-S3 and M1 download services.
- Return `ValidationError` (HTTP 422) for malformed UUIDs instead of a retryable 500.
- Add regression coverage for both storage paths.

## Tests

- `uv run --extra dev pytest tests/test_file_download_id_validation_unit.py tests/test_file_replace_unit.py tests/test_file_idempotent_upload_unit.py -q`
- `uv run --extra dev pytest -q` — 2354 passed, 642 skipped
- `uv run --extra dev ruff check app tests`