### PR TITLE
feat(frontend): unify loading and resource workspaces

### DIFF
--- a/frontend/DESIGN_SYSTEM.md
+++ b/frontend/DESIGN_SYSTEM.md
@@ -493,6 +493,39 @@ commits` control and `Full commit log` route. Below `xl`, the work area stacks
   full-page reader. Rendered / Raw and version changes retain preview state,
   while Edit deliberately promotes to the full page so unsaved work never lives
   in a dismissible reading overlay.
+- **File workspace**: file routes share the Document workspace's full-height,
+  full-bleed resource grammar: one 64px identity header, one 44px context row,
+  and one framed viewer inside an 8–12px canvas gutter. The title is the human
+  filename; the subtitle identifies the resource kind and Vault without
+  repeating the canonical URI. Collection, filename, uploader (when readable),
+  and creation age live in the context row. Format, byte size, and an optional
+  one-line description live in the viewer toolbar, with long descriptions
+  disclosed through `TooltipText`. Download is the single header action. Images,
+  PDF, HTML, JSON, and text use the shared inline preview renderer; unsupported
+  or failed formats retain the same viewer frame and provide a recoverable
+  preview/download state rather than collapsing into a generic empty card.
+  Initial discovery and file-body loading have separate layout-matched
+  `LoadingState` boundaries so the header and frame remain stable while large
+  content arrives.
+- **Table workspace**: table routes use the same resource shell, but the data
+  grid—not schema prose—is the primary canvas. The 64px header owns table
+  identity, read-only state, row/column totals, and a labelled Schema control.
+  The context row carries the table description and honest sample range. A
+  single framed data surface fills the remaining height and owns both horizontal
+  and vertical scrolling; its header and row-index column remain sticky, while
+  cell values use sans/tabular typography unless the value itself is structured
+  data. Responsive layouts preserve the grid via a focusable horizontal-scroll
+  region rather than converting records into unrelated cards. Schema opens as a
+  right overlay inspector and never reduces data width; it returns focus on
+  Close, backdrop click, or Escape. The inspector reads as a compact data
+  dictionary: a three-value overview exposes column, primary-key, and required
+  counts before a semantic `# | Column | Data type | Constraints` table. Every
+  row keeps stored order, identifier, type, and explicit Required/Nullable text
+  on stable visual axes; primary-key rows add both a key icon/label and a
+  restrained teal surface so color is never the only signal. On narrow screens
+  this table scrolls inside the inspector rather than compressing or stacking
+  unlike values. Loading, empty, query-error, and sampled-result states all
+  retain the same outer frame.
 
 ---
 
@@ -556,7 +589,8 @@ Compose pages from these instead of re-writing patterns inline.
 | `VaultChip`                                            | flat tinted **monogram** tile for a vault — a quiet identity anchor, **not** a glossy avatar or a `feat-*` hero. Swatch is a deterministic `--color-cat-*` picked by `hashHue(name) % 6` (the shared FNV-1a from `lib/utils`, §7), so a vault wears **one color** wherever its name appears — Recent rows and the vault directory. Fill `color-mix(in srgb, <cat> 14%, transparent)`, use the small radius token; `sm` (`h-5 w-5`) rides inline in a row, `md` (`h-7 w-7`) anchors a directory row. `aria-hidden` — the readable name always leads. |
 | `Input` / `Textarea` / `Select` / `Label` / `TagInput` | form primitives — pre-rounded, teal focus ring, `aria-[invalid]` hooks.                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `Dialog` / `ConfirmDialog`                             | overlay primitives; creation flows for documents, Vault files, and tables stay modal and preserve the surrounding workspace. `ConfirmDialog` surfaces a rejected `onConfirm` inline (`Alert`) and stays open for retry.                                                                                                                                                                                                                                                                                                                             |
-| `Tabs` / `Tooltip` / `Skeleton`                        | segmented control / hint / loading placeholder.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `Tabs` / `Tooltip` / `Skeleton`                        | segmented control / hint / visual loading placeholder. `Skeleton` is presentation-only and belongs inside `LoadingState`, not as a standalone status.                                                                                                                                                                                                                                                                                                                                                                                               |
+| `LoadingState` / `InlineLoadingState`                  | accessible async feedback. `LoadingState` owns one atomic `role=status`, hides its layout-matched skeleton children from assistive technology, and is used for page/panel/ledger discovery. `InlineLoadingState` is reserved for brief transitions or non-blocking refreshes where a structural skeleton would be misleading.                                                                                                                                                                                                                         |
 | `Logo` + `.feature-tile`/`.feat-*`                     | brand lockup + per-capability gradient tiles.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 
 Shell: `Layout` (glass `app-header` + responsive `AppSidebar` + content) and
@@ -665,9 +699,26 @@ filters; opening the global panel by itself never changes browser history.
 
 _Roadmap primitives_ (high-drift inline patterns being extracted): `IndexRow`
 (numbered list row), `ToggleGroup`/`ToggleChip` (segmented selection),
-`MetaList`/`MetaItem` (rail `dl`), `LoadingState` (`role=status` loading line +
-skeleton), `InlineCode` (single-token mono chip). Until shipped, match the
+`MetaList`/`MetaItem` (rail `dl`), `InlineCode` (single-token mono chip). Until shipped, match the
 existing inline pattern and flag for extraction.
+
+### Loading-state contract
+
+- Initial page and panel discovery keeps the final outer shell, masthead, rails,
+  and major content geometry in place. Use a layout-matched skeleton inside one
+  `LoadingState`; never return `null` or replace a whole page with a centered
+  loading word.
+- A refresh, filter change, or background revalidation preserves the last
+  successful content. Mark its owning region `aria-busy` and use
+  `InlineLoadingState` near the initiating control; do not blank the ledger or
+  block unrelated navigation.
+- Loading, empty, error, and ready are distinct states. A failed initial request
+  replaces its skeleton with a recoverable `Alert`; a failed background refresh
+  keeps the prior content and adds an inline error with retry where practical.
+- Skeleton dimensions approximate the final content at every breakpoint so
+  async completion does not cause avoidable layout shift. Skeleton blocks are
+  decorative, contain no fake readable copy, and inherit the global
+  reduced-motion rule.
 
 ---
 
@@ -680,7 +731,7 @@ existing inline pattern and flag for extraction.
 | **Focus ring**                | every interactive element keeps the `focus-visible:ring-2 ring-ring ring-offset-2` pattern (icon buttons included). Never remove it. |
 | **Icon-only button**          | `aria-label` required + `<Icon aria-hidden />`.                                                                                      |
 | **Labels**                    | every input has a visible `<Label>` or an `sr-only` label; placeholder is not a label.                                               |
-| **Async / loading**           | wrap loading + show-once secrets in `role=status aria-live=polite`; surface errors with `role=alert` (the `Alert` primitive).        |
+| **Async / loading**           | Use one `LoadingState` per async boundary (`role=status aria-live=polite`); preserve successful content during refresh, mark its owner `aria-busy`, and surface errors with `Alert`. |
 | **Destructive action**        | `ConfirmDialog`, never `window.confirm()`.                                                                                           |
 | **Reduced motion**            | respected globally — don't override.                                                                                                 |
 

--- a/frontend/src/components/__tests__/layout-auth-gate.test.tsx
+++ b/frontend/src/components/__tests__/layout-auth-gate.test.tsx
@@ -295,7 +295,7 @@ describe("Layout — auth gate", () => {
 
     window.dispatchEvent(new Event("focus"));
 
-    expect(await screen.findByText("Verifying session…")).toBeTruthy();
+    expect(await screen.findByText("Refreshing access…")).toBeTruthy();
     expect(screen.getByTestId("home")).toBe(mountedWorkspace);
     resolveForeground?.({
       user_id: "user-2",
@@ -308,7 +308,7 @@ describe("Layout — auth gate", () => {
     });
     await waitFor(() => expect(api.getMe).toHaveBeenCalledTimes(2));
     await waitFor(() => {
-      expect(screen.queryByText("Verifying session…")).toBeNull();
+      expect(screen.queryByText("Refreshing access…")).toBeNull();
     });
     expect(screen.getByTestId("home")).toBe(mountedWorkspace);
     expect(queryClient.getQueryData(["private", "alice"])).toBeUndefined();

--- a/frontend/src/components/__tests__/vault-explorer.test.tsx
+++ b/frontend/src/components/__tests__/vault-explorer.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, within, cleanup } from "@testing-library/react";
+import { render, screen, within, cleanup, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { VaultExplorer } from "@/components/vault-explorer";
@@ -158,6 +158,28 @@ describe("VaultExplorer — rendering", () => {
 });
 
 describe("VaultExplorer — interaction", () => {
+  it("preserves the current tree while a manual refresh is pending", async () => {
+    let resolveRefresh: ((value: typeof sample) => void) | undefined;
+    browseMock
+      .mockResolvedValueOnce(sample)
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolveRefresh = resolve;
+      }));
+    const user = userEvent.setup();
+    renderAt("/vault/v");
+
+    const architecture = await screen.findByRole("button", { name: /^architecture/i });
+    await user.click(screen.getByRole("button", { name: "Refresh collections" }));
+
+    expect(architecture).toBeInTheDocument();
+    expect(screen.getByRole("tree", { name: /v explorer/ })).toHaveAttribute("aria-busy", "true");
+
+    resolveRefresh?.(sample);
+    await waitFor(() => {
+      expect(screen.getByRole("tree", { name: /v explorer/ })).not.toHaveAttribute("aria-busy");
+    });
+  });
+
   it("toggles a collection on click", async () => {
     const user = userEvent.setup();
     renderAt("/vault/v");

--- a/frontend/src/components/auth-card-loading.tsx
+++ b/frontend/src/components/auth-card-loading.tsx
@@ -1,0 +1,36 @@
+import { LoadingState } from "@/components/ui/loading-state";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface AuthCardLoadingProps {
+  label?: string;
+  compact?: boolean;
+}
+
+/** Mirrors the final authentication card so policy discovery never flashes an empty panel. */
+export function AuthCardLoading({
+  label = "Loading authentication options",
+  compact = false,
+}: AuthCardLoadingProps) {
+  return (
+    <LoadingState label={label}>
+      <div className={compact ? "space-y-4" : "space-y-5"}>
+        {!compact && (
+          <div className="grid grid-cols-2 gap-1 rounded-[var(--radius-md)] bg-surface-2 p-1">
+            <Skeleton className="h-9 rounded-[var(--radius-sm)]" />
+            <Skeleton className="h-9 rounded-[var(--radius-sm)]" />
+          </div>
+        )}
+        <div className="space-y-2">
+          <Skeleton className="h-3 w-24 rounded-[var(--radius-sm)]" />
+          <Skeleton className="h-10 w-full rounded-[var(--radius-md)]" />
+        </div>
+        <div className="space-y-2">
+          <Skeleton className="h-3 w-20 rounded-[var(--radius-sm)]" />
+          <Skeleton className="h-10 w-full rounded-[var(--radius-md)]" />
+        </div>
+        <Skeleton className="h-10 w-full rounded-[var(--radius-md)]" />
+        <Skeleton className="mx-auto h-3 w-40 rounded-[var(--radius-sm)]" />
+      </div>
+    </LoadingState>
+  );
+}

--- a/frontend/src/components/document-view.tsx
+++ b/frontend/src/components/document-view.tsx
@@ -1,10 +1,12 @@
 import { useMemo, useState } from "react";
-import { Check, Code2, Copy, Eye, Loader2, Pencil } from "lucide-react";
+import { Check, Code2, Copy, Eye, Pencil } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { getDocument } from "@/lib/api";
 import { MarkdownRender } from "@/components/markdown-render";
 import { Alert } from "@/components/ui/alert";
 import { TooltipText } from "@/components/ui/tooltip-text";
+import { LoadingState } from "@/components/ui/loading-state";
+import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 
 type ViewMode = "rendered" | "raw";
@@ -95,12 +97,7 @@ export function DocumentView({
   }
 
   if (isLoading) {
-    return (
-      <div className="py-8 coord" role="status" aria-live="polite">
-        <Loader2 className="h-4 w-4 inline animate-spin mr-2" aria-hidden />
-        Loading…
-      </div>
-    );
+    return <DocumentViewLoading appearance={appearance} />;
   }
 
   if (error || !doc) {
@@ -197,6 +194,35 @@ export function DocumentView({
         </div>
       )}
     </section>
+  );
+}
+
+function DocumentViewLoading({ appearance }: { appearance: "plain" | "file" }) {
+  return (
+    <LoadingState
+      label="Loading document body"
+      className={cn(
+        appearance === "file" &&
+          "min-h-[28rem] overflow-hidden rounded-[var(--radius-lg)] border border-border bg-surface shadow-sm",
+      )}
+    >
+      <div className={cn(appearance !== "file" && "py-4")}>
+        <div className="flex min-h-11 items-center gap-2 border-b border-border bg-surface-2/60 px-3">
+          <Skeleton className="h-7 w-24 rounded-[var(--radius-sm)]" />
+          <Skeleton className="h-7 w-16 rounded-[var(--radius-sm)]" />
+          <Skeleton className="ml-auto h-3 w-28 rounded-[var(--radius-sm)]" />
+        </div>
+        <div className="mx-auto max-w-4xl space-y-4 px-5 py-8 sm:px-8 lg:px-12">
+          <Skeleton className="h-8 w-3/5 rounded-[var(--radius-md)]" />
+          <Skeleton className="h-4 w-full rounded-[var(--radius-sm)]" />
+          <Skeleton className="h-4 w-11/12 rounded-[var(--radius-sm)]" />
+          <Skeleton className="h-4 w-4/5 rounded-[var(--radius-sm)]" />
+          <Skeleton className="mt-7 h-6 w-2/5 rounded-[var(--radius-md)]" />
+          <Skeleton className="h-4 w-full rounded-[var(--radius-sm)]" />
+          <Skeleton className="h-4 w-5/6 rounded-[var(--radius-sm)]" />
+        </div>
+      </div>
+    </LoadingState>
   );
 }
 

--- a/frontend/src/components/file-viewer.tsx
+++ b/frontend/src/components/file-viewer.tsx
@@ -1,12 +1,20 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { Download } from "lucide-react";
 import { JsonTree } from "@/components/json-tree";
 import { Alert } from "@/components/ui/alert";
 import { CopyButton } from "@/components/ui/copy-button";
+import { LoadingState } from "@/components/ui/loading-state";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   publicationDownloadUrl,
   publicationRawUrl,
   type PublicationResponse,
 } from "@/lib/api";
+import {
+  effectiveFileMime,
+  filePreviewKind,
+  formatFileSize,
+} from "@/lib/file-preview";
 
 // Cap inline text/JSON previews so a multi-MB file can't freeze the tab; the
 // full file is always available via the download link.
@@ -22,10 +30,11 @@ export function FileViewer({ slug, data }: Props) {
   // application/octet-stream (legacy uploads from proxy <0.5.1), derive one
   // from the filename extension so preview still works.
   const rawMime = data.mime_type || "";
-  const mime = effectiveMime(rawMime, data.name || "");
+  const mime = effectiveFileMime(rawMime, data.name || "");
   const downloadUrl = publicationDownloadUrl(slug);
   const rawUrl = publicationRawUrl(slug);
-  const kind = pickKind(mime);
+  const kind = filePreviewKind(mime);
+  const kindLabel = kind.charAt(0).toUpperCase() + kind.slice(1);
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-[180px_1fr] gap-8">
@@ -38,7 +47,7 @@ export function FileViewer({ slug, data }: Props) {
         <div>
           <div className="coord mb-1">Format</div>
           <div className="text-sm font-medium font-mono break-all">
-            {kind.toUpperCase()}
+            {kindLabel}
           </div>
           <div className="coord mt-1 break-all">{mime || "—"}</div>
         </div>
@@ -46,7 +55,7 @@ export function FileViewer({ slug, data }: Props) {
           <div>
             <div className="coord mb-1">Size</div>
             <div className="font-display text-2xl font-semibold tracking-tight text-foreground">
-              {formatSize(data.size_bytes)}
+              {formatFileSize(data.size_bytes)}
             </div>
           </div>
         )}
@@ -63,16 +72,17 @@ export function FileViewer({ slug, data }: Props) {
           <a
             href={downloadUrl}
             download={data.name}
-            className="inline-block coord-spark underline rounded-[var(--radius-sm)] focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            className="inline-flex items-center gap-1.5 rounded-[var(--radius-sm)] text-sm font-medium text-link underline underline-offset-4 transition-token hover:text-link-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
           >
-            ↓ Download original
+            <Download className="h-4 w-4" aria-hidden />
+            Download original
           </a>
         </div>
       </aside>
 
       {/* Main column */}
       <div className="min-w-0">
-        <div className="coord-spark mb-4">File · {kind.toUpperCase()}</div>
+        <div className="coord mb-4">File · {kindLabel}</div>
         <h1 className="font-display text-3xl font-semibold tracking-tight text-foreground mb-2 break-words">
           {data.title || data.name}
         </h1>
@@ -86,10 +96,10 @@ export function FileViewer({ slug, data }: Props) {
               ⊞ Preview
             </span>
             <span className="coord-ink">
-              {kind.toUpperCase()}
+              {kindLabel}
             </span>
           </div>
-          <FileBody
+          <FilePreviewBody
             mime={mime}
             // Images/PDFs render inline from the same-origin proxy (not a
             // presigned S3 URL) so the vault name never leaks and the view stays
@@ -111,7 +121,7 @@ interface FileBodyProps {
   name: string;
 }
 
-function FileBody({ mime, directUrl, rawUrl, name }: FileBodyProps) {
+export function FilePreviewBody({ mime, directUrl, rawUrl, name }: FileBodyProps) {
   if (!directUrl) {
     return (
       <div className="p-8 text-center">
@@ -125,14 +135,7 @@ function FileBody({ mime, directUrl, rawUrl, name }: FileBodyProps) {
   }
 
   if (mime === "application/pdf") {
-    return (
-      <embed
-        src={directUrl}
-        type="application/pdf"
-        aria-label={name || "PDF preview"}
-        className="w-full h-[80vh]"
-      />
-    );
+    return <PdfFileBody directUrl={directUrl} name={name} />;
   }
 
   if (mime === "text/html") {
@@ -149,10 +152,10 @@ function FileBody({ mime, directUrl, rawUrl, name }: FileBodyProps) {
 
   return (
     <div className="p-12 text-center">
-      <div className="coord mb-2">— Preview unavailable —</div>
+      <p className="mb-2 text-sm font-medium text-foreground">Preview unavailable</p>
       <p className="text-sm text-foreground-muted">
         No inline view for <code className="font-mono">{mime || "this format"}</code>.
-        Use the download link in the side rail.
+        Download the original file to open it locally.
       </p>
     </div>
   );
@@ -160,25 +163,54 @@ function FileBody({ mime, directUrl, rawUrl, name }: FileBodyProps) {
 
 function ImageFileBody({ directUrl, name }: { directUrl: string; name: string }) {
   const [failed, setFailed] = useState(false);
+  const [loading, setLoading] = useState(true);
   if (failed) {
     return (
       <div className="p-12 text-center">
-        <div className="coord mb-2">— Preview failed —</div>
+        <p className="mb-2 text-sm font-medium text-foreground">Preview failed</p>
         <p className="text-sm text-foreground-muted">
-          The image couldn't be loaded. Use the download link in the side rail.
+          The image couldn't be loaded. Download the original file to open it locally.
         </p>
       </div>
     );
   }
   return (
-    <div className="flex justify-center bg-surface-2 p-6 min-h-[12rem]">
+    <div className="relative flex min-h-[12rem] justify-center bg-surface-2 p-6">
+      {loading && (
+        <LoadingState label="Loading image preview" className="absolute inset-0 p-6">
+          <Skeleton className="h-full min-h-40 w-full rounded-[var(--radius-md)]" />
+        </LoadingState>
+      )}
       <img
         src={directUrl}
         alt={name || "File preview image"}
         loading="lazy"
         decoding="async"
-        onError={() => setFailed(true)}
-        className="max-w-full max-h-[80vh] object-contain"
+        onLoad={() => setLoading(false)}
+        onError={() => {
+          setLoading(false);
+          setFailed(true);
+        }}
+        className={loading ? "max-h-[80vh] max-w-full object-contain opacity-0" : "max-h-[80vh] max-w-full object-contain"}
+      />
+    </div>
+  );
+}
+
+function PdfFileBody({ directUrl, name }: { directUrl: string; name: string }) {
+  const [loading, setLoading] = useState(true);
+  return (
+    <div className="relative min-h-[80vh]">
+      {loading && (
+        <LoadingState label="Loading PDF preview" className="absolute inset-0 p-4">
+          <Skeleton className="h-full w-full rounded-[var(--radius-md)]" />
+        </LoadingState>
+      )}
+      <iframe
+        src={directUrl}
+        title={name || "PDF preview"}
+        className="h-[80vh] w-full"
+        onLoad={() => setLoading(false)}
       />
     </div>
   );
@@ -186,6 +218,7 @@ function ImageFileBody({ directUrl, name }: { directUrl: string; name: string })
 
 function HtmlFileBody({ rawUrl, name }: { rawUrl: string; name: string }) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [loading, setLoading] = useState(true);
   // contentWidth is measured once per document load; resize just re-scales.
   const contentWidthRef = useRef<number | null>(null);
   const lastWidthRef = useRef<number>(0);
@@ -252,6 +285,7 @@ function HtmlFileBody({ rawUrl, name }: { rawUrl: string; name: string }) {
 
   // Invalidate the cached width when a new document loads (e.g. src change).
   const onLoad = useCallback(() => {
+    setLoading(false);
     contentWidthRef.current = null;
     lastWidthRef.current = 0;
     applyFit();
@@ -269,7 +303,13 @@ function HtmlFileBody({ rawUrl, name }: { rawUrl: string; name: string }) {
   }, [applyFit]);
 
   return (
-    <iframe
+    <div className="relative min-h-[80vh]">
+      {loading && (
+        <LoadingState label="Loading HTML preview" className="absolute inset-0 p-4">
+          <Skeleton className="h-full w-full rounded-[var(--radius-md)]" />
+        </LoadingState>
+      )}
+      <iframe
       ref={iframeRef}
       src={rawUrl}
       // Untrusted user-uploaded HTML. No allow-scripts (content stays inert) and
@@ -280,15 +320,16 @@ function HtmlFileBody({ rawUrl, name }: { rawUrl: string; name: string }) {
       // a soft risk — the durable fix is serving /raw from a separate sandboxed
       // origin or with CSP sandbox, backend-side.
       sandbox="allow-same-origin"
-      className="w-full h-[80vh]"
-      title={name || "HTML file preview"}
-      onLoad={onLoad}
-    />
+        className="h-[80vh] w-full"
+        title={name || "HTML file preview"}
+        onLoad={onLoad}
+      />
+    </div>
   );
 }
 
 function JsonFileBody({ url }: { url: string }) {
-  const [json, setJson] = useState<any>(null);
+  const [json, setJson] = useState<unknown>(undefined);
   const [error, setError] = useState("");
   useEffect(() => {
     let cancelled = false;
@@ -299,7 +340,7 @@ function JsonFileBody({ url }: { url: string }) {
     return () => { cancelled = true; };
   }, [url]);
   if (error) return <Alert variant="destructive" className="m-4">{error}</Alert>;
-  if (json === null) return <div className="p-4 coord" role="status" aria-live="polite">Loading…</div>;
+  if (json === undefined) return <FileBodyLoading label="Loading JSON preview" />;
   return (
     <div className="font-mono text-sm overflow-auto p-4 max-h-[80vh]">
       <JsonTree data={json} />
@@ -328,7 +369,7 @@ function TextFileBody({ url }: { url: string }) {
     return () => { cancelled = true; };
   }, [url]);
   if (error) return <Alert variant="destructive" className="m-4">{error}</Alert>;
-  if (text === null) return <div className="p-4 coord" role="status" aria-live="polite">Loading…</div>;
+  if (text === null) return <FileBodyLoading label="Loading text preview" />;
   return (
     <>
       {truncated && (
@@ -341,44 +382,16 @@ function TextFileBody({ url }: { url: string }) {
   );
 }
 
-function pickKind(mime: string): string {
-  if (mime.startsWith("image/")) return "image";
-  if (mime === "application/pdf") return "pdf";
-  if (mime === "application/json") return "json";
-  if (mime === "text/html") return "html";
-  if (mime.startsWith("text/")) return "text";
-  return "binary";
-}
-
-// Derive a usable MIME from filename extension when the stored mime_type is
-// missing or the generic application/octet-stream. Only overrides when the
-// stored value is non-informative — an explicit mime wins.
-const EXT_TO_MIME: Record<string, string> = {
-  html: "text/html", htm: "text/html",
-  pdf: "application/pdf",
-  json: "application/json", xml: "application/xml",
-  txt: "text/plain", md: "text/markdown", log: "text/plain",
-  csv: "text/csv", tsv: "text/tab-separated-values",
-  css: "text/css", js: "text/javascript", mjs: "text/javascript",
-  yaml: "application/yaml", yml: "application/yaml",
-  png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg",
-  gif: "image/gif", webp: "image/webp", svg: "image/svg+xml",
-  bmp: "image/bmp", ico: "image/x-icon",
-  mp3: "audio/mpeg", wav: "audio/wav",
-  mp4: "video/mp4", webm: "video/webm",
-};
-
-function effectiveMime(mime: string, name: string): string {
-  if (mime && mime !== "application/octet-stream") return mime;
-  const dot = name.lastIndexOf(".");
-  if (dot < 0) return mime || "application/octet-stream";
-  const ext = name.slice(dot + 1).toLowerCase();
-  return EXT_TO_MIME[ext] || mime || "application/octet-stream";
-}
-
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
-  return `${(bytes / 1024 / 1024 / 1024).toFixed(1)} GB`;
+function FileBodyLoading({ label }: { label: string }) {
+  return (
+    <LoadingState label={label} className="min-h-52 bg-surface p-4">
+      <div className="space-y-3">
+        <Skeleton className="h-4 w-2/5 rounded-[var(--radius-sm)]" />
+        <Skeleton className="h-4 w-full rounded-[var(--radius-sm)]" />
+        <Skeleton className="h-4 w-11/12 rounded-[var(--radius-sm)]" />
+        <Skeleton className="h-4 w-4/5 rounded-[var(--radius-sm)]" />
+        <Skeleton className="h-4 w-5/6 rounded-[var(--radius-sm)]" />
+      </div>
+    </LoadingState>
+  );
 }

--- a/frontend/src/components/layout.tsx
+++ b/frontend/src/components/layout.tsx
@@ -18,6 +18,8 @@ import { AppSidebar } from "@/components/app-sidebar";
 import { appRouteBoundaryForPath } from "@/app-route-contract";
 import { CurrentUserProvider } from "@/contexts/current-user-context";
 import { useAccessibleIndexingHealth } from "@/hooks/use-accessible-indexing-health";
+import { InlineLoadingState, LoadingState } from "@/components/ui/loading-state";
+import { Skeleton } from "@/components/ui/skeleton";
 
 const APP_SIDEBAR_COMPACT_KEY = "akb_app_sidebar_compact";
 
@@ -159,13 +161,7 @@ export function Layout() {
   }, [viewportLocked]);
 
   if (session.status === "checking") {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-background text-foreground">
-        <div className="coord" role="status" aria-live="polite">
-          Verifying session…
-        </div>
-      </div>
-    );
+    return <AppShellLoading />;
   }
 
   if (session.status === "unauthenticated") {
@@ -185,13 +181,11 @@ export function Layout() {
   return (
     <div className={rootClass} aria-busy={revalidating || undefined}>
       {revalidating && (
-        <div
-          className="fixed inset-0 z-[var(--z-toast)] flex items-center justify-center bg-background/95 backdrop-blur-sm"
-          role="status"
-          aria-live="polite"
-        >
-          <div className="coord">Verifying session…</div>
-        </div>
+        <InlineLoadingState
+          label="Refreshing access…"
+          size="sm"
+          className="fixed left-1/2 top-2 z-[var(--z-toast)] -translate-x-1/2 rounded-full border border-border bg-surface px-3 py-1.5 shadow-md"
+        />
       )}
       {/* Skip link — first focusable element; jumps keyboard/SR users past the
           header chrome to the page content on every route. */}
@@ -315,6 +309,61 @@ export function Layout() {
         </div>
       </div>
     </div>
+  );
+}
+
+function AppShellLoading() {
+  return (
+    <LoadingState label="Verifying session" className="min-h-screen bg-background text-foreground">
+      <div className="flex min-h-screen flex-col">
+        <header className="app-header shrink-0">
+          <div className="flex h-14 w-full items-center">
+            <div className="flex shrink-0 items-center px-3 lg:w-52">
+              <Logo size={28} wordmark subtitle variant="header" />
+            </div>
+            <div className="ml-auto flex min-w-0 items-center gap-3 pr-3">
+              <Skeleton className="hidden h-8 w-44 rounded-[var(--radius-md)] sm:block" />
+              <Skeleton className="h-9 w-9 rounded-full" />
+            </div>
+          </div>
+        </header>
+
+        <div className="flex min-h-0 flex-1">
+          <aside className="hidden w-52 shrink-0 border-r border-border bg-surface lg:block">
+            <div className="space-y-2 p-3">
+              {[0, 1, 2, 3].map((item) => (
+                <div key={item} className="flex h-10 items-center gap-3 rounded-[var(--radius-md)] px-2">
+                  <Skeleton className="h-8 w-8 shrink-0 rounded-[var(--radius-md)]" />
+                  <Skeleton className="h-3.5 w-24 rounded-[var(--radius-sm)]" />
+                </div>
+              ))}
+            </div>
+          </aside>
+
+          <main className="min-w-0 flex-1 px-4 py-8 sm:px-6 lg:px-8 xl:px-12 2xl:px-36">
+            <div className="border-b border-border pb-6">
+              <Skeleton className="h-3 w-28 rounded-[var(--radius-sm)]" />
+              <Skeleton className="mt-4 h-9 w-64 max-w-full rounded-[var(--radius-md)]" />
+              <Skeleton className="mt-3 h-4 w-full max-w-xl rounded-[var(--radius-sm)]" />
+            </div>
+            <div className="mt-8 grid gap-6 xl:grid-cols-[minmax(0,1fr)_21rem]">
+              <div className="space-y-6">
+                <section className="rounded-[var(--radius-lg)] border border-border bg-surface p-5 shadow-sm">
+                  <Skeleton className="h-5 w-36 rounded-[var(--radius-sm)]" />
+                  <div className="mt-5 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                    {[0, 1, 2].map((item) => (
+                      <Skeleton key={item} className="h-28 rounded-[var(--radius-lg)]" />
+                    ))}
+                  </div>
+                </section>
+                <Skeleton className="h-64 rounded-[var(--radius-lg)] border border-border" />
+              </div>
+              <Skeleton className="h-80 rounded-[var(--radius-lg)] border border-border" />
+            </div>
+          </main>
+        </div>
+      </div>
+    </LoadingState>
   );
 }
 

--- a/frontend/src/components/markdown-editor-fallback.tsx
+++ b/frontend/src/components/markdown-editor-fallback.tsx
@@ -1,13 +1,20 @@
-import { Loader2 } from "lucide-react";
+import { LoadingState } from "@/components/ui/loading-state";
+import { Skeleton } from "@/components/ui/skeleton";
 
 // Separate module so the Suspense fallback ships in the main bundle —
 // importing it from `markdown-editor.tsx` would pull in the full Plate
 // chunk before the editor is needed, defeating the lazy split.
 export function MarkdownEditorFallback() {
   return (
-    <div className="min-h-[300px] border border-border bg-surface-muted px-5 py-4 coord">
-      <Loader2 className="h-4 w-4 inline animate-spin mr-2" aria-hidden />
-      Loading editor…
-    </div>
+    <LoadingState label="Loading editor" className="min-h-[300px] border border-border bg-surface px-5 py-5">
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-52 rounded-[var(--radius-md)]" />
+        <Skeleton className="h-4 w-full rounded-[var(--radius-sm)]" />
+        <Skeleton className="h-4 w-11/12 rounded-[var(--radius-sm)]" />
+        <Skeleton className="h-4 w-4/5 rounded-[var(--radius-sm)]" />
+        <Skeleton className="mt-7 h-6 w-2/5 rounded-[var(--radius-md)]" />
+        <Skeleton className="h-4 w-full rounded-[var(--radius-sm)]" />
+      </div>
+    </LoadingState>
   );
 }

--- a/frontend/src/components/resource-workspace.tsx
+++ b/frontend/src/components/resource-workspace.tsx
@@ -1,0 +1,122 @@
+import type { ReactNode } from "react";
+import type { LucideIcon } from "lucide-react";
+import { Panel } from "@/components/ui/panel";
+import { TonalIcon, type TonalIconTone } from "@/components/ui/tonal-icon";
+import { cn } from "@/lib/utils";
+
+export function ResourceWorkspace({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <section
+      aria-label={label}
+      className="flex h-full min-h-0 flex-col overflow-hidden bg-background fade-in"
+    >
+      {children}
+    </section>
+  );
+}
+
+export function ResourceWorkspaceHeader({
+  icon: Icon,
+  iconTone,
+  title,
+  subtitle,
+  meta,
+  actions,
+}: {
+  icon: LucideIcon;
+  iconTone: TonalIconTone;
+  title: ReactNode;
+  subtitle: ReactNode;
+  meta?: ReactNode;
+  actions?: ReactNode;
+}) {
+  return (
+    <header className="relative z-[var(--z-sticky)] flex h-16 shrink-0 items-center gap-3 border-b border-border bg-surface px-3 sm:px-4 lg:px-5">
+      <TonalIcon tone={iconTone} size="lg" className="hidden sm:inline-flex">
+        <Icon aria-hidden />
+      </TonalIcon>
+      <div className="min-w-0">
+        <div className="flex min-w-0 items-center gap-2">
+          <h1 className="truncate font-display text-base font-semibold text-foreground sm:text-lg">
+            {title}
+          </h1>
+          {meta}
+        </div>
+        <p className="truncate text-xs text-foreground-muted">{subtitle}</p>
+      </div>
+      {actions && (
+        <div className="ml-auto flex shrink-0 items-center gap-2">{actions}</div>
+      )}
+    </header>
+  );
+}
+
+export function ResourceCanvas({ children }: { children: ReactNode }) {
+  return (
+    <main className="h-full overflow-hidden bg-background p-2 sm:p-3">
+      <div className="flex h-full min-h-0 flex-col">{children}</div>
+    </main>
+  );
+}
+
+export function ResourceContextBar({
+  children,
+  trailing,
+}: {
+  children: ReactNode;
+  trailing?: ReactNode;
+}) {
+  return (
+    <div className="mb-3 flex min-h-11 shrink-0 items-center gap-3 rounded-[var(--radius-lg)] border border-border bg-surface px-3 shadow-xs">
+      <div className="min-w-0 flex-1">{children}</div>
+      {trailing && (
+        <div className="flex shrink-0 items-center gap-3 text-xs text-foreground-muted">
+          {trailing}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ResourceViewerFrame({
+  icon: Icon,
+  label,
+  meta,
+  children,
+  className,
+  bodyClassName,
+}: {
+  icon: LucideIcon;
+  label: ReactNode;
+  meta?: ReactNode;
+  children: ReactNode;
+  className?: string;
+  bodyClassName?: string;
+}) {
+  return (
+    <Panel
+      variant="workspace"
+      className={cn(
+        "flex min-h-0 flex-1 flex-col rounded-[var(--radius-lg)] shadow-sm",
+        className,
+      )}
+    >
+      <div className="flex min-h-11 shrink-0 items-center gap-2 border-b border-border bg-surface-2/60 px-3">
+        <Icon className="h-3.5 w-3.5 text-link" aria-hidden />
+        <span className="text-xs font-semibold text-foreground">{label}</span>
+        {meta && (
+          <div className="ml-auto flex min-w-0 items-center gap-3 text-xs text-foreground-muted">
+            {meta}
+          </div>
+        )}
+      </div>
+      <div className={cn("min-h-0 flex-1 bg-surface", bodyClassName)}>{children}</div>
+    </Panel>
+  );
+}

--- a/frontend/src/components/skill/agent-preview.tsx
+++ b/frontend/src/components/skill/agent-preview.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { getVaultSkillPreview } from "@/lib/api";
 import { Alert } from "@/components/ui/alert";
 import { Skeleton } from "@/components/ui/skeleton";
+import { LoadingState } from "@/components/ui/loading-state";
 
 /**
  * The vault guide exactly as an agent receives it — the server-composed
@@ -15,7 +16,13 @@ export function AgentPreview({ vault }: { vault: string }) {
     queryFn: () => getVaultSkillPreview(vault),
     retry: false,
   });
-  if (helpQuery.isLoading) return <div className="p-4"><Skeleton className="h-64 w-full" /></div>;
+  if (helpQuery.isLoading) {
+    return (
+      <LoadingState label="Loading agent preview" className="p-4">
+        <Skeleton className="h-64 w-full rounded-[var(--radius-lg)]" />
+      </LoadingState>
+    );
+  }
   if (helpQuery.isError)
     return (
       <Alert variant="destructive" className="m-4">

--- a/frontend/src/components/skill/skill-section.tsx
+++ b/frontend/src/components/skill/skill-section.tsx
@@ -8,6 +8,7 @@ import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Skeleton } from "@/components/ui/skeleton";
+import { LoadingState } from "@/components/ui/loading-state";
 import { SkillBadge } from "@/components/ui/skill-badge";
 import { Panel } from "@/components/ui/panel";
 import { WorkspaceSectionHeader } from "@/components/ui/workspace-section-header";
@@ -147,7 +148,9 @@ export function SkillSection({
               in the external git repository that owns this content instead.
             </Alert>
           ) : loading ? (
-            <Skeleton className="h-40 w-full" />
+            <LoadingState label="Loading vault guide">
+              <Skeleton className="h-40 w-full rounded-[var(--radius-lg)]" />
+            </LoadingState>
           ) : !doc ? (
             <Alert variant="warning">
               The vault guide is missing. It is restored automatically by the

--- a/frontend/src/components/ui/__tests__/loading-state.test.tsx
+++ b/frontend/src/components/ui/__tests__/loading-state.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { InlineLoadingState, LoadingState } from "@/components/ui/loading-state";
+import { Skeleton } from "@/components/ui/skeleton";
+
+describe("LoadingState", () => {
+  it("exposes one named busy status and hides visual placeholders", () => {
+    render(
+      <LoadingState label="Loading account settings">
+        <Skeleton data-testid="placeholder" className="h-8" />
+      </LoadingState>,
+    );
+
+    const status = screen.getByRole("status", { name: "Loading account settings" });
+    expect(status).toHaveAttribute("aria-live", "polite");
+    expect(status).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByTestId("placeholder").parentElement).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("renders a visible compact status for short transitions", () => {
+    render(<InlineLoadingState label="Opening document composer…" />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Opening document composer…");
+  });
+});

--- a/frontend/src/components/ui/loading-state.tsx
+++ b/frontend/src/components/ui/loading-state.tsx
@@ -1,0 +1,73 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { Loader2 } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+interface LoadingStateProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "children"> {
+  /** A complete, user-facing description of the work in progress. */
+  label: string;
+  /** Visual placeholder content. It is hidden from assistive technology. */
+  children: ReactNode;
+}
+
+/**
+ * Accessible boundary for page, panel, and ledger skeletons.
+ *
+ * The boundary owns the single live status while its visual skeleton stays out
+ * of the accessibility tree. This prevents a page made from many placeholder
+ * blocks from producing repeated or meaningless announcements.
+ */
+function LoadingState({ label, children, className, ...props }: LoadingStateProps) {
+  return (
+    <div
+      {...props}
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      aria-busy="true"
+      aria-label={label}
+      className={className}
+    >
+      <div aria-hidden>{children}</div>
+    </div>
+  );
+}
+
+interface InlineLoadingStateProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, "children"> {
+  label: string;
+  size?: "sm" | "md";
+}
+
+/** Compact feedback for brief transitions where a structural skeleton is not useful. */
+function InlineLoadingState({
+  label,
+  size = "md",
+  className,
+  ...props
+}: InlineLoadingStateProps) {
+  return (
+    <div
+      {...props}
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      aria-busy="true"
+      className={cn(
+        "inline-flex items-center justify-center text-foreground-muted",
+        size === "sm" ? "gap-1.5 text-xs" : "gap-2 text-sm",
+        className,
+      )}
+    >
+      <Loader2
+        className={cn("shrink-0 animate-spin text-link", size === "sm" ? "h-3.5 w-3.5" : "h-4 w-4")}
+        aria-hidden
+      />
+      <span>{label}</span>
+    </div>
+  );
+}
+
+export { InlineLoadingState, LoadingState };
+export type { InlineLoadingStateProps, LoadingStateProps };

--- a/frontend/src/components/vault-explorer.tsx
+++ b/frontend/src/components/vault-explorer.tsx
@@ -21,6 +21,8 @@ import {
   Upload,
 } from "lucide-react";
 import { Alert } from "@/components/ui/alert";
+import { LoadingState } from "@/components/ui/loading-state";
+import { Skeleton } from "@/components/ui/skeleton";
 import { SkillBadge } from "@/components/ui/skill-badge";
 import { useVaultTree, useExpandedPaths, type NodeKind, type TreeNode } from "@/hooks/use-vault-tree";
 import { useVaultRefresh } from "@/contexts/vault-refresh-context";
@@ -93,7 +95,7 @@ export function VaultExplorer({
   onRefetchReady,
   onCollapse,
 }: VaultExplorerProps) {
-  const { tree, loading, error, refetch } = useVaultTree(vault);
+  const { tree, loading, refreshing, error, refetch } = useVaultTree(vault);
   const openCreateDocument = useOpenDocumentCreateDialog();
   const refreshCtx = useVaultRefresh();
   // Prefer the explicit prop; otherwise fall back to context. This lets
@@ -383,12 +385,12 @@ export function VaultExplorer({
           <button
             type="button"
             onClick={() => refetch()}
-            disabled={loading}
+            disabled={loading || refreshing}
             aria-label="Refresh collections"
             title="Refresh collections"
             className={headBtn}
           >
-            <RefreshCw className={loading ? "h-3 w-3 animate-spin" : "h-3 w-3"} aria-hidden />
+            <RefreshCw className={loading || refreshing ? "h-3 w-3 animate-spin" : "h-3 w-3"} aria-hidden />
           </button>
           {canWrite && (
             <RootCreateMenu
@@ -448,23 +450,24 @@ export function VaultExplorer({
         ref={listRef}
         role="tree"
         aria-label={`${vault} explorer`}
+        aria-busy={loading || refreshing || undefined}
         onKeyDown={onKeyDown}
         className="flex-1 overflow-y-auto"
       >
-        {loading && <div className="coord px-3 py-3" role="status" aria-live="polite">— Loading —</div>}
+        {loading && <VaultExplorerLoading />}
         {error && <Alert variant="destructive" className="m-2">{error}</Alert>}
-        {!loading && !error && total === 0 && (
+        {!loading && total === 0 && (
           <div className="px-3 py-4 text-xs leading-relaxed text-foreground-muted" role="status">
             No collections yet — the tree fills in with your first document.
           </div>
         )}
-        {!loading && !error && total > 0 && visibleRows.length === 0 && (
+        {!loading && total > 0 && visibleRows.length === 0 && (
           <div className="coord px-3 py-2" role="status">
             No resources match these filters.
           </div>
         )}
 
-        {!loading && !error &&
+        {!loading &&
           visibleRows.map((row) => {
             if (row.type === "kind-group") {
               return (
@@ -524,7 +527,7 @@ export function VaultExplorer({
             );
           })}
 
-        {!loading && !error &&
+        {!loading &&
           fullRows.length > visibleRows.length && (
             <button
               type="button"
@@ -617,6 +620,19 @@ export function VaultExplorer({
         }}
       />
     </aside>
+  );
+}
+
+function VaultExplorerLoading() {
+  return (
+    <LoadingState label="Loading collections" className="space-y-1 px-2 py-2">
+      {[0, 1, 2, 3, 4, 5].map((item) => (
+        <div key={item} className="flex h-8 items-center gap-2 px-1" style={{ paddingLeft: `${4 + (item % 3) * 12}px` }}>
+          <Skeleton className="h-4 w-4 shrink-0 rounded-[var(--radius-sm)]" />
+          <Skeleton className={item % 2 === 0 ? "h-3 w-28 rounded-[var(--radius-sm)]" : "h-3 w-20 rounded-[var(--radius-sm)]"} />
+        </div>
+      ))}
+    </LoadingState>
   );
 }
 

--- a/frontend/src/components/vault-rail.tsx
+++ b/frontend/src/components/vault-rail.tsx
@@ -29,6 +29,8 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import { LoadingState } from "@/components/ui/loading-state";
+import { Skeleton } from "@/components/ui/skeleton";
 
 /**
  * The vault column — an always-visible, favoritable, role-aware list of vaults
@@ -385,9 +387,7 @@ export function VaultRail({
 
       <div className="flex-1 overflow-y-auto rail-scroll py-1">
         {vaults.length === 0 ? (
-          <p className="px-3 py-2 coord" aria-live="polite">
-            {loading ? "Loading…" : "No vaults yet"}
-          </p>
+          loading ? <VaultRailLoading /> : <p className="px-3 py-2 coord">No vaults yet</p>
         ) : filtered.length === 0 ? (
           <div className="px-3 py-2">
             <p className="coord">
@@ -427,5 +427,18 @@ export function VaultRail({
         )}
       </div>
     </nav>
+  );
+}
+
+function VaultRailLoading() {
+  return (
+    <LoadingState label="Loading vaults" className="space-y-1 px-2 py-2">
+      {[0, 1, 2, 3].map((item) => (
+        <div key={item} className="flex h-10 items-center gap-2 rounded-[var(--radius-md)] px-1">
+          <Skeleton className="h-8 w-8 shrink-0 rounded-[var(--radius-md)]" />
+          <Skeleton className={item % 2 === 0 ? "h-3.5 w-24 rounded-[var(--radius-sm)]" : "h-3.5 w-32 rounded-[var(--radius-sm)]"} />
+        </div>
+      ))}
+    </LoadingState>
   );
 }

--- a/frontend/src/components/vault-shell.tsx
+++ b/frontend/src/components/vault-shell.tsx
@@ -38,6 +38,9 @@ export function VaultShell() {
   const navigate = useNavigate();
   const isGraph = location.pathname.endsWith("/graph");
   const isDocument = location.pathname.includes("/doc/");
+  const isTable = location.pathname.includes("/table/");
+  const isFile = location.pathname.includes("/file/");
+  const isResourceViewer = isDocument || isTable || isFile;
   const isPublications = location.pathname.endsWith("/publications");
   const isSearch = location.pathname.endsWith("/search");
   const isMembers = location.pathname.endsWith("/members");
@@ -425,7 +428,7 @@ export function VaultShell() {
               showBack={false}
             />
 
-            {isGraph || isDocument || isSearch ? (
+            {isGraph || isResourceViewer || isSearch ? (
               <div className="relative min-h-0 min-w-0 flex-1 overflow-hidden bg-background">
                 <ErrorBoundary resetKeys={[location.pathname]}>
                   <Outlet />

--- a/frontend/src/hooks/use-vault-tree.ts
+++ b/frontend/src/hooks/use-vault-tree.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { browseVault } from "@/lib/api";
 import { isReservedCollection } from "@/lib/skill";
 import { parseFileUri } from "@/lib/uri";
@@ -47,8 +47,10 @@ interface BrowseItem {
  * require a future browse contract with collection + kind + cursor inputs.
  */
 export function useVaultTree(vault: string | undefined) {
-  const [items, setItems] = useState<BrowseItem[] | null>(null);
+  const [snapshot, setSnapshot] = useState<{ vault: string; items: BrowseItem[] } | null>(null);
+  const snapshotRef = useRef<{ vault: string; items: BrowseItem[] } | null>(null);
   const [error, setError] = useState<string>("");
+  const [refreshing, setRefreshing] = useState(false);
   // Counter bumped on every refetch invocation so the underlying
   // effect re-runs even when `vault` is unchanged (manual refresh,
   // post-mutation invalidate).
@@ -62,22 +64,41 @@ export function useVaultTree(vault: string | undefined) {
   // user fires refetch twice before the first resolves), we don't want
   // a late response to clobber the newer state.
   useEffect(() => {
-    if (!vault) return;
+    if (!vault) {
+      snapshotRef.current = null;
+      setSnapshot(null);
+      setRefreshing(false);
+      setError("");
+      return;
+    }
     let alive = true;
-    setItems(null);
+    const hasCurrentSnapshot = snapshotRef.current?.vault === vault;
+    setRefreshing(hasCurrentSnapshot);
     setError("");
     browseVault(vault, undefined, -1)
-      .then((d) => { if (alive) setItems(d.items as BrowseItem[]); })
-      .catch((e) => { if (alive) setError(e.message || String(e)); });
+      .then((d) => {
+        if (!alive) return;
+        const next = { vault, items: d.items as BrowseItem[] };
+        snapshotRef.current = next;
+        setSnapshot(next);
+      })
+      .catch((e) => {
+        if (alive) setError(e.message || String(e));
+      })
+      .finally(() => {
+        if (alive) setRefreshing(false);
+      });
     return () => { alive = false; };
   }, [vault, refetchTick]);
+
+  const items = snapshot && snapshot.vault === vault ? snapshot.items : null;
 
   const tree = useMemo<TreeNode[] | null>(() => {
     if (!items) return null;
     return buildTree(items);
   }, [items]);
 
-  return { tree, loading: items === null && !error, error, refetch };
+  return { tree, loading: items === null && !error, refreshing, error, refetch };
 }
 
 export function buildTree(items: BrowseItem[]): TreeNode[] {

--- a/frontend/src/hooks/use-vaults.ts
+++ b/frontend/src/hooks/use-vaults.ts
@@ -22,7 +22,9 @@ export function useVaults() {
     setLoading(true);
     listVaults()
       .then((d) => setVaults((d.vaults as VaultSummary[]) || []))
-      .catch(() => setVaults([]))
+      // Preserve the last successful list on a transient refresh failure so
+      // the navigation rail does not collapse beneath the user.
+      .catch(() => {})
       .finally(() => setLoading(false));
   }, []);
 

--- a/frontend/src/lib/file-preview.ts
+++ b/frontend/src/lib/file-preview.ts
@@ -1,0 +1,40 @@
+export function filePreviewKind(mime: string): string {
+  if (mime.startsWith("image/")) return "image";
+  if (mime === "application/pdf") return "pdf";
+  if (mime === "application/json") return "json";
+  if (mime === "text/html") return "html";
+  if (mime.startsWith("text/")) return "text";
+  return "binary";
+}
+
+// Derive a usable MIME from the filename only when the stored value is
+// missing or non-informative. An explicit MIME always wins.
+const EXT_TO_MIME: Record<string, string> = {
+  html: "text/html", htm: "text/html",
+  pdf: "application/pdf",
+  json: "application/json", xml: "application/xml",
+  txt: "text/plain", md: "text/markdown", log: "text/plain",
+  csv: "text/csv", tsv: "text/tab-separated-values",
+  css: "text/css", js: "text/javascript", mjs: "text/javascript",
+  yaml: "application/yaml", yml: "application/yaml",
+  png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg",
+  gif: "image/gif", webp: "image/webp", svg: "image/svg+xml",
+  bmp: "image/bmp", ico: "image/x-icon",
+  mp3: "audio/mpeg", wav: "audio/wav",
+  mp4: "video/mp4", webm: "video/webm",
+};
+
+export function effectiveFileMime(mime: string, name: string): string {
+  if (mime && mime !== "application/octet-stream") return mime;
+  const dot = name.lastIndexOf(".");
+  if (dot < 0) return mime || "application/octet-stream";
+  const ext = name.slice(dot + 1).toLowerCase();
+  return EXT_TO_MIME[ext] || mime || "application/octet-stream";
+}
+
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+  return `${(bytes / 1024 / 1024 / 1024).toFixed(1)} GB`;
+}

--- a/frontend/src/pages/__tests__/auth-forgot.test.tsx
+++ b/frontend/src/pages/__tests__/auth-forgot.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
+import userEvent from "@testing-library/user-event";
 
 import { AUTH_CONFIG_UNAVAILABLE, getAuthConfig } from "@/lib/api";
 import AuthForgotPage from "../auth-forgot";
@@ -22,6 +23,19 @@ afterEach(() => {
 });
 
 describe("AuthForgotPage", () => {
+  it("replaces a failed policy lookup with a retryable error", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getAuthConfig)
+      .mockRejectedValueOnce(new Error("Policy service unavailable"))
+      .mockResolvedValueOnce(AUTH_CONFIG_UNAVAILABLE);
+
+    render(<MemoryRouter><AuthForgotPage /></MemoryRouter>);
+
+    expect(await screen.findByText("Policy service unavailable")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+    expect(await screen.findByRole("heading", { name: /password recovery unavailable/i })).toBeInTheDocument();
+  });
+
   it("renders password guidance only for validated local mode", async () => {
     vi.mocked(getAuthConfig).mockResolvedValue({
       available: true,

--- a/frontend/src/pages/__tests__/vault-activity-redesign.test.tsx
+++ b/frontend/src/pages/__tests__/vault-activity-redesign.test.tsx
@@ -133,6 +133,31 @@ describe("Activity page redesign", () => {
     ).toHaveAttribute("aria-pressed", "true");
   });
 
+  it("keeps the current ledger visible while an author filter refreshes", async () => {
+    const user = userEvent.setup();
+    let resolveFiltered: ((value: { vault: string; total: number; activity: ReturnType<typeof activity>[] }) => void) | undefined;
+    getVaultActivityMock
+      .mockResolvedValueOnce({
+        vault: "platform-docs",
+        total: 2,
+        activity: [activity(0), activity(1, "codex")],
+      })
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolveFiltered = resolve;
+      }));
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "Filter by JY Kim (1 change)" }));
+    expect(await screen.findByText("Refreshing activity")).toBeInTheDocument();
+    expect(screen.getByText("Change 1")).toBeInTheDocument();
+    expect(screen.getByRole("list", { name: "Vault activity" }).closest("section")?.parentElement).toHaveAttribute("aria-busy", "true");
+
+    resolveFiltered?.({ vault: "platform-docs", total: 1, activity: [activity(0)] });
+    await waitFor(() => {
+      expect(screen.queryByText("Refreshing activity")).not.toBeInTheDocument();
+    });
+  });
+
   it("keeps empty and error states inside the same registry surface", async () => {
     getVaultActivityMock.mockResolvedValue({
       vault: "platform-docs",

--- a/frontend/src/pages/admin.tsx
+++ b/frontend/src/pages/admin.tsx
@@ -9,6 +9,8 @@ import { Input } from "@/components/ui/input";
 import { Panel, PanelHeader } from "@/components/ui/panel";
 import { Logo } from "@/components/logo";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { LoadingState } from "@/components/ui/loading-state";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   adminLocalLogin,
   adminLogout,
@@ -112,7 +114,7 @@ export default function AdminPage() {
           </div>
 
           {(configQuery.isPending || (config?.available && sessionQuery.isPending)) && (
-            <p className="text-sm text-foreground-muted" role="status">Verifying admin policy…</p>
+            <AdminPolicyLoading />
           )}
 
           {unavailable && (
@@ -269,7 +271,7 @@ function SsoProviderControl() {
   }
 
   if (catalogQuery.isPending) {
-    return <p className="text-sm text-foreground-muted" role="status">Loading SSO providers…</p>;
+    return <SsoProvidersLoading />;
   }
   if (catalogQuery.isError || !catalog) {
     return <Alert variant="destructive">SSO provider configuration could not be loaded.</Alert>;
@@ -356,6 +358,46 @@ function SsoProviderControl() {
         </form>
       </Panel>
     </div>
+  );
+}
+
+function AdminPolicyLoading() {
+  return (
+    <LoadingState label="Verifying admin policy">
+      <div className="space-y-4">
+        <div className="rounded-[var(--radius-lg)] border border-border bg-surface-2 p-4">
+          <Skeleton className="h-4 w-36 rounded-[var(--radius-sm)]" />
+          <Skeleton className="mt-3 h-3 w-52 rounded-[var(--radius-sm)]" />
+          <Skeleton className="mt-4 h-3 w-28 rounded-[var(--radius-sm)]" />
+        </div>
+        <Skeleton className="h-10 w-full rounded-[var(--radius-md)]" />
+      </div>
+    </LoadingState>
+  );
+}
+
+function SsoProvidersLoading() {
+  return (
+    <LoadingState label="Loading SSO providers" className="space-y-4">
+      <div>
+        <Skeleton className="h-6 w-40 rounded-[var(--radius-md)]" />
+        <Skeleton className="mt-2 h-4 w-3/4 rounded-[var(--radius-sm)]" />
+      </div>
+      <div className="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-surface">
+        <div className="border-b border-border p-4">
+          <Skeleton className="h-4 w-36 rounded-[var(--radius-sm)]" />
+        </div>
+        {[0, 1].map((item) => (
+          <div key={item} className="flex items-center gap-4 border-b border-border p-4 last:border-b-0">
+            <div className="min-w-0 flex-1 space-y-2">
+              <Skeleton className="h-4 w-40 rounded-[var(--radius-sm)]" />
+              <Skeleton className="h-3 w-64 max-w-full rounded-[var(--radius-sm)]" />
+            </div>
+            <Skeleton className="h-9 w-20 rounded-[var(--radius-md)]" />
+          </div>
+        ))}
+      </div>
+    </LoadingState>
   );
 }
 

--- a/frontend/src/pages/auth-callback.tsx
+++ b/frontend/src/pages/auth-callback.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { ArrowLeft, Loader2 } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 import { Logo } from "@/components/logo";
 import {
   getAuthConfig,
@@ -8,6 +8,7 @@ import {
   markLegacySsoSession,
   setToken,
 } from "@/lib/api";
+import { InlineLoadingState } from "@/components/ui/loading-state";
 
 /**
  * Compatibility callback for the exact pre-v2 Keycloak contract. Current v2
@@ -102,10 +103,12 @@ export default function AuthCallbackPage() {
 
   if (state === "checking") {
     return (
-      <div className="relative flex min-h-screen items-center justify-center bg-background text-foreground">
-        <div className="flex flex-col items-center gap-4 text-sm text-foreground-muted" role="status" aria-live="polite">
-          <Loader2 className="h-6 w-6 animate-spin text-primary" aria-hidden />
-          <span>Completing sign-in…</span>
+      <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background p-6 text-foreground">
+        <div className="hero-glow flex w-full max-w-md flex-col items-center gap-8 text-center">
+          <Logo size={40} subtitle />
+          <div className="w-full rounded-[var(--radius-lg)] border border-border bg-surface p-8 shadow-lg">
+            <InlineLoadingState label="Completing sign-in…" className="py-8" />
+          </div>
         </div>
       </div>
     );

--- a/frontend/src/pages/auth-forgot.tsx
+++ b/frontend/src/pages/auth-forgot.tsx
@@ -4,10 +4,15 @@ import { ArrowLeft } from "lucide-react";
 import { getAuthConfig, getMe, getToken, type AuthConfig } from "@/lib/api";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Logo } from "@/components/logo";
+import { AuthCardLoading } from "@/components/auth-card-loading";
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 
 export default function AuthForgotPage() {
   const navigate = useNavigate();
   const [authConfig, setAuthConfig] = useState<AuthConfig | null>(null);
+  const [configError, setConfigError] = useState("");
+  const [configAttempt, setConfigAttempt] = useState(0);
   const localPasswordHelp =
     authConfig?.available === true &&
     (authConfig.auth_mode === "local" || authConfig.auth_mode === "hybrid") &&
@@ -16,26 +21,35 @@ export default function AuthForgotPage() {
   useEffect(() => {
     let cancelled = false;
     void (async () => {
-      const config = await getAuthConfig();
-      if (cancelled) return;
-      const hasSessionCandidate =
-        config.available === true &&
-        (config.auth_mode === "sso" || getToken() !== null);
-      if (hasSessionCandidate) {
-        try {
-          await getMe({ redirectOnUnauthorized: false });
-          if (!cancelled) navigate("/", { replace: true });
-          return;
-        } catch {
-          // No active session; render mode-specific recovery guidance.
+      try {
+        setConfigError("");
+        const config = await getAuthConfig();
+        if (cancelled) return;
+        const hasSessionCandidate =
+          config.available === true &&
+          (config.auth_mode === "sso" || getToken() !== null);
+        if (hasSessionCandidate) {
+          try {
+            await getMe({ redirectOnUnauthorized: false });
+            if (!cancelled) navigate("/", { replace: true });
+            return;
+          } catch {
+            // No active session; render mode-specific recovery guidance.
+          }
+        }
+        if (!cancelled) setAuthConfig(config);
+      } catch (caught) {
+        if (!cancelled) {
+          setConfigError(
+            caught instanceof Error ? caught.message : "Authentication options could not be loaded.",
+          );
         }
       }
-      if (!cancelled) setAuthConfig(config);
     })();
     return () => {
       cancelled = true;
     };
-  }, [navigate]);
+  }, [configAttempt, navigate]);
 
   return (
     <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background text-foreground p-6">
@@ -49,10 +63,17 @@ export default function AuthForgotPage() {
         </div>
 
         <div className="rounded-[var(--radius-lg)] border border-border bg-surface shadow-lg p-7 sm:p-8">
-          {authConfig === null ? (
-            <div className="py-6 text-center coord" role="status" aria-live="polite">
-              Loading authentication options…
+          {configError ? (
+            <div className="space-y-4">
+              <Alert variant="destructive" title="Recovery options unavailable">
+                {configError}
+              </Alert>
+              <Button type="button" variant="outline" className="w-full" onClick={() => setConfigAttempt((value) => value + 1)}>
+                Try again
+              </Button>
             </div>
+          ) : authConfig === null ? (
+            <AuthCardLoading label="Loading authentication options" compact />
           ) : localPasswordHelp ? (
             <>
               <h1 className="font-display text-2xl tracking-tight text-foreground mb-4">

--- a/frontend/src/pages/auth.tsx
+++ b/frontend/src/pages/auth.tsx
@@ -17,6 +17,7 @@ import { Alert } from "@/components/ui/alert";
 import { Input } from "@/components/ui/input";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Logo } from "@/components/logo";
+import { AuthCardLoading } from "@/components/auth-card-loading";
 import { cn } from "@/lib/utils";
 
 declare const PasswordCredential: {
@@ -51,6 +52,8 @@ export default function AuthPage() {
   // Unknown until the versioned public policy is validated. No UI capability
   // is inferred while loading or when the fetch/schema fails.
   const [authConfig, setAuthConfig] = useState<AuthConfig | null>(null);
+  const [configError, setConfigError] = useState("");
+  const [configAttempt, setConfigAttempt] = useState(0);
   const next = safeNext(new URLSearchParams(window.location.search).get("next"));
   const localAuthEnabled =
     authConfig?.available === true &&
@@ -70,33 +73,42 @@ export default function AuthPage() {
   useEffect(() => {
     let cancelled = false;
     void (async () => {
-      const config = await getAuthConfig();
-      if (cancelled) return;
-      if (config.available !== true || config.auth_mode === null) {
-        setAuthConfig(config);
-        return;
-      }
-      if (config.auth_mode === "sso" && getToken()) {
-        // Defense in depth for mocked/legacy config clients: a local JWT must
-        // never shadow the SSO cookie carrier.
-        setToken(null);
-      }
-      const hasSessionCandidate = config.auth_mode === "sso" || getToken() !== null;
-      if (hasSessionCandidate) {
-        try {
-          await getMe({ redirectOnUnauthorized: false });
-          if (!cancelled) navigate(next, { replace: true });
+      try {
+        setConfigError("");
+        const config = await getAuthConfig();
+        if (cancelled) return;
+        if (config.available !== true || config.auth_mode === null) {
+          setAuthConfig(config);
           return;
-        } catch {
-          // No current session: reveal only the options allowed by config.
+        }
+        if (config.auth_mode === "sso" && getToken()) {
+          // Defense in depth for mocked/legacy config clients: a local JWT must
+          // never shadow the SSO cookie carrier.
+          setToken(null);
+        }
+        const hasSessionCandidate = config.auth_mode === "sso" || getToken() !== null;
+        if (hasSessionCandidate) {
+          try {
+            await getMe({ redirectOnUnauthorized: false });
+            if (!cancelled) navigate(next, { replace: true });
+            return;
+          } catch {
+            // No current session: reveal only the options allowed by config.
+          }
+        }
+        if (!cancelled) setAuthConfig(config);
+      } catch (caught) {
+        if (!cancelled) {
+          setConfigError(
+            caught instanceof Error ? caught.message : "Authentication options could not be loaded.",
+          );
         }
       }
-      if (!cancelled) setAuthConfig(config);
     })();
     return () => {
       cancelled = true;
     };
-  }, [navigate, next]);
+  }, [configAttempt, navigate, next]);
 
   function startSso(loginUrl: string | null) {
     if (!loginUrl) return;
@@ -197,9 +209,16 @@ export default function AuthPage() {
             <Logo size={40} subtitle />
           </div>
           <div className="rounded-[var(--radius-lg)] border border-border bg-surface shadow-lg p-7 sm:p-8">
-            {authConfig === null && (
-              <div className="py-8 text-center coord" role="status" aria-live="polite">
-                Loading sign-in options…
+            {authConfig === null && !configError && <AuthCardLoading label="Loading sign-in options" />}
+
+            {configError && (
+              <div className="space-y-4">
+                <Alert variant="destructive" title="Sign-in options unavailable">
+                  {configError}
+                </Alert>
+                <Button type="button" variant="outline" className="w-full" onClick={() => setConfigAttempt((value) => value + 1)}>
+                  Try again
+                </Button>
               </div>
             )}
 

--- a/frontend/src/pages/document-new.tsx
+++ b/frontend/src/pages/document-new.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react";
-import { Loader2 } from "lucide-react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { useOpenDocumentCreateDialog } from "@/contexts/document-create-dialog-context";
+import { InlineLoadingState } from "@/components/ui/loading-state";
 
 /**
  * Compatibility bridge for bookmarks and older links. VaultShell owns the
@@ -24,13 +24,8 @@ export default function DocumentNewPage() {
   }, [initialCollection, name, navigate, openCreateDocument]);
 
   return (
-    <div
-      className="flex min-h-[20rem] items-center justify-center text-sm text-foreground-muted"
-      role="status"
-      aria-live="polite"
-    >
-      <Loader2 className="mr-2 h-4 w-4 animate-spin text-link" aria-hidden />
-      Opening document composer…
+    <div className="flex min-h-[20rem] items-center justify-center">
+      <InlineLoadingState label="Opening document composer…" />
     </div>
   );
 }

--- a/frontend/src/pages/document.tsx
+++ b/frontend/src/pages/document.tsx
@@ -61,6 +61,8 @@ import { MarkdownEditorFallback } from "@/components/markdown-editor-fallback";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { PublishOptionsDialog } from "@/components/publish-options-dialog";
 import { TooltipText } from "@/components/ui/tooltip-text";
+import { LoadingState } from "@/components/ui/loading-state";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useVaultRefresh } from "@/contexts/vault-refresh-context";
 import { RelationsPanel } from "@/components/relations/relations-panel";
 import { relationIsInVault } from "@/components/relations/relation-row-utils";
@@ -487,12 +489,7 @@ export default function DocumentPage({
   }
 
   if (!doc) {
-    return (
-      <div className="py-8 coord">
-        <Loader2 className="h-4 w-4 inline animate-spin mr-2" aria-hidden />
-        Loading…
-      </div>
-    );
+    return <DocumentPageLoading presentation={presentation} />;
   }
 
   async function handleUnpublish() {
@@ -1148,6 +1145,62 @@ export default function DocumentPage({
         }}
       />
     </>
+  );
+}
+
+function DocumentPageLoading({ presentation }: { presentation: "page" | "preview" }) {
+  return (
+    <LoadingState
+      label="Loading document"
+      className="flex h-full min-h-0 flex-col overflow-hidden bg-background"
+    >
+      <div className="flex h-full min-h-0 flex-col overflow-hidden">
+        <header
+          className={cn(
+            "flex h-16 shrink-0 items-center gap-3 border-b border-border bg-surface pl-3 sm:pl-4 lg:pl-5",
+            presentation === "preview" ? "pr-12 sm:pr-14" : "pr-3 sm:pr-4 lg:pr-5",
+          )}
+        >
+          <Skeleton className="hidden h-9 w-9 shrink-0 rounded-[var(--radius-md)] sm:block" />
+          <div className="min-w-0 flex-1 space-y-2">
+            <Skeleton className="h-5 w-2/3 max-w-56 rounded-[var(--radius-sm)]" />
+            <Skeleton className="h-3 w-1/2 max-w-40 rounded-[var(--radius-sm)]" />
+          </div>
+          <div className="flex shrink-0 gap-2">
+            <Skeleton className="h-8 w-20 rounded-[var(--radius-md)]" />
+            <Skeleton className="hidden h-8 w-24 rounded-[var(--radius-md)] sm:block" />
+          </div>
+        </header>
+
+        <div className="min-h-0 flex-1 overflow-hidden">
+          <main className="h-full overflow-hidden bg-background p-2 sm:p-3">
+            <div className="mb-3 flex min-h-11 items-center gap-3 rounded-[var(--radius-lg)] border border-border bg-surface px-3 shadow-xs">
+              <Skeleton className="h-4 w-4 shrink-0 rounded-[var(--radius-sm)]" />
+              <Skeleton className="h-3 w-2/3 max-w-64 rounded-[var(--radius-sm)]" />
+              <Skeleton className="ml-auto hidden h-3 w-32 rounded-[var(--radius-sm)] sm:block" />
+            </div>
+
+            <section className="min-h-[32rem] overflow-hidden rounded-[var(--radius-lg)] border border-border bg-surface shadow-sm">
+              <div className="flex min-h-11 items-center gap-2 border-b border-border bg-surface-2/60 px-3">
+                <Skeleton className="h-7 w-24 rounded-[var(--radius-sm)]" />
+                <Skeleton className="h-7 w-16 rounded-[var(--radius-sm)]" />
+                <Skeleton className="ml-auto h-3 w-28 rounded-[var(--radius-sm)]" />
+              </div>
+              <div className="mx-auto max-w-4xl space-y-4 px-5 py-8 sm:px-8 lg:px-12">
+                <Skeleton className="h-8 w-3/5 rounded-[var(--radius-md)]" />
+                <Skeleton className="h-4 w-full rounded-[var(--radius-sm)]" />
+                <Skeleton className="h-4 w-11/12 rounded-[var(--radius-sm)]" />
+                <Skeleton className="h-4 w-4/5 rounded-[var(--radius-sm)]" />
+                <Skeleton className="mt-7 h-6 w-2/5 rounded-[var(--radius-md)]" />
+                <Skeleton className="h-4 w-full rounded-[var(--radius-sm)]" />
+                <Skeleton className="h-4 w-5/6 rounded-[var(--radius-sm)]" />
+                <Skeleton className="mt-6 h-32 w-full rounded-[var(--radius-lg)]" />
+              </div>
+            </section>
+          </main>
+        </div>
+      </div>
+    </LoadingState>
   );
 }
 

--- a/frontend/src/pages/file.tsx
+++ b/frontend/src/pages/file.tsx
@@ -1,11 +1,38 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
-import { Download, File } from "lucide-react";
+import {
+  Clock3,
+  Download,
+  Eye,
+  File,
+  FolderTree,
+  RefreshCw,
+  UserRound,
+} from "lucide-react";
+import {
+  FilePreviewBody,
+} from "@/components/file-viewer";
+import {
+  ResourceCanvas,
+  ResourceContextBar,
+  ResourceViewerFrame,
+  ResourceWorkspace,
+  ResourceWorkspaceHeader,
+} from "@/components/resource-workspace";
 import { Alert } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { LoadingState } from "@/components/ui/loading-state";
 import { Skeleton } from "@/components/ui/skeleton";
-import { parseFileUri } from "@/lib/uri";
+import { TooltipText } from "@/components/ui/tooltip-text";
 import { authenticatedFetch } from "@/lib/api";
+import {
+  effectiveFileMime,
+  filePreviewKind,
+  formatFileSize,
+} from "@/lib/file-preview";
+import { parseFileUri } from "@/lib/uri";
+import { timeAgo } from "@/lib/utils";
 
 interface FileInfo {
   uri: string;
@@ -16,120 +43,274 @@ interface FileInfo {
   size_bytes?: number;
   created_by?: string;
   created_at?: string;
+}
+
+interface FileAccess {
+  name?: string;
   download_url?: string;
+  mime_type?: string;
+  size_bytes?: number;
 }
 
 export default function FilePage() {
   const { name: vault, id: fileId } = useParams<{ name: string; id: string }>();
   const [info, setInfo] = useState<FileInfo | null>(null);
-  const [error, setError] = useState("");
-  const [downloading, setDownloading] = useState(false);
+  const [access, setAccess] = useState<FileAccess | null>(null);
+  const [loadError, setLoadError] = useState("");
+  const [previewError, setPreviewError] = useState("");
+  const [infoLoading, setInfoLoading] = useState(true);
+  const [previewLoading, setPreviewLoading] = useState(true);
 
   useEffect(() => {
     if (!vault || !fileId) return;
     let cancelled = false;
-    // Reset stale state from previous param before re-fetch resolves.
     setInfo(null);
-    setError("");
+    setLoadError("");
+    setInfoLoading(true);
+
     authenticatedFetch(`/api/v1/files/${encodeURIComponent(vault)}`)
-      .then(async (r) => {
-        if (!r.ok) {
-          if (!cancelled) setError(`Couldn't load the file list (${r.status}).`);
-          return null;
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`Couldn't load the file list (${response.status}).`);
         }
-        return r.json().catch(() => null);
+        return response.json().catch(() => null);
       })
-      .then((d) => {
-        if (cancelled || !d) return;
-        // Backend rows carry a canonical `uri` (akb://{vault}/file/{id}) and
-        // no separate `id` field after the URI-canonical refactor.
-        const found = (d.items || []).find(
-          (x: any) => parseFileUri(x.uri)?.id === fileId,
+      .then((data) => {
+        if (cancelled || !data) return;
+        const found = (data.items || []).find(
+          (item: FileInfo) => parseFileUri(item.uri)?.id === fileId,
         );
         if (found) setInfo(found);
-        else setError("File not found in vault.");
+        else setLoadError("File not found in vault.");
       })
-      .catch((e) => !cancelled && setError(String(e)));
-    return () => { cancelled = true; };
+      .catch((error) => {
+        if (!cancelled) setLoadError(error instanceof Error ? error.message : String(error));
+      })
+      .finally(() => {
+        if (!cancelled) setInfoLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [vault, fileId]);
 
-  async function download() {
-    setDownloading(true);
-    setError("");
+  const loadPreview = useCallback(async () => {
+    if (!vault || !fileId) return;
+    setPreviewLoading(true);
+    setPreviewError("");
     try {
-      const r = await authenticatedFetch(
-        `/api/v1/files/${encodeURIComponent(vault || "")}/${encodeURIComponent(fileId || "")}/download`,
+      const response = await authenticatedFetch(
+        `/api/v1/files/${encodeURIComponent(vault)}/${encodeURIComponent(fileId)}/download`,
       );
-      if (!r.ok) {
-        setError(`Download failed (${r.status}).`);
-        return;
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || !data.download_url) {
+        throw new Error(data.error || data.detail || `Preview unavailable (${response.status}).`);
       }
-      const d = await r.json().catch(() => ({}));
-      if (d.download_url) window.open(d.download_url, "_blank");
-      else setError(d.error || d.detail || "Failed to get a download URL.");
-    } catch (e) {
-      setError(String(e));
+      setAccess(data);
+    } catch (error) {
+      setAccess(null);
+      setPreviewError(error instanceof Error ? error.message : String(error));
     } finally {
-      setDownloading(false);
+      setPreviewLoading(false);
     }
+  }, [vault, fileId]);
+
+  useEffect(() => {
+    void loadPreview();
+  }, [loadPreview]);
+
+  const displayName = info?.name || access?.name || fileId || "File";
+  const mime = effectiveFileMime(
+    info?.mime_type || access?.mime_type || "",
+    displayName,
+  );
+  const kind = filePreviewKind(mime);
+  const kindLabel = kind.charAt(0).toUpperCase() + kind.slice(1);
+  const size = info?.size_bytes ?? access?.size_bytes;
+  const creator = useMemo(() => readableCreator(info?.created_by), [info?.created_by]);
+
+  if (infoLoading && !info && !access) {
+    return <FilePageLoading />;
   }
 
-  const loading = info === null && !error;
-
   return (
-    <div className="min-w-0 fade-up max-w-[1280px] mx-auto">
-      <div className="coord mb-3">
-        Vault · <span className="font-mono">{vault}</span> · File · <span className="font-mono">{info?.name || fileId}</span>
-      </div>
+    <ResourceWorkspace label="File workspace">
+      <ResourceWorkspaceHeader
+        icon={File}
+        iconTone="file"
+        title={displayName}
+        subtitle={
+          <>
+            File <span aria-hidden>·</span>{" "}
+            <span className="font-medium text-foreground">{vault}</span>
+          </>
+        }
+        meta={<Badge variant="outline">{kindLabel}</Badge>}
+        actions={
+          access?.download_url ? (
+            <Button asChild size="sm">
+              <a
+                href={access.download_url}
+                target="_blank"
+                rel="noreferrer"
+                download={displayName}
+              >
+                <Download className="h-4 w-4" aria-hidden />
+                <span className="hidden sm:inline">Download</span>
+              </a>
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              loading={previewLoading}
+              onClick={() => void loadPreview()}
+            >
+              {!previewLoading && <RefreshCw className="h-4 w-4" aria-hidden />}
+              <span className="hidden sm:inline">Retry preview</span>
+            </Button>
+          )
+        }
+      />
 
-      <header className="flex items-baseline justify-between flex-wrap gap-x-4 gap-y-2 pb-3 border-b border-border">
-        <h1 className="font-display text-[28px] font-semibold tracking-tight text-foreground break-all min-w-0">
-          {info?.name || fileId}
-        </h1>
-        <div className="flex items-center gap-4 coord tabular-nums shrink-0">
-          {info?.mime_type && (
-            <span className="text-foreground-muted font-mono">{info.mime_type}</span>
+      <div className="relative min-h-0 flex-1 overflow-hidden">
+        <ResourceCanvas>
+          {loadError && !info ? (
+            <div className="mx-auto w-full max-w-2xl pt-6">
+              <Alert variant="destructive" title="File unavailable">
+                {loadError}
+              </Alert>
+            </div>
+          ) : (
+            <>
+              <ResourceContextBar
+                trailing={
+                  info?.created_at ? (
+                    <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
+                      <Clock3 className="h-3.5 w-3.5" aria-hidden />
+                      {timeAgo(info.created_at)}
+                    </span>
+                  ) : undefined
+                }
+              >
+                <div className="flex min-w-0 items-center gap-2 text-xs text-foreground-muted">
+                  <FolderTree className="h-3.5 w-3.5 shrink-0 text-link" aria-hidden />
+                  <span className="truncate">
+                    <span className="font-medium text-foreground">
+                      {info?.collection || "Root"}
+                    </span>
+                    <span aria-hidden> / </span>
+                    <span className="font-mono">{displayName}</span>
+                  </span>
+                  {creator && (
+                    <span className="hidden shrink-0 items-center gap-1.5 border-l border-border pl-3 xl:inline-flex">
+                      <UserRound className="h-3.5 w-3.5" aria-hidden />
+                      <span className="font-medium text-foreground">{creator}</span>
+                    </span>
+                  )}
+                </div>
+              </ResourceContextBar>
+
+              <ResourceViewerFrame
+                icon={Eye}
+                label="File preview"
+                meta={
+                  <>
+                    {info?.description && (
+                      <TooltipText
+                        tip={info.description}
+                        className="hidden max-w-80 truncate xl:inline-block"
+                      >
+                        {info.description}
+                      </TooltipText>
+                    )}
+                    <span className="hidden font-mono lg:inline">{mime || "Unknown format"}</span>
+                    {size !== undefined && (
+                      <span className="whitespace-nowrap tabular-nums">{formatFileSize(size)}</span>
+                    )}
+                  </>
+                }
+                bodyClassName="overflow-auto"
+              >
+                {previewLoading ? (
+                  <FilePreviewLoading />
+                ) : previewError || !access?.download_url ? (
+                  <div className="mx-auto flex min-h-64 max-w-xl items-center px-4 py-10">
+                    <Alert variant="warning" title="Preview unavailable" className="w-full">
+                      <div className="space-y-3">
+                        <p>{previewError || "The original file URL was not returned."}</p>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() => void loadPreview()}
+                        >
+                          <RefreshCw className="h-4 w-4" aria-hidden />
+                          Retry
+                        </Button>
+                      </div>
+                    </Alert>
+                  </div>
+                ) : (
+                  <FilePreviewBody
+                    key={access.download_url}
+                    mime={mime}
+                    directUrl={access.download_url}
+                    rawUrl={access.download_url}
+                    name={displayName}
+                  />
+                )}
+              </ResourceViewerFrame>
+            </>
           )}
-          {info?.size_bytes !== undefined && <span>{formatSize(info.size_bytes)}</span>}
-          {info?.collection && <span>{info.collection}</span>}
-        </div>
-      </header>
-
-      {info?.description && (
-        <p className="font-medium tracking-[-0.01em] text-[17px] leading-[1.55] text-foreground-muted mt-3">
-          {info.description}
-        </p>
-      )}
-
-      {error && <Alert variant="destructive" className="mt-6">{error}</Alert>}
-
-      {loading && (
-        <div className="mt-6 space-y-2" role="status" aria-live="polite" aria-label="Loading file">
-          <Skeleton className="h-4 w-64 rounded-[var(--radius-sm)]" />
-          <Skeleton className="h-40 w-full rounded-[var(--radius-lg)]" />
-        </div>
-      )}
-
-      {!loading && (
-      <div className="mt-8 rounded-[var(--radius-lg)] border border-border bg-surface shadow-sm p-10 text-center">
-        <File className="h-12 w-12 text-foreground-muted mx-auto mb-4" aria-hidden />
-        <p className="text-sm font-medium text-foreground">Inline preview pending</p>
-        <p className="mt-1 text-sm text-foreground-muted max-w-md mx-auto leading-relaxed">
-          Authenticated in-browser previews aren't built yet — fetch the original via presigned S3.
-        </p>
-        <Button onClick={download} loading={downloading} disabled={!!error} variant="accent" className="mt-5">
-          {!downloading && <Download className="h-4 w-4" aria-hidden />}
-          {downloading ? "Preparing…" : "Download"}
-        </Button>
+        </ResourceCanvas>
       </div>
-      )}
-    </div>
+    </ResourceWorkspace>
   );
 }
 
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
-  return `${(bytes / 1024 / 1024 / 1024).toFixed(1)} GB`;
+function FilePageLoading() {
+  return (
+    <LoadingState
+      label="Loading file"
+      className="flex h-full min-h-0 flex-col overflow-hidden bg-background"
+    >
+      <div className="flex h-full min-h-0 flex-col overflow-hidden">
+        <header className="flex h-16 shrink-0 items-center gap-3 border-b border-border bg-surface px-3 sm:px-4 lg:px-5">
+          <Skeleton className="hidden h-9 w-9 shrink-0 rounded-[var(--radius-md)] sm:block" />
+          <div className="min-w-0 flex-1 space-y-2">
+            <Skeleton className="h-5 w-2/3 max-w-56 rounded-[var(--radius-sm)]" />
+            <Skeleton className="h-3 w-1/2 max-w-36 rounded-[var(--radius-sm)]" />
+          </div>
+          <Skeleton className="h-8 w-24 rounded-[var(--radius-md)]" />
+        </header>
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden p-2 sm:p-3">
+          <Skeleton className="mb-3 h-11 w-full rounded-[var(--radius-lg)]" />
+          <div className="flex min-h-80 flex-1 flex-col overflow-hidden rounded-[var(--radius-lg)] border border-border bg-surface">
+            <div className="flex h-11 shrink-0 items-center gap-3 border-b border-border bg-surface-2/60 px-3">
+              <Skeleton className="h-4 w-28 rounded-[var(--radius-sm)]" />
+              <Skeleton className="ml-auto h-3 w-32 rounded-[var(--radius-sm)]" />
+            </div>
+            <FilePreviewLoading />
+          </div>
+        </div>
+      </div>
+    </LoadingState>
+  );
+}
+
+function FilePreviewLoading() {
+  return (
+    <LoadingState label="Loading file preview" className="min-h-64 flex-1 p-4 sm:p-6">
+      <Skeleton className="h-full min-h-56 w-full rounded-[var(--radius-md)]" />
+    </LoadingState>
+  );
+}
+
+function readableCreator(value?: string): string | null {
+  if (!value) return null;
+  if (/^[0-9a-f]{8}-[0-9a-f-]{27,}$/i.test(value)) return null;
+  return value;
 }

--- a/frontend/src/pages/public-publication.tsx
+++ b/frontend/src/pages/public-publication.tsx
@@ -19,6 +19,8 @@ import { Logo } from "@/components/logo";
 import { Alert } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { LoadingState } from "@/components/ui/loading-state";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export default function PublicationPage() {
   const { slug } = useParams<{ slug: string }>();
@@ -94,13 +96,7 @@ export default function PublicationPage() {
   }
 
   if (!data) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-background text-foreground">
-        <div className="text-sm text-foreground-muted" role="status" aria-live="polite">
-          Loading…
-        </div>
-      </div>
-    );
+    return <PublicationPageLoading />;
   }
 
   return (
@@ -174,6 +170,47 @@ export default function PublicationPage() {
         </div>
       </footer>
     </div>
+  );
+}
+
+function PublicationPageLoading() {
+  return (
+    <LoadingState label="Loading publication" className="min-h-screen bg-background text-foreground">
+      <div className="min-h-screen">
+        <header className="border-b border-border">
+          <div className="mx-auto flex max-w-[1200px] items-center justify-between gap-4 px-6 py-3">
+            <Logo size={26} subtitle />
+            <div className="flex items-center gap-3">
+              <Skeleton className="h-6 w-14 rounded-full" />
+              <Skeleton className="h-9 w-9 rounded-full" />
+            </div>
+          </div>
+        </header>
+        <main className="mx-auto grid max-w-[1200px] grid-cols-1 gap-8 px-6 py-12 lg:grid-cols-[180px_1fr]">
+          <aside className="space-y-5">
+            {[0, 1, 2].map((item) => (
+              <div key={item} className="space-y-2">
+                <Skeleton className="h-3 w-16 rounded-[var(--radius-sm)]" />
+                <Skeleton className="h-5 w-28 rounded-[var(--radius-sm)]" />
+              </div>
+            ))}
+          </aside>
+          <article className="min-w-0">
+            <Skeleton className="h-3 w-32 rounded-[var(--radius-sm)]" />
+            <Skeleton className="mt-5 h-10 w-3/5 rounded-[var(--radius-md)]" />
+            <Skeleton className="mt-3 h-4 w-44 rounded-[var(--radius-sm)]" />
+            <div className="mt-10 space-y-4">
+              <Skeleton className="h-5 w-full rounded-[var(--radius-sm)]" />
+              <Skeleton className="h-5 w-11/12 rounded-[var(--radius-sm)]" />
+              <Skeleton className="h-5 w-4/5 rounded-[var(--radius-sm)]" />
+              <Skeleton className="mt-8 h-7 w-2/5 rounded-[var(--radius-md)]" />
+              <Skeleton className="h-5 w-full rounded-[var(--radius-sm)]" />
+              <Skeleton className="h-5 w-5/6 rounded-[var(--radius-sm)]" />
+            </div>
+          </article>
+        </main>
+      </div>
+    </LoadingState>
   );
 }
 

--- a/frontend/src/pages/settings/index.tsx
+++ b/frontend/src/pages/settings/index.tsx
@@ -23,6 +23,8 @@ import {
 } from "@/components/ui/tabs";
 import { PageHeader } from "@/components/ui/page-header";
 import { PageShell } from "@/components/ui/page-shell";
+import { LoadingState } from "@/components/ui/loading-state";
+import { Skeleton } from "@/components/ui/skeleton";
 import { RoleBadge } from "@/components/status-badge";
 import { cn } from "@/lib/utils";
 import { ProfileSection, type User } from "./profile-section";
@@ -147,7 +149,7 @@ export default function SettingsPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user, searchParams, users]);
 
-  if (!user) return null;
+  if (!user) return <SettingsPageLoading />;
 
   // Active tab synced to `?tab=` so Profile/Tokens/etc. are deep-linkable.
   // `admin` is only a valid value when the viewer is an admin — otherwise
@@ -174,14 +176,7 @@ export default function SettingsPage() {
 
   return (
     <PageShell
-      header={
-        <PageHeader
-          eyebrow="Personal workspace"
-          title="Account settings"
-          subtitle="Manage how you appear, how agents connect, and how AKB looks on this device."
-          className="mb-7"
-        />
-      }
+      header={<SettingsPageHeader />}
       contentWidth="full"
     >
       <Tabs
@@ -277,6 +272,75 @@ export default function SettingsPage() {
           )}
         </div>
       </Tabs>
+    </PageShell>
+  );
+}
+
+function SettingsPageHeader() {
+  return (
+    <PageHeader
+      eyebrow="Personal workspace"
+      title="Account settings"
+      subtitle="Manage how you appear, how agents connect, and how AKB looks on this device."
+      className="mb-7"
+    />
+  );
+}
+
+function SettingsPageLoading() {
+  return (
+    <PageShell header={<SettingsPageHeader />} contentWidth="full">
+      <LoadingState
+        label="Loading account settings"
+        className="grid items-start gap-5 lg:grid-cols-[16.5rem_minmax(0,1fr)] xl:gap-8 xl:grid-cols-[18rem_minmax(0,1fr)]"
+      >
+        <aside className="min-w-0 rounded-[var(--radius-md)] border border-border bg-surface p-4 shadow-xs xl:p-5">
+          <div className="border-b border-border pb-5">
+            <Skeleton className="h-3 w-16 rounded-[var(--radius-sm)]" />
+            <div className="mt-3 flex items-center gap-3">
+              <Skeleton className="h-11 w-11 shrink-0 rounded-full" />
+              <div className="min-w-0 flex-1 space-y-2">
+                <Skeleton className="h-4 w-3/4 rounded-[var(--radius-sm)]" />
+                <Skeleton className="h-3 w-1/2 rounded-[var(--radius-sm)]" />
+              </div>
+            </div>
+            <Skeleton className="mt-3 h-3 w-4/5 rounded-[var(--radius-sm)]" />
+          </div>
+          <div className="mt-4 space-y-2">
+            {[0, 1, 2].map((item) => (
+              <div key={item} className="flex items-center gap-3 rounded-[var(--radius-md)] px-3 py-2.5">
+                <Skeleton className="h-8 w-8 shrink-0 rounded-[var(--radius-md)]" />
+                <div className="min-w-0 flex-1 space-y-2">
+                  <Skeleton className="h-3.5 w-2/3 rounded-[var(--radius-sm)]" />
+                  <Skeleton className="h-3 w-4/5 rounded-[var(--radius-sm)]" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </aside>
+
+        <div className="min-w-0 space-y-6">
+          {[0, 1].map((section) => (
+            <section
+              key={section}
+              className="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-surface shadow-sm"
+            >
+              <div className="border-b border-border px-5 py-4 sm:px-6">
+                <Skeleton className="h-5 w-36 rounded-[var(--radius-sm)]" />
+                <Skeleton className="mt-2 h-3 w-2/3 rounded-[var(--radius-sm)]" />
+              </div>
+              <div className="grid gap-5 p-5 sm:grid-cols-2 sm:p-6">
+                {[0, 1, 2, 3].map((field) => (
+                  <div key={field} className="space-y-2">
+                    <Skeleton className="h-3 w-24 rounded-[var(--radius-sm)]" />
+                    <Skeleton className="h-10 w-full rounded-[var(--radius-md)]" />
+                  </div>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      </LoadingState>
     </PageShell>
   );
 }

--- a/frontend/src/pages/table.tsx
+++ b/frontend/src/pages/table.tsx
@@ -1,10 +1,38 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
-import { EmptyState } from "@/components/empty-state";
+import {
+  Asterisk,
+  Braces,
+  CalendarClock,
+  Columns3,
+  Database,
+  Fingerprint,
+  Hash,
+  Info,
+  KeyRound,
+  PanelRightClose,
+  PanelRightOpen,
+  Rows3,
+  Table2,
+  ToggleLeft,
+  Type,
+  X,
+} from "lucide-react";
+import {
+  ResourceCanvas,
+  ResourceContextBar,
+  ResourceViewerFrame,
+  ResourceWorkspace,
+  ResourceWorkspaceHeader,
+} from "@/components/resource-workspace";
 import { Alert } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { LoadingState } from "@/components/ui/loading-state";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TooltipText } from "@/components/ui/tooltip-text";
 import { authenticatedFetch } from "@/lib/api";
+import { cn } from "@/lib/utils";
 
 interface Column {
   name: string;
@@ -12,6 +40,7 @@ interface Column {
   required?: boolean;
   primary_key?: boolean;
 }
+
 interface TableInfo {
   name: string;
   description?: string;
@@ -22,200 +51,503 @@ interface TableInfo {
 export default function TablePage() {
   const { name: vault, table } = useParams<{ name: string; table: string }>();
   const [info, setInfo] = useState<TableInfo | null>(null);
-  const [rows, setRows] = useState<Record<string, any>[]>([]);
+  const [rows, setRows] = useState<Record<string, unknown>[]>([]);
   const [cols, setCols] = useState<string[]>([]);
   const [total, setTotal] = useState(0);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(true);
-  const [limit] = useState(50);
+  const [infoLoading, setInfoLoading] = useState(true);
+  const [schemaOpen, setSchemaOpen] = useState(false);
+  const schemaToggleRef = useRef<HTMLButtonElement | null>(null);
+  const schemaCloseRef = useRef<HTMLButtonElement | null>(null);
+  const limit = 50;
+
+  const closeSchema = useCallback(() => {
+    setSchemaOpen(false);
+    window.requestAnimationFrame(() => schemaToggleRef.current?.focus());
+  }, []);
 
   useEffect(() => {
     if (!vault || !table) return;
     let cancelled = false;
-    // Reset stale state from previous param before re-fetch resolves.
     setInfo(null);
     setRows([]);
     setCols([]);
     setTotal(0);
     setError("");
     setLoading(true);
+    setInfoLoading(true);
+
     authenticatedFetch(`/api/v1/tables/${encodeURIComponent(vault)}`)
-      .then((r) => (r.ok ? r.json().catch(() => null) : null))
-      .then((d) => {
-        if (cancelled || !d) return;
-        const found = (d.items || []).find((x: any) => x.name === table);
+      .then((response) => (response.ok ? response.json().catch(() => null) : null))
+      .then((data) => {
+        if (cancelled || !data) return;
+        const found = (data.items || []).find((item: TableInfo) => item.name === table);
         if (found) setInfo(found);
       })
-      .catch(() => {});
-    // Reference the table by its BARE short name so the backend akb_sql
-    // rewriter resolves it to the physical `vt_<vault>__<table>` relation
-    // (PG ACL still bounds visibility via SET LOCAL ROLE). A double-quoted
-    // identifier is intentionally NOT rewritten — the rewriter skips quoted
-    // spans so it can't corrupt string literals — so quoting here silently
-    // bypassed the mapping → "relation <table> does not exist". Table names are
-    // constrained to ^[a-z][a-z0-9_]*$, so a bare reference is always well-formed.
-    const ident = table || "";
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setInfoLoading(false);
+      });
+
+    // Table identifiers are restricted to ^[a-z][a-z0-9_]*$. Keep the bare
+    // name so the backend SQL rewriter maps it to the vault-scoped relation.
     authenticatedFetch(`/api/v1/tables/${encodeURIComponent(vault)}/sql`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ sql: `SELECT * FROM ${ident} LIMIT ${limit}` }),
+      body: JSON.stringify({ sql: `SELECT * FROM ${table} LIMIT ${limit}` }),
     })
-      .then((r) => r.json())
-      .then((d) => {
+      .then((response) => response.json())
+      .then((data) => {
         if (cancelled) return;
-        if (d.error || d.detail) {
-          setError(d.error || d.detail);
+        if (data.error || data.detail) {
+          setError(data.error || data.detail);
           return;
         }
-        setRows(d.items || []);
-        setCols(d.columns || []);
-        setTotal(d.total ?? d.items?.length ?? 0);
+        setRows(data.items || []);
+        setCols(data.columns || []);
+        setTotal(data.total ?? data.items?.length ?? 0);
       })
-      .catch((e) => !cancelled && setError(String(e)))
-      .finally(() => !cancelled && setLoading(false));
-    return () => { cancelled = true; };
-  }, [vault, table, limit]);
+      .catch((queryError) => {
+        if (!cancelled) setError(String(queryError));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [vault, table]);
+
+  useEffect(() => {
+    if (!schemaOpen) return;
+    const focusFrame = window.requestAnimationFrame(() => schemaCloseRef.current?.focus());
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      closeSchema();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.cancelAnimationFrame(focusFrame);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [closeSchema, schemaOpen]);
+
+  const columnByName = useMemo(
+    () => new Map((info?.columns || []).map((column) => [column.name, column])),
+    [info?.columns],
+  );
+
+  const rowCount = info?.row_count ?? total;
+  const columnCount = info?.columns?.length || cols.length;
+  const primaryKeyCount = info?.columns?.filter((column) => column.primary_key).length || 0;
+  const requiredCount =
+    info?.columns?.filter((column) => column.required || column.primary_key).length || 0;
+  const sampled = rowCount > rows.length;
+
+  if (loading || infoLoading) {
+    return <TablePageLoading />;
+  }
 
   return (
-    <div className="min-w-0 fade-up max-w-[1280px] mx-auto">
-      <div className="coord mb-3">
-        Vault · {vault} · Table · {table}
-      </div>
-
-      <header className="flex items-baseline justify-between flex-wrap gap-x-4 gap-y-2 pb-3 border-b border-border">
-        <h1 className="font-mono text-[28px] font-semibold tracking-tight text-foreground break-all min-w-0">
-          {table}
-        </h1>
-        <div className="flex items-center gap-4 coord tabular-nums shrink-0">
-          {info && (
-            <>
-              <span>
-                <span className="text-foreground font-medium">{info.row_count}</span> rows
+    <ResourceWorkspace label="Table workspace">
+      <ResourceWorkspaceHeader
+        icon={Table2}
+        iconTone="data"
+        title={table || "Table"}
+        subtitle={
+          <>
+            Table <span aria-hidden>·</span>{" "}
+            <span className="font-medium text-foreground">{vault}</span>
+          </>
+        }
+        meta={<Badge variant="outline">Read only</Badge>}
+        actions={
+          <>
+            <div className="mr-1 hidden items-center gap-3 text-xs text-foreground-muted xl:flex">
+              <span className="inline-flex items-center gap-1.5 whitespace-nowrap tabular-nums">
+                <Rows3 className="h-3.5 w-3.5" aria-hidden />
+                {rowCount} rows
               </span>
-              <span>
-                <span className="text-foreground font-medium">{info.columns?.length || 0}</span> cols
+              <span className="inline-flex items-center gap-1.5 whitespace-nowrap tabular-nums">
+                <Columns3 className="h-3.5 w-3.5" aria-hidden />
+                {columnCount} columns
               </span>
-            </>
-          )}
-          <span>Preview {limit}</span>
-        </div>
-      </header>
+            </div>
+            <Button
+              ref={schemaToggleRef}
+              type="button"
+              variant="outline"
+              size="sm"
+              aria-controls="table-schema-panel"
+              aria-expanded={schemaOpen}
+              onClick={() => (schemaOpen ? closeSchema() : setSchemaOpen(true))}
+            >
+              {schemaOpen ? (
+                <PanelRightClose className="h-4 w-4" aria-hidden />
+              ) : (
+                <PanelRightOpen className="h-4 w-4" aria-hidden />
+              )}
+              <span className="hidden sm:inline">Schema</span>
+            </Button>
+          </>
+        }
+      />
 
-      {info?.description && (
-        <p className="font-medium tracking-[-0.01em] text-[17px] leading-[1.55] text-foreground-muted mt-3">
-          {info.description}
-        </p>
-      )}
-
-      {/* Schema — compact inline list */}
-      {info?.columns && info.columns.length > 0 && (
-        <section className="mt-6" aria-labelledby="schema-heading">
-          <div className="flex items-baseline gap-3 mb-2">
-            <span id="schema-heading" className="coord-ink">Schema</span>
-            <span className="coord tabular-nums">[{info.columns.length}]</span>
-          </div>
-          <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs font-mono">
-            {info.columns.map((c) => (
-              <div key={c.name} className="flex items-baseline gap-1.5">
-                <span className="text-foreground font-medium">{c.name}</span>
-                <span className="text-foreground-muted">{(c.type || "text").toLowerCase()}</span>
-                {c.primary_key && <span className="coord-spark">PK</span>}
-                {c.required && !c.primary_key && (
-                  <span className="text-accent-strong" aria-label="required">*</span>
-                )}
-              </div>
-            ))}
-          </div>
-        </section>
-      )}
-
-      {error && (
-        <Alert variant="destructive" title="Query failed" className="mt-6">
-          <span className="font-mono">{error}</span>
-        </Alert>
-      )}
-
-      {/* Rows preview */}
-      <section className="mt-6" aria-labelledby="preview-heading">
-        <div className="flex items-baseline gap-3 mb-2">
-          <span id="preview-heading" className="coord-ink">Preview</span>
-          <span className="coord tabular-nums">
-            {total} row{total === 1 ? "" : "s"}
-            {info?.row_count && info.row_count > total ? ` of ${info.row_count}` : ""}
-          </span>
-        </div>
-
-        {loading ? (
-          <div className="space-y-2" role="status" aria-live="polite" aria-label="Loading rows">
-            <Skeleton className="h-8 w-full rounded-[var(--radius-sm)]" />
-            <Skeleton className="h-8 w-full rounded-[var(--radius-sm)]" />
-            <Skeleton className="h-8 w-full rounded-[var(--radius-sm)]" />
-          </div>
-        ) : rows.length === 0 && !error ? (
-          <EmptyState title="No rows" />
-        ) : (
-          <div
-            role="region"
-            aria-label={`Preview rows for ${table}`}
-            tabIndex={0}
-            className="rounded-[var(--radius-lg)] border border-border bg-surface overflow-hidden shadow-sm overflow-x-auto focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      <div className="relative min-h-0 flex-1 overflow-hidden">
+        <ResourceCanvas>
+          <ResourceContextBar
+            trailing={
+              <span className="inline-flex items-center gap-1.5 whitespace-nowrap tabular-nums">
+                <Rows3 className="h-3.5 w-3.5" aria-hidden />
+                {sampled ? `${rows.length} of ${rowCount}` : `${rows.length} rows`}
+              </span>
+            }
           >
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-border bg-surface-2">
-                  <th
-                    scope="col"
-                    className="px-3 py-2 text-left font-mono text-[10px] uppercase tracking-wider text-foreground-muted border-r border-border w-10"
-                  >
-                    #
-                  </th>
-                  {cols.map((c) => (
-                    <th
-                      key={c}
-                      scope="col"
-                      className="px-3 py-2 text-left font-mono text-[10px] tracking-wide text-foreground-muted border-r border-border last:border-r-0 whitespace-nowrap"
-                    >
-                      {c}
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border">
-                {rows.map((row, i) => (
-                  <tr key={i} className="hover:bg-surface-hover transition-colors">
-                    <td className="coord px-3 py-1.5 border-r border-border tabular-nums">
-                      {i + 1}
-                    </td>
-                    {cols.map((c) => (
-                      <TooltipText key={c} asChild tip={formatCell(row[c])}>
-                        <td
-                          className={`px-3 py-1.5 font-mono text-xs text-foreground border-r border-border last:border-r-0 whitespace-nowrap max-w-xs truncate ${typeof row[c] === "number" ? "tabular-nums" : ""}`}
-                        >
-                          {formatCell(row[c])}
-                        </td>
-                      </TooltipText>
-                    ))}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </section>
+            <div className="flex min-w-0 items-center gap-2 text-xs text-foreground-muted">
+              <Info className="h-3.5 w-3.5 shrink-0 text-link" aria-hidden />
+              <TooltipText
+                tip={info?.description || "A read-only sample of this Vault table."}
+                className="truncate"
+              >
+                {info?.description || "A read-only sample of this Vault table."}
+              </TooltipText>
+            </div>
+          </ResourceContextBar>
 
-      {total >= limit && info?.row_count && info.row_count > limit && (
-        <p className="coord mt-3">
-          Preview limited to {limit} rows · use <code className="font-mono text-foreground">akb_sql</code> via agent for full-range queries.
-        </p>
-      )}
+          <ResourceViewerFrame
+            icon={Database}
+            label="Data preview"
+            meta={
+              <>
+                <span className="tabular-nums">{cols.length} columns</span>
+                <span className="hidden sm:inline">
+                  {sampled ? `First ${limit} rows` : "Complete result"}
+                </span>
+              </>
+            }
+            bodyClassName="overflow-hidden"
+          >
+            {error ? (
+              <div className="p-4 sm:p-6">
+                <Alert variant="destructive" title="Query failed">
+                  <span className="font-mono">{error}</span>
+                </Alert>
+              </div>
+            ) : rows.length === 0 ? (
+              <div className="flex min-h-64 flex-col items-center justify-center px-6 py-12 text-center">
+                <Table2 className="h-9 w-9 text-foreground-muted" aria-hidden />
+                <h2 className="mt-4 text-sm font-semibold text-foreground">No rows yet</h2>
+                <p className="mt-1 max-w-sm text-sm text-foreground-muted">
+                  The schema is ready, but this table does not contain any records.
+                </p>
+              </div>
+            ) : (
+              <div
+                role="region"
+                aria-label={`Preview rows for ${table}`}
+                tabIndex={0}
+                className="h-full overflow-auto focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+              >
+                <table className="min-w-full border-separate border-spacing-0 text-sm">
+                  <thead>
+                    <tr>
+                      <th
+                        scope="col"
+                        className="sticky left-0 top-0 z-[var(--z-sticky)] w-12 border-b border-r border-border bg-surface-2 px-3 py-2.5 text-left text-xs font-medium text-foreground-muted"
+                      >
+                        #
+                      </th>
+                      {cols.map((columnName) => (
+                        <th
+                          key={columnName}
+                          scope="col"
+                          className="sticky top-0 z-[var(--z-raised)] min-w-36 border-b border-r border-border bg-surface-2 px-3 py-2.5 text-left last:border-r-0"
+                        >
+                          <span className="block whitespace-nowrap font-mono text-xs font-medium text-foreground">
+                            {columnName}
+                          </span>
+                          {columnByName.get(columnName)?.type && (
+                            <span className="mt-0.5 block whitespace-nowrap text-xs font-normal text-foreground-muted">
+                              {columnByName.get(columnName)?.type}
+                            </span>
+                          )}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {rows.map((row, rowIndex) => (
+                      <tr key={rowIndex} className="group transition-colors hover:bg-surface-hover">
+                        <td className="sticky left-0 z-[var(--z-raised)] border-b border-r border-border bg-surface px-3 py-2 text-xs text-foreground-muted tabular-nums group-hover:bg-surface-hover">
+                          {rowIndex + 1}
+                        </td>
+                        {cols.map((columnName) => {
+                          const value = row[columnName];
+                          return (
+                            <TooltipText key={columnName} asChild tip={formatCellFull(value)}>
+                              <td
+                                className={cn(
+                                  "max-w-md truncate whitespace-nowrap border-b border-r border-border px-3 py-2 text-foreground last:border-r-0",
+                                  typeof value === "number" && "text-right tabular-nums",
+                                  value !== null && typeof value === "object" && "font-mono text-xs",
+                                  value === null && "italic text-foreground-muted",
+                                )}
+                              >
+                                {formatCell(value)}
+                              </td>
+                            </TooltipText>
+                          );
+                        })}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </ResourceViewerFrame>
+        </ResourceCanvas>
+
+        {schemaOpen && (
+          <button
+            type="button"
+            aria-label="Close table schema"
+            onClick={closeSchema}
+            className="absolute inset-0 z-[var(--z-raised)] bg-black/40 lg:hidden"
+          />
+        )}
+        <aside
+          id="table-schema-panel"
+          aria-label="Table schema"
+          aria-hidden={!schemaOpen}
+          inert={!schemaOpen}
+          className={cn(
+            "absolute inset-y-0 right-0 z-[var(--z-overlay)] flex w-full max-w-xl flex-col overflow-hidden border-l border-border bg-surface shadow-xl transition-transform duration-[var(--duration-base)] ease-[var(--ease-out)] lg:w-[30rem]",
+            schemaOpen ? "translate-x-0" : "pointer-events-none translate-x-full",
+          )}
+        >
+          <div className="flex h-14 shrink-0 items-center justify-between border-b border-border px-4">
+            <div>
+              <h2 className="text-sm font-semibold text-foreground">Table schema</h2>
+              <p className="text-xs text-foreground-muted">Columns and constraints</p>
+            </div>
+            <Button
+              ref={schemaCloseRef}
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label="Close table schema"
+              onClick={closeSchema}
+            >
+              <X className="h-4 w-4" aria-hidden />
+            </Button>
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto p-4 rail-scroll">
+            {info?.columns?.length ? (
+              <>
+                <section aria-labelledby="schema-overview-title">
+                  <div className="mb-2 flex items-center justify-between gap-3">
+                    <h3 id="schema-overview-title" className="text-xs font-semibold text-foreground">
+                      At a glance
+                    </h3>
+                    <span className="max-w-48 truncate font-mono text-xs text-foreground-muted">
+                      {table}
+                    </span>
+                  </div>
+                  <dl className="grid grid-cols-3 overflow-hidden rounded-[var(--radius-md)] border border-border bg-surface-2/60">
+                    <SchemaStat value={columnCount} label="Columns" icon={Columns3} />
+                    <SchemaStat value={primaryKeyCount} label="Primary keys" icon={KeyRound} />
+                    <SchemaStat value={requiredCount} label="Required" icon={Asterisk} />
+                  </dl>
+                </section>
+
+                <section className="mt-5" aria-labelledby="schema-columns-title">
+                  <div className="mb-2 flex items-end justify-between gap-3">
+                    <div>
+                      <h3 id="schema-columns-title" className="text-xs font-semibold text-foreground">
+                        Column dictionary
+                      </h3>
+                      <p className="mt-0.5 text-xs text-foreground-muted">Stored order and constraints</p>
+                    </div>
+                    <span className="text-xs text-foreground-muted tabular-nums">
+                      {columnCount} total
+                    </span>
+                  </div>
+
+                  <div className="overflow-x-auto rounded-[var(--radius-md)] border border-border">
+                    <table className="w-full min-w-[26rem] table-fixed border-separate border-spacing-0 text-xs">
+                      <colgroup>
+                        <col className="w-10" />
+                        <col />
+                        <col className="w-28" />
+                        <col className="w-32" />
+                      </colgroup>
+                      <thead>
+                        <tr className="bg-surface-2 text-left text-foreground-muted">
+                          <th scope="col" className="border-b border-r border-border px-2 py-2 font-medium">
+                            #
+                          </th>
+                          <th scope="col" className="border-b border-r border-border px-3 py-2 font-medium">
+                            Column
+                          </th>
+                          <th scope="col" className="border-b border-r border-border px-3 py-2 font-medium">
+                            Data type
+                          </th>
+                          <th scope="col" className="border-b border-border px-3 py-2 font-medium">
+                            Constraints
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody className="[&>tr:last-child>*]:border-b-0">
+                        {info.columns.map((column, index) => (
+                          <SchemaColumn key={column.name} column={column} index={index} />
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </section>
+              </>
+            ) : (
+              <Alert variant="info" title="Schema unavailable">
+                Column metadata was not included in the table catalog response.
+              </Alert>
+            )}
+          </div>
+        </aside>
+      </div>
+    </ResourceWorkspace>
+  );
+}
+
+function SchemaStat({
+  value,
+  label,
+  icon: Icon,
+}: {
+  value: number;
+  label: string;
+  icon: typeof Columns3;
+}) {
+  return (
+    <div className="border-r border-border px-3 py-3 last:border-r-0">
+      <dt className="flex items-center gap-1.5 text-xs text-foreground-muted">
+        <Icon className="h-3.5 w-3.5" aria-hidden />
+        <span className="truncate">{label}</span>
+      </dt>
+      <dd className="mt-1 text-lg font-semibold leading-none text-foreground tabular-nums">{value}</dd>
     </div>
   );
 }
 
-function formatCell(v: any): string {
-  if (v === null || v === undefined) return "—";
-  if (typeof v === "number" && !Number.isFinite(v)) return "—";
-  if (typeof v === "object") return JSON.stringify(v);
-  const s = String(v);
-  return s.length > 80 ? s.slice(0, 80) + "…" : s;
+function SchemaColumn({ column, index }: { column: Column; index: number }) {
+  const dataType = column.type || "text";
+  const TypeIcon = columnTypeIcon(dataType);
+  const isRequired = column.required || column.primary_key;
+
+  return (
+    <tr
+      className={cn(
+        "align-top text-foreground",
+        column.primary_key && "bg-surface-selected",
+      )}
+    >
+      <td className="border-b border-r border-border px-2 py-3 text-right text-foreground-muted tabular-nums">
+        {index + 1}
+      </td>
+      <th
+        scope="row"
+        className="border-b border-r border-border px-3 py-3 text-left font-normal"
+      >
+        <code className="block break-all font-mono text-xs font-semibold text-foreground">
+          {column.name}
+        </code>
+      </th>
+      <td className="border-b border-r border-border px-3 py-2.5">
+        <span className="inline-flex h-7 max-w-full items-center gap-1.5 rounded-[var(--radius-sm)] border border-border bg-surface px-2 text-foreground">
+          <TypeIcon className="h-3.5 w-3.5 shrink-0 text-foreground-muted" aria-hidden />
+          <span className="truncate font-mono" title={dataType}>
+            {dataType}
+          </span>
+        </span>
+      </td>
+      <td className="border-b border-border px-3 py-2.5">
+        <div className="flex flex-col items-start gap-1.5 text-foreground-muted">
+          {column.primary_key && (
+            <span className="inline-flex items-center gap-1 font-medium text-link">
+              <KeyRound className="h-3 w-3" aria-hidden />
+              Primary key
+            </span>
+          )}
+          <span className="inline-flex items-center gap-1">
+            {isRequired ? (
+              <Asterisk className="h-3 w-3" aria-hidden />
+            ) : (
+              <span className="h-2 w-2 rounded-full border border-border-strong" aria-hidden />
+            )}
+            {isRequired ? "Required" : "Nullable"}
+          </span>
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+function columnTypeIcon(type: string) {
+  const normalized = type.toLowerCase();
+  if (/bool/.test(normalized)) return ToggleLeft;
+  if (/date|time/.test(normalized)) return CalendarClock;
+  if (/int|decimal|numeric|float|double|real|serial/.test(normalized)) return Hash;
+  if (/json|array|map|struct/.test(normalized)) return Braces;
+  if (/uuid/.test(normalized)) return Fingerprint;
+  return Type;
+}
+
+function TablePageLoading() {
+  return (
+    <LoadingState
+      label="Loading rows"
+      className="flex h-full min-h-0 flex-col overflow-hidden bg-background"
+    >
+      <div className="flex h-full min-h-0 flex-col overflow-hidden">
+        <header className="flex h-16 shrink-0 items-center gap-3 border-b border-border bg-surface px-3 sm:px-4 lg:px-5">
+          <Skeleton className="hidden h-9 w-9 shrink-0 rounded-[var(--radius-md)] sm:block" />
+          <div className="min-w-0 flex-1 space-y-2">
+            <Skeleton className="h-5 w-2/3 max-w-48 rounded-[var(--radius-sm)]" />
+            <Skeleton className="h-3 w-1/2 max-w-36 rounded-[var(--radius-sm)]" />
+          </div>
+          <Skeleton className="h-8 w-20 rounded-[var(--radius-md)]" />
+        </header>
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden p-2 sm:p-3">
+          <Skeleton className="mb-3 h-11 w-full shrink-0 rounded-[var(--radius-lg)]" />
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-[var(--radius-lg)] border border-border bg-surface">
+            <div className="flex h-11 shrink-0 items-center gap-3 border-b border-border bg-surface-2/60 px-3">
+              <Skeleton className="h-4 w-28 rounded-[var(--radius-sm)]" />
+              <Skeleton className="ml-auto h-3 w-24 rounded-[var(--radius-sm)]" />
+            </div>
+            <div className="min-h-0 flex-1 space-y-2 p-3">
+              <Skeleton className="h-11 w-full rounded-[var(--radius-sm)]" />
+              <Skeleton className="h-10 w-full rounded-[var(--radius-sm)]" />
+              <Skeleton className="h-10 w-full rounded-[var(--radius-sm)]" />
+              <Skeleton className="h-10 w-full rounded-[var(--radius-sm)]" />
+              <Skeleton className="h-10 w-full rounded-[var(--radius-sm)]" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </LoadingState>
+  );
+}
+
+function formatCellFull(value: unknown): string {
+  if (value === null || value === undefined) return "null";
+  if (typeof value === "number" && !Number.isFinite(value)) return "—";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+function formatCell(value: unknown): string {
+  const full = formatCellFull(value);
+  return full.length > 120 ? `${full.slice(0, 120)}…` : full;
 }

--- a/frontend/src/pages/vault-activity.tsx
+++ b/frontend/src/pages/vault-activity.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import {
   AlertCircle,
@@ -12,11 +12,13 @@ import {
 } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
+import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Panel } from "@/components/ui/panel";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { Skeleton } from "@/components/ui/skeleton";
+import { InlineLoadingState, LoadingState } from "@/components/ui/loading-state";
 import { TooltipText } from "@/components/ui/tooltip-text";
 import { TonalIcon, type TonalIconTone } from "@/components/ui/tonal-icon";
 import { useDebounce } from "@/hooks/use-debounce";
@@ -30,14 +32,20 @@ export default function VaultActivityPage() {
   const debouncedAuthor = useDebounce(author.trim(), 250);
   const [entries, setEntries] = useState<ActivityEntry[] | null>(null);
   const [quickAuthors, setQuickAuthors] = useState<Array<[string, number]>>([]);
+  const [appliedAuthor, setAppliedAuthor] = useState("");
   const [total, setTotal] = useState(0);
   const [error, setError] = useState("");
+  const [refreshing, setRefreshing] = useState(false);
+  const loadedVaultRef = useRef<string | null>(null);
+  const hasEntriesRef = useRef(false);
   const [retryKey, setRetryKey] = useState(0);
 
   useEffect(() => {
     if (!name) return;
     let active = true;
-    setEntries(null);
+    const canPreserve = loadedVaultRef.current === name && hasEntriesRef.current;
+    if (!canPreserve) setEntries(null);
+    setRefreshing(canPreserve);
     setError("");
 
     getVaultActivity(name, {
@@ -47,14 +55,20 @@ export default function VaultActivityPage() {
       .then((result) => {
         if (!active) return;
         const activity = result.activity || [];
+        loadedVaultRef.current = name;
+        hasEntriesRef.current = true;
         setEntries(activity);
         setTotal(result.total ?? activity.length);
+        setAppliedAuthor(debouncedAuthor);
         if (!debouncedAuthor) setQuickAuthors(topActivityAuthors(activity));
       })
       .catch((caught: unknown) => {
         if (!active) return;
         setError(errorMessage(caught, "Failed to load activity"));
-        setEntries(null);
+        if (!canPreserve) setEntries(null);
+      })
+      .finally(() => {
+        if (active) setRefreshing(false);
       });
 
     return () => {
@@ -80,7 +94,7 @@ export default function VaultActivityPage() {
         Activity
       </h1>
 
-      <Panel variant="workspace" className="w-full">
+      <Panel variant="workspace" className="w-full" aria-busy={entries === null || refreshing || undefined}>
         <section aria-labelledby="activity-heading">
           <div
             data-testid="activity-ledger-header"
@@ -104,12 +118,15 @@ export default function VaultActivityPage() {
                     ? error
                       ? "Unavailable"
                       : "Loading changes…"
-                    : debouncedAuthor
-                      ? `Changes by ${debouncedAuthor}`
+                    : refreshing
+                      ? "Updating changes…"
+                    : appliedAuthor
+                      ? `Changes by ${appliedAuthor}`
                       : `Latest commits in ${name}`}
                 </span>
               </div>
             </div>
+            {refreshing && <InlineLoadingState label="Refreshing activity" size="sm" className="shrink-0" />}
             {count > 0 && (
               <Button asChild variant="ghost" size="sm" className="shrink-0">
                 <Link to={`/vault/${name}`}>
@@ -132,7 +149,15 @@ export default function VaultActivityPage() {
             />
           )}
 
-          {error ? (
+          {error && entries !== null && (
+            <div className="border-b border-border bg-surface px-4 py-3 sm:px-5">
+              <Alert variant="destructive" title="Activity could not be refreshed">
+                {error}
+              </Alert>
+            </div>
+          )}
+
+          {error && entries === null ? (
             <ActivityError
               error={error}
               onRetry={() => setRetryKey((current) => current + 1)}
@@ -434,7 +459,7 @@ function ActivityError({
 
 function ActivitySkeleton() {
   return (
-    <div role="status" aria-live="polite" aria-label="Loading activity">
+    <LoadingState label="Loading activity">
       {[0, 1, 2, 3].map((index) => (
         <div
           key={index}
@@ -450,8 +475,7 @@ function ActivitySkeleton() {
           <Skeleton className="h-3 w-24 rounded-[var(--radius-sm)]" />
         </div>
       ))}
-      <span className="sr-only">Loading activity…</span>
-    </div>
+    </LoadingState>
   );
 }
 

--- a/frontend/src/stories/pages-vault-admin.stories.tsx
+++ b/frontend/src/stories/pages-vault-admin.stories.tsx
@@ -46,7 +46,11 @@ const adminShellHandlers = [
 async function expectVaultShell(canvasElement: HTMLElement) {
   const canvas = within(canvasElement);
   await expect(await canvas.findByRole("navigation", { name: "Vaults" })).toBeInTheDocument();
-  await expect(await canvas.findByRole("tree", { name: "akb explorer" })).toBeInTheDocument();
+  // Operational Vault routes intentionally start with Collections folded so
+  // their ledger/form owns the working width. The reveal control is the stable
+  // shell contract for Publications, Activity, Members, and Settings.
+  await expect(await canvas.findByRole("button", { name: "Show collection tree" })).toBeInTheDocument();
+  await expect(canvas.queryByRole("tree", { name: "akb explorer" })).not.toBeInTheDocument();
 }
 
 export const PublicationsList: Story = {
@@ -107,7 +111,9 @@ export const PublicationsLoading: Story = {
   render: () => <AkbRouteTree />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(await canvas.findByText("Loading…")).toBeInTheDocument();
+    await expect(
+      await canvas.findByRole("status", { name: "Loading published links" }),
+    ).toBeInTheDocument();
     await expectVaultShell(canvasElement);
   },
 };
@@ -400,7 +406,9 @@ export const ActivityLoading: Story = {
   render: () => <AkbRouteTree />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(await canvas.findByText("Loading activity…")).toBeInTheDocument();
+    await expect(
+      await canvas.findByRole("status", { name: "Loading activity" }),
+    ).toBeInTheDocument();
     await expectVaultShell(canvasElement);
   },
 };

--- a/frontend/src/stories/pages-vault-resources.stories.tsx
+++ b/frontend/src/stories/pages-vault-resources.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, within } from "storybook/test";
+import { expect, userEvent, within } from "storybook/test";
 import { delay, http, HttpResponse } from "msw";
 import {
   API,
@@ -31,6 +31,19 @@ const resourceShellHandlers = [
   defaultVaultInfoHandler,
   http.get("/health/vault/akb", () => HttpResponse.json(vaultHealth)),
 ];
+
+const storyFilePreviewUrl = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(`
+  <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="720" viewBox="0 0 1200 720">
+    <rect width="1200" height="720" fill="#edf5f7"/>
+    <rect x="96" y="88" width="1008" height="544" rx="28" fill="#ffffff" stroke="#c8ced6" stroke-width="4"/>
+    <rect x="140" y="136" width="920" height="72" rx="14" fill="#004059"/>
+    <rect x="140" y="248" width="312" height="304" rx="18" fill="#e0eef2"/>
+    <rect x="488" y="248" width="572" height="44" rx="12" fill="#dfe3e8"/>
+    <rect x="488" y="320" width="492" height="28" rx="10" fill="#ebeef2"/>
+    <rect x="488" y="372" width="536" height="28" rx="10" fill="#ebeef2"/>
+    <rect x="488" y="448" width="196" height="56" rx="14" fill="#c44a1e"/>
+  </svg>
+`)}`;
 
 async function expectVaultShell(canvasElement: HTMLElement) {
   const canvas = within(canvasElement);
@@ -123,6 +136,18 @@ export const TablePreview: Story = {
     const canvas = within(canvasElement);
     await expect(await canvas.findByRole("heading", { name: "releases" })).toBeInTheDocument();
     await expect(await canvas.findByText("0.6.0")).toBeInTheDocument();
+    await userEvent.click(canvas.getByRole("button", { name: "Schema" }));
+    const schema = canvas.getByRole("complementary", { name: "Table schema" });
+    const schemaCanvas = within(schema);
+    await expect(schema).toBeVisible();
+    await expect(schemaCanvas.getByRole("table")).toBeVisible();
+    await expect(schemaCanvas.getByRole("columnheader", { name: "Column" })).toBeVisible();
+    await expect(schemaCanvas.getByRole("columnheader", { name: "Data type" })).toBeVisible();
+    await expect(schemaCanvas.getByRole("columnheader", { name: "Constraints" })).toBeVisible();
+    await expect(schemaCanvas.getByText("Primary key")).toBeInTheDocument();
+    await userEvent.keyboard("{Escape}");
+    await expect(canvas.queryByRole("complementary", { name: "Table schema" })).not.toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Schema" })).toHaveFocus();
     await expectVaultShell(canvasElement);
   },
 };
@@ -146,7 +171,7 @@ export const TableEmpty: Story = {
   render: () => <AkbRouteTree />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(await canvas.findByText("No rows")).toBeInTheDocument();
+    await expect(await canvas.findByText("No rows yet")).toBeInTheDocument();
     await expectVaultShell(canvasElement);
   },
 };
@@ -205,7 +230,11 @@ export const FileReady: Story = {
         ...resourceShellHandlers,
         http.get(`${API}/files/akb`, () => HttpResponse.json({ items: storyFiles })),
         http.get(`${API}/files/akb/f-storybook/download`, () =>
-          HttpResponse.json({ download_url: "https://files.example.test/storybook.png" }),
+          HttpResponse.json({
+            download_url: storyFilePreviewUrl,
+            mime_type: "image/png",
+            size_bytes: 184320,
+          }),
         ),
       ],
     },
@@ -214,7 +243,8 @@ export const FileReady: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(await canvas.findByRole("heading", { name: "storybook.png" })).toBeInTheDocument();
-    await expect(await canvas.findByText("Inline preview pending")).toBeInTheDocument();
+    await expect(await canvas.findByRole("img", { name: "storybook.png" })).toBeInTheDocument();
+    await expect(canvas.queryByRole("button", { name: "Schema" })).not.toBeInTheDocument();
     await expectVaultShell(canvasElement);
   },
 };


### PR DESCRIPTION
## Summary
- standardize route-level loading states across authentication, administration, settings, activity, and Vault surfaces
- redesign file and table viewers around the document workspace layout, including inline file previews and a semantic table schema inspector
- improve responsive navigation, focus handling, empty/error states, and Storybook coverage

## Validation
- `npm run design:check`
- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings only)
- `npm run test` (628 tests)
- `npm run build`
- targeted Table/File Storybook interaction scenarios

## Notes
- no backend or deployment manifest changes
- no Kubernetes changes are part of this PR