### PR TITLE
feat: surface collection context in browse and search

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3572
+        "line_number": 3580
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5400,5 +5400,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-26T05:02:09Z"
+  "generated_at": "2026-08-27T05:00:52Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -7,6 +7,14 @@ specifically; the proxy has its own log in
 
 ## Unreleased
 
+### Added collection intent to browse and search responses
+
+`akb_browse` now returns metadata for its current vault or collection root,
+and keeps collection summaries in the default slim response. Search results
+now include their parent collection summary and vault description. These
+fields are hydrated from the catalog after retrieval, so they add context
+without creating collection index records or affecting ranking.
+
 ### Fixed repeated production-scale BM25 rebuilds and bounded rebuild memory
 
 The BM25 refresher no longer compares all non-null chunks with the smaller set

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -210,12 +210,29 @@ class BrowseItem(BaseModel):
     version: str | None = None
 
 
+class BrowseContext(BaseModel):
+    """Metadata for the browse root itself.
+
+    Collection summaries describe why a collection exists; they are context
+    for the resources beneath it, not searchable resources of their own.
+    Vault descriptions serve the same purpose at the vault root.
+    """
+
+    type: Literal["vault", "collection"]
+    uri: str
+    name: str
+    path: str
+    summary: str | None = None
+    description: str | None = None
+
+
 class BrowseResponse(BaseModel):
     """Response for akb_browse."""
 
     kind: Literal["document"] = "document"
     vault: str
     path: str
+    context: BrowseContext | None = None
     items: list[BrowseItem]
     hint: str | None = None
 
@@ -234,6 +251,8 @@ class SearchResult(BaseModel):
     path: str
     title: str
     collection: str | None = None                     # containing collection (null at vault root)
+    collection_summary: str | None = None             # parent collection intent; not part of search scoring
+    vault_description: str | None = None              # containing vault intent; not part of search scoring
     doc_type: str | None = None
     summary: str | None = None
     tags: list[str] = Field(default_factory=list)

--- a/backend/app/repositories/document_repo.py
+++ b/backend/app/repositories/document_repo.py
@@ -843,6 +843,19 @@ class CollectionRepository:
             )
             return [dict(r) for r in rows]
 
+    async def get_by_path(self, vault_id: uuid.UUID, path: str) -> dict | None:
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT path, name, summary, doc_count, last_updated
+                  FROM collections
+                 WHERE vault_id = $1 AND path = $2
+                """,
+                vault_id,
+                path,
+            )
+            return dict(row) if row else None
+
     async def increment_count(self, collection_id: uuid.UUID, now: datetime, conn=None) -> None:
         sql = "UPDATE collections SET doc_count = doc_count + 1, last_updated = $1 WHERE id = $2"
         if conn is not None:

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -115,6 +115,7 @@ from app.db.postgres import get_pool
 from app.exceptions import AKBError, ConflictError, NotFoundError, ValidationError, WriteBusyError
 from app.models.document import (
     DOC_STATUSES,
+    BrowseContext,
     BrowseItem,
     BrowseResponse,
     DocumentPutRequest,
@@ -147,7 +148,7 @@ from app.services.kg_service import (
 )
 from app.services.resource_hash import HASH_ALGORITHM, compute_text_content_hash
 from app.services.role_sync import get_role_sync
-from app.services.uri_service import coll_uri, doc_uri, file_uri, table_uri
+from app.services.uri_service import coll_uri, doc_uri, file_uri, table_uri, vault_uri
 from app.services.user_directory import resolve_display_names
 from app.services.write_lane import run_compensation, run_git_write, write_lane
 from app.repositories import table_data_repo
@@ -1743,11 +1744,30 @@ class DocumentService:
         """
         vault_repo, doc_repo, coll_repo = await self._repos()
 
-        vault_id = await vault_repo.get_id_by_name(vault)
         browse_path = collection or ""
+        vault_row = await vault_repo.get_by_name(vault)
 
-        if not vault_id:
+        if not vault_row:
             return BrowseResponse(vault=vault, path=browse_path, items=[])
+        vault_id = vault_row["id"]
+
+        if collection:
+            collection_row = await coll_repo.get_by_path(vault_id, collection)
+            context = BrowseContext(
+                type="collection",
+                uri=coll_uri(vault, collection),
+                name=(collection_row or {}).get("name") or collection.rsplit("/", 1)[-1],
+                path=collection,
+                summary=(collection_row or {}).get("summary"),
+            )
+        else:
+            context = BrowseContext(
+                type="vault",
+                uri=vault_uri(vault),
+                name=vault,
+                path="",
+                description=vault_row.get("description"),
+            )
 
         show_docs = content_type in ("all", "documents")
         show_tables = content_type in ("all", "tables")
@@ -1779,7 +1799,13 @@ class DocumentService:
             ))
 
         hint = self._browse_hint(vault, collection, items)
-        return BrowseResponse(vault=vault, path=browse_path, items=items, hint=hint)
+        return BrowseResponse(
+            vault=vault,
+            path=browse_path,
+            context=context,
+            items=items,
+            hint=hint,
+        )
 
     async def _browse_collections(self, coll_repo, vault: str, vault_id, prefix: str) -> list[BrowseItem]:
         """Emit collection rows. With ``prefix`` empty, emits every

--- a/backend/app/services/native_document_service.py
+++ b/backend/app/services/native_document_service.py
@@ -19,6 +19,7 @@ from app.db.postgres import get_pool
 from app.exceptions import AKBError, ConflictError, NotFoundError, ValidationError
 from app.models.document import (
     DOC_STATUSES,
+    BrowseContext,
     BrowseItem,
     BrowseResponse,
     DocumentPutRequest,
@@ -52,7 +53,7 @@ from app.services.native_revision_service import (
 )
 from app.services.resource_hash import HASH_ALGORITHM
 from app.services.role_sync import get_role_sync
-from app.services.uri_service import coll_uri, doc_uri, file_uri, table_uri
+from app.services.uri_service import coll_uri, doc_uri, file_uri, table_uri, vault_uri
 from app.util.text import (
     doc_path,
     like_escape,
@@ -986,15 +987,36 @@ class NativeDocumentService(DocumentService):
     ) -> BrowseResponse:
         """Return the legacy browse envelope with Native document Heads."""
         prefix = normalize_collection_path(collection) if collection is not None else ""
-        vault_id = await self._vault_id(vault)
+        pool = await self._pool()
+        vault_row = await VaultRepository(pool).get_by_name(vault)
+        if vault_row is None:
+            raise NotFoundError("Vault", vault)
+        vault_id = vault_row["id"]
+        collection_repo = CollectionRepository(pool)
+        if prefix:
+            collection_row = await collection_repo.get_by_path(vault_id, prefix)
+            context = BrowseContext(
+                type="collection",
+                uri=coll_uri(vault, prefix),
+                name=(collection_row or {}).get("name") or prefix.rsplit("/", 1)[-1],
+                path=prefix,
+                summary=(collection_row or {}).get("summary"),
+            )
+        else:
+            context = BrowseContext(
+                type="vault",
+                uri=vault_uri(vault),
+                name=vault,
+                path="",
+                description=vault_row.get("description"),
+            )
         show_docs = content_type in ("all", "documents")
         show_tables = content_type in ("all", "tables")
         show_files = content_type in ("all", "files")
 
         items: list[BrowseItem] = []
         if show_docs:
-            pool = await self._pool()
-            for row in await CollectionRepository(pool).list_by_vault(vault_id):
+            for row in await collection_repo.list_by_vault(vault_id):
                 if prefix and not row["path"].startswith(prefix + "/"):
                     continue
                 items.append(
@@ -1037,7 +1059,13 @@ class NativeDocumentService(DocumentService):
 
         browse_path = prefix
         hint = self._browse_hint(vault, prefix or None, items)
-        return BrowseResponse(vault=vault, path=browse_path, items=items, hint=hint)
+        return BrowseResponse(
+            vault=vault,
+            path=browse_path,
+            context=context,
+            items=items,
+            hint=hint,
+        )
 
     async def create_vault(
         self,

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -927,6 +927,46 @@ class SearchService:
                         "collection": r["collection"],
                     }
 
+            # Parent descriptions are response context only. Fetch them from
+            # the source-of-truth catalog after hit selection so they do not
+            # create vector points or influence retrieval/rerank scores.
+            vault_names = sorted({m["vault"] for m in meta.values()})
+            collection_paths = sorted({
+                m["collection"] for m in meta.values() if m.get("collection")
+            })
+            if vault_names:
+                rows = await conn.fetch(
+                    """
+                    SELECT v.name AS vault_name,
+                           v.description AS vault_description,
+                           c.path AS collection_path,
+                           c.summary AS collection_summary
+                      FROM vaults v
+                      LEFT JOIN collections c
+                        ON c.vault_id = v.id
+                       AND c.path = ANY($2::text[])
+                     WHERE v.name = ANY($1::text[])
+                    """,
+                    vault_names,
+                    collection_paths,
+                )
+                vault_descriptions: dict[str, str | None] = {}
+                collection_summaries: dict[tuple[str, str], str | None] = {}
+                for row in rows:
+                    vault_descriptions[row["vault_name"]] = row["vault_description"]
+                    if row["collection_path"] is not None:
+                        collection_summaries[(row["vault_name"], row["collection_path"])] = row[
+                            "collection_summary"
+                        ]
+                for item in meta.values():
+                    item["vault_description"] = vault_descriptions.get(item["vault"])
+                    collection_path = item.get("collection")
+                    item["collection_summary"] = (
+                        collection_summaries.get((item["vault"], collection_path))
+                        if collection_path
+                        else None
+                    )
+
         from app.services.uri_service import doc_uri, table_uri, file_uri
 
         results: list[SearchResult] = []
@@ -952,6 +992,8 @@ class SearchService:
                     uri=uri,
                     vault=m["vault"], path=m["path"], title=m["title"],
                     collection=m.get("collection"),
+                    collection_summary=m.get("collection_summary"),
+                    vault_description=m.get("vault_description"),
                     doc_type=m["doc_type"], summary=m["summary"],
                     tags=m["tags"], score=h.score,
                     matched_section=(strip_chunk_metadata_header(h.content) or "")[:500] or None,

--- a/backend/mcp_server/response_projection.py
+++ b/backend/mcp_server/response_projection.py
@@ -1,0 +1,20 @@
+"""Pure response-shaping helpers for MCP tool envelopes."""
+
+from __future__ import annotations
+
+from app.models.document import BrowseResponse
+
+
+def browse_payload(result: BrowseResponse, *, include_summary: bool) -> dict:
+    """Keep navigation context while bounding large resource summaries.
+
+    Collection summaries are small, first-class navigation context and stay
+    visible by default. Document, table, and file summaries retain the
+    historical opt-in behavior to avoid inflating large browse responses.
+    """
+    payload = result.model_dump()
+    if not include_summary:
+        for item in payload.get("items") or []:
+            if item.get("type") != "collection":
+                item.pop("summary", None)
+    return payload

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -66,6 +66,7 @@ from app.models.document import DocumentPutRequest, DocumentUpdateRequest
 from app.repositories.document_repo import DocumentRepository
 
 from mcp_server.tools import TOOLS
+from mcp_server.response_projection import browse_payload
 from mcp_server.help import _resolve_help
 from mcp_server.instructions import INSTRUCTIONS
 from mcp_server.vault_contract import project_accessible_vault
@@ -732,9 +733,9 @@ async def _handle_delete(args: dict, uid: str, user: _MCPUser) -> dict:
 
 @_h("akb_browse")
 async def _handle_browse(args: dict, uid: str, user: _MCPUser) -> dict:
-    # `summary` is dropped from items by default — it's the largest
-    # field on `BrowseItem` and dominates payload size on
-    # collection-heavy vaults. Opt in with `include_summary=true`.
+    # Resource summaries are dropped by default because they dominate large
+    # browse payloads. Collection summaries remain: they explain the intent
+    # of the navigation target and are not independently indexed.
     #
     # Browse target may be specified two ways: legacy (`vault` +
     # optional `collection`) or canonical (`uri` — vault root or
@@ -764,9 +765,7 @@ async def _handle_browse(args: dict, uid: str, user: _MCPUser) -> dict:
         include_archived=args.get("include_archived", False),
     )
     include_summary = args.get("include_summary")
-    payload = result.model_dump(
-        exclude={"items": {"__all__": {"summary"}}} if not include_summary else None
-    )
+    payload = browse_payload(result, include_summary=bool(include_summary))
 
     needle = _filter_arg(args)
     if needle:

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -300,9 +300,11 @@ TOOLS = [
             "0 = direct children only (no descent), N = descend N collection levels, "
             "-1 = entire subtree. Collection rows are always emitted as navigation "
             "aids regardless of depth.\n\n"
-            "Response is slim by default (no `summary` field) so large vaults "
-            "(70+ collections) fit in the agent's context window. Returns "
-            "{vault, path, items, total, returned, truncated?, hint?}."
+            "The response includes metadata for the current browse root in `context`, "
+            "and collection items include `summary` by default so agents understand "
+            "their intended purpose. Other resource summaries stay opt-in so large "
+            "vaults fit in the agent's context window. Returns "
+            "{vault, path, context, items, total, returned, truncated?, hint?}."
         ),
         inputSchema={
             "type": "object",
@@ -346,7 +348,13 @@ TOOLS = [
                 "filter": {"type": "string", "description": "Substring filter on item name/path (case-insensitive)."},
                 "limit": {"type": "integer", "description": "Cap returned item count."},
                 "offset": {"type": "integer", "description": "Skip first N items (default 0)."},
-                "include_summary": {"type": "boolean", "description": "Include the per-item summary field (default false, drops to keep payload small)."},
+                "include_summary": {
+                    "type": "boolean",
+                    "description": (
+                        "Include document, table, and file summaries. Collection "
+                        "summaries and browse-root context are always included."
+                    ),
+                },
                 "include_hashes": {
                     "type": "boolean",
                     "description": (
@@ -372,7 +380,9 @@ TOOLS = [
             "BM25 sparse (keyword) via Reciprocal Rank Fusion. Handles both natural-language "
             "questions and short keyword queries well. For exact string / regex matches "
             "(code, URLs, version numbers) prefer akb_grep. Returns each hit's `uri`; "
-            "use akb_drill_down or akb_get with that URI for full content. "
+            "`collection_summary` and `vault_description` describe the hit's parent "
+            "context but do not affect matching or ranking. "
+            "Use akb_drill_down or akb_get with that URI for full content. "
             "Response reports `returned` (in `results`) and `total_matches` (size of the "
             "deduped prefetch pool — NOT a corpus-wide hit count; vector ANN is top-K only). "
             "When `truncated=true` the prefetch pool was capped, meaning the corpus may hold "

--- a/backend/tests/concurrency/test_native_ledger_b_core.py
+++ b/backend/tests/concurrency/test_native_ledger_b_core.py
@@ -3198,8 +3198,9 @@ async def test_native_browse_uses_native_heads_for_collection_root_and_depth():
             vault = await conn.fetchval("SELECT name FROM vaults WHERE id = $1", vault_id)
             await conn.execute(
                 """
-                INSERT INTO collections (vault_id, path, name)
-                VALUES ($1, 'guides', 'guides'), ($1, 'guides/nested', 'nested')
+                INSERT INTO collections (vault_id, path, name, summary)
+                VALUES ($1, 'guides', 'guides', 'Guides for operators'),
+                       ($1, 'guides/nested', 'nested', 'Detailed guides')
                 """,
                 vault_id,
             )
@@ -3240,6 +3241,9 @@ async def test_native_browse_uses_native_heads_for_collection_root_and_depth():
         )
 
         root = await service.browse(vault, depth=0)
+        assert root.context is not None
+        assert root.context.type == "vault"
+        assert root.context.uri == f"akb://{vault}"
         assert {item.path for item in root.items if item.type == "document"} == {"root.md"}
         assert {item.path for item in root.items if item.type == "collection"} == {
             "guides",
@@ -3247,6 +3251,11 @@ async def test_native_browse_uses_native_heads_for_collection_root_and_depth():
         }
 
         collection_root = await service.browse(vault, collection="guides", depth=0)
+        assert collection_root.context is not None
+        assert collection_root.context.type == "collection"
+        assert collection_root.context.name == "guides"
+        assert collection_root.context.path == "guides"
+        assert collection_root.context.summary == "Guides for operators"
         assert {item.path for item in collection_root.items if item.type == "document"} == {
             "guides/direct.md",
         }

--- a/backend/tests/test_browse_context_unit.py
+++ b/backend/tests/test_browse_context_unit.py
@@ -1,0 +1,58 @@
+from app.models.document import BrowseContext, BrowseItem, BrowseResponse
+from mcp_server.response_projection import browse_payload
+
+
+def _response() -> BrowseResponse:
+    return BrowseResponse(
+        vault="reef-akb",
+        path="research",
+        context=BrowseContext(
+            type="collection",
+            uri="akb://reef-akb/coll/research",
+            name="research",
+            path="research",
+            summary="Technical comparisons and AKB recommendations",
+        ),
+        items=[
+            BrowseItem(
+                name="designs",
+                path="research/designs",
+                type="collection",
+                uri="akb://reef-akb/coll/research/designs",
+                summary="Approved and proposed designs",
+            ),
+            BrowseItem(
+                name="catalog.md",
+                path="research/catalog.md",
+                type="document",
+                uri="akb://reef-akb/coll/research/doc/catalog.md",
+                summary="A large resource summary",
+            ),
+            BrowseItem(
+                name="evidence.pdf",
+                path="research/evidence.pdf",
+                type="file",
+                uri="akb://reef-akb/coll/research/file/00000000-0000-0000-0000-000000000001",
+                summary="Another large resource summary",
+            ),
+        ],
+    )
+
+
+def test_default_browse_keeps_collection_intent_but_drops_resource_summaries():
+    payload = browse_payload(_response(), include_summary=False)
+
+    assert payload["context"]["summary"] == "Technical comparisons and AKB recommendations"
+    assert payload["items"][0]["summary"] == "Approved and proposed designs"
+    assert "summary" not in payload["items"][1]
+    assert "summary" not in payload["items"][2]
+
+
+def test_include_summary_keeps_every_resource_summary():
+    payload = browse_payload(_response(), include_summary=True)
+
+    assert [item["summary"] for item in payload["items"]] == [
+        "Approved and proposed designs",
+        "A large resource summary",
+        "Another large resource summary",
+    ]

--- a/backend/tests/test_search_parent_context_unit.py
+++ b/backend/tests/test_search_parent_context_unit.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.services import search_service
+from app.services.search_service import SearchService
+from app.services.vector_store import VectorHit
+
+pytestmark = pytest.mark.asyncio
+
+
+class _ContextConn:
+    def __init__(self, doc_id: uuid.UUID):
+        self.doc_id = doc_id
+        self.queries: list[str] = []
+
+    async def fetch(self, sql: str, *_params):
+        self.queries.append(sql)
+        if "FROM documents d" in sql:
+            return [{
+                "id": self.doc_id,
+                "vault_name": "reef-akb",
+                "path": "research/catalog.md",
+                "title": "MCP Tool Catalog",
+                "collection": "research",
+                "doc_type": "report",
+                "summary": "Document-level summary",
+                "tags": ["topic:mcp"],
+            }]
+        if "c.path = ANY" in sql:
+            return [{
+                "vault_name": "reef-akb",
+                "vault_description": "AKB project knowledge workspace",
+                "collection_path": "research",
+                "collection_summary": "Technical comparisons and AKB recommendations",
+            }]
+        return []
+
+
+class _Acquire:
+    def __init__(self, conn: _ContextConn):
+        self.conn = conn
+
+    async def __aenter__(self):
+        return self.conn
+
+    async def __aexit__(self, *_args):
+        return None
+
+
+class _Pool:
+    def __init__(self, conn: _ContextConn):
+        self.conn = conn
+
+    def acquire(self):
+        return _Acquire(self.conn)
+
+
+async def test_search_hydration_adds_parent_context_without_changing_score(monkeypatch):
+    doc_id = uuid.uuid4()
+    conn = _ContextConn(doc_id)
+
+    async def get_test_pool():
+        return _Pool(conn)
+
+    monkeypatch.setattr(search_service, "get_pool", get_test_pool)
+    monkeypatch.setattr(search_service, "_configured_document_source_type", lambda: "document")
+
+    results = await SearchService()._hydrate_hits([
+        VectorHit(
+            chunk_id=str(uuid.uuid4()),
+            source_type="document",
+            source_id=str(doc_id),
+            section_path="",
+            content="matching section",
+            score=0.82,
+        )
+    ])
+
+    assert len(results) == 1
+    assert results[0].collection == "research"
+    assert results[0].collection_summary == "Technical comparisons and AKB recommendations"
+    assert results[0].vault_description == "AKB project knowledge workspace"
+    assert results[0].score == 0.82
+    assert all("INSERT" not in sql and "UPDATE" not in sql for sql in conn.queries)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1434,7 +1434,19 @@ export const createVaultTable = (
 export const browseVault = (vault: string, collection?: string, depth = 1) => {
   const p = new URLSearchParams({ depth: String(depth) });
   if (collection) p.set("collection", collection);
-  return api<{ vault: string; path: string; items: any[] }>(`/browse/${vault}?${p}`);
+  return api<{
+    vault: string;
+    path: string;
+    context?: {
+      type: "vault" | "collection";
+      uri: string;
+      name: string;
+      path: string;
+      summary?: string | null;
+      description?: string | null;
+    } | null;
+    items: any[];
+  }>(`/browse/${vault}?${p}`);
 };
 
 export interface KnowledgeImportResult {

--- a/packages/akb-client/src/core/openapi-codegen.ts
+++ b/packages/akb-client/src/core/openapi-codegen.ts
@@ -529,6 +529,8 @@ function schemaLines(): string[] {
     "  path: string;",
     "  title: string;",
     "  collection?: string | null;",
+    "  collection_summary?: string | null;",
+    "  vault_description?: string | null;",
     "  doc_type?: string | null;",
     "  summary?: string | null;",
     "  tags: string[];",

--- a/packages/akb-client/src/core/schema.gen.ts
+++ b/packages/akb-client/src/core/schema.gen.ts
@@ -157,6 +157,8 @@ export interface AkbSearchResult {
   path: string;
   title: string;
   collection?: string | null;
+  collection_summary?: string | null;
+  vault_description?: string | null;
   doc_type?: string | null;
   summary?: string | null;
   tags: string[];


### PR DESCRIPTION
## Summary

- return the current vault or collection metadata in the browse context envelope
- keep collection summaries in the default slim browse response while leaving document, table, and file summaries opt-in
- hydrate search hits with collection_summary and vault_description after retrieval
- align the public client types and frontend browse contract with the additive response fields

## Motivation

Collection names alone are often too ambiguous for an agent to infer why a resource belongs there. The collection summary already captures that intent, but discovery responses did not expose it unless callers requested every resource summary.

This change carries parent intent alongside existing resources. It deliberately does not index collections, create a new source type, generate collection chunks, or alter matching and ranking.

## Compatibility

- response changes are additive and nullable
- existing clients can ignore the new fields
- no database migration or reindex is required
- search scores and searchable resource types are unchanged
- older stored data remains valid; missing descriptions are returned as null

## Test plan

- [x] targeted browse/search regression tests: 21 passed
- [x] full repository check gate: Ruff, Mypy, Bandit, TypeScript, generated contracts, SDK tests, frontend tests, and secret scan
- [x] SDK tests: 50 passed
- [x] frontend tests: 623 passed
- [x] rebuilt the local backend and frontend Compose services
- [x] exercised an ephemeral MCP user, vault, collection, and document against localhost
- [x] verified default browse, scoped browse, include_summary opt-in, and search parent context
- [x] deleted the ephemeral verification vault after the run

## Checklist

- [x] user-facing behavior is documented in the backend changelog
- [x] no configuration changes or migrations are required
- [x] no collection indexing or ranking behavior was introduced
- [x] production was not changed