### PR TITLE
feat: add permission-aware resource deletion

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3572
+        "line_number": 3585
       }
     ],
     "backend/mcp_server/help.py": [
@@ -166,7 +166,7 @@
         "filename": "backend/mcp_server/help.py",
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_verified": false,
-        "line_number": 1190,
+        "line_number": 1191,
         "is_secret": false
       }
     ],
@@ -5395,10 +5395,10 @@
         "filename": "frontend/src/pages/__tests__/document-view-toggle.test.tsx",
         "hashed_secret": "6c688927eafd673c7d9194b46b2b88e096e6c9f7",
         "is_verified": false,
-        "line_number": 72,
+        "line_number": 74,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-08-26T05:02:09Z"
+  "generated_at": "2026-08-27T05:19:08Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -7,6 +7,19 @@ specifically; the proxy has its own log in
 
 ## Unreleased
 
+### Aligned resource deletion with Vault permission boundaries
+
+Recursive collection deletion can no longer be used by a Vault writer to
+drop a table that requires administrator access on the dedicated table
+endpoint. REST and MCP collection deletion now derive the table-drop
+capability from the authenticated Vault role and reject the whole operation
+before any mutation when the caller lacks it.
+
+The web app now exposes permission-aware delete actions for documents, files,
+and tables in both resource viewers and the Vault explorer. Table deletion
+requires exact-name confirmation and identifies affected rows, while every
+successful deletion refreshes the explorer and returns the user to the Vault.
+
 ### Fixed repeated production-scale BM25 rebuilds and bounded rebuild memory
 
 The BM25 refresher no longer compares all non-null chunks with the smaller set

--- a/backend/app/api/routes/collections.py
+++ b/backend/app/api/routes/collections.py
@@ -9,6 +9,7 @@ from app.api.deps import get_current_user
 from app.exceptions import NotFoundError
 from app.models.document import BrowseResponse
 from app.services.access_service import check_vault_access
+from app.services.access_contributions import role_level
 from app.services.auth_service import AuthenticatedUser
 from app.services.collection_service import (
     CollectionNotEmptyError,
@@ -132,13 +133,14 @@ async def delete_collection(
         HEAD endpoint (see plan Task 14+) will expose totals up-front so
         clients can confirm or paginate.
     """
-    await check_vault_access(user.user_id, vault, required_role="writer")
+    access = await check_vault_access(user.user_id, vault, required_role="writer")
     try:
         result = await collection_service.delete(
             vault=vault,
             path=path,
             recursive=recursive,
             agent_id=user.user_id,
+            allow_table_delete=role_level(access.get("role")) >= role_level("admin"),
         )
         return {"kind": "collection_delete", **result}
     except InvalidPathError as exc:

--- a/backend/app/services/collection_service.py
+++ b/backend/app/services/collection_service.py
@@ -15,7 +15,7 @@ import uuid
 import asyncpg
 
 from app.db.postgres import get_pool
-from app.exceptions import ConflictError, NotFoundError
+from app.exceptions import ConflictError, ForbiddenError, NotFoundError
 from app.repositories import table_data_repo, table_registry_repo, vault_files_repo
 from app.repositories.document_repo import CollectionRepository, DocumentRepository
 from app.repositories.events_repo import emit_event
@@ -184,6 +184,7 @@ class CollectionService:
         path: str,
         recursive: bool,
         agent_id: str | None,
+        allow_table_delete: bool = False,
     ) -> dict:
         """Delete a collection using **prefix semantics** over the path.
 
@@ -206,8 +207,10 @@ class CollectionService:
         - Cascade mode (`recursive=True`): delete everything at and
           under `P` — all sub-collection rows + all docs (one git
           commit) + all files (s3 outbox) + the row at `P` if it
-          exists. Returns `{ok, collection, deleted_docs,
-          deleted_files, deleted_sub_collections}`.
+          exists. If the prefix contains a table, the caller must pass
+          the admin-derived `allow_table_delete` capability. Returns
+          `{ok, collection, deleted_docs, deleted_files,
+          deleted_sub_collections, deleted_tables}`.
 
         Race-safety: the target row (if any) and all sub-collection
         rows are locked `FOR UPDATE` inside the same transaction, so a
@@ -294,6 +297,18 @@ class CollectionService:
                 if not recursive and (sub_rows or docs or files or tables):
                     raise CollectionNotEmptyError(
                         len(docs), len(files), len(sub_rows), len(tables),
+                    )
+
+                # A table DROP is admin-only on the dedicated table endpoint.
+                # Enforce the same boundary here *after* taking the collection
+                # snapshot and *before* any mutation so a writer cannot bypass
+                # it by recursively deleting the containing collection. The
+                # capability is resolved by the authenticated boundary; this
+                # service never trusts a client-supplied role string.
+                if recursive and tables and not allow_table_delete:
+                    raise ForbiddenError(
+                        "Deleting a collection that contains tables requires "
+                        f"'admin' role on vault '{vault}'"
                     )
 
                 # ── PG cleanup (same TX, locks still held) ──────

--- a/backend/app/services/skill_reservation_backfill.py
+++ b/backend/app/services/skill_reservation_backfill.py
@@ -356,6 +356,7 @@ async def run(
                 await collection_service.delete(
                     vault=item["vault_name"], path=item["path"],
                     recursive=False, agent_id=_ACTOR,
+                    allow_table_delete=False,
                 )
                 done["delete_subcollection"] += 1
             except Exception as e:  # noqa: BLE001 — report residue, continue batch

--- a/backend/mcp_server/help.py
+++ b/backend/mcp_server/help.py
@@ -1086,14 +1086,15 @@ Requires writer role.""",
 
 The `path` is treated as a **prefix**, not a single row. Deleting `P`
 covers the row at `P` (if any) plus every sub-collection, document,
-and file under `P/`.
+file, and table under `P/`.
 
 - Empty mode (default): succeeds only if the row at `P` exists and
   nothing else lives under the prefix. Any sub-collection, document,
-  or file rejects with `not_empty` and the counts.
+  file, or table rejects with `not_empty` and the counts.
 - `recursive=true`: cascade-delete the row at `P` (if any), every
   sub-collection row beneath it, all documents (one git commit), and
-  all files (s3 outbox).
+  all files (s3 outbox). If any table is included, admin or owner role
+  is required and the physical PostgreSQL tables are dropped.
 - A path with no row and no descendants returns a NotFound error.
 
 ## Parameters
@@ -1101,7 +1102,7 @@ and file under `P/`.
 |-------|----------|-------------|
 | vault | ✓ | Vault name |
 | path | ✓ | Collection path (prefix) |
-| recursive | | Default `false`. Set `true` to cascade sub-collections + docs + files. |
+| recursive | | Default `false`. Set `true` to cascade sub-collections + docs + files + tables. |
 
 ## Examples
 ```
@@ -1109,7 +1110,7 @@ akb_delete_collection(vault="eng", path="old-specs")
 akb_delete_collection(vault="eng", path="legacy", recursive=True)
 ```
 
-Requires writer role.""",
+Requires writer role, or admin/owner when the collection contains tables.""",
 
     "akb_delete": """# akb_delete — Delete a Document
 

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -1452,16 +1452,18 @@ async def _handle_create_collection(args: dict, uid: str, user: _MCPUser) -> dic
 
 @_h("akb_delete_collection")
 async def _handle_delete_collection(args: dict, uid: str, user: _MCPUser) -> dict:
+    from app.services.access_contributions import role_level
     from app.services.collection_service import (
         CollectionService, CollectionNotEmptyError, InvalidPathError,
     )
-    await check_vault_access(uid, args["vault"], required_role="writer")
+    access = await check_vault_access(uid, args["vault"], required_role="writer")
     svc = CollectionService()
     try:
         return await svc.delete(
             vault=args["vault"], path=args["path"],
             recursive=bool(args.get("recursive", False)),
             agent_id=uid,
+            allow_table_delete=role_level(access.get("role")) >= role_level("admin"),
         )
     except InvalidPathError as exc:
         return err(str(exc), code=INVALID_PATH)

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -1151,8 +1151,9 @@ TOOLS = [
         name="akb_delete_collection",
         description=(
             "Delete a collection. If empty, removes the metadata row. If non-empty, requires "
-            "recursive=true to cascade delete every document and file under the path. "
-            "Cascade emits one git commit for the entire batch. Writer or higher role."
+            "recursive=true to cascade delete every document, file, and table under the path. "
+            "Cascade emits one git commit for the document batch. Writer or higher role; "
+            "admin or higher when any table is included."
         ),
         inputSchema={
             "type": "object",

--- a/backend/tests/concurrency/test_invariants_unit.py
+++ b/backend/tests/concurrency/test_invariants_unit.py
@@ -1013,6 +1013,7 @@ async def test_p2_archived_vault_blocks_writes(pool):
 @pytest.mark.asyncio
 async def test_p2_collection_delete_handles_tables(pool):
     from app.services import table_service
+    from app.exceptions import ForbiddenError
     from app.services.collection_service import CollectionService, CollectionNotEmptyError
     from app.services.role_sync import RoleSync, set_role_sync, get_role_sync
 
@@ -1032,8 +1033,34 @@ async def test_p2_collection_delete_handles_tables(pool):
         await svc.delete(vault=name, path="specs", recursive=False, agent_id="t")
     assert ei.value.table_count == 1
 
+    # A writer-equivalent caller must not bypass the table endpoint's admin
+    # boundary by deleting its parent collection. The denial happens before
+    # either the registry or physical table is mutated.
+    with pytest.raises(ForbiddenError, match="contains tables requires 'admin'"):
+        await svc.delete(
+            vault=name,
+            path="specs",
+            recursive=True,
+            agent_id="t",
+            allow_table_delete=False,
+        )
+    async with pool.acquire() as conn:
+        assert await conn.fetchval(
+            "SELECT COUNT(*) FROM vault_tables WHERE vault_id = $1", vid,
+        ) == 1
+        assert await conn.fetchval(
+            "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = $1",
+            table_service.table_data_repo.pg_table_name(name, "items"),
+        ) == 1
+
     # recursive delete actually drops the table (registry + dynamic table)
-    out = await svc.delete(vault=name, path="specs", recursive=True, agent_id="t")
+    out = await svc.delete(
+        vault=name,
+        path="specs",
+        recursive=True,
+        agent_id="t",
+        allow_table_delete=True,
+    )
     assert out["deleted_tables"] == 1
 
     async with pool.acquire() as conn:

--- a/backend/tests/test_collection_lifecycle_e2e.sh
+++ b/backend/tests/test_collection_lifecycle_e2e.sh
@@ -343,6 +343,49 @@ HTTP_CODE=$(curl -sk -o /dev/null -w "%{http_code}" \
 [ "$HTTP_CODE" = "403" ] && pass "reader role REST DELETE → 403" \
   || fail "reader DELETE 403" "got HTTP $HTTP_CODE (expected 403)"
 
+# ── 11b. Writer cannot bypass admin-only table deletion ─────
+echo ""
+echo "▸ 11b. Table deletion permission boundary"
+
+# Promote the second account to Writer, then create a table inside a
+# collection as the owner. Writer must be denied both by the dedicated table
+# endpoint and by recursive collection deletion; the table must survive both.
+R=$(mcp_call akb_grant "{\"vault\":\"$VAULT\",\"user\":\"$READER_USER\",\"role\":\"writer\"}" | mcp_result)
+WRITER_GRANTED=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('granted',False))" 2>/dev/null)
+[ "$WRITER_GRANTED" = "True" ] && pass "promoted second account to writer" \
+  || fail "grant writer" "granted=$WRITER_GRANTED; raw=$R"
+
+R=$(mcp_call akb_create_table "{\"vault\":\"$VAULT\",\"collection\":\"writer-guard\",\"name\":\"writer_guard_table\",\"columns\":[{\"name\":\"value\",\"type\":\"text\"}]}" | mcp_result)
+GUARD_TABLE=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('name',''))" 2>/dev/null)
+[ "$GUARD_TABLE" = "writer_guard_table" ] && pass "seeded table inside writer-guard collection" \
+  || fail "seed guard table" "name=$GUARD_TABLE; raw=$R"
+
+HTTP_CODE=$(curl -sk -o "$REST_BODY" -w "%{http_code}" \
+  -X DELETE "$BASE_URL/api/v1/tables/$VAULT/writer_guard_table" \
+  -H "Authorization: Bearer $PAT2" 2>/dev/null)
+[ "$HTTP_CODE" = "403" ] && pass "writer direct table delete → 403" \
+  || fail "writer table DELETE 403" "got HTTP $HTTP_CODE; body=$(cat "$REST_BODY")"
+
+HTTP_CODE=$(curl -sk -o "$REST_BODY" -w "%{http_code}" \
+  -X DELETE "$BASE_URL/api/v1/collections/$VAULT/writer-guard?recursive=true" \
+  -H "Authorization: Bearer $PAT2" 2>/dev/null)
+[ "$HTTP_CODE" = "403" ] && pass "writer recursive collection delete containing table → 403" \
+  || fail "writer collection table bypass" "got HTTP $HTTP_CODE; body=$(cat "$REST_BODY")"
+
+TABLE_SURVIVED=$(curl -sk "$BASE_URL/api/v1/tables/$VAULT" \
+  -H "Authorization: Bearer $PAT" \
+  | python3 -c 'import sys,json; d=json.load(sys.stdin); print(any(i.get("name")=="writer_guard_table" for i in d.get("items",[])))' 2>/dev/null)
+[ "$TABLE_SURVIVED" = "True" ] && pass "table survives both writer denials" \
+  || fail "table survives writer denial" "table missing after rejected operations"
+
+HTTP_CODE=$(curl -sk -o "$REST_BODY" -w "%{http_code}" \
+  -X DELETE "$BASE_URL/api/v1/collections/$VAULT/writer-guard?recursive=true" \
+  -H "Authorization: Bearer $PAT" 2>/dev/null)
+ADMIN_DELETE=$(python3 -c 'import sys,json; print(json.load(sys.stdin).get("deleted_tables", -1))' <"$REST_BODY" 2>/dev/null)
+[ "$HTTP_CODE" = "200" ] && [ "$ADMIN_DELETE" = "1" ] \
+  && pass "owner recursive collection delete removes one table" \
+  || fail "owner collection table delete" "http=$HTTP_CODE deleted_tables=$ADMIN_DELETE; body=$(cat "$REST_BODY")"
+
 # ── 12. Nested parent delete (prefix semantics) ─────────────
 echo ""
 echo "▸ 12. Nested parent delete"
@@ -394,6 +437,13 @@ NP_MCP_SUB=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)
 [ "$NP_MCP_CODE" = "conflict" ] && [ "$NP_MCP_SUB" -ge 1 ] 2>/dev/null \
   && pass "MCP delete_collection on nested parent → conflict sub_collection_count=$NP_MCP_SUB" \
   || fail "MCP nested not_empty" "code=$NP_MCP_CODE sub_collection_count=$NP_MCP_SUB; raw=$R"
+
+# Clean up the ephemeral Vault even when an earlier assertion failed. The
+# generated test users are intentionally left to the auth lifecycle suites.
+R=$(mcp_call akb_delete_vault "{\"vault\":\"$VAULT\"}" | mcp_result)
+CLEANED=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('deleted'))" 2>/dev/null)
+[ "$CLEANED" = "True" ] && pass "ephemeral vault cleaned up" \
+  || fail "cleanup vault" "deleted=$CLEANED; raw=$R"
 
 # ── Summary ──────────────────────────────────────────────────
 echo ""

--- a/backend/tests/test_collection_mcp_permission_unit.py
+++ b/backend/tests/test_collection_mcp_permission_unit.py
@@ -1,0 +1,55 @@
+"""MCP collection deletion forwards the same table-drop capability as REST."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("role", "expected"),
+    [("writer", False), ("admin", True), ("owner", True)],
+)
+async def test_delete_collection_derives_table_capability_from_authorized_role(
+    monkeypatch: pytest.MonkeyPatch,
+    role: str,
+    expected: bool,
+) -> None:
+    from app.services import collection_service
+    from mcp_server import server
+
+    captured: dict[str, Any] = {}
+
+    async def check_access(*_args: Any, **kwargs: Any) -> dict[str, str]:
+        assert kwargs["required_role"] == "writer"
+        return {"role": role}
+
+    class FakeCollectionService:
+        async def delete(self, **kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            return {
+                "ok": True,
+                "collection": "data",
+                "deleted_docs": 0,
+                "deleted_files": 0,
+                "deleted_sub_collections": 0,
+                "deleted_tables": 0,
+            }
+
+    monkeypatch.setattr(server, "check_vault_access", check_access)
+    monkeypatch.setattr(
+        collection_service,
+        "CollectionService",
+        FakeCollectionService,
+    )
+
+    result = await server._handle_delete_collection(
+        {"vault": "reef", "path": "data", "recursive": True},
+        "user-id",
+        object(),  # type: ignore[arg-type]
+    )
+
+    assert result["ok"] is True
+    assert captured["allow_table_delete"] is expected

--- a/backend/tests/test_collection_routes_unit.py
+++ b/backend/tests/test_collection_routes_unit.py
@@ -83,6 +83,7 @@ def test_delete_adds_only_literal_kind_and_preserves_all_counts(client, monkeypa
             "path": "guides/api",
             "recursive": True,
             "agent_id": "u-collections",
+            "allow_table_delete": False,
         }
         return {
             "ok": True,
@@ -109,6 +110,33 @@ def test_delete_adds_only_literal_kind_and_preserves_all_counts(client, monkeypa
         "deleted_sub_collections": 1,
         "deleted_tables": 0,
     }
+
+
+def test_delete_passes_admin_table_capability(client, monkeypatch):
+    async def _admin(*_args, **_kwargs):
+        return {"role": "admin"}
+
+    async def _delete(**kwargs):
+        assert kwargs["allow_table_delete"] is True
+        return {
+            "ok": True,
+            "collection": "data",
+            "deleted_docs": 0,
+            "deleted_files": 0,
+            "deleted_sub_collections": 0,
+            "deleted_tables": 1,
+        }
+
+    monkeypatch.setattr(collections, "check_vault_access", _admin)
+    monkeypatch.setattr(collections.collection_service, "delete", _delete)
+
+    response = client.delete(
+        "/api/v1/collections/reef/data",
+        params={"recursive": "true"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["deleted_tables"] == 1
 
 
 def test_non_empty_409_keeps_legacy_detail_and_normalized_details(client, monkeypatch):

--- a/backend/tests/test_skill_backfill_unit.py
+++ b/backend/tests/test_skill_backfill_unit.py
@@ -98,8 +98,18 @@ class _FakeCollectionService:
         self.calls = []
         self.error = error
 
-    async def delete(self, *, vault, path, recursive, agent_id):
-        self.calls.append((vault, path, recursive, agent_id))
+    async def delete(
+        self,
+        *,
+        vault,
+        path,
+        recursive,
+        agent_id,
+        allow_table_delete=False,
+    ):
+        self.calls.append(
+            (vault, path, recursive, agent_id, allow_table_delete)
+        )
         if self.error:
             raise self.error
         return {"ok": True}

--- a/frontend/src/components/__tests__/resource-delete-dialog.test.tsx
+++ b/frontend/src/components/__tests__/resource-delete-dialog.test.tsx
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ResourceDeleteDialog } from "@/components/resource-delete-dialog";
+
+afterEach(() => cleanup());
+
+describe("ResourceDeleteDialog", () => {
+  it("uses a standard confirmation for documents", async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ResourceDeleteDialog
+        open
+        onOpenChange={() => {}}
+        kind="document"
+        name="Architecture"
+        onConfirm={onConfirm}
+      />,
+    );
+
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Delete document" }));
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
+  });
+
+  it("requires an exact table name and reports the row impact", async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ResourceDeleteDialog
+        open
+        onOpenChange={() => {}}
+        kind="table"
+        name="audit_log"
+        rowCount={23}
+        onConfirm={onConfirm}
+      />,
+    );
+
+    expect(screen.getByText(/all 23 rows/i)).toBeInTheDocument();
+    const confirm = screen.getByRole("button", { name: "Delete table" });
+    expect(confirm).toBeDisabled();
+
+    const input = screen.getByLabelText(/type the table name/i);
+    await user.type(input, "audit");
+    expect(confirm).toBeDisabled();
+    await user.type(input, "_log");
+    expect(confirm).toBeEnabled();
+    await user.click(confirm);
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
+  });
+
+  it("keeps an API conflict inside the dialog for correction", async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn().mockRejectedValue(
+      new Error("Other tables still reference this table"),
+    );
+    render(
+      <ResourceDeleteDialog
+        open
+        onOpenChange={() => {}}
+        kind="table"
+        name="parent"
+        rowCount={1}
+        onConfirm={onConfirm}
+      />,
+    );
+
+    await user.type(screen.getByLabelText(/type the table name/i), "parent");
+    await user.click(screen.getByRole("button", { name: "Delete table" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Other tables still reference this table",
+    );
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/vault-explorer.test.tsx
+++ b/frontend/src/components/__tests__/vault-explorer.test.tsx
@@ -14,6 +14,9 @@ vi.mock("@/lib/api", () => ({
   updateCollection: vi.fn(),
   uploadVaultFile: vi.fn(),
   createVaultTable: vi.fn(),
+  deleteDocument: vi.fn(),
+  deleteVaultFile: vi.fn(),
+  deleteVaultTable: vi.fn(),
   ApiError: class ApiError extends Error {
     status?: number;
   },
@@ -318,6 +321,27 @@ describe("VaultExplorer — role gating", () => {
     expect(screen.getByRole("menuitem", { name: /upload file/i })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: /new table/i })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: /new sub-collection/i })).toBeInTheDocument();
+    // This collection contains a table, so Writer cannot use collection
+    // deletion to bypass the table endpoint's Admin requirement.
+    expect(screen.queryByRole("menuitem", { name: /delete collection/i })).not.toBeInTheDocument();
+  });
+
+  it("shows document/file delete actions to writers and table actions to admins", async () => {
+    const user = userEvent.setup();
+    vaultInfoMock.mockResolvedValue({ role: "writer" });
+    const view = renderAt("/vault/v");
+    await user.click(await screen.findByRole("button", { name: /^architecture/i }));
+
+    expect(screen.getByRole("button", { name: "Actions for Schema" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Actions for diagram.png" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Actions for owners" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Actions for audit_log" })).not.toBeInTheDocument();
+
+    view.unmount();
+    vaultInfoMock.mockResolvedValue({ role: "admin" });
+    renderAt("/vault/v");
+    expect(await screen.findByRole("button", { name: "Actions for audit_log" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /collection actions for architecture/i }));
     expect(screen.getByRole("menuitem", { name: /delete collection/i })).toBeInTheDocument();
   });
 

--- a/frontend/src/components/resource-actions-menu.tsx
+++ b/frontend/src/components/resource-actions-menu.tsx
@@ -1,0 +1,61 @@
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { MoreHorizontal, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface ResourceActionsMenuProps {
+  resourceName: string;
+  deleteLabel: string;
+  onDelete: () => void;
+  className?: string;
+  side?: "top" | "right" | "bottom" | "left";
+  align?: "start" | "center" | "end";
+}
+
+/** Shared overflow action for document, file, and table resources.
+ *
+ * The menu keeps destructive actions out of the primary button row while
+ * making them consistently discoverable in both workspace headers and the
+ * Vault explorer. Confirmation remains the responsibility of the caller.
+ */
+export function ResourceActionsMenu({
+  resourceName,
+  deleteLabel,
+  onDelete,
+  className,
+  side = "bottom",
+  align = "end",
+}: ResourceActionsMenuProps) {
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label={`Actions for ${resourceName}`}
+          title={`Actions for ${resourceName}`}
+          className={cn("shrink-0", className)}
+        >
+          <MoreHorizontal className="h-4 w-4" aria-hidden />
+        </Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          side={side}
+          align={align}
+          sideOffset={4}
+          className="z-[var(--z-popover)] min-w-48 overflow-hidden rounded-[var(--radius-md)] border border-border bg-surface p-1 shadow-md"
+        >
+          <DropdownMenu.Item
+            onSelect={onDelete}
+            className="flex cursor-pointer select-none items-center gap-2 rounded-[var(--radius-sm)] px-2.5 py-2 text-sm text-destructive outline-none data-[highlighted]:bg-destructive-soft data-[highlighted]:text-destructive-soft-foreground"
+          >
+            <Trash2 className="h-4 w-4" aria-hidden />
+            {deleteLabel}
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+}

--- a/frontend/src/components/resource-delete-dialog.tsx
+++ b/frontend/src/components/resource-delete-dialog.tsx
@@ -1,0 +1,58 @@
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+
+export type DeletableResourceKind = "document" | "file" | "table";
+
+interface ResourceDeleteDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  kind: DeletableResourceKind;
+  name: string;
+  rowCount?: number;
+  onConfirm: () => void | Promise<void>;
+}
+
+const LABELS: Record<DeletableResourceKind, string> = {
+  document: "document",
+  file: "file",
+  table: "table",
+};
+
+/** One deletion contract for every first-class Vault resource.
+ *
+ * Documents and files use a standard destructive confirmation. Tables add an
+ * exact-name gate because the operation removes a physical database relation
+ * and all rows. API errors stay inside ConfirmDialog so conflicts can be fixed
+ * and retried without losing context.
+ */
+export function ResourceDeleteDialog({
+  open,
+  onOpenChange,
+  kind,
+  name,
+  rowCount = 0,
+  onConfirm,
+}: ResourceDeleteDialogProps) {
+  const label = LABELS[kind];
+  const description =
+    kind === "document"
+      ? "The document, search index entries, relationships, and publication links will be removed. Git history is preserved, but this cannot be undone from the UI."
+      : kind === "file"
+        ? "The file record, preview, search index entries, relationships, and publication links will be removed. Stored content is cleaned up asynchronously. This cannot be undone."
+        : `The physical table and all ${rowCount.toLocaleString()} ${rowCount === 1 ? "row" : "rows"}, search index entries, and relationships will be permanently removed. References from another table will block deletion.`;
+
+  return (
+    <ConfirmDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={`Delete ${label} “${name}”?`}
+      description={description}
+      confirmLabel={`Delete ${label}`}
+      variant="destructive"
+      confirmationText={kind === "table" ? name : undefined}
+      confirmationLabel={
+        kind === "table" ? "Type the table name to confirm permanent deletion" : undefined
+      }
+      onConfirm={onConfirm}
+    />
+  );
+}

--- a/frontend/src/components/ui/confirm-dialog.tsx
+++ b/frontend/src/components/ui/confirm-dialog.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useId, useState, type ReactNode } from "react";
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   Dialog,
   DialogContent,
@@ -22,6 +24,8 @@ interface ConfirmDialogProps {
   variant?: Variant;
   onConfirm: () => void | Promise<void>;
   busy?: boolean;
+  confirmationText?: string;
+  confirmationLabel?: string;
 }
 
 export function ConfirmDialog({
@@ -34,15 +38,24 @@ export function ConfirmDialog({
   variant = "default",
   onConfirm,
   busy = false,
+  confirmationText,
+  confirmationLabel = "Type the name to confirm permanent deletion",
 }: ConfirmDialogProps) {
   const [internalBusy, setInternalBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [typedConfirmation, setTypedConfirmation] = useState("");
+  const confirmationId = useId();
   const isBusy = busy || internalBusy;
+  const confirmationMatches =
+    confirmationText === undefined || typedConfirmation === confirmationText;
 
   // Clear any stale error each time the dialog (re)opens so a prior failure
   // doesn't bleed into the next confirmation.
   useEffect(() => {
-    if (open) setError(null);
+    if (open) {
+      setError(null);
+      setTypedConfirmation("");
+    }
   }, [open]);
 
   async function handleConfirm() {
@@ -71,6 +84,23 @@ export function ConfirmDialog({
             </DialogDescription>
           )}
         </DialogHeader>
+        {confirmationText !== undefined && (
+          <div className="space-y-2">
+            <Label htmlFor={confirmationId}>{confirmationLabel}</Label>
+            <Input
+              id={confirmationId}
+              value={typedConfirmation}
+              onChange={(event) => setTypedConfirmation(event.target.value)}
+              autoComplete="off"
+              autoFocus
+              className="font-mono"
+              disabled={isBusy}
+            />
+            <p className="text-xs text-foreground-muted">
+              Enter <code className="font-mono text-foreground">{confirmationText}</code> exactly.
+            </p>
+          </div>
+        )}
         {error && <Alert variant="destructive">{error}</Alert>}
         <DialogFooter>
           <Button
@@ -80,7 +110,7 @@ export function ConfirmDialog({
             disabled={isBusy}
             // Destructive dialogs focus Cancel, not Confirm, so a stray Enter on
             // open can't fire the irreversible action.
-            autoFocus={variant === "destructive"}
+            autoFocus={variant === "destructive" && confirmationText === undefined}
           >
             {cancelLabel}
           </Button>
@@ -88,7 +118,7 @@ export function ConfirmDialog({
             type="button"
             variant={variant === "destructive" ? "destructive" : "default"}
             onClick={handleConfirm}
-            disabled={isBusy}
+            disabled={isBusy || !confirmationMatches}
             autoFocus={variant !== "destructive"}
           >
             {isBusy ? "Working…" : confirmLabel}

--- a/frontend/src/components/vault-explorer.tsx
+++ b/frontend/src/components/vault-explorer.tsx
@@ -40,7 +40,12 @@ import {
   type FlatMoreRow,
   type FlatRow,
 } from "@/lib/tree-route";
-import { getVaultInfo } from "@/lib/api";
+import {
+  deleteDocument,
+  deleteVaultFile,
+  deleteVaultTable,
+  getVaultInfo,
+} from "@/lib/api";
 import { recentTone } from "@/lib/recent";
 import { isReservedCollection } from "@/lib/skill";
 import { CreateCollectionDialog } from "@/components/create-collection-dialog";
@@ -53,6 +58,12 @@ import { FileUploadDialog } from "@/components/file-upload-dialog";
 import { TableCreateDialog } from "@/components/table-create-dialog";
 import { SelectMenu } from "@/components/ui/select-menu";
 import { parseFileUri } from "@/lib/uri";
+import { ResourceActionsMenu } from "@/components/resource-actions-menu";
+import {
+  ResourceDeleteDialog,
+  type DeletableResourceKind,
+} from "@/components/resource-delete-dialog";
+import { ROLE_RANK, type Role } from "@/lib/roles";
 
 const PAGE_SIZE = 10;
 const TYPEAHEAD_TIMEOUT_MS = 500;
@@ -129,21 +140,34 @@ export function VaultExplorer({
   // (`VaultShell`) doesn't have it cached and adding a redundant fetch in
   // the shell would slow first paint. document.tsx uses the same pattern.
   const [vaultRole, setVaultRole] = useState<string | null>(null);
+  const [vaultReadOnly, setVaultReadOnly] = useState(true);
   useEffect(() => {
     let alive = true;
+    setVaultRole(null);
+    setVaultReadOnly(true);
     getVaultInfo(vault)
       .then((d) => {
-        if (alive) setVaultRole(d?.role || null);
+        if (alive) {
+          setVaultRole(d?.role || null);
+          setVaultReadOnly(Boolean(d?.is_archived || d?.is_external_git));
+        }
       })
       .catch(() => {
-        if (alive) setVaultRole(null);
+        if (alive) {
+          setVaultRole(null);
+          setVaultReadOnly(true);
+        }
       });
     return () => {
       alive = false;
     };
   }, [vault]);
   const canWrite =
-    vaultRole === "writer" || vaultRole === "admin" || vaultRole === "owner";
+    !vaultReadOnly &&
+    (vaultRole === "writer" || vaultRole === "admin" || vaultRole === "owner");
+  const canAdmin =
+    !vaultReadOnly &&
+    (ROLE_RANK[vaultRole as Role] ?? 0) >= ROLE_RANK.admin;
 
   // Dialog state.
   const [createOpen, setCreateOpen] = useState(false);
@@ -171,6 +195,13 @@ export function VaultExplorer({
   } | null>(null);
   const [uploadCollection, setUploadCollection] = useState<string | null>(null);
   const [tableCollection, setTableCollection] = useState<string | null>(null);
+  const [resourceDeleteTarget, setResourceDeleteTarget] = useState<{
+    kind: DeletableResourceKind;
+    name: string;
+    ref: string;
+    rowCount: number;
+    active: boolean;
+  } | null>(null);
   const mutationTriggerRef = useRef<HTMLElement | null>(null);
 
   const rememberMutationTrigger = useCallback(() => {
@@ -498,6 +529,7 @@ export function VaultExplorer({
                 vault={vault}
                 onToggle={toggle}
                 canWrite={canWrite}
+                canAdmin={canAdmin}
                 onCreateDoc={(node) =>
                   openCreateDocument({ collection: node.path })
                 }
@@ -521,6 +553,15 @@ export function VaultExplorer({
                     tableCount: counts.tables,
                     fileCount: counts.files,
                     subCollectionCount: countSubCollections(node),
+                  });
+                }}
+                onDeleteResource={(node) => {
+                  setResourceDeleteTarget({
+                    kind: node.kind as DeletableResourceKind,
+                    name: node.name,
+                    ref: node.path,
+                    rowCount: Number(node.raw?.row_count || 0),
+                    active: `${node.kind}:${node.path}` === activeSig,
                   });
                 }}
               />
@@ -576,6 +617,28 @@ export function VaultExplorer({
           handleMutation();
         }}
       />
+      {resourceDeleteTarget && (
+        <ResourceDeleteDialog
+          open
+          onOpenChange={(next) => {
+            if (!next) setResourceDeleteTarget(null);
+          }}
+          kind={resourceDeleteTarget.kind}
+          name={resourceDeleteTarget.name}
+          rowCount={resourceDeleteTarget.rowCount}
+          onConfirm={async () => {
+            if (resourceDeleteTarget.kind === "document") {
+              await deleteDocument(vault, resourceDeleteTarget.ref);
+            } else if (resourceDeleteTarget.kind === "file") {
+              await deleteVaultFile(vault, resourceDeleteTarget.ref);
+            } else {
+              await deleteVaultTable(vault, resourceDeleteTarget.ref);
+            }
+            handleMutation();
+            if (resourceDeleteTarget.active) navigate(`/vault/${vault}`);
+          }}
+        />
+      )}
       <CollectionDetailsDialog
         vault={vault}
         path={detailsTarget?.path ?? ""}
@@ -649,9 +712,13 @@ interface RowProps {
   /** Writer+ unlocks per-row destructive affordances (collection rows
    *  only for now). Readers see the row unchanged. */
   canWrite?: boolean;
+  /** Admin+ is required for physical table deletion. */
+  canAdmin?: boolean;
   /** Fired when the user clicks the trash icon on a collection row.
    *  Parent decides which dialog to open and seeds it with counts. */
   onDeleteCollection?: (node: TreeNode) => void;
+  /** Open the matching document/file/table deletion flow. */
+  onDeleteResource?: (node: TreeNode) => void;
   /** Open the collection metadata and resource-count inspector. */
   onOpenDetails?: (node: TreeNode) => void;
   /** Fired when the user clicks the `+` (new sub-collection) icon on a
@@ -668,7 +735,7 @@ interface RowProps {
 }
 
 const TreeRow = memo(function TreeRow({
-  node, depth, sig, isOpen, isActive, vault, onToggle, canWrite, onDeleteCollection, onOpenDetails, onCreateSubCollection, onCreateDoc, onUploadFile, onCreateTable,
+  node, depth, sig, isOpen, isActive, vault, onToggle, canWrite, canAdmin, onDeleteCollection, onDeleteResource, onOpenDetails, onCreateSubCollection, onCreateDoc, onUploadFile, onCreateTable,
 }: RowProps) {
   const indent = { paddingLeft: `${depth * 12 + 12}px` };
 
@@ -678,6 +745,7 @@ const TreeRow = memo(function TreeRow({
     // rejects writes into it, so the tree shows it read-only (locked, no row
     // actions) rather than offering affordances that would 403.
     const isReserved = isReservedCollection(node.path);
+    const containsTables = countCollectionResources(node).tables > 0;
     return (
       <div
         role="treeitem"
@@ -746,7 +814,10 @@ const TreeRow = memo(function TreeRow({
                 : undefined
             }
             onDelete={
-              !isReserved && canWrite && onDeleteCollection
+              !isReserved &&
+              canWrite &&
+              (canAdmin || !containsTables) &&
+              onDeleteCollection
                 ? () => onDeleteCollection(node)
                 : undefined
             }
@@ -765,47 +836,65 @@ const TreeRow = memo(function TreeRow({
   // shape in a flat list. (Was text-accent ORANGE for table/file/skill, which
   // was off-system + spent the one-marquee-orange budget.) Skill = teal.
   const leafTone = isSkill ? "var(--color-primary)" : recentTone(node.kind);
+  const canDeleteResource =
+    !isSkill &&
+    Boolean(onDeleteResource) &&
+    (node.kind === "table" ? Boolean(canAdmin) : Boolean(canWrite));
 
   return (
-    <Link
-      to={href}
-      data-sig={sig}
-      role="treeitem"
-      aria-level={depth + 1}
-      aria-current={isActive ? "page" : undefined}
-      aria-selected={isActive}
-      style={indent}
-      className={`flex items-center gap-1.5 pr-2 py-1.5 min-h-9 group transition-colors hover:bg-surface-hover focus:bg-surface-hover focus:outline-none ${
-        isActive ? "bg-surface-selected text-surface-selected-foreground border-l-2 border-primary -ml-[2px]" : ""
-      }`}
-    >
-      {/* Tinted icon chip — the same kind-swatch grammar Home + the vault
-          overview use, so a doc vs table vs file is pre-attentive here too
-          (was a bare 12px glyph, the one surface that dropped the chip). */}
-      <span
-        className="inline-flex h-4 w-4 items-center justify-center rounded-[var(--radius-sm)] shrink-0"
-        style={{
-          color: leafTone,
-          backgroundColor: `color-mix(in srgb, ${leafTone} 12%, transparent)`,
-        }}
-        aria-hidden
+    <div role="none" className="group flex min-h-9 items-stretch focus-within:bg-surface-hover">
+      <Link
+        to={href}
+        data-sig={sig}
+        role="treeitem"
+        aria-level={depth + 1}
+        aria-current={isActive ? "page" : undefined}
+        aria-selected={isActive}
+        style={indent}
+        className={`flex min-h-9 min-w-0 flex-1 items-center gap-1.5 py-1.5 pr-1 transition-colors hover:bg-surface-hover focus:bg-surface-hover focus:outline-none ${
+          isActive ? "-ml-[2px] border-l-2 border-primary bg-surface-selected text-surface-selected-foreground" : ""
+        }`}
       >
-        <LeafIcon className="h-2.5 w-2.5" aria-hidden />
-      </span>
-      {/* The chip is aria-hidden, so name kind to assistive tech in words
-          (otherwise a SR user hears the bare title with no type). */}
-      <span className="sr-only">
-        {node.kind === "document"
-          ? isSkill
-            ? "Skill: "
-            : "Document: "
-          : node.kind === "table"
-            ? "Table: "
-            : "File: "}
-      </span>
-      <span title={node.name} className="truncate min-w-0 text-[13px] group-hover:text-link">{node.name}</span>
-      {isSkill && <SkillBadge defined className="ml-auto shrink-0" />}
-    </Link>
+        {/* Tinted icon chip — the same kind-swatch grammar Home + the vault
+            overview use, so a doc vs table vs file is pre-attentive here too
+            (was a bare 12px glyph, the one surface that dropped the chip). */}
+        <span
+          className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-[var(--radius-sm)]"
+          style={{
+            color: leafTone,
+            backgroundColor: `color-mix(in srgb, ${leafTone} 12%, transparent)`,
+          }}
+          aria-hidden
+        >
+          <LeafIcon className="h-2.5 w-2.5" aria-hidden />
+        </span>
+        {/* The chip is aria-hidden, so name kind to assistive tech in words
+            (otherwise a SR user hears the bare title with no type). */}
+        <span className="sr-only">
+          {node.kind === "document"
+            ? isSkill
+              ? "Skill: "
+              : "Document: "
+            : node.kind === "table"
+              ? "Table: "
+              : "File: "}
+        </span>
+        <span title={node.name} className="min-w-0 truncate text-[13px] group-hover:text-link">
+          {node.name}
+        </span>
+        {isSkill && <SkillBadge defined className="ml-auto shrink-0" />}
+      </Link>
+      {canDeleteResource && (
+        <ResourceActionsMenu
+          resourceName={node.name}
+          deleteLabel={`Delete ${node.kind}`}
+          onDelete={() => onDeleteResource?.(node)}
+          side="right"
+          align="start"
+          className="h-9 w-9 rounded-none opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100"
+        />
+      )}
+    </div>
   );
 });
 

--- a/frontend/src/lib/__tests__/api-resource-delete.test.ts
+++ b/frontend/src/lib/__tests__/api-resource-delete.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { deleteVaultFile, deleteVaultTable } from "@/lib/api";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("resource delete API", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  it("deletes a file through its user-facing endpoint with encoded segments", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        kind: "file",
+        vault: "team vault",
+        name: "notes.txt",
+        deleted: true,
+      }),
+    );
+
+    const result = await deleteVaultFile("team vault", "file/id");
+
+    expect(result.deleted).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/files/team%20vault/file%2Fid",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("deletes a table through the admin endpoint with encoded segments", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        kind: "table",
+        uri: "akb://v/table/audit_log",
+        vault: "v",
+        name: "audit_log",
+        deleted: true,
+      }),
+    );
+
+    const result = await deleteVaultTable("v", "audit log");
+
+    expect(result.deleted).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/tables/v/audit%20log",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("surfaces a table reference conflict without converting it to success", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ detail: "other vault tables reference it" }, 409),
+    );
+
+    await expect(deleteVaultTable("v", "parent")).rejects.toThrow(
+      "other vault tables reference it",
+    );
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1319,6 +1319,15 @@ export interface VaultFileUploadResult {
   version?: string | null;
 }
 
+export interface VaultFileDeleteResult {
+  kind: "file";
+  uri?: string | null;
+  vault: string;
+  collection?: string | null;
+  name: string;
+  deleted: true;
+}
+
 /**
  * Complete the backend's presigned file flow from the browser: reserve the
  * file record, PUT the bytes directly to object storage, then certify the
@@ -1393,6 +1402,12 @@ export async function uploadVaultFile(
   }
 }
 
+export const deleteVaultFile = (vault: string, fileId: string) =>
+  api<VaultFileDeleteResult>(
+    `/files/${encodeURIComponent(vault)}/${encodeURIComponent(fileId)}`,
+    { method: "DELETE" },
+  );
+
 // ── Vault tables ──
 export interface VaultTableColumnInput {
   name: string;
@@ -1417,6 +1432,15 @@ export interface VaultTableCreateResult {
   created?: boolean;
 }
 
+export interface VaultTableDeleteResult {
+  kind: "table";
+  uri: string;
+  vault: string;
+  collection?: string | null;
+  name: string;
+  deleted: true;
+}
+
 export const createVaultTable = (
   vault: string,
   input: VaultTableCreateInput,
@@ -1429,6 +1453,12 @@ export const createVaultTable = (
       collection: input.collection?.trim() || undefined,
     }),
   });
+
+export const deleteVaultTable = (vault: string, tableName: string) =>
+  api<VaultTableDeleteResult>(
+    `/tables/${encodeURIComponent(vault)}/${encodeURIComponent(tableName)}`,
+    { method: "DELETE" },
+  );
 
 // ── Browse ──
 export const browseVault = (vault: string, collection?: string, depth = 1) => {

--- a/frontend/src/pages/__tests__/document-view-toggle.test.tsx
+++ b/frontend/src/pages/__tests__/document-view-toggle.test.tsx
@@ -37,6 +37,7 @@ vi.mock("@/components/markdown-editor", () => ({
 }));
 
 import {
+  deleteDocument,
   getDocument,
   getVaultInfo,
   getRelations,
@@ -44,6 +45,7 @@ import {
 } from "@/lib/api";
 
 const getDocumentMock = getDocument as unknown as ReturnType<typeof vi.fn>;
+const deleteDocumentMock = deleteDocument as unknown as ReturnType<typeof vi.fn>;
 const getVaultInfoMock = getVaultInfo as unknown as ReturnType<typeof vi.fn>;
 const getRelationsMock = getRelations as unknown as ReturnType<typeof vi.fn>;
 const updateDocumentMock = updateDocument as unknown as ReturnType<typeof vi.fn>;
@@ -85,6 +87,7 @@ function LocationProbe() {
   const loc = useLocation();
   return (
     <>
+      <div data-testid="location-pathname">{loc.pathname}</div>
       <div data-testid="location-search">{loc.search}</div>
       <div data-testid="location-state">{JSON.stringify(loc.state)}</div>
     </>
@@ -148,6 +151,7 @@ function renderPreviewAt(url: string) {
 beforeEach(() => {
   localStorage.clear();
   getDocumentMock.mockReset();
+  deleteDocumentMock.mockReset();
   getVaultInfoMock.mockReset();
   getRelationsMock.mockReset();
   updateDocumentMock.mockReset();
@@ -159,6 +163,7 @@ beforeEach(() => {
     current_commit: UPDATED_COMMIT,
     commit_hash: UPDATED_COMMIT,
   });
+  deleteDocumentMock.mockResolvedValue({ deleted: true });
 
   // /activity is fetched directly via fetch() — stub it to a no-op.
   vi.stubGlobal(
@@ -523,5 +528,20 @@ describe("DocumentPage view toggle", () => {
         expect(screen.getByText("Updated from pinned HEAD")).toBeInTheDocument(),
       { timeout: 5_000 },
     );
+  });
+
+  it("exposes document deletion in the header for writers and leaves the stale route", async () => {
+    const user = userEvent.setup();
+    getVaultInfoMock.mockResolvedValue({ role: "writer" });
+    renderAt("/vault/v/doc/notes%2Fhello.md");
+
+    await user.click(await screen.findByRole("button", { name: "Actions for DocTitle" }));
+    await user.click(screen.getByRole("menuitem", { name: "Delete document" }));
+    await user.click(screen.getByRole("button", { name: "Delete document" }));
+
+    await waitFor(() =>
+      expect(deleteDocumentMock).toHaveBeenCalledWith("v", "notes/hello.md"),
+    );
+    expect(screen.getByTestId("location-pathname")).toHaveTextContent("/vault/v");
   });
 });

--- a/frontend/src/pages/__tests__/resource-delete-pages.test.tsx
+++ b/frontend/src/pages/__tests__/resource-delete-pages.test.tsx
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { VaultRefreshProvider } from "@/contexts/vault-refresh-context";
+import FilePage from "@/pages/file";
+import TablePage from "@/pages/table";
+
+vi.mock("@/lib/api", () => ({
+  authenticatedFetch: vi.fn(),
+  getVaultInfo: vi.fn(),
+  deleteVaultFile: vi.fn(),
+  deleteVaultTable: vi.fn(),
+}));
+
+import {
+  authenticatedFetch,
+  deleteVaultFile,
+  deleteVaultTable,
+  getVaultInfo,
+} from "@/lib/api";
+
+const fetchMock = authenticatedFetch as unknown as ReturnType<typeof vi.fn>;
+const vaultInfoMock = getVaultInfo as unknown as ReturnType<typeof vi.fn>;
+const deleteFileMock = deleteVaultFile as unknown as ReturnType<typeof vi.fn>;
+const deleteTableMock = deleteVaultTable as unknown as ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function LocationProbe() {
+  return <span data-testid="pathname">{useLocation().pathname}</span>;
+}
+
+function renderRoute(path: string, refetchTree = vi.fn()) {
+  return {
+    refetchTree,
+    ...render(
+      <MemoryRouter initialEntries={[path]}>
+        <VaultRefreshProvider refetchVaults={vi.fn()} refetchTree={refetchTree}>
+          <Routes>
+            <Route path="/vault/:name/file/:id" element={<FilePage />} />
+            <Route path="/vault/:name/table/:table" element={<TablePage />} />
+            <Route path="/vault/:name" element={<div>Vault overview</div>} />
+          </Routes>
+          <LocationProbe />
+        </VaultRefreshProvider>
+      </MemoryRouter>,
+    ),
+  };
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vaultInfoMock.mockReset();
+  deleteFileMock.mockReset();
+  deleteTableMock.mockReset();
+  deleteFileMock.mockResolvedValue({ deleted: true });
+  deleteTableMock.mockResolvedValue({ deleted: true });
+});
+
+afterEach(() => cleanup());
+
+describe("resource viewer deletion", () => {
+  it("lets a writer delete a file, refreshes the tree, and leaves the stale viewer", async () => {
+    vaultInfoMock.mockResolvedValue({ role: "writer" });
+    fetchMock.mockImplementation((url: string) => {
+      if (url.endsWith("/download")) {
+        return Promise.resolve(jsonResponse({
+          name: "diagram.png",
+          download_url: "https://example.test/diagram.png",
+          mime_type: "image/png",
+        }));
+      }
+      return Promise.resolve(jsonResponse({
+        items: [
+          {
+            uri: "akb://v/file/file-1",
+            name: "diagram.png",
+            mime_type: "image/png",
+          },
+        ],
+      }));
+    });
+    const user = userEvent.setup();
+    const { refetchTree } = renderRoute("/vault/v/file/file-1");
+
+    await user.click(await screen.findByRole("button", { name: "Actions for diagram.png" }));
+    await user.click(screen.getByRole("menuitem", { name: "Delete file" }));
+    await user.click(screen.getByRole("button", { name: "Delete file" }));
+
+    await waitFor(() => expect(deleteFileMock).toHaveBeenCalledWith("v", "file-1"));
+    expect(refetchTree).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("pathname")).toHaveTextContent("/vault/v");
+  });
+
+  it("requires an admin and an exact name before deleting a table", async () => {
+    vaultInfoMock.mockResolvedValue({ role: "admin" });
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === "POST" && url.endsWith("/sql")) {
+        return Promise.resolve(jsonResponse({
+          items: [{ id: 1, title: "First" }],
+          columns: ["id", "title"],
+          total: 1,
+        }));
+      }
+      return Promise.resolve(jsonResponse({
+        items: [
+          {
+            name: "audit_log",
+            row_count: 1,
+            columns: [{ name: "id", type: "int", primary_key: true }],
+          },
+        ],
+      }));
+    });
+    const user = userEvent.setup();
+    const { refetchTree } = renderRoute("/vault/v/table/audit_log");
+
+    await user.click(await screen.findByRole("button", { name: "Actions for audit_log" }));
+    await user.click(screen.getByRole("menuitem", { name: "Delete table" }));
+    const confirm = screen.getByRole("button", { name: "Delete table" });
+    expect(confirm).toBeDisabled();
+    await user.type(screen.getByLabelText(/type the table name/i), "audit_log");
+    await user.click(confirm);
+
+    await waitFor(() => expect(deleteTableMock).toHaveBeenCalledWith("v", "audit_log"));
+    expect(refetchTree).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("pathname")).toHaveTextContent("/vault/v");
+  });
+
+  it("does not expose table deletion to a writer", async () => {
+    vaultInfoMock.mockResolvedValue({ role: "writer" });
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === "POST" && url.endsWith("/sql")) {
+        return Promise.resolve(jsonResponse({ items: [], columns: [], total: 0 }));
+      }
+      return Promise.resolve(jsonResponse({
+        items: [{ name: "audit_log", row_count: 0, columns: [] }],
+      }));
+    });
+    renderRoute("/vault/v/table/audit_log");
+
+    await screen.findByRole("heading", { name: "audit_log" });
+    expect(screen.queryByRole("button", { name: "Actions for audit_log" })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/document.tsx
+++ b/frontend/src/pages/document.tsx
@@ -30,7 +30,6 @@ import {
   PanelRightOpen,
   Pencil,
   Share2,
-  Trash2,
 } from "lucide-react";
 import {
   authenticatedFetch,
@@ -68,6 +67,8 @@ import { RelationsPanel } from "@/components/relations/relations-panel";
 import { relationIsInVault } from "@/components/relations/relation-row-utils";
 import { useCurrentUser } from "@/contexts/current-user-context";
 import { recordRecentDocumentView } from "@/lib/recent-document-views";
+import { ResourceActionsMenu } from "@/components/resource-actions-menu";
+import { ResourceDeleteDialog } from "@/components/resource-delete-dialog";
 
 // Plate is heavy (~hundreds of KB gzipped); lazy-load so the read-only path
 // (Rendered / Raw) stays cheap.
@@ -106,6 +107,7 @@ export default function DocumentPage({
   const [articleEl, setArticleEl] = useState<HTMLElement | null>(null);
   const [vaultRole, setVaultRole] = useState<string | null>(null);
   const [vaultKind, setVaultKind] = useState<"normal" | "mirror" | "error" | null>(null);
+  const [vaultReadOnly, setVaultReadOnly] = useState(true);
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [publishOpen, setPublishOpen] = useState(false);
@@ -198,14 +200,17 @@ export default function DocumentPage({
     if (!name) return;
     setVaultRole(null);
     setVaultKind(null);
+    setVaultReadOnly(true);
     getVaultInfo(name)
       .then((d) => {
         setVaultRole(d?.role || null);
         setVaultKind(d?.is_external_git ? "mirror" : "normal");
+        setVaultReadOnly(Boolean(d?.is_archived || d?.is_external_git));
       })
       .catch(() => {
         setVaultRole(null);
         setVaultKind("error");
+        setVaultReadOnly(true);
       });
   }, [name]);
 
@@ -530,6 +535,7 @@ export default function DocumentPage({
     (doc.created_by && !isUuid(doc.created_by) ? doc.created_by : null);
   const canWrite =
     vaultRole === "writer" || vaultRole === "admin" || vaultRole === "owner";
+  const canDelete = canWrite && !vaultReadOnly && !isHistorical;
 
   const closeDetails = () => {
     setDetailsOpen(false);
@@ -627,6 +633,13 @@ export default function DocumentPage({
                 <Maximize2 className="h-4 w-4" aria-hidden />
                 <span className="hidden lg:inline">Full page</span>
               </Button>
+            )}
+            {canDelete && !inEditMode && (
+              <ResourceActionsMenu
+                resourceName={doc.title || fileName}
+                deleteLabel="Delete document"
+                onDelete={() => setDeleteOpen(true)}
+              />
             )}
             {inEditMode ? (
               <>
@@ -1028,20 +1041,6 @@ export default function DocumentPage({
                 )}
               </section>
 
-                  {canWrite && !isHistorical && (
-                    <div className="mt-4 border-t border-border pt-3">
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        className="w-full justify-start text-destructive hover:bg-destructive-soft hover:text-destructive-soft-foreground"
-                        onClick={() => setDeleteOpen(true)}
-                      >
-                        <Trash2 className="h-3.5 w-3.5" aria-hidden />
-                        Delete document
-                      </Button>
-                    </div>
-                  )}
                 </TabsContent>
 
                 <TabsContent value="outline" className="min-h-0 flex-1 overflow-y-auto px-4 pb-4 pt-3 rail-scroll">
@@ -1109,15 +1108,11 @@ export default function DocumentPage({
         onPublished={(slug) => setDocOverride({ ...doc, is_public: true, public_slug: slug })}
       />
 
-      <ConfirmDialog
+      <ResourceDeleteDialog
         open={deleteOpen}
         onOpenChange={setDeleteOpen}
-        title={`Delete "${doc.title || doc.path}"?`}
-        description={
-          "The document, its embeddings, and its publication links are removed.\nGit history of the file is preserved in the vault repo.\nThis cannot be undone from the UI."
-        }
-        confirmLabel="Delete document"
-        variant="destructive"
+        kind="document"
+        name={doc.title || doc.path}
         onConfirm={async () => {
           await deleteDocument(name!, docId);
           refetchTree();

--- a/frontend/src/pages/file.tsx
+++ b/frontend/src/pages/file.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import {
   Clock3,
   Download,
@@ -25,13 +25,17 @@ import { Button } from "@/components/ui/button";
 import { LoadingState } from "@/components/ui/loading-state";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TooltipText } from "@/components/ui/tooltip-text";
-import { authenticatedFetch } from "@/lib/api";
+import { ResourceActionsMenu } from "@/components/resource-actions-menu";
+import { ResourceDeleteDialog } from "@/components/resource-delete-dialog";
+import { useVaultRefresh } from "@/contexts/vault-refresh-context";
+import { authenticatedFetch, deleteVaultFile, getVaultInfo } from "@/lib/api";
 import {
   effectiveFileMime,
   filePreviewKind,
   formatFileSize,
 } from "@/lib/file-preview";
 import { parseFileUri } from "@/lib/uri";
+import { canEdit } from "@/lib/roles";
 import { timeAgo } from "@/lib/utils";
 
 interface FileInfo {
@@ -54,12 +58,36 @@ interface FileAccess {
 
 export default function FilePage() {
   const { name: vault, id: fileId } = useParams<{ name: string; id: string }>();
+  const navigate = useNavigate();
+  const { refetchTree } = useVaultRefresh();
   const [info, setInfo] = useState<FileInfo | null>(null);
   const [access, setAccess] = useState<FileAccess | null>(null);
   const [loadError, setLoadError] = useState("");
   const [previewError, setPreviewError] = useState("");
   const [infoLoading, setInfoLoading] = useState(true);
   const [previewLoading, setPreviewLoading] = useState(true);
+  const [canDelete, setCanDelete] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  useEffect(() => {
+    if (!vault) return;
+    let cancelled = false;
+    setCanDelete(false);
+    getVaultInfo(vault)
+      .then((data) => {
+        if (!cancelled) {
+          setCanDelete(
+            canEdit(data?.role) && !data?.is_archived && !data?.is_external_git,
+          );
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setCanDelete(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [vault]);
 
   useEffect(() => {
     if (!vault || !fileId) return;
@@ -148,30 +176,39 @@ export default function FilePage() {
         }
         meta={<Badge variant="outline">{kindLabel}</Badge>}
         actions={
-          access?.download_url ? (
-            <Button asChild size="sm">
-              <a
-                href={access.download_url}
-                target="_blank"
-                rel="noreferrer"
-                download={displayName}
+          <>
+            {access?.download_url ? (
+              <Button asChild size="sm">
+                <a
+                  href={access.download_url}
+                  target="_blank"
+                  rel="noreferrer"
+                  download={displayName}
+                >
+                  <Download className="h-4 w-4" aria-hidden />
+                  <span className="hidden sm:inline">Download</span>
+                </a>
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                loading={previewLoading}
+                onClick={() => void loadPreview()}
               >
-                <Download className="h-4 w-4" aria-hidden />
-                <span className="hidden sm:inline">Download</span>
-              </a>
-            </Button>
-          ) : (
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              loading={previewLoading}
-              onClick={() => void loadPreview()}
-            >
-              {!previewLoading && <RefreshCw className="h-4 w-4" aria-hidden />}
-              <span className="hidden sm:inline">Retry preview</span>
-            </Button>
-          )
+                {!previewLoading && <RefreshCw className="h-4 w-4" aria-hidden />}
+                <span className="hidden sm:inline">Retry preview</span>
+              </Button>
+            )}
+            {canDelete && (
+              <ResourceActionsMenu
+                resourceName={displayName}
+                deleteLabel="Delete file"
+                onDelete={() => setDeleteOpen(true)}
+              />
+            )}
+          </>
         }
       />
 
@@ -267,6 +304,17 @@ export default function FilePage() {
           )}
         </ResourceCanvas>
       </div>
+      <ResourceDeleteDialog
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        kind="file"
+        name={displayName}
+        onConfirm={async () => {
+          await deleteVaultFile(vault!, fileId!);
+          refetchTree();
+          navigate(`/vault/${vault}`);
+        }}
+      />
     </ResourceWorkspace>
   );
 }

--- a/frontend/src/pages/table.tsx
+++ b/frontend/src/pages/table.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import {
   Asterisk,
   Braces,
@@ -31,7 +31,11 @@ import { Button } from "@/components/ui/button";
 import { LoadingState } from "@/components/ui/loading-state";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TooltipText } from "@/components/ui/tooltip-text";
-import { authenticatedFetch } from "@/lib/api";
+import { ResourceActionsMenu } from "@/components/resource-actions-menu";
+import { ResourceDeleteDialog } from "@/components/resource-delete-dialog";
+import { useVaultRefresh } from "@/contexts/vault-refresh-context";
+import { authenticatedFetch, deleteVaultTable, getVaultInfo } from "@/lib/api";
+import { ROLE_RANK, type Role } from "@/lib/roles";
 import { cn } from "@/lib/utils";
 
 interface Column {
@@ -50,6 +54,8 @@ interface TableInfo {
 
 export default function TablePage() {
   const { name: vault, table } = useParams<{ name: string; table: string }>();
+  const navigate = useNavigate();
+  const { refetchTree } = useVaultRefresh();
   const [info, setInfo] = useState<TableInfo | null>(null);
   const [rows, setRows] = useState<Record<string, unknown>[]>([]);
   const [cols, setCols] = useState<string[]>([]);
@@ -58,9 +64,34 @@ export default function TablePage() {
   const [loading, setLoading] = useState(true);
   const [infoLoading, setInfoLoading] = useState(true);
   const [schemaOpen, setSchemaOpen] = useState(false);
+  const [canDelete, setCanDelete] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
   const schemaToggleRef = useRef<HTMLButtonElement | null>(null);
   const schemaCloseRef = useRef<HTMLButtonElement | null>(null);
   const limit = 50;
+
+  useEffect(() => {
+    if (!vault) return;
+    let cancelled = false;
+    setCanDelete(false);
+    getVaultInfo(vault)
+      .then((data) => {
+        const roleRank = ROLE_RANK[data?.role as Role] ?? 0;
+        if (!cancelled) {
+          setCanDelete(
+            roleRank >= ROLE_RANK.admin &&
+              !data?.is_archived &&
+              !data?.is_external_git,
+          );
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setCanDelete(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [vault]);
 
   const closeSchema = useCallback(() => {
     setSchemaOpen(false);
@@ -192,6 +223,13 @@ export default function TablePage() {
               )}
               <span className="hidden sm:inline">Schema</span>
             </Button>
+            {canDelete && (
+              <ResourceActionsMenu
+                resourceName={table || "Table"}
+                deleteLabel="Delete table"
+                onDelete={() => setDeleteOpen(true)}
+              />
+            )}
           </>
         }
       />
@@ -417,6 +455,18 @@ export default function TablePage() {
           </div>
         </aside>
       </div>
+      <ResourceDeleteDialog
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        kind="table"
+        name={table || "Table"}
+        rowCount={rowCount}
+        onConfirm={async () => {
+          await deleteVaultTable(vault!, table!);
+          refetchTree();
+          navigate(`/vault/${vault}`);
+        }}
+      />
     </ResourceWorkspace>
   );
 }


### PR DESCRIPTION
## Summary\n\n- close the collection-delete permission bypass that let a Vault writer drop admin-only tables through recursive collection deletion\n- add shared, permission-aware delete actions for documents, files, and tables in both resource viewers and the Vault explorer\n- require exact table-name confirmation, surface affected row counts, preserve backend conflict details, refresh the tree, and leave stale resource routes after successful deletion\n- document the user-facing behavior and add REST, MCP, service, API-wrapper, component, page, and explorer regression coverage\n\n## Permission model\n\n- document and file deletion remains available to mutable Vault writers and above\n- physical table deletion remains restricted to Vault admins and owners\n- recursive collection deletion now derives a table-drop capability from the authenticated role and fails before any mutation when a writer targets a collection containing tables\n- archived and external-git Vaults remain read-only in the UI\n\n## Validation\n\n- bash scripts/check.sh (Python 3.14 analyzer preflight, ruff, mypy, bandit, frontend lint/typecheck, SDK build/typecheck/50 tests, frontend 639 tests, generated contract checks, packed-consumer proof, and secret scan)\n- AKB_URL=http://localhost:8000 bash backend/tests/test_collection_lifecycle_e2e.sh — 49 passed, including the original writer bypass scenario and post-denial table survival\n- local Docker Compose rebuild and redeploy; /livez, /readyz, and frontend returned healthy responses\n- local browser smoke test for owner document/file/table menus, table exact-name gate, reader non-exposure, and console errors (none)\n\n## Deployment scope\n\nValidation used the local Compose stack only. No Kubernetes context, cluster workload, registry, or other external environment was changed.