### PR TITLE
feat(frontend): complete document actions and editor workflows

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -5395,10 +5395,10 @@
         "filename": "frontend/src/pages/__tests__/document-view-toggle.test.tsx",
         "hashed_secret": "6c688927eafd673c7d9194b46b2b88e096e6c9f7",
         "is_verified": false,
-        "line_number": 74,
+        "line_number": 80,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-08-27T05:46:02Z"
+  "generated_at": "2026-08-27T06:43:05Z"
 }

--- a/frontend/DESIGN_SYSTEM.md
+++ b/frontend/DESIGN_SYSTEM.md
@@ -497,6 +497,16 @@ commits` control and `Full commit log` route. Below `xl`, the work area stacks
   never flattened silently. Upload errors stay inside the editor with an
   announced reason and explicit recovery: Retry appears only for transient
   failures, while Choose another and Dismiss are always available.
+  Tables and images are atomic authoring blocks, so the editor always maintains
+  a trailing paragraph as a keyboard and pointer escape route. An editable table
+  owns one compact caption toolbar with labelled Row, Column, and Continue below
+  actions plus a spatially separated Delete table control; GFM tables remain
+  rectangular because merged cells cannot round-trip to Markdown. Removing a
+  table restores focus to the following text block and remains reversible through
+  editor Undo. Image removal is an always-discoverable neutral `X` inset at the
+  image's own top-right corner—not the document measure's edge—and returns focus
+  to the nearest text block. All block controls are omitted in read-only mode,
+  use Lucide icons, expose accessible names, and never rely on hover alone.
   A document opened from Search uses this same reader inside a route-backed
   preview dialog rather than replacing the result ledger. The dialog leaves the
   persistent Vault navigation visible on wide screens, becomes full-screen on

--- a/frontend/DESIGN_SYSTEM.md
+++ b/frontend/DESIGN_SYSTEM.md
@@ -442,16 +442,17 @@ commits` control and `Full commit log` route. Below `xl`, the work area stacks
   exceeds the viewport.
 - **Document workspace**: document routes are full-bleed inside `VaultShell`
   (no generic page padding) and use the same `h-16` workspace header as the new
-  document composer. The header identifies the file and vault and keeps
-  read/edit/detail actions at the right. Do not repeat the raw canonical
-  `akb://` URI in this title bar; the path row and Details context already own
-  document location and technical metadata. The
-  main column is a Git-style framed file viewer with Rendered / Raw / Edit modes
-  and only an 8–12px outer gutter in read mode. Details is closed by default and
-  opens as a 24rem right overlay inspector: it never reserves canvas width or
-  reflows the document. On narrow screens it gains a dismissible backdrop;
-  backdrop click, Close, and Escape dismiss it and return focus to the Details
-  trigger. The inspector treats Info, Outline, Relations, and History as four
+  document composer. The header identifies the file and vault; its right edge
+  keeps one primary `Edit` action next to the resource overflow menu. Do not
+  repeat the raw canonical `akb://` URI in this title bar; the path row and
+  document panel already own location and technical metadata. The
+  main column is a Git-style framed file viewer with Rendered / Raw read modes
+  and only an 8–12px outer gutter in read mode. The document panel is closed by
+  default and opens as a 24rem right overlay from an icon-only toggle at the
+  far right of the dense file-context row, next to History: it never reserves
+  canvas width or reflows the document. On narrow screens it gains a dismissible
+  backdrop; backdrop click, Close, and Escape dismiss it and return focus to the
+  panel toggle. The inspector treats Info, Outline, Relations, and History as four
   peer views below one fixed header; the selected view owns all remaining panel
   height instead of sitting beneath a permanently expanded Properties block.
   Publish state and destructive actions stay inside Info, so they do not tax the
@@ -459,20 +460,36 @@ commits` control and `Full commit log` route. Below `xl`, the work area stacks
   the reading flow. Rendered headings, paragraphs, lists, and quotes share one
   centered 64rem measure so their left and right edges stay aligned regardless
   of font size; Korean-heavy technical documents still use most of the file
-  frame without creating a one-sided void. Code, tables, and media may use the
-  full workspace. The
+  frame without creating a one-sided void. Ordinary tables align to this same
+  measure and scroll horizontally inside their framed wrapper when their columns
+  need more room. Code and media may use the full workspace. The
   file toolbar keeps logical line count and UTF-8 byte size at the left, uses
   its flexible middle slot for a labelled single-line document summary when
   metadata and horizontal space are available, exposes Copy in both Rendered
-  and Raw views, and keeps the Rendered / Raw / Edit mode control right-aligned.
+  and Raw views, and keeps the Rendered / Raw mode control right-aligned. Edit is
+  a document mutation, not a read-mode tab: edit mode replaces the file toolbar
+  with a compact editing-status strip while Cancel / Save changes live in the
+  workspace header. Cancel always exits a clean editor and asks for confirmation
+  before discarding unsaved work.
   Bound and disclose summary overflow through the shared tooltip text primitive;
-  hide the compact summary when horizontal space is constrained, while Details /
+  hide the compact summary when horizontal space is constrained, while the panel's
   Info remains the complete metadata view at every breakpoint. The
   document title is the compact workspace-header H1 and is not repeated as a
   page hero; path, author, commit, age, and History share one dense file-context
   row immediately above the content surface. Never add another vertical summary
   band before the file viewer, and omit the compact summary entirely when older
   backends return no value.
+  The document header overflow exposes Move or rename for every current
+  document instead of hiding the capability from readers or read-only Vaults.
+  When unavailable, the action remains visible with the exact permission,
+  historical-version, mirror, or reserved-guide reason. The move dialog is a
+  destination review rather than a generic metadata form: it shows current and
+  normalized target paths, selects an existing Collection (or Vault root), edits
+  the filename/slug, and accepts an optional Git commit message. Submission
+  preserves entered values on failure; after success the backend-returned path
+  is authoritative, the reader replaces the stale route, and a compact status
+  notice names the destination Collection. Git history, old-URI aliases,
+  relations, and publication rewrites remain backend responsibilities.
   Composer images use a 10 MB transfer ceiling and the asset service's 12 MP /
   8,192px decode boundary. The client automatically fits oversized still PNG,
   JPEG, and WebP images to that resolution before upload so a highly compressed

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,6 +55,7 @@
     "@platejs/list": "~53.0.2",
     "@platejs/markdown": "~53.0.4",
     "@platejs/table": "~53.0.0",
+    "@platejs/utils": "~53.0.3",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@platejs/table':
         specifier: ~53.0.0
         version: 53.0.0(platejs@53.0.3(@types/react@19.2.14)(immer@10.2.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(scheduler@0.27.0)(use-sync-external-store@1.6.0(react@19.2.4)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@platejs/utils':
+        specifier: ~53.0.3
+        version: 53.0.3(@types/react@19.2.14)(immer@10.2.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(scheduler@0.27.0)(use-sync-external-store@1.6.0(react@19.2.4))
       '@radix-ui/react-avatar':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/frontend/src/components/__tests__/document-move-dialog.test.tsx
+++ b/frontend/src/components/__tests__/document-move-dialog.test.tsx
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { DocumentMoveDialog } from "@/components/document-move-dialog";
+import { previewDocumentSlug } from "@/lib/document-move";
+
+vi.mock("@/lib/api", () => ({
+  ApiError: class ApiError extends Error {
+    status: number;
+    detail: unknown;
+    constructor(message: string, status: number, detail: unknown) {
+      super(message);
+      this.status = status;
+      this.detail = detail;
+    }
+  },
+  browseVault: vi.fn(),
+  moveDocument: vi.fn(),
+}));
+
+import { ApiError, browseVault, moveDocument } from "@/lib/api";
+
+const browseVaultMock = browseVault as unknown as ReturnType<typeof vi.fn>;
+const moveDocumentMock = moveDocument as unknown as ReturnType<typeof vi.fn>;
+
+function renderDialog(onMoved = vi.fn(), onOpenChange = vi.fn()) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return {
+    onMoved,
+    onOpenChange,
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <DocumentMoveDialog
+          open
+          onOpenChange={onOpenChange}
+          vault="engineering"
+          path="drafts/api-contract.md"
+          title="API contract"
+          onMoved={onMoved}
+        />
+      </QueryClientProvider>,
+    ),
+  };
+}
+
+beforeEach(() => {
+  browseVaultMock.mockReset();
+  moveDocumentMock.mockReset();
+  browseVaultMock.mockResolvedValue({
+    items: [
+      { type: "collection", path: "archive" },
+      { type: "collection", path: "drafts" },
+      { type: "collection", path: "projects/akb" },
+      { type: "collection", path: "overview" },
+    ],
+  });
+  moveDocumentMock.mockResolvedValue({
+    kind: "document_write",
+    uri: "akb://engineering/coll/archive/doc/final-contract.md",
+    vault: "engineering",
+    path: "archive/final-contract.md",
+    commit_hash: "abc1234",
+    current_commit: "abc1234",
+    action: "moved",
+  });
+});
+
+afterEach(() => cleanup());
+
+describe("DocumentMoveDialog", () => {
+  it("reviews the path change and submits only changed destination fields", async () => {
+    const user = userEvent.setup();
+    const { onMoved, onOpenChange } = renderDialog();
+
+    expect(screen.getAllByText("drafts/api-contract.md")).toHaveLength(2);
+    expect(screen.getByRole("button", { name: "Move document" })).toBeDisabled();
+
+    const collection = await screen.findByLabelText("Target collection");
+    await user.click(collection);
+    expect(screen.queryByRole("menuitemradio", { name: /overview/i })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("menuitemradio", { name: "archive" }));
+
+    const fileName = screen.getByLabelText("File name");
+    await user.clear(fileName);
+    await user.type(fileName, "Final Contract");
+    await user.type(
+      screen.getByLabelText(/commit message/i),
+      "Move the approved contract",
+    );
+
+    expect(screen.getByText("archive/final-contract.md")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Move document" }));
+
+    await waitFor(() =>
+      expect(moveDocumentMock).toHaveBeenCalledWith(
+        "engineering",
+        "drafts/api-contract.md",
+        {
+          collection: "archive",
+          slug: "Final Contract",
+          message: "Move the approved contract",
+        },
+      ),
+    );
+    expect(onMoved).toHaveBeenCalledWith(
+      expect.objectContaining({ path: "archive/final-contract.md" }),
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("keeps the form open with a recoverable collision message", async () => {
+    moveDocumentMock.mockRejectedValue(
+      new Error("Document already exists at path: archive/api-contract.md"),
+    );
+    const user = userEvent.setup();
+    const { onMoved, onOpenChange } = renderDialog();
+
+    await user.click(await screen.findByLabelText("Target collection"));
+    await user.click(screen.getByRole("menuitemradio", { name: "archive" }));
+    await user.click(screen.getByRole("button", { name: "Move document" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "A document already uses that file name in the selected collection",
+    );
+    expect(screen.getByLabelText("Target collection")).toHaveTextContent("archive");
+    expect(onMoved).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("keeps rename available when only the destination list fails", async () => {
+    browseVaultMock.mockRejectedValue(new Error("browse unavailable"));
+    const user = userEvent.setup();
+    renderDialog();
+
+    expect(
+      await screen.findByText(/still rename this document in its current location/i),
+    ).toBeInTheDocument();
+    const fileName = screen.getByLabelText("File name");
+    await user.clear(fileName);
+    await user.type(fileName, "API contract final");
+    await user.click(screen.getByRole("button", { name: "Move document" }));
+
+    await waitFor(() =>
+      expect(moveDocumentMock).toHaveBeenCalledWith(
+        "engineering",
+        "drafts/api-contract.md",
+        { slug: "API contract final" },
+      ),
+    );
+  });
+
+  it("explains when a legacy backend does not provide the move endpoint", async () => {
+    moveDocumentMock.mockRejectedValue(
+      new ApiError("Not Found", 404, { detail: "Not Found" }),
+    );
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(await screen.findByLabelText("Target collection"));
+    await user.click(screen.getByRole("menuitemradio", { name: "archive" }));
+    await user.click(screen.getByRole("button", { name: "Move document" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Move or rename is not available on this server yet.",
+    );
+  });
+
+  it("normalizes Unicode file names for the destination preview", () => {
+    expect(previewDocumentSlug("  주간 보고서 V2!  ")).toBe("주간-보고서-v2");
+    expect(previewDocumentSlug("***")).toBe("untitled");
+  });
+});

--- a/frontend/src/components/__tests__/markdown-editor-image.test.tsx
+++ b/frontend/src/components/__tests__/markdown-editor-image.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MarkdownEditor } from "@/components/markdown-editor";
 import { EDITOR_IMAGE_MAX_BYTES, validateEditorImage } from "@/lib/image-assets";
 
@@ -161,7 +162,7 @@ describe("MarkdownEditor image insertion", () => {
     await screen.findByRole("img", { name: "diagram" });
     const removeButton = screen.getByRole("button", { name: "Remove image: diagram" });
     expect(removeButton.querySelector(".lucide-x")).not.toBeNull();
-    expect(removeButton).toHaveClass("right-2", "top-2");
+    expect(removeButton.parentElement).toHaveClass("absolute", "right-2", "top-2");
     expect(removeButton).not.toHaveClass("opacity-0");
     fireEvent.click(removeButton);
 
@@ -179,6 +180,83 @@ describe("MarkdownEditor image insertion", () => {
     // An existing image may already be referenced by Git history, so removing
     // its current link must not physically delete the retained bytes.
     expect(apiMocks.discardAsset).not.toHaveBeenCalled();
+  });
+
+  it("edits the image description used by alt text and markdown", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <MarkdownEditor
+        value={`![diagram](/api/assets/${ASSET_ID})`}
+        vault="team"
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: "Edit image description: diagram" }),
+    );
+    const field = screen.getByLabelText("Description");
+    await user.clear(field);
+    await user.click(screen.getByRole("button", { name: "Save description" }));
+    expect(screen.getByRole("alert")).toHaveTextContent(/describe the image/i);
+
+    await user.type(field, "System architecture diagram");
+    await user.click(screen.getByRole("button", { name: "Save description" }));
+
+    expect(
+      await screen.findByRole("img", { name: "System architecture diagram" }),
+    ).toBeVisible();
+    await waitFor(() =>
+      expect(
+        onChange.mock.calls.some(([markdown]) =>
+          markdown.includes(`![System architecture diagram](/api/assets/${ASSET_ID})`),
+        ),
+      ).toBe(true),
+    );
+  });
+
+  it("replaces an image in place instead of inserting a duplicate", async () => {
+    const replacementId = "1de35742-b719-42ed-b140-623ed81151a2";
+    apiMocks.uploadAsset.mockResolvedValue({
+      id: replacementId,
+      url: `/api/assets/${replacementId}`,
+      name: "replacement.png",
+      mime_type: "image/png",
+      size_bytes: 5,
+    });
+    const onChange = vi.fn();
+    const { container } = render(
+      <MarkdownEditor
+        value={`![diagram](/api/assets/${ASSET_ID})`}
+        vault="team"
+        onChange={onChange}
+        initialUnclaimedAssetIds={[ASSET_ID]}
+      />,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Replace image: diagram" }),
+    );
+    fireEvent.change(container.querySelector('input[type="file"]')!, {
+      target: {
+        files: [new File(["replacement"], "replacement.png", { type: "image/png" })],
+      },
+    });
+
+    expect(await screen.findByRole("img", { name: "replacement" })).toBeVisible();
+    await waitFor(() =>
+      expect(
+        onChange.mock.calls.some(
+          ([markdown, ids]) =>
+            markdown.includes(`/api/assets/${replacementId}`) &&
+            !markdown.includes(`/api/assets/${ASSET_ID}`) &&
+            ids.length === 1,
+        ),
+      ).toBe(true),
+    );
+    expect(screen.getAllByRole("img")).toHaveLength(1);
+    await waitFor(() => expect(apiMocks.discardAsset).toHaveBeenCalledWith("team", ASSET_ID));
   });
 
   it("uses the exact document revision when resolving an existing image", async () => {

--- a/frontend/src/components/__tests__/markdown-editor-image.test.tsx
+++ b/frontend/src/components/__tests__/markdown-editor-image.test.tsx
@@ -159,7 +159,11 @@ describe("MarkdownEditor image insertion", () => {
     );
 
     await screen.findByRole("img", { name: "diagram" });
-    fireEvent.click(screen.getByRole("button", { name: "Remove image: diagram" }));
+    const removeButton = screen.getByRole("button", { name: "Remove image: diagram" });
+    expect(removeButton.querySelector(".lucide-x")).not.toBeNull();
+    expect(removeButton).toHaveClass("right-2", "top-2");
+    expect(removeButton).not.toHaveClass("opacity-0");
+    fireEvent.click(removeButton);
 
     await waitFor(() => expect(screen.queryByRole("img", { name: "diagram" })).toBeNull());
     await waitFor(() =>

--- a/frontend/src/components/__tests__/markdown-editor-table.test.tsx
+++ b/frontend/src/components/__tests__/markdown-editor-table.test.tsx
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MarkdownEditor } from "@/components/markdown-editor";
+
+const TABLE_MARKDOWN = [
+  "| Service | Owner |",
+  "| --- | --- |",
+  "| Search | Platform |",
+].join("\n");
+
+describe("MarkdownEditor table interactions", () => {
+  it("keeps a writable paragraph after a terminal table", () => {
+    render(
+      <MarkdownEditor
+        value={TABLE_MARKDOWN}
+        vault="team"
+        ariaLabel="Document content"
+        onChange={vi.fn()}
+      />,
+    );
+
+    const editor = screen.getByRole("textbox", { name: "Document content" });
+    expect(screen.getByRole("table", { name: "Editable table" })).toHaveClass(
+      "!table",
+      "w-full",
+    );
+    expect(editor.lastElementChild?.tagName).toBe("P");
+  });
+
+  it("moves focus below the table without a pointer-only escape", async () => {
+    const user = userEvent.setup();
+    render(
+      <MarkdownEditor
+        value={TABLE_MARKDOWN}
+        vault="team"
+        ariaLabel="Document content"
+        onChange={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Continue below" }));
+    await waitFor(() =>
+      expect(screen.getByRole("textbox", { name: "Document content" })).toHaveFocus(),
+    );
+    expect(
+      screen.getByRole("textbox", { name: "Document content" }).lastElementChild?.tagName,
+    ).toBe("P");
+  });
+
+  it("adds rows and columns from the table-local toolbar", async () => {
+    const user = userEvent.setup();
+    render(
+      <MarkdownEditor value={TABLE_MARKDOWN} vault="team" onChange={vi.fn()} />,
+    );
+
+    const table = screen.getByRole("table", { name: "Editable table" });
+    const tableActions = within(table).getByRole("toolbar", { name: "Table actions" });
+    expect(within(table).getAllByRole("row")).toHaveLength(2);
+    expect(within(table).getAllByRole("columnheader")).toHaveLength(2);
+
+    await user.click(within(tableActions).getByRole("button", { name: "Row" }));
+    expect(
+      within(screen.getByRole("table", { name: "Editable table" })).getAllByRole("row"),
+    ).toHaveLength(3);
+
+    const updatedTable = screen.getByRole("table", { name: "Editable table" });
+    await user.click(
+      within(updatedTable).getByRole("button", { name: "Column" }),
+    );
+    expect(
+      within(screen.getByRole("table", { name: "Editable table" }))
+        .getAllByRole("row")[0]
+        .querySelectorAll("th, td"),
+    ).toHaveLength(3);
+  });
+
+  it("deletes the entire table and restores an editable cursor target", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <MarkdownEditor
+        value={TABLE_MARKDOWN}
+        vault="team"
+        ariaLabel="Document content"
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Delete table" }));
+
+    expect(screen.queryByRole("table", { name: "Editable table" })).toBeNull();
+    await waitFor(() =>
+      expect(screen.getByRole("textbox", { name: "Document content" })).toHaveFocus(),
+    );
+    await waitFor(() =>
+      expect(onChange.mock.calls.some(([markdown]) => !markdown.includes("| Service"))).toBe(true),
+    );
+    expect(
+      screen.getByRole("textbox", { name: "Document content" }).lastElementChild?.tagName,
+    ).toBe("P");
+  });
+
+  it("does not expose editing actions in read-only mode", () => {
+    render(
+      <MarkdownEditor value={TABLE_MARKDOWN} vault="team" readOnly />,
+    );
+
+    expect(screen.getByRole("table", { name: "Table" })).toBeVisible();
+    expect(screen.queryByRole("toolbar", { name: "Table actions" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Delete table" })).toBeNull();
+  });
+});

--- a/frontend/src/components/__tests__/markdown-editor-table.test.tsx
+++ b/frontend/src/components/__tests__/markdown-editor-table.test.tsx
@@ -75,6 +75,25 @@ describe("MarkdownEditor table interactions", () => {
     ).toHaveLength(3);
   });
 
+  it("removes the selected row and column without deleting the whole table", async () => {
+    const user = userEvent.setup();
+    render(
+      <MarkdownEditor value={TABLE_MARKDOWN} vault="team" onChange={vi.fn()} />,
+    );
+
+    await user.click(screen.getByText("Search"));
+    await user.click(screen.getByRole("button", { name: "Remove row" }));
+    expect(
+      within(screen.getByRole("table", { name: "Editable table" })).getAllByRole("row"),
+    ).toHaveLength(1);
+
+    await user.click(screen.getByText("Search"));
+    await user.click(screen.getByRole("button", { name: "Remove column" }));
+    const remainingTable = screen.getByRole("table", { name: "Editable table" });
+    expect(remainingTable.querySelectorAll("th, td")).toHaveLength(1);
+    expect(screen.getByRole("button", { name: "Delete table" })).toBeVisible();
+  });
+
   it("deletes the entire table and restores an editable cursor target", async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();

--- a/frontend/src/components/__tests__/markdown-editor-toolbar.test.tsx
+++ b/frontend/src/components/__tests__/markdown-editor-toolbar.test.tsx
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MarkdownEditor } from "@/components/markdown-editor";
+import { normalizeEditorLinkUrl } from "@/lib/editor-link";
+
+describe("MarkdownEditor formatting toolbar", () => {
+  it("uses one tab stop and arrow keys to move through toolbar controls", async () => {
+    const user = userEvent.setup();
+    render(<MarkdownEditor value="Draft" vault="team" onChange={vi.fn()} />);
+
+    await user.tab();
+    expect(screen.getByRole("button", { name: "Paragraph" })).toHaveFocus();
+    await user.keyboard("{ArrowRight}");
+    expect(screen.getByRole("button", { name: "Heading 1" })).toHaveFocus();
+    await user.keyboard("{End}");
+    expect(screen.getByRole("button", { name: "Insert image" })).toHaveFocus();
+    await user.keyboard("{Home}");
+    expect(screen.getByRole("button", { name: "Paragraph" })).toHaveFocus();
+  });
+
+  it("loads multiline code as distinct code lines", () => {
+    const onChange = vi.fn();
+    render(
+      <MarkdownEditor
+        value={'```\nline one\nline two\n```'}
+        vault="team"
+        ariaLabel="Document content"
+        onChange={onChange}
+      />,
+    );
+
+    const editor = screen.getByRole("textbox", { name: "Document content" });
+    const codeBlock = editor.querySelector("pre");
+    expect(codeBlock).not.toBeNull();
+    expect(codeBlock?.children).toHaveLength(2);
+    expect(codeBlock?.children[0]).toHaveTextContent("line one");
+    expect(codeBlock?.children[1]).toHaveTextContent("line two");
+  });
+
+  it("shows recoverable validation for unsafe link destinations", async () => {
+    const user = userEvent.setup();
+    render(
+      <MarkdownEditor
+        value="Plate docs"
+        vault="team"
+        ariaLabel="Document content"
+        onChange={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Insert link" }));
+    await user.type(screen.getByLabelText("URL"), "javascript:alert(1)");
+    await user.click(screen.getByRole("button", { name: "Insert link" }));
+    expect(screen.getByRole("alert")).toHaveTextContent(/http\(s\), email, phone/i);
+    await waitFor(() => expect(screen.getByLabelText("URL")).toHaveFocus());
+  });
+
+  it("normalizes common safe links and rejects active-content URLs", () => {
+    expect(normalizeEditorLinkUrl("platejs.org")).toBe("https://platejs.org");
+    expect(normalizeEditorLinkUrl("/vault/team")).toBe("/vault/team");
+    expect(normalizeEditorLinkUrl("mailto:owner@example.com")).toBe(
+      "mailto:owner@example.com",
+    );
+    expect(normalizeEditorLinkUrl("javascript:alert(1)")).toBeNull();
+  });
+
+  it.each([
+    ["heading", "## Terminal heading"],
+    ["blockquote", "> Terminal quote"],
+    ["code", "```\nterminal code\n```"],
+    ["table", "| A | B |\n| --- | --- |\n| 1 | 2 |"],
+  ])("does not persist the editor-only trailing paragraph after a %s", async (_name, value) => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <MarkdownEditor
+        value={value}
+        vault="team"
+        ariaLabel="Document content"
+        onChange={onChange}
+      />,
+    );
+    const editor = screen.getByRole("textbox", { name: "Document content" });
+    const trailingParagraph = editor.lastElementChild as HTMLElement;
+    expect(trailingParagraph.tagName).toBe("P");
+    await user.click(trailingParagraph);
+    await user.type(trailingParagraph, "x");
+    await user.keyboard("{Backspace}");
+
+    await waitFor(() => expect(onChange).toHaveBeenCalled());
+    const latest = onChange.mock.calls.at(-1)?.[0] as string;
+    expect(latest).not.toContain("\u200b");
+    expect(latest).not.toContain("\ufeff");
+  });
+});

--- a/frontend/src/components/__tests__/markdown-render-layout.test.tsx
+++ b/frontend/src/components/__tests__/markdown-render-layout.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MarkdownRender } from "@/components/markdown-render";
+
+describe("MarkdownRender layout", () => {
+  it("gives tables a centered reading-measure wrapper with horizontal overflow", () => {
+    render(
+      <MarkdownRender
+        markdown={[
+          "| Name | Owner | Status |",
+          "| --- | --- | --- |",
+          "| Search | Platform | Active |",
+        ].join("\n")}
+        className="document-reading-flow"
+      />,
+    );
+
+    const table = screen.getByRole("table");
+    expect(table).toHaveClass("w-max", "min-w-full");
+    expect(table.parentElement).toHaveClass("akb-md-table", "overflow-x-auto");
+  });
+});

--- a/frontend/src/components/document-create-dialog.tsx
+++ b/frontend/src/components/document-create-dialog.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState, type CSSProperties, type RefObject } from "react";
 import { DocumentCreateForm } from "@/components/document-create-form";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { discardAsset } from "@/lib/api";
+import { clearDocumentDraft } from "@/lib/document-draft";
 
 export interface DocumentCreateDialogProps {
   open: boolean;
@@ -32,6 +34,7 @@ export function DocumentCreateDialog({
   const [creating, setCreating] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [discardOpen, setDiscardOpen] = useState(false);
+  const [draftAssetIds, setDraftAssetIds] = useState<readonly string[]>([]);
 
   useEffect(() => {
     if (open) return;
@@ -39,6 +42,7 @@ export function DocumentCreateDialog({
     setCreating(false);
     setUploading(false);
     setDiscardOpen(false);
+    setDraftAssetIds([]);
   }, [open]);
 
   function requestClose() {
@@ -94,6 +98,7 @@ export function DocumentCreateDialog({
               onDirtyChange={setDirty}
               onCreatingChange={setCreating}
               onUploadingChange={setUploading}
+              onAssetIdsChange={setDraftAssetIds}
             />
           )}
         </DialogContent>
@@ -110,7 +115,16 @@ export function DocumentCreateDialog({
         }
         confirmLabel="Discard draft"
         variant="destructive"
-        onConfirm={() => onOpenChange(false)}
+        onConfirm={async () => {
+          // Keep temporary uploads alive across an unexpected reload so the
+          // local draft can recover. An explicit discard is the authoritative
+          // cleanup path; the server TTL remains the fallback for failures.
+          await Promise.allSettled(
+            draftAssetIds.map((assetId) => discardAsset(vault, assetId)),
+          );
+          clearDocumentDraft(vault);
+          onOpenChange(false);
+        }}
       />
     </>
   );

--- a/frontend/src/components/document-create-form.tsx
+++ b/frontend/src/components/document-create-form.tsx
@@ -19,6 +19,11 @@ import {
 } from "lucide-react";
 import { ApiError, putDocument } from "@/lib/api";
 import { DOC_TYPES, type DocType } from "@/lib/doc-constants";
+import {
+  clearDocumentDraft,
+  loadDocumentDraft,
+  saveDocumentDraft,
+} from "@/lib/document-draft";
 import { isReservedCollection } from "@/lib/skill";
 import { useVaultTree, type TreeNode } from "@/hooks/use-vault-tree";
 import { useVaultRefresh } from "@/contexts/vault-refresh-context";
@@ -46,6 +51,7 @@ export interface DocumentCreateFormProps {
   onDirtyChange?: (dirty: boolean) => void;
   onCreatingChange?: (creating: boolean) => void;
   onUploadingChange?: (uploading: boolean) => void;
+  onAssetIdsChange?: (assetIds: readonly string[]) => void;
 }
 
 /** Depth-first collection paths for the location suggestions. */
@@ -73,7 +79,9 @@ export function DocumentCreateForm({
   onDirtyChange,
   onCreatingChange,
   onUploadingChange,
+  onAssetIdsChange,
 }: DocumentCreateFormProps) {
+  const restoredDraft = useMemo(() => loadDocumentDraft(vault), [vault]);
   const { tree } = useVaultTree(vault);
   const { refetchTree, refetchVaults } = useVaultRefresh();
   const collectionOptions = useMemo(
@@ -84,19 +92,27 @@ export function DocumentCreateForm({
     [tree],
   );
 
-  const [title, setTitle] = useState("");
-  const [collection, setCollection] = useState(initialCollection);
-  const [type, setType] = useState<DocType>("note");
-  const [domain, setDomain] = useState("");
-  const [summary, setSummary] = useState("");
-  const [tags, setTags] = useState<string[]>([]);
-  const [body, setBody] = useState("");
-  const [bodyAssetIds, setBodyAssetIds] = useState<readonly string[]>([]);
+  const [title, setTitle] = useState(restoredDraft?.title ?? "");
+  const [collection, setCollection] = useState(
+    restoredDraft?.collection ?? initialCollection,
+  );
+  const [type, setType] = useState<DocType>(restoredDraft?.type ?? "note");
+  const [domain, setDomain] = useState(restoredDraft?.domain ?? "");
+  const [summary, setSummary] = useState(restoredDraft?.summary ?? "");
+  const [tags, setTags] = useState<string[]>(restoredDraft?.tags ?? []);
+  const [body, setBody] = useState(restoredDraft?.body ?? "");
+  const [bodyAssetIds, setBodyAssetIds] = useState<readonly string[]>(
+    restoredDraft?.assetIds ?? [],
+  );
   const [claimedAssetIds, setClaimedAssetIds] = useState<readonly string[] | null>(null);
   const [error, setError] = useState("");
   const [invalidField, setInvalidField] = useState<InvalidField>(null);
   const [creating, setCreating] = useState(false);
   const [uploadingImage, setUploadingImage] = useState(false);
+  const [draftStatus, setDraftStatus] = useState<
+    "idle" | "restored" | "saving" | "saved" | "error"
+  >(restoredDraft ? "restored" : "idle");
+  const skipInitialDraftSaveRef = useRef(Boolean(restoredDraft));
   const [detailsOpen, setDetailsOpen] = useState(() =>
     typeof window === "undefined"
       ? true
@@ -132,6 +148,36 @@ export function DocumentCreateForm({
   useEffect(() => onDirtyChange?.(hasUnsavedWork), [hasUnsavedWork, onDirtyChange]);
   useEffect(() => onCreatingChange?.(creating), [creating, onCreatingChange]);
   useEffect(() => onUploadingChange?.(uploadingImage), [uploadingImage, onUploadingChange]);
+  useEffect(() => onAssetIdsChange?.(bodyAssetIds), [bodyAssetIds, onAssetIdsChange]);
+
+  useEffect(() => {
+    if (creating) return;
+    if (skipInitialDraftSaveRef.current) {
+      skipInitialDraftSaveRef.current = false;
+      return;
+    }
+    if (!isDirty) {
+      clearDocumentDraft(vault);
+      setDraftStatus("idle");
+      return;
+    }
+    setDraftStatus("saving");
+    const timer = window.setTimeout(() => {
+      const saved = saveDocumentDraft({
+        vault,
+        title,
+        collection,
+        type,
+        domain,
+        summary,
+        tags,
+        body,
+        assetIds: [...bodyAssetIds],
+      });
+      setDraftStatus(saved ? "saved" : "error");
+    }, 300);
+    return () => window.clearTimeout(timer);
+  }, [body, bodyAssetIds, collection, creating, domain, isDirty, summary, tags, title, type, vault]);
 
   useEffect(() => {
     const media = window.matchMedia("(min-width: 1024px)");
@@ -212,6 +258,7 @@ export function DocumentCreateForm({
         setClaimedAssetIds(assetIdsToClaim);
       });
       created = true;
+      clearDocumentDraft(vault);
       onCreated(result?.path);
     } catch (caught: unknown) {
       setError(
@@ -281,7 +328,21 @@ export function DocumentCreateForm({
                 aria-hidden
               />
             )}
-            <span>{uploadingImage ? "Uploading image…" : canSubmit ? "Ready to create" : "Draft saved locally"}</span>
+            <span>
+              {uploadingImage
+                ? "Uploading image…"
+                : draftStatus === "restored"
+                  ? "Local draft restored"
+                  : draftStatus === "saving"
+                    ? "Saving draft…"
+                    : draftStatus === "saved"
+                      ? "Draft saved locally"
+                      : draftStatus === "error"
+                        ? "Draft storage unavailable"
+                        : canSubmit
+                          ? "Ready to create"
+                          : "Unsaved draft"}
+            </span>
           </div>
           <Button
             type="button"
@@ -395,7 +456,7 @@ export function DocumentCreateForm({
               >
                 <Suspense fallback={<MarkdownEditorFallback />}>
                   <MarkdownEditor
-                    value=""
+                    value={body}
                     onChange={(markdown, assetIds) => {
                       setBody(markdown);
                       setBodyAssetIds(assetIds);
@@ -411,7 +472,8 @@ export function DocumentCreateForm({
                       setUploadingImage(uploading);
                       if (uploading) setClaimedAssetIds(null);
                     }}
-                    preserveUploadsOnUnmount={creating}
+                    initialUnclaimedAssetIds={restoredDraft?.assetIds}
+                    preserveUploadsOnUnmount
                     claimedAssetIds={claimedAssetIds}
                   />
                 </Suspense>

--- a/frontend/src/components/document-move-dialog.tsx
+++ b/frontend/src/components/document-move-dialog.tsx
@@ -1,0 +1,353 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  ArrowDown,
+  FileText,
+  FolderTree,
+  GitCommitHorizontal,
+} from "lucide-react";
+import {
+  ApiError,
+  browseVault,
+  moveDocument,
+  type DocumentMoveResult,
+} from "@/lib/api";
+import { previewDocumentSlug } from "@/lib/document-move";
+import { isReservedCollection } from "@/lib/skill";
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { SelectMenu, type SelectOption } from "@/components/ui/select-menu";
+
+interface DocumentMoveDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  vault: string;
+  path: string;
+  title: string;
+  onMoved: (result: DocumentMoveResult) => void;
+}
+
+function splitDocumentPath(path: string) {
+  const stem = path.endsWith(".md") ? path.slice(0, -3) : path;
+  const separator = stem.lastIndexOf("/");
+  return separator < 0
+    ? { collection: "", slug: stem }
+    : {
+        collection: stem.slice(0, separator),
+        slug: stem.slice(separator + 1),
+      };
+}
+
+function moveErrorMessage(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  const status = error instanceof ApiError ? error.status : null;
+
+  if (status === 409 || /already exists|\b409\b/i.test(message)) {
+    return "A document already uses that file name in the selected collection. Choose another file name.";
+  }
+  if (/move is a no-op|target path equals/i.test(message)) {
+    return "Choose a different collection or file name.";
+  }
+  if (status === 403 || /forbidden|required role|writer access/i.test(message)) {
+    return "Your access changed. Writer access or higher is required to move this document.";
+  }
+  if (
+    status === 404 ||
+    status === 405 ||
+    /\b405 method not allowed\b/i.test(message) ||
+    /^404 not found$/i.test(message.trim())
+  ) {
+    return "Move or rename is not available on this server yet.";
+  }
+  return message || "The document could not be moved. Review the destination and try again.";
+}
+
+export function DocumentMoveDialog({
+  open,
+  onOpenChange,
+  vault,
+  path,
+  title,
+  onMoved,
+}: DocumentMoveDialogProps) {
+  const current = useMemo(() => splitDocumentPath(path), [path]);
+  const [collection, setCollection] = useState(current.collection);
+  const [fileName, setFileName] = useState(current.slug);
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+  const [moving, setMoving] = useState(false);
+  const [discardOpen, setDiscardOpen] = useState(false);
+  const hydratedPathRef = useRef(path);
+
+  const collectionsQuery = useQuery({
+    queryKey: ["document-move-collections", vault],
+    queryFn: () => browseVault(vault, undefined, -1),
+    enabled: open && Boolean(vault),
+    retry: false,
+    staleTime: 30_000,
+  });
+
+  useEffect(() => {
+    if (!open) return;
+    hydratedPathRef.current = path;
+    setCollection(current.collection);
+    setFileName(current.slug);
+    setMessage("");
+    setError("");
+    setMoving(false);
+  }, [current.collection, current.slug, open, path]);
+
+  const collectionOptions = useMemo<SelectOption[]>(() => {
+    const paths = new Set<string>();
+    for (const item of collectionsQuery.data?.items || []) {
+      if (item?.type !== "collection" || typeof item.path !== "string") continue;
+      if (isReservedCollection(item.path)) continue;
+      paths.add(item.path);
+    }
+    if (current.collection && !isReservedCollection(current.collection)) {
+      paths.add(current.collection);
+    }
+    return [
+      { value: "", label: "Vault root", hint: "Outside every collection" },
+      ...Array.from(paths)
+        .sort((a, b) => a.localeCompare(b))
+        .map((value) => ({
+          value,
+          label: value,
+          hint: value === current.collection ? "Current collection" : undefined,
+        })),
+    ];
+  }, [collectionsQuery.data?.items, current.collection]);
+
+  const normalizedSlug = previewDocumentSlug(fileName);
+  const destinationPath = collection
+    ? `${collection}/${normalizedSlug}.md`
+    : `${normalizedSlug}.md`;
+  const destinationChanged = destinationPath !== path;
+  const isDirty =
+    collection !== current.collection ||
+    fileName !== current.slug ||
+    message.trim().length > 0;
+
+  function requestClose() {
+    if (moving) return;
+    if (isDirty) setDiscardOpen(true);
+    else onOpenChange(false);
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!fileName.trim()) {
+      setError("Enter a file name.");
+      return;
+    }
+    if (!destinationChanged) {
+      setError("Choose a different collection or file name.");
+      return;
+    }
+
+    const payload: { collection?: string; slug?: string; message?: string } = {};
+    if (collection !== current.collection) payload.collection = collection;
+    if (normalizedSlug !== current.slug) payload.slug = fileName.trim();
+    if (message.trim()) payload.message = message.trim();
+
+    setMoving(true);
+    setError("");
+    let result: DocumentMoveResult;
+    try {
+      result = await moveDocument(vault, hydratedPathRef.current, payload);
+    } catch (nextError) {
+      setError(moveErrorMessage(nextError));
+      setMoving(false);
+      return;
+    }
+
+    // The move has already committed when this callback runs. Keep local UI
+    // follow-up failures out of the request error state so users are never
+    // invited to retry an operation the backend has successfully completed.
+    setMoving(false);
+    onMoved(result);
+    onOpenChange(false);
+  }
+
+  return (
+    <>
+      <Dialog
+        open={open}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen) requestClose();
+        }}
+      >
+        <DialogContent
+          className="max-w-2xl gap-0 overflow-hidden p-0"
+          onEscapeKeyDown={(event) => {
+            event.preventDefault();
+            requestClose();
+          }}
+          onInteractOutside={(event) => {
+            event.preventDefault();
+            requestClose();
+          }}
+        >
+          <form onSubmit={handleSubmit}>
+            <DialogHeader className="border-b border-border px-5 py-4 pr-14 sm:px-6">
+              <DialogTitle>Move or rename document</DialogTitle>
+              <DialogDescription>
+                Change where “{title}” lives without losing its identity or version history.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-5 px-5 py-5 sm:px-6">
+              <section aria-label="Location change" className="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-surface shadow-xs">
+                <div className="flex items-center gap-3 px-3.5 py-3">
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-md)] bg-surface-2 text-foreground-muted">
+                    <FileText className="h-4 w-4" aria-hidden />
+                  </span>
+                  <div className="min-w-0">
+                    <p className="text-xs font-medium text-foreground-muted">Current location</p>
+                    <code className="block truncate font-mono text-sm text-foreground" title={path}>{path}</code>
+                  </div>
+                </div>
+                <div className="flex h-7 items-center border-y border-border bg-surface-2 px-4 text-foreground-muted">
+                  <ArrowDown className="h-3.5 w-3.5" aria-hidden />
+                  <span className="ml-2 text-xs">Destination preview</span>
+                </div>
+                <div className="flex items-center gap-3 bg-surface-selected px-3.5 py-3 text-surface-selected-foreground">
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-md)] border border-primary/20 bg-surface">
+                    <FolderTree className="h-4 w-4" aria-hidden />
+                  </span>
+                  <code className="min-w-0 truncate font-mono text-sm font-medium" title={destinationPath}>
+                    {destinationPath}
+                  </code>
+                </div>
+              </section>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-1.5">
+                  <Label htmlFor="document-move-collection">Target collection</Label>
+                  <SelectMenu
+                    id="document-move-collection"
+                    value={collection}
+                    onValueChange={(value) => {
+                      setCollection(value);
+                      setError("");
+                    }}
+                    options={collectionOptions}
+                    placeholder={collectionsQuery.isPending ? "Loading collections…" : "Select a collection"}
+                    disabled={collectionsQuery.isPending || collectionsQuery.isError || moving}
+                    searchable
+                    searchPlaceholder="Filter collections…"
+                    mono
+                  />
+                  <p className="text-xs leading-relaxed text-foreground-muted">
+                    Choose Vault root to move the document outside every collection.
+                  </p>
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label htmlFor="document-move-filename">File name</Label>
+                  <Input
+                    id="document-move-filename"
+                    value={fileName}
+                    onChange={(event) => {
+                      setFileName(event.currentTarget.value);
+                      setError("");
+                    }}
+                    autoFocus
+                    disabled={moving}
+                    aria-invalid={Boolean(error && !fileName.trim()) || undefined}
+                    aria-describedby="document-move-filename-help"
+                  />
+                  <p id="document-move-filename-help" className="text-xs leading-relaxed text-foreground-muted">
+                    The .md extension is added automatically. The document title stays unchanged.
+                  </p>
+                </div>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="document-move-message">
+                  Commit message <span className="font-normal text-foreground-muted">(optional)</span>
+                </Label>
+                <div className="relative">
+                  <GitCommitHorizontal className="pointer-events-none absolute left-3 top-3 h-4 w-4 text-foreground-muted" aria-hidden />
+                  <Input
+                    id="document-move-message"
+                    value={message}
+                    onChange={(event) => {
+                      setMessage(event.currentTarget.value);
+                      setError("");
+                    }}
+                    className="pl-9"
+                    placeholder="Explain why this location changed"
+                    disabled={moving}
+                  />
+                </div>
+              </div>
+
+              {collectionsQuery.isError && (
+                <Alert variant="destructive" title="Collections could not be loaded">
+                  <span>
+                    You can still rename this document in its current location, or retry loading other destinations.
+                  </span>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="mt-2"
+                    onClick={() => collectionsQuery.refetch()}
+                  >
+                    Retry
+                  </Button>
+                </Alert>
+              )}
+              {error && <Alert variant="destructive">{error}</Alert>}
+            </div>
+
+            <DialogFooter className="border-t border-border bg-surface-2 px-5 py-4 sm:px-6">
+              <Button type="button" variant="outline" onClick={requestClose} disabled={moving}>
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                variant="accent"
+                loading={moving}
+                disabled={
+                  moving ||
+                  collectionsQuery.isPending ||
+                  !fileName.trim() ||
+                  !destinationChanged
+                }
+              >
+                {moving ? "Moving…" : "Move document"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmDialog
+        open={discardOpen}
+        onOpenChange={setDiscardOpen}
+        title="Discard destination changes?"
+        description="The document has not moved yet. Your selected collection, file name, and commit message will be lost."
+        confirmLabel="Discard changes"
+        variant="destructive"
+        onConfirm={() => {
+          setDiscardOpen(false);
+          onOpenChange(false);
+        }}
+      />
+    </>
+  );
+}

--- a/frontend/src/components/document-view.tsx
+++ b/frontend/src/components/document-view.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { Check, Code2, Copy, Eye, Pencil } from "lucide-react";
+import { Check, Code2, Copy, Eye } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { getDocument } from "@/lib/api";
 import { MarkdownRender } from "@/components/markdown-render";
@@ -17,14 +17,6 @@ interface DocumentViewProps {
   /** Controlled view — provide this + onViewChange to sync with URL params */
   view?: ViewMode;
   onViewChange?: (next: ViewMode) => void;
-  /**
-   * Optional extra segmented-control tab appended after RENDERED/RAW.
-   * The parent owns the click handler — DocumentView does not switch
-   * its own view state when the extra tab is clicked. Used by
-   * DocumentPage to inject the body-editor entry point without
-   * folding the editor into this read-focused component.
-   */
-  extraTab?: { label: string; onClick: () => void };
   /**
    * Optional git commit hash. When set, the body is fetched at that
    * commit via getDocument(..., version) and the queryKey carries the
@@ -57,7 +49,6 @@ export function DocumentView({
   docId,
   view: viewProp,
   onViewChange,
-  extraTab,
   version,
   appearance = "plain",
 }: DocumentViewProps) {
@@ -123,12 +114,11 @@ export function DocumentView({
          WAI-ARIA tabs pattern: ArrowLeft/ArrowRight (and Home/End)
          move focus between tabs; Enter/Space activates. Each tab
          points at its panel via aria-controls so screen readers
-         announce the relationship. The extra tab (e.g. EDIT) is
-         a navigation trigger, not a panel, so it owns no panel id. */}
+         announce the relationship. Editing is a document action in
+         the workspace header, not a third read-mode tab. */}
       <TabStrip
         view={view}
         onSelect={setView}
-        extraTab={extraTab}
         appearance={appearance}
         copiedRaw={copiedRaw}
         onCopyRaw={copyRaw}
@@ -230,7 +220,6 @@ function DocumentViewLoading({ appearance }: { appearance: "plain" | "file" }) {
 interface TabStripProps {
   view: ViewMode;
   onSelect: (next: ViewMode) => void;
-  extraTab?: { label: string; onClick: () => void };
   appearance: "plain" | "file";
   copiedRaw: boolean;
   onCopyRaw: () => void;
@@ -242,7 +231,6 @@ interface TabStripProps {
 function TabStrip({
   view,
   onSelect,
-  extraTab,
   appearance,
   copiedRaw,
   onCopyRaw,
@@ -251,7 +239,7 @@ function TabStrip({
   summary,
 }: TabStripProps) {
   const tabs: Array<{
-    key: ViewMode | "extra";
+    key: ViewMode;
     label: string;
     selected: boolean;
     onActivate: () => void;
@@ -260,9 +248,6 @@ function TabStrip({
     { key: "rendered", label: "Rendered", selected: view === "rendered", onActivate: () => onSelect("rendered"), icon: Eye },
     { key: "raw", label: "Raw", selected: view === "raw", onActivate: () => onSelect("raw"), icon: Code2 },
   ];
-  if (extraTab) {
-    tabs.push({ key: "extra", label: extraTab.label, selected: false, onActivate: extraTab.onClick, icon: Pencil });
-  }
 
   function onKey(e: React.KeyboardEvent<HTMLButtonElement>, idx: number) {
     let next: number;
@@ -345,7 +330,6 @@ function TabStrip({
         )}
       >
         {tabs.map((t, i) => {
-          const isPanelTab = t.key !== "extra";
           const Icon = t.icon;
           const cls = cn(
             "inline-flex items-center gap-1.5 px-3 py-1 text-xs font-medium rounded-[var(--radius-sm)] transition-token cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
@@ -359,9 +343,9 @@ function TabStrip({
             <button
               key={t.key}
               role="tab"
-              id={isPanelTab ? `docview-tab-${t.key}` : undefined}
+              id={`docview-tab-${t.key}`}
               aria-selected={t.selected}
-              aria-controls={isPanelTab ? `docview-panel-${t.key}` : undefined}
+              aria-controls={`docview-panel-${t.key}`}
               tabIndex={t.selected || (!tabs.some((x) => x.selected) && i === 0) ? 0 : -1}
               onClick={t.onActivate}
               onKeyDown={(e) => onKey(e, i)}

--- a/frontend/src/components/markdown-editor.tsx
+++ b/frontend/src/components/markdown-editor.tsx
@@ -14,8 +14,11 @@ import {
 } from "platejs/react";
 import { MarkdownPlugin } from "@platejs/markdown";
 import { toggleList, ListStyleType } from "@platejs/list";
-import { upsertLink } from "@platejs/link";
+import { unwrapLink, upsertLink } from "@platejs/link";
+import { toggleCodeBlock } from "@platejs/code-block";
 import {
+  deleteColumn,
+  deleteRow,
   insertTable,
   insertTableColumn,
   insertTableRow,
@@ -47,6 +50,10 @@ import {
   CornerDownLeft,
   Trash2,
   X,
+  Pencil,
+  Replace,
+  Rows2,
+  Columns2,
 } from "lucide-react";
 import {
   BlockquotePlugin,
@@ -79,7 +86,18 @@ import remarkGfm from "remark-gfm";
 import { AssetImage } from "@/components/asset-image";
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { discardAsset, uploadAsset } from "@/lib/api";
+import { normalizeEditorLinkUrl } from "@/lib/editor-link";
 import {
   assetIdFromUrl,
   classifyEditorImageUploadFailure,
@@ -166,10 +184,6 @@ function ListElement(props: PlateElementProps) {
   return <PlateElement {...props} as={Tag} className={cls} />;
 }
 
-function ListItemElement(props: PlateElementProps) {
-  return <PlateElement {...props} as="li" className="leading-7" />;
-}
-
 function TableElement(props: PlateElementProps) {
   const editor = useEditorRef();
   const editorLifecycle = React.useContext(EditorAssetLifecycleContext);
@@ -184,6 +198,21 @@ function TableElement(props: PlateElementProps) {
     // Keep pointer and keyboard users in the authoring flow after a block
     // action instead of leaving focus stranded on the caption toolbar.
     requestAnimationFrame(() => editorLifecycle?.focusEditor());
+  };
+
+  const ensureCellSelection = (tablePath: number[]) => {
+    const cellEntry = editor.api.above({
+      match: (node) => {
+        const type = (node as { type?: string } | null)?.type;
+        return type === TableCellPlugin.key || type === TableCellHeaderPlugin.key;
+      },
+    });
+    const belongsToThisTable =
+      cellEntry &&
+      tablePath.every((segment, index) => cellEntry[1][index] === segment);
+    if (!belongsToThisTable) {
+      editor.tf.select(editor.api.start([...tablePath, 0, 0]));
+    }
   };
 
   const continueBelow = () => {
@@ -281,6 +310,42 @@ function TableElement(props: PlateElementProps) {
                   variant="ghost"
                   size="sm"
                   className="h-8 px-2"
+                  title="Remove the selected row"
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={() => {
+                    withTablePath((path) => {
+                      ensureCellSelection(path);
+                      deleteRow(editor);
+                      focusEditor();
+                    });
+                  }}
+                >
+                  <Rows2 className="h-3.5 w-3.5" aria-hidden />
+                  Remove row
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 px-2"
+                  title="Remove the selected column"
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={() => {
+                    withTablePath((path) => {
+                      ensureCellSelection(path);
+                      deleteColumn(editor);
+                      focusEditor();
+                    });
+                  }}
+                >
+                  <Columns2 className="h-3.5 w-3.5" aria-hidden />
+                  Remove column
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 px-2"
                   title="Move the cursor to a paragraph below this table"
                   onMouseDown={(event) => event.preventDefault()}
                   onClick={continueBelow}
@@ -335,6 +400,7 @@ interface EditorAssetLifecycle {
   commit?: string;
   readOnly?: boolean;
   focusEditor: () => void;
+  requestImageReplacement: (path: number[]) => void;
 }
 
 const EditorAssetLifecycleContext = React.createContext<EditorAssetLifecycle | null>(null);
@@ -347,6 +413,11 @@ function ImageElement(props: PlateElementProps) {
     caption?: Array<{ text?: string }>;
   };
   const alt = element.caption?.map((part) => part.text || "").join("") || "";
+  const [descriptionOpen, setDescriptionOpen] = React.useState(false);
+  const [descriptionDraft, setDescriptionDraft] = React.useState(alt);
+  const [descriptionError, setDescriptionError] = React.useState("");
+
+  React.useEffect(() => setDescriptionDraft(alt), [alt]);
 
   const removeImage = () => {
     const path = editor.api.findPath(props.element);
@@ -360,6 +431,26 @@ function ImageElement(props: PlateElementProps) {
     }
     editor.tf.select(editor.api.start(path));
     requestAnimationFrame(() => assetLifecycle?.focusEditor());
+  };
+
+  const saveDescription = () => {
+    const next = descriptionDraft.trim();
+    if (!next) {
+      setDescriptionError("Describe the image so it remains understandable without sight.");
+      return;
+    }
+    const path = editor.api.findPath(props.element);
+    if (!path) return;
+    editor.tf.setNodes({ caption: [{ text: next }] }, { at: path });
+    setDescriptionError("");
+    setDescriptionOpen(false);
+    requestAnimationFrame(() => assetLifecycle?.focusEditor());
+  };
+
+  const replaceImage = () => {
+    const path = editor.api.findPath(props.element);
+    if (!path) return;
+    assetLifecycle?.requestImageReplacement(path);
   };
 
   return (
@@ -382,18 +473,48 @@ function ImageElement(props: PlateElementProps) {
             className="my-0 max-h-[70vh] max-w-full object-contain"
           />
           {!assetLifecycle?.readOnly && (
-            <Button
-              type="button"
-              variant="secondary"
-              size="icon"
-              aria-label={alt ? `Remove image: ${alt}` : "Remove image"}
-              title="Remove image"
-              className="absolute right-2 top-2 h-8 w-8 border border-border bg-surface/90 text-foreground-muted shadow-sm backdrop-blur-sm hover:border-border-strong hover:bg-surface hover:text-foreground"
-              onMouseDown={(event) => event.preventDefault()}
-              onClick={removeImage}
-            >
-              <X className="h-4 w-4" aria-hidden />
-            </Button>
+            <div className="absolute right-2 top-2 flex items-center gap-1 rounded-[var(--radius-md)] border border-border bg-surface/90 p-1 shadow-sm backdrop-blur-sm">
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label={alt ? `Edit image description: ${alt}` : "Edit image description"}
+                title="Edit image description"
+                className="h-7 w-7 text-foreground-muted hover:bg-surface-hover hover:text-foreground"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => {
+                  setDescriptionDraft(alt);
+                  setDescriptionError("");
+                  setDescriptionOpen(true);
+                }}
+              >
+                <Pencil className="h-3.5 w-3.5" aria-hidden />
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label={alt ? `Replace image: ${alt}` : "Replace image"}
+                title="Replace image"
+                className="h-7 w-7 text-foreground-muted hover:bg-surface-hover hover:text-foreground"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={replaceImage}
+              >
+                <Replace className="h-3.5 w-3.5" aria-hidden />
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label={alt ? `Remove image: ${alt}` : "Remove image"}
+                title="Remove image"
+                className="h-7 w-7 text-foreground-muted hover:bg-destructive/10 hover:text-destructive"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={removeImage}
+              >
+                <X className="h-3.5 w-3.5" aria-hidden />
+              </Button>
+            </div>
           )}
         </div>
         {alt && (
@@ -403,6 +524,47 @@ function ImageElement(props: PlateElementProps) {
         )}
       </figure>
       {props.children}
+      <Dialog open={descriptionOpen} onOpenChange={setDescriptionOpen}>
+        <DialogContent
+          className="sm:max-w-md"
+          onCloseAutoFocus={(event) => {
+            event.preventDefault();
+            assetLifecycle?.focusEditor();
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle>Image description</DialogTitle>
+            <DialogDescription>
+              This text is used as the image alt text and visible caption.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="editor-image-description">Description</Label>
+            <Input
+              id="editor-image-description"
+              value={descriptionDraft}
+              onChange={(event) => {
+                setDescriptionDraft(event.target.value);
+                if (descriptionError) setDescriptionError("");
+              }}
+              aria-invalid={descriptionError ? true : undefined}
+              aria-describedby={descriptionError ? "editor-image-description-error" : undefined}
+              autoFocus
+            />
+            {descriptionError && (
+              <p id="editor-image-description-error" role="alert" className="text-xs text-destructive">
+                {descriptionError}
+              </p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setDescriptionOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="button" onClick={saveDescription}>Save description</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </PlateElement>
   );
 }
@@ -586,13 +748,15 @@ function RibbonButton({ label, active, disabled, onClick, children }: RibbonButt
       aria-label={label}
       aria-pressed={active}
       disabled={disabled}
+      tabIndex={-1}
+      data-editor-toolbar-button
       title={label}
       // Prevent the editor from losing its selection when the button is pressed.
       onMouseDown={(e) => e.preventDefault()}
       onClick={onClick}
       className={cn(TOOLBAR_BTN, active && TOOLBAR_BTN_ACTIVE)}
     >
-      {children}
+      <span aria-hidden="true" className="contents">{children}</span>
     </button>
   );
 }
@@ -600,6 +764,7 @@ function RibbonButton({ label, active, disabled, onClick, children }: RibbonButt
 interface EditorToolbarProps {
   uploadingImage: boolean;
   onChooseImages: (files: File[]) => void;
+  onOpenImagePicker: () => void;
   appearance: "framed" | "canvas" | "workspace";
   imageInputRef: React.RefObject<HTMLInputElement | null>;
 }
@@ -607,6 +772,7 @@ interface EditorToolbarProps {
 function EditorToolbar({
   uploadingImage,
   onChooseImages,
+  onOpenImagePicker,
   appearance,
   imageInputRef,
 }: EditorToolbarProps) {
@@ -614,6 +780,15 @@ function EditorToolbar({
   // useEditorRef gives a stable handle for the mutating callbacks.
   const editor = useEditorRef();
   const state = useEditorState();
+  const toolbarRef = React.useRef<HTMLDivElement>(null);
+  const [linkOpen, setLinkOpen] = React.useState(false);
+  const [linkUrl, setLinkUrl] = React.useState("");
+  const [linkText, setLinkText] = React.useState("");
+  const [linkError, setLinkError] = React.useState("");
+  const linkSelectionRef = React.useRef(editor.selection);
+  const linkUrlInputRef = React.useRef<HTMLInputElement>(null);
+  const linkUrlId = React.useId();
+  const linkTextId = React.useId();
   // Active mark lookup — editor.api.marks() returns the marks that would apply
   // at the current selection (null when none).
   const marks = (state.api.marks() ?? {}) as Record<string, unknown>;
@@ -625,6 +800,25 @@ function EditorToolbar({
     ? ((blockEntry[0] as { type?: string }).type ?? ParagraphPlugin.key)
     : undefined;
   const isBlock = (type: string) => blockType === type;
+  const blockNode = blockEntry?.[0] as {
+    listStyleType?: string;
+  } | undefined;
+  const codeBlockEntry = state.api.above({
+    match: (node) =>
+      typeof node === "object" &&
+      node !== null &&
+      "type" in node &&
+      (node as { type?: string }).type === CodeBlockPlugin.key,
+  });
+  const linkEntry = state.api.above({
+    match: (node) =>
+      typeof node === "object" &&
+      node !== null &&
+      "type" in node &&
+      (node as { type?: string }).type === LinkPlugin.key,
+  });
+  const canUndo = state.history.undos.length > 0;
+  const canRedo = state.history.redos.length > 0;
 
   const toggleMark = (key: string) => editor.tf.toggleMark(key);
 
@@ -642,11 +836,47 @@ function EditorToolbar({
     });
   };
 
-  const onLink = () => {
-    // Only meaningful on a non-collapsed selection; upsertLink wraps it.
-    if (state.api.isExpanded()) {
-      upsertLink(editor, { url: "https://" });
+  const openLinkEditor = () => {
+    linkSelectionRef.current = editor.selection;
+    const currentLink = linkEntry?.[0] as { url?: string } | undefined;
+    const selectedText = editor.selection
+      ? editor.api.string(editor.selection)
+      : "";
+    setLinkUrl(currentLink?.url ?? "");
+    setLinkText(
+      linkEntry
+        ? editor.api.string(linkEntry[1])
+        : selectedText,
+    );
+    setLinkError("");
+    setLinkOpen(true);
+  };
+
+  const applyLink = () => {
+    const normalizedUrl = normalizeEditorLinkUrl(linkUrl);
+    if (!normalizedUrl) {
+      setLinkError("Enter an http(s), email, phone, anchor, or relative URL.");
+      requestAnimationFrame(() => linkUrlInputRef.current?.focus());
+      return;
     }
+    if (linkSelectionRef.current) editor.tf.select(linkSelectionRef.current);
+    const text = linkText.trim() || normalizedUrl;
+    const inserted = upsertLink(editor, {
+      url: normalizedUrl,
+      text,
+      skipValidation: true,
+    });
+    if (!inserted) {
+      setLinkError("The link could not be applied at this cursor position.");
+      return;
+    }
+    setLinkOpen(false);
+  };
+
+  const removeCurrentLink = () => {
+    if (linkSelectionRef.current) editor.tf.select(linkSelectionRef.current);
+    unwrapLink(editor);
+    setLinkOpen(false);
   };
 
   const onTable = () => {
@@ -657,11 +887,53 @@ function EditorToolbar({
     ? "inline-flex items-center gap-0.5 border-r border-border pr-1.5 last:border-r-0 last:pr-0"
     : TOOLBAR_GROUP;
 
+  React.useLayoutEffect(() => {
+    const buttons = toolbarRef.current?.querySelectorAll<HTMLButtonElement>(
+      "button[data-editor-toolbar-button]:not(:disabled)",
+    );
+    if (!buttons?.length) return;
+    if (!Array.from(buttons).some((button) => button.tabIndex === 0)) {
+      buttons[0].tabIndex = 0;
+    }
+  });
+
+  const handleToolbarKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!(event.target instanceof HTMLButtonElement)) return;
+    if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) return;
+    const buttons = Array.from(
+      toolbarRef.current?.querySelectorAll<HTMLButtonElement>(
+        "button[data-editor-toolbar-button]:not(:disabled)",
+      ) ?? [],
+    );
+    if (buttons.length === 0) return;
+    event.preventDefault();
+    const currentIndex = Math.max(0, buttons.indexOf(event.target));
+    const nextIndex = event.key === "Home"
+      ? 0
+      : event.key === "End"
+        ? buttons.length - 1
+        : (currentIndex + (event.key === "ArrowRight" ? 1 : -1) + buttons.length) % buttons.length;
+    for (const button of buttons) button.tabIndex = -1;
+    buttons[nextIndex].tabIndex = 0;
+    buttons[nextIndex].focus();
+  };
+
   return (
     <div
+      ref={toolbarRef}
       contentEditable={false}
       role="toolbar"
       aria-label="Text formatting"
+      aria-orientation="horizontal"
+      onFocusCapture={(event) => {
+        if (!(event.target instanceof HTMLButtonElement)) return;
+        for (const button of toolbarRef.current?.querySelectorAll<HTMLButtonElement>(
+          "button[data-editor-toolbar-button]",
+        ) ?? []) {
+          button.tabIndex = button === event.target ? 0 : -1;
+        }
+      }}
+      onKeyDown={handleToolbarKeyDown}
       className={cn(
         "sticky top-0 z-10 flex flex-wrap items-center gap-1.5",
         "border-b border-border select-none",
@@ -716,12 +988,14 @@ function EditorToolbar({
       <div className={toolbarGroupClass} role="group" aria-label="Lists">
         <RibbonButton
           label="Bulleted list"
+          active={blockNode?.listStyleType === ListStyleType.Disc}
           onClick={() => toggleList(editor, { listStyleType: ListStyleType.Disc })}
         >
           <List className="h-4 w-4" />
         </RibbonButton>
         <RibbonButton
           label="Numbered list"
+          active={blockNode?.listStyleType === ListStyleType.Decimal}
           onClick={() => toggleList(editor, { listStyleType: ListStyleType.Decimal })}
         >
           <ListOrdered className="h-4 w-4" />
@@ -739,8 +1013,8 @@ function EditorToolbar({
         </RibbonButton>
         <RibbonButton
           label="Code block"
-          active={isBlock(CodeBlockPlugin.key)}
-          onClick={() => setBlock(CodeBlockPlugin.key)}
+          active={Boolean(codeBlockEntry)}
+          onClick={() => toggleCodeBlock(editor)}
         >
           <Code2 className="h-4 w-4" />
         </RibbonButton>
@@ -751,7 +1025,11 @@ function EditorToolbar({
 
       {/* Link + table */}
       <div className={toolbarGroupClass} role="group" aria-label="Insert">
-        <RibbonButton label="Insert link on selection" onClick={onLink}>
+        <RibbonButton
+          label={linkEntry ? "Edit link" : "Insert link"}
+          active={Boolean(linkEntry)}
+          onClick={openLinkEditor}
+        >
           <Link2 className="h-4 w-4" />
         </RibbonButton>
         <RibbonButton label="Insert table" onClick={onTable}>
@@ -760,7 +1038,7 @@ function EditorToolbar({
         <RibbonButton
           label={uploadingImage ? "Uploading image" : "Insert image"}
           disabled={uploadingImage}
-          onClick={() => imageInputRef.current?.click()}
+          onClick={onOpenImagePicker}
         >
           {uploadingImage ? (
             <Loader2 className="h-4 w-4 animate-spin" />
@@ -785,15 +1063,105 @@ function EditorToolbar({
 
       {/* History */}
       <div className={toolbarGroupClass} role="group" aria-label="History">
-        <RibbonButton label="Undo" onClick={() => editor.tf.undo()}>
+        <RibbonButton label="Undo" disabled={!canUndo} onClick={() => editor.tf.undo()}>
           <Undo2 className="h-4 w-4" />
         </RibbonButton>
-        <RibbonButton label="Redo" onClick={() => editor.tf.redo()}>
+        <RibbonButton label="Redo" disabled={!canRedo} onClick={() => editor.tf.redo()}>
           <Redo2 className="h-4 w-4" />
         </RibbonButton>
       </div>
+      <Dialog open={linkOpen} onOpenChange={setLinkOpen}>
+        <DialogContent
+          className="sm:max-w-md"
+          onCloseAutoFocus={(event) => {
+            event.preventDefault();
+            editor.tf.focus();
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle>{linkEntry ? "Edit link" : "Insert link"}</DialogTitle>
+            <DialogDescription>
+              Add a safe destination and choose the text readers will see.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor={linkUrlId}>URL</Label>
+              <Input
+                ref={linkUrlInputRef}
+                id={linkUrlId}
+                value={linkUrl}
+                onChange={(event) => {
+                  setLinkUrl(event.target.value);
+                  if (linkError) setLinkError("");
+                }}
+                placeholder="https://example.com"
+                inputMode="url"
+                autoComplete="url"
+                aria-invalid={linkError ? true : undefined}
+                aria-describedby={linkError ? `${linkUrlId}-error` : undefined}
+                autoFocus
+              />
+              {linkError && (
+                <p id={`${linkUrlId}-error`} role="alert" className="text-xs text-destructive">
+                  {linkError}
+                </p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor={linkTextId}>Text</Label>
+              <Input
+                id={linkTextId}
+                value={linkText}
+                onChange={(event) => setLinkText(event.target.value)}
+                placeholder="Link text"
+              />
+              <p className="text-xs text-foreground-muted">
+                Leave blank to use the destination as the visible text.
+              </p>
+            </div>
+          </div>
+          <DialogFooter className="sm:justify-between">
+            {linkEntry ? (
+              <Button type="button" variant="ghost" className="text-destructive" onClick={removeCurrentLink}>
+                Remove link
+              </Button>
+            ) : (
+              <span aria-hidden />
+            )}
+            <div className="flex flex-col-reverse gap-2 sm:flex-row">
+              <Button type="button" variant="outline" onClick={() => setLinkOpen(false)}>
+                Cancel
+              </Button>
+              <Button type="button" onClick={applyLink}>
+                {linkEntry ? "Save link" : "Insert link"}
+              </Button>
+            </div>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
+}
+
+function nodeText(node: unknown): string {
+  if (!node || typeof node !== "object") return "";
+  if ("text" in node && typeof (node as { text?: unknown }).text === "string") {
+    return (node as { text: string }).text;
+  }
+  const children = (node as { children?: unknown[] }).children;
+  return Array.isArray(children) ? children.map(nodeText).join("") : "";
+}
+
+function valueWithoutEditorTrailingBlock(nodes: readonly unknown[]): unknown[] {
+  if (nodes.length < 2) return [...nodes];
+  const last = nodes.at(-1) as { type?: string } | undefined;
+  const previous = nodes.at(-2) as { type?: string } | undefined;
+  const isEmptyTrailingParagraph =
+    last?.type === ParagraphPlugin.key &&
+    nodeText(last).replace(/[\u200b\ufeff]/g, "").length === 0 &&
+    previous?.type !== ParagraphPlugin.key;
+  return isEmptyTrailingParagraph ? nodes.slice(0, -1) : [...nodes];
 }
 
 // ── Public component ──────────────────────────────────────────────────────
@@ -829,6 +1197,8 @@ export interface MarkdownEditorProps {
   preserveUploadsOnUnmount?: boolean;
   /** Image-node ids from the exact editor snapshot accepted by the server. */
   claimedAssetIds?: readonly string[] | null;
+  /** Temporary image ids recovered with a locally saved new-document draft. */
+  initialUnclaimedAssetIds?: readonly string[];
 }
 
 export function MarkdownEditor({
@@ -848,6 +1218,7 @@ export function MarkdownEditor({
   onUploadingChange,
   preserveUploadsOnUnmount = false,
   claimedAssetIds = null,
+  initialUnclaimedAssetIds = [],
 }: MarkdownEditorProps) {
   const [uploadingImage, setUploadingImage] = React.useState(false);
   const [uploadingName, setUploadingName] = React.useState("");
@@ -856,13 +1227,15 @@ export function MarkdownEditor({
     message: string;
     retryable: boolean;
     kind: "error" | "queued";
+    replacementPath?: number[];
   } | null>(null);
   const uploadControllerRef = React.useRef<AbortController | null>(null);
   const imageInputRef = React.useRef<HTMLInputElement>(null);
+  const replacementPathRef = React.useRef<number[] | null>(null);
   const editorSurfaceRef = React.useRef<HTMLDivElement | null>(null);
   const uploadInFlightRef = React.useRef(false);
   const deferredImageFilesRef = React.useRef<File[]>([]);
-  const unclaimedAssetIdsRef = React.useRef(new Set<string>());
+  const unclaimedAssetIdsRef = React.useRef(new Set(initialUnclaimedAssetIds));
   const discardingAssetIdsRef = React.useRef(new Set<string>());
   const mountedRef = React.useRef(true);
   const onUploadingChangeRef = React.useRef(onUploadingChange);
@@ -961,7 +1334,11 @@ export function MarkdownEditor({
   }, [claimedAssetIds, discardUnclaimedAsset]);
 
   const uploadImages = React.useCallback(
-    async (files: File[], insertionRange = editor.selection) => {
+    async (
+      files: File[],
+      insertionRange = editor.selection,
+      replacementPath?: number[],
+    ) => {
       if (readOnly || uploadInFlightRef.current || files.length === 0) return;
 
       for (const file of files) {
@@ -975,6 +1352,7 @@ export function MarkdownEditor({
             message: `${file.name}: ${validationMessage} No images were uploaded.`,
             retryable: false,
             kind: "error",
+            replacementPath,
           });
           return;
         }
@@ -1016,15 +1394,32 @@ export function MarkdownEditor({
           }
           restoredInsertion = true;
           const alt = file.name.replace(/\.[^.]+$/, "") || "Image";
-          editor.tf.insertNodes(
-            {
-              type: ImagePlugin.key,
-              url: asset.url,
-              caption: [{ text: alt }],
-              children: [{ text: "" }],
-            },
-            { select: true },
-          );
+          if (replacementPath && index === 0) {
+            const target = editor.api.node(replacementPath)?.[0] as {
+              type?: string;
+              url?: string;
+            } | undefined;
+            if (target?.type !== ImagePlugin.key) {
+              throw new Error("The image to replace is no longer available.");
+            }
+            const replacedUrl = target.url;
+            editor.tf.setNodes(
+              { url: asset.url, caption: [{ text: alt }] },
+              { at: replacementPath },
+            );
+            editor.tf.select(replacementPath);
+            discardIfUnclaimed(replacedUrl);
+          } else {
+            editor.tf.insertNodes(
+              {
+                type: ImagePlugin.key,
+                url: asset.url,
+                caption: [{ text: alt }],
+                children: [{ text: "" }],
+              },
+              { select: true },
+            );
+          }
         }
       } catch (error) {
         const aborted =
@@ -1044,13 +1439,15 @@ export function MarkdownEditor({
             message: failure.message,
             retryable: failure.retryable,
             kind: "error",
+            replacementPath,
           });
         } else if (mountedRef.current && deferredImageFilesRef.current.length > 0) {
           setUploadFailure({
             files: deferredImageFilesRef.current.splice(0),
             message: "The current upload was cancelled before the next batch started.",
-            retryable: true,
-            kind: "error",
+              retryable: true,
+              kind: "error",
+              replacementPath,
           });
         }
       } finally {
@@ -1084,6 +1481,10 @@ export function MarkdownEditor({
       commit,
       readOnly,
       focusEditor: () => editorSurfaceRef.current?.focus(),
+      requestImageReplacement: (path: number[]) => {
+        replacementPathRef.current = path;
+        imageInputRef.current?.click();
+      },
     }),
     [commit, document, readOnly, vault],
   );
@@ -1148,7 +1549,9 @@ export function MarkdownEditor({
             // Serialize on every change — for documents in the typical AKB size
             // (single-digit KB markdown), this is well under a millisecond. Move
             // to a debounce only if profiling shows the cost.
-            const md = ed.getApi(MarkdownPlugin).markdown.serialize();
+            const md = ed.getApi(MarkdownPlugin).markdown.serialize({
+              value: valueWithoutEditorTrailingBlock(ed.children) as typeof ed.children,
+            });
             const assetIds: string[] = [];
             const visit = (nodes: unknown[]) => {
               for (const node of nodes) {
@@ -1172,7 +1575,15 @@ export function MarkdownEditor({
       {!readOnly && (
         <EditorToolbar
           uploadingImage={uploadingImage}
-          onChooseImages={(files) => void uploadImages(files)}
+          onChooseImages={(files) => {
+            const replacementPath = replacementPathRef.current ?? undefined;
+            replacementPathRef.current = null;
+            void uploadImages(files, editor.selection, replacementPath);
+          }}
+          onOpenImagePicker={() => {
+            replacementPathRef.current = null;
+            imageInputRef.current?.click();
+          }}
           appearance={appearance}
           imageInputRef={imageInputRef}
         />
@@ -1212,7 +1623,13 @@ export function MarkdownEditor({
                   type="button"
                   variant="outline"
                   size="sm"
-                  onClick={() => void uploadImages(uploadFailure.files)}
+                  onClick={() =>
+                    void uploadImages(
+                      uploadFailure.files,
+                      editor.selection,
+                      uploadFailure.replacementPath,
+                    )
+                  }
                 >
                   <RotateCcw className="h-3.5 w-3.5" aria-hidden />
                   {uploadFailure.kind === "queued" ? "Upload" : "Retry"}
@@ -1222,7 +1639,10 @@ export function MarkdownEditor({
                 type="button"
                 variant="outline"
                 size="sm"
-                onClick={() => imageInputRef.current?.click()}
+                onClick={() => {
+                  replacementPathRef.current = uploadFailure.replacementPath ?? null;
+                  imageInputRef.current?.click();
+                }}
               >
                 <ImagePlus className="h-3.5 w-3.5" aria-hidden />
                 Choose another

--- a/frontend/src/components/markdown-editor.tsx
+++ b/frontend/src/components/markdown-editor.tsx
@@ -15,7 +15,12 @@ import {
 import { MarkdownPlugin } from "@platejs/markdown";
 import { toggleList, ListStyleType } from "@platejs/list";
 import { upsertLink } from "@platejs/link";
-import { insertTable } from "@platejs/table";
+import {
+  insertTable,
+  insertTableColumn,
+  insertTableRow,
+} from "@platejs/table";
+import { TrailingBlockPlugin } from "@platejs/utils";
 import {
   Bold,
   Italic,
@@ -37,6 +42,9 @@ import {
   Loader2,
   Pilcrow,
   RotateCcw,
+  Rows3,
+  Columns3,
+  CornerDownLeft,
   Trash2,
   X,
 } from "lucide-react";
@@ -163,14 +171,143 @@ function ListItemElement(props: PlateElementProps) {
 }
 
 function TableElement(props: PlateElementProps) {
+  const editor = useEditorRef();
+  const editorLifecycle = React.useContext(EditorAssetLifecycleContext);
+
+  const withTablePath = (action: (path: number[]) => void) => {
+    const path = editor.api.findPath(props.element);
+    if (!path) return;
+    action(path);
+  };
+
+  const focusEditor = () => {
+    // Keep pointer and keyboard users in the authoring flow after a block
+    // action instead of leaving focus stranded on the caption toolbar.
+    requestAnimationFrame(() => editorLifecycle?.focusEditor());
+  };
+
+  const continueBelow = () => {
+    withTablePath((path) => {
+      const nextPath = [...path];
+      nextPath[nextPath.length - 1] += 1;
+      const nextEntry = editor.api.node(nextPath);
+      const nextType = (nextEntry?.[0] as { type?: string } | undefined)?.type;
+      if (nextType !== ParagraphPlugin.key) {
+        editor.tf.insertNodes(
+          { type: ParagraphPlugin.key, children: [{ text: "" }] },
+          { at: nextPath },
+        );
+      }
+      editor.tf.select(editor.api.start(nextPath));
+      focusEditor();
+    });
+  };
+
+  const deleteCurrentTable = () => {
+    withTablePath((path) => {
+      editor.tf.removeNodes({ at: path });
+      // TrailingBlockPlugin covers a terminal table. If another block follows,
+      // it shifts into the removed table's path and becomes the natural target.
+      if (!editor.api.node(path)) {
+        editor.tf.insertNodes(
+          { type: ParagraphPlugin.key, children: [{ text: "" }] },
+          { at: path },
+        );
+      }
+      editor.tf.select(editor.api.start(path));
+      focusEditor();
+    });
+  };
+
   // Wide tables scroll within themselves instead of pushing the whole
   // authoring surface into a page-level horizontal scroll.
   return (
     <PlateElement
       {...props}
-      as="table"
-      className="my-4 w-full border border-border text-sm block overflow-x-auto max-w-full"
-    />
+      as="div"
+      className="my-4 max-w-full overflow-x-auto"
+    >
+      <table
+        aria-label={editorLifecycle?.readOnly ? "Table" : "Editable table"}
+        className="!table !overflow-visible w-full min-w-[36rem] border-collapse border border-border text-sm"
+      >
+        {!editorLifecycle?.readOnly && (
+          <caption
+            contentEditable={false}
+            className="caption-top border-b border-border bg-surface-2 px-2 py-1.5 text-left"
+          >
+            <div className="flex min-w-max items-center justify-between gap-3">
+              <span className="inline-flex items-center gap-1.5 px-1 text-xs font-medium text-foreground-muted">
+                <TableIcon className="h-3.5 w-3.5" aria-hidden />
+                Table
+              </span>
+              <div className="flex items-center gap-1" role="toolbar" aria-label="Table actions">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 px-2"
+                  title="Add row to the end"
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={() => {
+                    withTablePath((path) => {
+                      insertTableRow(editor, { at: path, select: true });
+                      focusEditor();
+                    });
+                  }}
+                >
+                  <Rows3 className="h-3.5 w-3.5" aria-hidden />
+                  Row
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 px-2"
+                  title="Add column to the end"
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={() => {
+                    withTablePath((path) => {
+                      insertTableColumn(editor, { at: path, select: true });
+                      focusEditor();
+                    });
+                  }}
+                >
+                  <Columns3 className="h-3.5 w-3.5" aria-hidden />
+                  Column
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 px-2"
+                  title="Move the cursor to a paragraph below this table"
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={continueBelow}
+                >
+                  <CornerDownLeft className="h-3.5 w-3.5" aria-hidden />
+                  Continue below
+                </Button>
+                <span className="mx-0.5 h-4 w-px bg-border" aria-hidden />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Delete table"
+                  title="Delete table (you can undo this action)"
+                  className="h-8 w-8 text-foreground-muted hover:bg-destructive/10 hover:text-destructive"
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={deleteCurrentTable}
+                >
+                  <Trash2 className="h-3.5 w-3.5" aria-hidden />
+                </Button>
+              </div>
+            </div>
+          </caption>
+        )}
+        <tbody>{props.children}</tbody>
+      </table>
+    </PlateElement>
   );
 }
 
@@ -196,6 +333,8 @@ interface EditorAssetLifecycle {
   vault: string;
   document?: string;
   commit?: string;
+  readOnly?: boolean;
+  focusEditor: () => void;
 }
 
 const EditorAssetLifecycleContext = React.createContext<EditorAssetLifecycle | null>(null);
@@ -208,46 +347,60 @@ function ImageElement(props: PlateElementProps) {
     caption?: Array<{ text?: string }>;
   };
   const alt = element.caption?.map((part) => part.text || "").join("") || "";
+
+  const removeImage = () => {
+    const path = editor.api.findPath(props.element);
+    if (!path) return;
+    editor.tf.removeNodes({ at: path });
+    if (!editor.api.node(path)) {
+      editor.tf.insertNodes(
+        { type: ParagraphPlugin.key, children: [{ text: "" }] },
+        { at: path },
+      );
+    }
+    editor.tf.select(editor.api.start(path));
+    requestAnimationFrame(() => assetLifecycle?.focusEditor());
+  };
+
   return (
     <PlateElement {...props} className="my-4">
-      <figure contentEditable={false} className="group relative m-0">
-        <AssetImage
-          src={element.url}
-          alt={alt}
-          assetContext={
-            assetLifecycle
-              ? {
-                  mode: "authenticated",
-                  vault: assetLifecycle.vault,
-                  document: assetLifecycle.document,
-                  commit: assetLifecycle.commit,
-                }
-              : undefined
-          }
-          className="my-0 max-h-[70vh] object-contain"
-        />
+      <figure contentEditable={false} className="group m-0">
+        <div className="relative mx-auto w-fit max-w-full">
+          <AssetImage
+            src={element.url}
+            alt={alt}
+            assetContext={
+              assetLifecycle
+                ? {
+                    mode: "authenticated",
+                    vault: assetLifecycle.vault,
+                    document: assetLifecycle.document,
+                    commit: assetLifecycle.commit,
+                  }
+                : undefined
+            }
+            className="my-0 max-h-[70vh] max-w-full object-contain"
+          />
+          {!assetLifecycle?.readOnly && (
+            <Button
+              type="button"
+              variant="secondary"
+              size="icon"
+              aria-label={alt ? `Remove image: ${alt}` : "Remove image"}
+              title="Remove image"
+              className="absolute right-2 top-2 h-8 w-8 border border-border bg-surface/90 text-foreground-muted shadow-sm backdrop-blur-sm hover:border-border-strong hover:bg-surface hover:text-foreground"
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={removeImage}
+            >
+              <X className="h-4 w-4" aria-hidden />
+            </Button>
+          )}
+        </div>
         {alt && (
           <figcaption className="mt-1.5 text-center text-xs text-foreground-muted">
             {alt}
           </figcaption>
         )}
-        <Button
-          type="button"
-          variant="destructive"
-          size="icon"
-          aria-label={alt ? `Remove image: ${alt}` : "Remove image"}
-          title="Remove image"
-          className="absolute right-2 top-2 h-8 w-8 opacity-0 shadow-sm group-hover:opacity-100 group-focus-within:opacity-100 focus:opacity-100"
-          onMouseDown={(event) => event.preventDefault()}
-          onClick={() => {
-            const path = editor.api.findPath(props.element);
-            if (path) {
-              editor.tf.removeNodes({ at: path });
-            }
-          }}
-        >
-          <Trash2 className="h-4 w-4" aria-hidden />
-        </Button>
       </figure>
       {props.children}
     </PlateElement>
@@ -303,11 +456,17 @@ const plugins = [
   CodeSyntaxPlugin,
   ListPlugin,
   LinkPlugin,
-  TablePlugin,
+  // Markdown/GFM has no merged-cell representation. Keeping table editing in
+  // rectangular mode makes row/column transforms deterministic and prevents
+  // an unround-trippable editor state.
+  TablePlugin.configure({ options: { disableMerge: true } }),
   TableRowPlugin,
   TableCellPlugin,
   TableCellHeaderPlugin,
   ImagePlugin,
+  // Full editors must always have a text block after terminal atomic blocks
+  // (tables, images, rules). This is the keyboard and pointer escape route.
+  TrailingBlockPlugin,
   // Marks
   BoldPlugin,
   ItalicPlugin,
@@ -700,6 +859,7 @@ export function MarkdownEditor({
   } | null>(null);
   const uploadControllerRef = React.useRef<AbortController | null>(null);
   const imageInputRef = React.useRef<HTMLInputElement>(null);
+  const editorSurfaceRef = React.useRef<HTMLDivElement | null>(null);
   const uploadInFlightRef = React.useRef(false);
   const deferredImageFilesRef = React.useRef<File[]>([]);
   const unclaimedAssetIdsRef = React.useRef(new Set<string>());
@@ -765,7 +925,18 @@ export function MarkdownEditor({
     components,
     value: (ed) => {
       try {
-        return ed.getApi(MarkdownPlugin).markdown.deserialize(value || "");
+        const nodes = ed.getApi(MarkdownPlugin).markdown.deserialize(value || "");
+        const lastNode = nodes.at(-1) as { type?: string } | undefined;
+        // Initial markdown is deserialized before the normalizer's first edit.
+        // Seed the same invariant that TrailingBlockPlugin maintains later so
+        // a document loaded with a terminal table/image is immediately escapable.
+        if (lastNode?.type !== ParagraphPlugin.key) {
+          return [
+            ...nodes,
+            { type: ParagraphPlugin.key, children: [{ text: "" }] },
+          ];
+        }
+        return nodes;
       } catch (err) {
         // Plate's mdast deserializer can throw on malformed input
         // (unsupported HTML, broken tables, etc). Surface the editor with
@@ -907,8 +1078,14 @@ export function MarkdownEditor({
   );
 
   const assetLifecycle = React.useMemo(
-    () => ({ vault, document, commit }),
-    [commit, document, vault],
+    () => ({
+      vault,
+      document,
+      commit,
+      readOnly,
+      focusEditor: () => editorSurfaceRef.current?.focus(),
+    }),
+    [commit, document, readOnly, vault],
   );
 
   const handleImageDragOver = React.useCallback(
@@ -1063,6 +1240,9 @@ export function MarkdownEditor({
         </Alert>
       )}
       <PlateContent
+        ref={(node) => {
+          editorSurfaceRef.current = node as HTMLDivElement | null;
+        }}
         autoFocus={autoFocus}
         readOnly={readOnly}
         placeholder={placeholder}

--- a/frontend/src/components/markdown-render.tsx
+++ b/frontend/src/components/markdown-render.tsx
@@ -651,8 +651,8 @@ function buildComponents(markdown: string, assetContext?: AssetContext): Compone
 
     /* ── Tables ───────────────────────────────────────────────── */
     table: ({ node: _node, children, ...props }) => (
-      <div className="my-5 overflow-x-auto max-w-full rounded-[var(--radius-lg)] border border-border">
-        <table className="min-w-full border-collapse text-[0.92em]" {...props}>
+      <div className="akb-md-table my-5 overflow-x-auto rounded-[var(--radius-lg)] border border-border">
+        <table className="w-max min-w-full border-collapse text-[0.92em]" {...props}>
           {children}
         </table>
       </div>

--- a/frontend/src/components/resource-actions-menu.tsx
+++ b/frontend/src/components/resource-actions-menu.tsx
@@ -1,12 +1,14 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
-import { MoreHorizontal, Trash2 } from "lucide-react";
+import { FilePenLine, MoreHorizontal, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 interface ResourceActionsMenuProps {
   resourceName: string;
-  deleteLabel: string;
-  onDelete: () => void;
+  deleteLabel?: string;
+  onDelete?: () => void;
+  onMoveOrRename?: () => void;
+  moveDisabledReason?: string;
   className?: string;
   side?: "top" | "right" | "bottom" | "left";
   align?: "start" | "center" | "end";
@@ -22,10 +24,16 @@ export function ResourceActionsMenu({
   resourceName,
   deleteLabel,
   onDelete,
+  onMoveOrRename,
+  moveDisabledReason,
   className,
   side = "bottom",
   align = "end",
 }: ResourceActionsMenuProps) {
+  const showMoveAction = Boolean(onMoveOrRename || moveDisabledReason);
+  const showDeleteAction = Boolean(deleteLabel && onDelete);
+  if (!showMoveAction && !showDeleteAction) return null;
+
   return (
     <DropdownMenu.Root>
       <DropdownMenu.Trigger asChild>
@@ -47,13 +55,44 @@ export function ResourceActionsMenu({
           sideOffset={4}
           className="z-[var(--z-popover)] min-w-48 overflow-hidden rounded-[var(--radius-md)] border border-border bg-surface p-1 shadow-md"
         >
-          <DropdownMenu.Item
-            onSelect={onDelete}
-            className="flex cursor-pointer select-none items-center gap-2 rounded-[var(--radius-sm)] px-2.5 py-2 text-sm text-destructive outline-none data-[highlighted]:bg-destructive-soft data-[highlighted]:text-destructive-soft-foreground"
-          >
-            <Trash2 className="h-4 w-4" aria-hidden />
-            {deleteLabel}
-          </DropdownMenu.Item>
+          {showMoveAction && (
+            <DropdownMenu.Item
+              aria-disabled={moveDisabledReason ? true : undefined}
+              onSelect={(event) => {
+                if (moveDisabledReason || !onMoveOrRename) {
+                  event.preventDefault();
+                  return;
+                }
+                onMoveOrRename();
+              }}
+              className={cn(
+                "flex cursor-pointer select-none items-start gap-2 rounded-[var(--radius-sm)] px-2.5 py-2 text-sm text-foreground outline-none data-[highlighted]:bg-surface-hover",
+                moveDisabledReason && "cursor-not-allowed opacity-50",
+              )}
+            >
+              <FilePenLine className="mt-0.5 h-4 w-4 shrink-0 text-link" aria-hidden />
+              <span className="min-w-0">
+                <span className="block font-medium">Move or rename</span>
+                {moveDisabledReason && (
+                  <span className="mt-0.5 block max-w-64 text-xs leading-snug text-foreground-muted">
+                    {moveDisabledReason}
+                  </span>
+                )}
+              </span>
+            </DropdownMenu.Item>
+          )}
+          {showMoveAction && showDeleteAction && (
+            <DropdownMenu.Separator className="my-1 h-px bg-border" />
+          )}
+          {showDeleteAction && (
+            <DropdownMenu.Item
+              onSelect={onDelete}
+              className="flex cursor-pointer select-none items-center gap-2 rounded-[var(--radius-sm)] px-2.5 py-2 text-sm text-destructive outline-none data-[highlighted]:bg-destructive-soft data-[highlighted]:text-destructive-soft-foreground"
+            >
+              <Trash2 className="h-4 w-4" aria-hidden />
+              {deleteLabel}
+            </DropdownMenu.Item>
+          )}
         </DropdownMenu.Content>
       </DropdownMenu.Portal>
     </DropdownMenu.Root>

--- a/frontend/src/components/ui/confirm-dialog.tsx
+++ b/frontend/src/components/ui/confirm-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useState, type ReactNode } from "react";
+import { useEffect, useId, useState, type ReactNode, type RefObject } from "react";
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -26,6 +26,7 @@ interface ConfirmDialogProps {
   busy?: boolean;
   confirmationText?: string;
   confirmationLabel?: string;
+  returnFocusRef?: RefObject<HTMLElement | null>;
 }
 
 export function ConfirmDialog({
@@ -40,6 +41,7 @@ export function ConfirmDialog({
   busy = false,
   confirmationText,
   confirmationLabel = "Type the name to confirm permanent deletion",
+  returnFocusRef,
 }: ConfirmDialogProps) {
   const [internalBusy, setInternalBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -75,7 +77,13 @@ export function ConfirmDialog({
 
   return (
     <Dialog open={open} onOpenChange={(o) => !isBusy && onOpenChange(o)}>
-      <DialogContent>
+      <DialogContent
+        onCloseAutoFocus={(event) => {
+          if (!returnFocusRef?.current) return;
+          event.preventDefault();
+          returnFocusRef.current.focus();
+        }}
+      >
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           {description && (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -738,9 +738,10 @@ body::before {
 .akb-md .katex-display > .katex { white-space: nowrap; }
 
 /* The document file frame may grow into space reclaimed from either rail.
-   Keep prose scannable without constraining tables, code blocks, or media that
-   benefit from the wider Git-style workspace. */
-.document-reading-flow > :where(h1, h2, h3, h4, h5, h6, p, ul, ol, blockquote) {
+   Keep prose and ordinary tables aligned on one scannable measure. Tables may
+   still overflow horizontally inside their own wrapper when their columns need
+   more room; code blocks and media continue to use the wider workspace. */
+.document-reading-flow > :where(h1, h2, h3, h4, h5, h6, p, ul, ol, blockquote, .akb-md-table) {
   width: 100%;
   max-width: 64rem;
   margin-inline: auto;

--- a/frontend/src/lib/__tests__/api-document-move.test.ts
+++ b/frontend/src/lib/__tests__/api-document-move.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { moveDocument } from "@/lib/api";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("document move API", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  it("posts the destination fields to an encoded document move endpoint", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        kind: "document_write",
+        uri: "akb://team vault/coll/archive/doc/final-spec.md",
+        vault: "team vault",
+        path: "archive/final-spec.md",
+        commit_hash: "abc1234",
+        current_commit: "abc1234",
+        action: "moved",
+      }),
+    );
+
+    const result = await moveDocument("team vault", "drafts/spec v1.md", {
+      collection: "archive",
+      slug: "final spec",
+      message: "Move the approved spec",
+    });
+
+    expect(result.path).toBe("archive/final-spec.md");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/documents/team%20vault/drafts%2Fspec%20v1.md/move",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          collection: "archive",
+          slug: "final spec",
+          message: "Move the approved spec",
+        }),
+      }),
+    );
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1187,6 +1187,40 @@ export const getDocument = (vault: string, id: string, version?: string) => {
 };
 export const updateDocument = (vault: string, id: string, data: any) =>
   api<any>(`/documents/${vault}/${encodeURIComponent(id)}`, { method: "PATCH", body: JSON.stringify(data) });
+
+export interface DocumentMoveInput {
+  collection?: string;
+  slug?: string;
+  message?: string;
+}
+
+export interface DocumentMoveResult {
+  kind: "document_write";
+  uri: string;
+  vault: string;
+  path: string;
+  commit_hash: string;
+  current_commit?: string | null;
+  previous_commit?: string | null;
+  action?: string | null;
+}
+
+/** Move a document without changing its stable resource identity.
+ *
+ * The backend owns Git history, old-URI aliases, relationships, publications,
+ * and destination collision checks. Callers must navigate to `result.path`
+ * rather than predicting the server-normalized destination.
+ */
+export const moveDocument = (
+  vault: string,
+  id: string,
+  data: DocumentMoveInput,
+) =>
+  api<DocumentMoveResult>(
+    `/documents/${encodeURIComponent(vault)}/${encodeURIComponent(id)}/move`,
+    { method: "POST", body: JSON.stringify(data) },
+  );
+
 export const deleteDocument = (vault: string, id: string) =>
   api<any>(`/documents/${vault}/${encodeURIComponent(id)}`, { method: "DELETE" });
 

--- a/frontend/src/lib/document-draft.ts
+++ b/frontend/src/lib/document-draft.ts
@@ -1,0 +1,79 @@
+import { DOC_TYPES, type DocType } from "@/lib/doc-constants";
+
+const DRAFT_VERSION = 1;
+const DRAFT_PREFIX = "akb:document-draft:";
+
+export interface StoredDocumentDraft {
+  version: typeof DRAFT_VERSION;
+  vault: string;
+  title: string;
+  collection: string;
+  type: DocType;
+  domain: string;
+  summary: string;
+  tags: string[];
+  body: string;
+  assetIds: string[];
+  updatedAt: string;
+}
+
+export function documentDraftStorageKey(vault: string): string {
+  return `${DRAFT_PREFIX}${encodeURIComponent(vault)}`;
+}
+
+export function loadDocumentDraft(vault: string): StoredDocumentDraft | null {
+  try {
+    const raw = window.localStorage.getItem(documentDraftStorageKey(vault));
+    if (!raw) return null;
+    const draft = JSON.parse(raw) as Partial<StoredDocumentDraft>;
+    if (
+      draft.version !== DRAFT_VERSION ||
+      draft.vault !== vault ||
+      typeof draft.title !== "string" ||
+      typeof draft.collection !== "string" ||
+      !DOC_TYPES.includes(draft.type as DocType) ||
+      typeof draft.domain !== "string" ||
+      typeof draft.summary !== "string" ||
+      !Array.isArray(draft.tags) ||
+      !draft.tags.every((tag) => typeof tag === "string") ||
+      typeof draft.body !== "string" ||
+      !Array.isArray(draft.assetIds) ||
+      !draft.assetIds.every((assetId) => typeof assetId === "string") ||
+      typeof draft.updatedAt !== "string"
+    ) {
+      window.localStorage.removeItem(documentDraftStorageKey(vault));
+      return null;
+    }
+    return draft as StoredDocumentDraft;
+  } catch {
+    return null;
+  }
+}
+
+export function saveDocumentDraft(
+  draft: Omit<StoredDocumentDraft, "version" | "updatedAt">,
+): boolean {
+  try {
+    window.localStorage.setItem(
+      documentDraftStorageKey(draft.vault),
+      JSON.stringify({
+        ...draft,
+        version: DRAFT_VERSION,
+        updatedAt: new Date().toISOString(),
+      } satisfies StoredDocumentDraft),
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function clearDocumentDraft(vault: string): void {
+  try {
+    window.localStorage.removeItem(documentDraftStorageKey(vault));
+  } catch {
+    // Storage can be unavailable in hardened/private browsing contexts. The
+    // in-memory composer remains usable and its close confirmation still
+    // protects the current session.
+  }
+}

--- a/frontend/src/lib/document-move.ts
+++ b/frontend/src/lib/document-move.ts
@@ -1,0 +1,13 @@
+/**
+ * Browser preview of the backend's Unicode-aware slug normalization.
+ * The move response remains authoritative and is always used for navigation.
+ */
+export function previewDocumentSlug(value: string) {
+  const cleaned = value
+    .toLocaleLowerCase()
+    .trim()
+    .replace(/[^\p{L}\p{N}_\s-]/gu, "")
+    .replace(/[-\s]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return Array.from(cleaned).slice(0, 80).join("").replace(/-+$/g, "") || "untitled";
+}

--- a/frontend/src/lib/editor-link.ts
+++ b/frontend/src/lib/editor-link.ts
@@ -1,0 +1,11 @@
+import { sanitizeLinkUrl } from "@/lib/utils";
+
+export function normalizeEditorLinkUrl(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const withScheme = /^[\w.-]+\.[a-z]{2,}(?:[/:?#]|$)/i.test(trimmed)
+    ? `https://${trimmed}`
+    : trimmed;
+  const safe = sanitizeLinkUrl(withScheme);
+  return safe === "#" && withScheme !== "#" ? null : safe;
+}

--- a/frontend/src/pages/__tests__/document-new-reserved-collection.test.tsx
+++ b/frontend/src/pages/__tests__/document-new-reserved-collection.test.tsx
@@ -5,10 +5,13 @@ import { MemoryRouter } from "react-router-dom";
 import { DocumentCreateDialog } from "@/components/document-create-dialog";
 
 const putDocument = vi.fn();
+const discardAsset = vi.fn();
+const ASSET_ID = "123e4567-e89b-42d3-a456-426614174000";
 
 vi.mock("@/lib/api", () => ({
   ApiError: class ApiError extends Error {},
   putDocument: (...args: unknown[]) => putDocument(...args),
+  discardAsset: (...args: unknown[]) => discardAsset(...args),
 }));
 
 vi.mock("@/hooks/use-vault-tree", () => ({
@@ -21,15 +24,18 @@ vi.mock("@/contexts/vault-refresh-context", () => ({
 
 vi.mock("@/components/markdown-editor", () => ({
   default: ({
+    value,
     onChange,
     onUploadingChange,
   }: {
+    value: string;
     onChange: (body: string, ids: string[]) => void;
     onUploadingChange?: (uploading: boolean) => void;
   }) => (
     <>
       <textarea
         aria-label="Document body"
+        value={value}
         onChange={(event) => onChange(event.target.value, [])}
       />
       <input
@@ -39,7 +45,8 @@ vi.mock("@/components/markdown-editor", () => ({
         onChange={(event) => {
           if (!event.currentTarget.files?.length) return;
           onUploadingChange?.(true);
-          onChange("![Local image](/api/assets/pending)", []);
+          onChange(`![Local image](/api/assets/${ASSET_ID})`, [ASSET_ID]);
+          onUploadingChange?.(false);
         }}
       />
     </>
@@ -66,6 +73,7 @@ function renderPage(initialCollection = "overview") {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  window.localStorage.clear();
 });
 
 describe("DocumentCreateDialog reserved collection feedback", () => {
@@ -172,5 +180,47 @@ describe("DocumentCreateDialog reserved collection feedback", () => {
       );
       expect(onCreated).toHaveBeenCalledWith("notes/a-note.md");
     });
+  });
+
+  it("restores an autosaved local draft and clears it on explicit discard", async () => {
+    const user = userEvent.setup();
+    const first = renderPage("notes");
+    await user.type(screen.getByLabelText(/^title/i), "Recovered note");
+    await user.type(screen.getByLabelText(/document body/i), "Recovered body");
+    await screen.findByText(/draft saved locally/i);
+    first.unmount();
+
+    const second = renderPage("notes");
+    expect(screen.getByLabelText(/^title/i)).toHaveValue("Recovered note");
+    expect(screen.getByText(/local draft restored/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /close document composer/i }));
+    await user.click(screen.getByRole("button", { name: /discard draft/i }));
+    expect(second.onOpenChange).toHaveBeenCalledWith(false);
+    expect(window.localStorage.length).toBe(0);
+  });
+
+  it("restores temporary image ids and discards them with the saved draft", async () => {
+    const user = userEvent.setup();
+    const first = renderPage("notes");
+    await user.type(screen.getByLabelText(/^title/i), "Draft with image");
+    fireEvent.change(screen.getByLabelText(/local image/i), {
+      target: { files: [new File(["image"], "diagram.png", { type: "image/png" })] },
+    });
+    await screen.findByText(/draft saved locally/i);
+    first.unmount();
+
+    const second = renderPage("notes");
+    expect(screen.getByLabelText(/document body/i)).toHaveValue(
+      `![Local image](/api/assets/${ASSET_ID})`,
+    );
+
+    await user.click(screen.getByRole("button", { name: /close document composer/i }));
+    await user.click(screen.getByRole("button", { name: /discard draft/i }));
+    await waitFor(() => {
+      expect(discardAsset).toHaveBeenCalledWith("my-v", ASSET_ID);
+      expect(second.onOpenChange).toHaveBeenCalledWith(false);
+    });
+    expect(window.localStorage.length).toBe(0);
   });
 });

--- a/frontend/src/pages/__tests__/document-view-toggle.test.tsx
+++ b/frontend/src/pages/__tests__/document-view-toggle.test.tsx
@@ -16,6 +16,8 @@ vi.mock("@/lib/api", () => ({
   publishDoc: vi.fn(),
   unpublishDoc: vi.fn(),
   updateDocument: vi.fn(),
+  browseVault: vi.fn(),
+  moveDocument: vi.fn(),
 }));
 
 vi.mock("@/components/markdown-editor", () => ({
@@ -41,6 +43,8 @@ import {
   getDocument,
   getVaultInfo,
   getRelations,
+  browseVault,
+  moveDocument,
   updateDocument,
 } from "@/lib/api";
 
@@ -49,6 +53,8 @@ const deleteDocumentMock = deleteDocument as unknown as ReturnType<typeof vi.fn>
 const getVaultInfoMock = getVaultInfo as unknown as ReturnType<typeof vi.fn>;
 const getRelationsMock = getRelations as unknown as ReturnType<typeof vi.fn>;
 const updateDocumentMock = updateDocument as unknown as ReturnType<typeof vi.fn>;
+const browseVaultMock = browseVault as unknown as ReturnType<typeof vi.fn>;
+const moveDocumentMock = moveDocument as unknown as ReturnType<typeof vi.fn>;
 
 const SAMPLE_CONTENT = "# BodyHeading\n\nworld";
 const UPDATED_COMMIT = "fedcba987654321"; // pragma: allowlist secret — synthetic Git commit
@@ -155,6 +161,8 @@ beforeEach(() => {
   getVaultInfoMock.mockReset();
   getRelationsMock.mockReset();
   updateDocumentMock.mockReset();
+  browseVaultMock.mockReset();
+  moveDocumentMock.mockReset();
 
   getDocumentMock.mockResolvedValue(makeDoc());
   getVaultInfoMock.mockResolvedValue({ role: "reader" });
@@ -162,6 +170,21 @@ beforeEach(() => {
   updateDocumentMock.mockResolvedValue({
     current_commit: UPDATED_COMMIT,
     commit_hash: UPDATED_COMMIT,
+  });
+  browseVaultMock.mockResolvedValue({
+    items: [
+      { type: "collection", path: "notes" },
+      { type: "collection", path: "archive" },
+    ],
+  });
+  moveDocumentMock.mockResolvedValue({
+    kind: "document_write",
+    uri: "akb://v/coll/archive/doc/hello.md",
+    vault: "v",
+    path: "archive/hello.md",
+    commit_hash: UPDATED_COMMIT,
+    current_commit: UPDATED_COMMIT,
+    action: "moved",
   });
   deleteDocumentMock.mockResolvedValue({ deleted: true });
 
@@ -278,7 +301,7 @@ describe("DocumentPage view toggle", () => {
     );
 
     const details = document.getElementById("document-details-panel") as HTMLElement;
-    const detailsToggle = screen.getByRole("button", { name: "Details" });
+    const detailsToggle = screen.getByRole("button", { name: "Open document panel" });
     expect(details).toHaveAttribute("aria-hidden", "true");
     expect(details).toHaveClass("translate-x-full");
     expect(detailsToggle).toHaveAttribute("aria-expanded", "false");
@@ -287,6 +310,7 @@ describe("DocumentPage view toggle", () => {
     expect(details).toHaveAttribute("aria-hidden", "false");
     expect(details).toHaveClass("translate-x-0");
     expect(detailsToggle).toHaveAttribute("aria-expanded", "true");
+    expect(detailsToggle).toHaveAccessibleName("Hide document panel");
     expect(details).toHaveClass("lg:w-96");
 
     const detailViews = screen.getByRole("tablist", { name: "Document detail views" });
@@ -304,7 +328,7 @@ describe("DocumentPage view toggle", () => {
       "overflow-y-auto",
     );
 
-    await user.click(screen.getByRole("button", { name: "Hide document details" }));
+    await user.click(screen.getByRole("button", { name: "Close document panel" }));
     expect(details).toHaveAttribute("aria-hidden", "true");
     await waitFor(() => expect(detailsToggle).toHaveFocus());
 
@@ -331,6 +355,53 @@ describe("DocumentPage view toggle", () => {
     );
     // The raw <pre> should NOT be present.
     expect(screen.queryByTestId("doc-raw")).not.toBeInTheDocument();
+  });
+
+  it("keeps Edit in the document header and exits a clean editor with Cancel", async () => {
+    const user = userEvent.setup();
+    getVaultInfoMock.mockResolvedValue({ role: "owner" });
+    renderAt("/vault/v/doc/notes%2Fhello.md");
+
+    const edit = await screen.findByRole("button", { name: "Edit" });
+    expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
+      "Rendered",
+      "Raw",
+    ]);
+
+    await user.click(edit);
+    expect(await screen.findByText("Editing document")).toBeInTheDocument();
+    expect(screen.queryByRole("tablist", { name: "Document view" })).not.toBeInTheDocument();
+
+    const cancel = screen.getByRole("button", { name: "Cancel" });
+    expect(cancel).toBeEnabled();
+    await user.click(cancel);
+
+    await screen.findByRole("heading", { level: 2, name: "BodyHeading" });
+    expect(screen.getByTestId("location-search")).toHaveTextContent("");
+    await waitFor(() => expect(screen.getByRole("button", { name: "Edit" })).toHaveFocus());
+  });
+
+  it("confirms before Cancel discards body edits and then returns to reading", async () => {
+    const user = userEvent.setup();
+    getVaultInfoMock.mockResolvedValue({ role: "owner" });
+    renderAt("/vault/v/doc/notes%2Fhello.md");
+
+    await user.click(await screen.findByRole("button", { name: "Edit" }));
+    const editor = await screen.findByRole("textbox", {
+      name: "Document body (markdown)",
+    });
+    await user.type(editor, "XY");
+    expect(screen.getByText("Unsaved changes")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(
+      await screen.findByRole("heading", { name: "Discard unsaved changes?" }),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Discard changes" }));
+
+    await screen.findByRole("heading", { level: 2, name: "BodyHeading" });
+    expect(screen.queryByRole("textbox", { name: "Document body (markdown)" })).not.toBeInTheDocument();
+    expect(updateDocumentMock).not.toHaveBeenCalled();
   });
 
   it("merges a compact summary into the document viewer toolbar without opening Details", async () => {
@@ -404,7 +475,7 @@ describe("DocumentPage view toggle", () => {
 
     renderAt("/vault/v/doc/notes%2Fhello.md");
 
-    await userEvent.setup().click(await screen.findByRole("button", { name: "Details" }));
+    await userEvent.setup().click(await screen.findByRole("button", { name: "Open document panel" }));
     const relationsTab = await screen.findByRole("tab", { name: /^Relations/ });
     expect(relationsTab).toHaveTextContent(/^Relations1$/);
     expect(relationsTab).not.toHaveTextContent("2");
@@ -543,5 +614,47 @@ describe("DocumentPage view toggle", () => {
       expect(deleteDocumentMock).toHaveBeenCalledWith("v", "notes/hello.md"),
     );
     expect(screen.getByTestId("location-pathname")).toHaveTextContent("/vault/v");
+  });
+
+  it("keeps move discoverable for readers and explains why it is unavailable", async () => {
+    const user = userEvent.setup();
+    renderAt("/vault/v/doc/notes%2Fhello.md");
+
+    await user.click(await screen.findByRole("button", { name: "Actions for DocTitle" }));
+    const move = screen.getByRole("menuitem", { name: /Move or rename/i });
+    expect(move).toHaveAttribute("aria-disabled", "true");
+    expect(move).toHaveTextContent("Writer access or higher is required.");
+  });
+
+  it("moves a writer to the backend-returned path and names the destination", async () => {
+    const user = userEvent.setup();
+    getVaultInfoMock.mockResolvedValue({ role: "writer" });
+    getDocumentMock.mockImplementation(async (_vault: string, path: string) =>
+      makeDoc({ path }),
+    );
+    renderAt("/vault/v/doc/notes%2Fhello.md");
+
+    await user.click(await screen.findByRole("button", { name: "Actions for DocTitle" }));
+    await user.click(screen.getByRole("menuitem", { name: "Move or rename" }));
+    await user.click(await screen.findByLabelText("Target collection"));
+    await user.click(screen.getByRole("menuitemradio", { name: "archive" }));
+    await user.click(screen.getByRole("button", { name: "Move document" }));
+
+    await waitFor(() =>
+      expect(moveDocumentMock).toHaveBeenCalledWith(
+        "v",
+        "notes/hello.md",
+        { collection: "archive" },
+      ),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("location-pathname")).toHaveTextContent(
+        "/vault/v/doc/archive%2Fhello.md",
+      ),
+    );
+    const movedStatus = (await screen.findByText("Moved to archive")).closest(
+      '[role="status"]',
+    );
+    expect(movedStatus).toHaveTextContent("archive/hello.md");
   });
 });

--- a/frontend/src/pages/__tests__/document-view-toggle.test.tsx
+++ b/frontend/src/pages/__tests__/document-view-toggle.test.tsx
@@ -404,6 +404,28 @@ describe("DocumentPage view toggle", () => {
     expect(updateDocumentMock).not.toHaveBeenCalled();
   });
 
+  it("returns focus to the edit Cancel action when discard confirmation is dismissed", async () => {
+    const user = userEvent.setup();
+    getVaultInfoMock.mockResolvedValue({ role: "owner" });
+    renderAt("/vault/v/doc/notes%2Fhello.md");
+
+    await user.click(await screen.findByRole("button", { name: "Edit" }));
+    await user.type(
+      await screen.findByRole("textbox", { name: "Document body (markdown)" }),
+      "unsaved",
+    );
+    const pageCancel = screen.getByRole("button", { name: "Cancel" });
+    await user.click(pageCancel);
+    await screen.findByRole("heading", { name: "Discard unsaved changes?" });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => expect(pageCancel).toHaveFocus());
+    expect(
+      screen.getByRole("textbox", { name: "Document body (markdown)" }),
+    ).toBeInTheDocument();
+  });
+
   it("merges a compact summary into the document viewer toolbar without opening Details", async () => {
     getDocumentMock.mockResolvedValue(
       makeDoc({ summary: "A concise orientation to the document before the full body begins." }),

--- a/frontend/src/pages/document.tsx
+++ b/frontend/src/pages/document.tsx
@@ -14,7 +14,6 @@ import {
   Box,
   CheckCircle2,
   Clock3,
-  Code2,
   ExternalLink,
   FileText,
   FolderTree,
@@ -69,6 +68,7 @@ import { useCurrentUser } from "@/contexts/current-user-context";
 import { recordRecentDocumentView } from "@/lib/recent-document-views";
 import { ResourceActionsMenu } from "@/components/resource-actions-menu";
 import { ResourceDeleteDialog } from "@/components/resource-delete-dialog";
+import { DocumentMoveDialog } from "@/components/document-move-dialog";
 
 // Plate is heavy (~hundreds of KB gzipped); lazy-load so the read-only path
 // (Rendered / Raw) stays cheap.
@@ -109,12 +109,15 @@ export default function DocumentPage({
   const [vaultKind, setVaultKind] = useState<"normal" | "mirror" | "error" | null>(null);
   const [vaultReadOnly, setVaultReadOnly] = useState(true);
   const [editOpen, setEditOpen] = useState(false);
+  const [moveOpen, setMoveOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [publishOpen, setPublishOpen] = useState(false);
   const [detailsOpen, setDetailsOpen] = useState(false);
   const [detailsTab, setDetailsTab] = useState<"info" | "outline" | "relations" | "history">("info");
   const detailsToggleRef = useRef<HTMLButtonElement | null>(null);
   const detailsCloseRef = useRef<HTMLButtonElement | null>(null);
+  const editButtonRef = useRef<HTMLButtonElement | null>(null);
+  const restoreEditFocusRef = useRef(false);
   // Plate manages its own state; we remount via `editorKey` when hydrating
   // a fresh server value rather than treating `value` as controlled.
   const [editingContent, setEditingContent] = useState("");
@@ -126,12 +129,20 @@ export default function DocumentPage({
   const [claimedAssetIds, setClaimedAssetIds] = useState<readonly string[] | null>(null);
   const [bodyError, setBodyError] = useState("");
   const [savedAt, setSavedAt] = useState<number | null>(null);
+  const [moveNotice, setMoveNotice] = useState<{ collection: string; path: string } | null>(null);
   // Plate's markdown roundtrip is not byte-identity: adopt the first
   // post-hydration emission as the new `originalContent` baseline so the
   // editor doesn't flash "UNSAVED" the moment it mounts.
   const hydratedKey = useRef<number | null>(null);
   const isDirty = editingContent !== originalContent;
   const hasUnsavedWork = isDirty || uploadingImage;
+
+  useEffect(() => {
+    if (!moveNotice) return;
+    const timer = window.setTimeout(() => setMoveNotice(null), 4_500);
+    return () => window.clearTimeout(timer);
+  }, [moveNotice]);
+
   const docId = id ? decodeURIComponent(id) : "";
   const visibleRelationCount = useMemo(
     () => relations.filter((row) => name && relationIsInVault(row, name)).length,
@@ -150,6 +161,9 @@ export default function DocumentPage({
     if (view === "edit" && next !== "edit" && hasUnsavedWork) {
       setPendingView(next);
       return;
+    }
+    if (view === "edit" && next !== "edit") {
+      restoreEditFocusRef.current = true;
     }
     applyView(next);
   };
@@ -234,6 +248,13 @@ export default function DocumentPage({
       window.removeEventListener("keydown", handleKeyDown);
     };
   }, [detailsOpen]);
+
+  useEffect(() => {
+    if (view === "edit" || !restoreEditFocusRef.current) return;
+    restoreEditFocusRef.current = false;
+    const frame = window.requestAnimationFrame(() => editButtonRef.current?.focus());
+    return () => window.cancelAnimationFrame(frame);
+  }, [view]);
 
   const docQuery = useQuery({
     queryKey: ["document", name, docId, commitHash],
@@ -394,6 +415,7 @@ export default function DocumentPage({
       // newer HEAD. Return to the live document instead of leaving the URL on
       // the now-historical revision while showing the new body.
       p.delete("commit");
+      restoreEditFocusRef.current = true;
       updateRouteParams(p, { replace: true });
     } catch (e: unknown) {
       const status = e instanceof ApiError ? e.status : 0;
@@ -435,9 +457,8 @@ export default function DocumentPage({
   );
 
   function handleCancelBody() {
-    setEditingContent(originalContent);
-    setEditorKey((k) => k + 1);
     setBodyError("");
+    setView("rendered");
   }
 
   // History = `git log -- <doc.path>` scoped to this document.
@@ -535,7 +556,18 @@ export default function DocumentPage({
     (doc.created_by && !isUuid(doc.created_by) ? doc.created_by : null);
   const canWrite =
     vaultRole === "writer" || vaultRole === "admin" || vaultRole === "owner";
-  const canDelete = canWrite && !vaultReadOnly && !isHistorical;
+  const moveDisabledReason = documentMoveDisabledReason({
+    path: doc.path,
+    vaultRole,
+    vaultKind,
+    vaultReadOnly,
+    isHistorical,
+  });
+  const canDelete =
+    canWrite &&
+    !vaultReadOnly &&
+    !isHistorical &&
+    doc.path !== VAULT_SKILL_PATH;
 
   const closeDetails = () => {
     setDetailsOpen(false);
@@ -602,27 +634,6 @@ export default function DocumentPage({
               )}
               <span>{savedAt ? "Saved just now" : doc.updated_at ? `Changed ${timeAgo(doc.updated_at)}` : "Versioned in Git"}</span>
             </div>
-            {!inEditMode && (
-              <Button
-                ref={detailsToggleRef}
-                type="button"
-                variant="outline"
-                size="sm"
-                aria-controls="document-details-panel"
-                aria-expanded={detailsOpen}
-                onClick={() => {
-                  if (detailsOpen) closeDetails();
-                  else setDetailsOpen(true);
-                }}
-              >
-                {detailsOpen ? (
-                  <PanelRightClose className="h-4 w-4" aria-hidden />
-                ) : (
-                  <PanelRightOpen className="h-4 w-4" aria-hidden />
-                )}
-                <span className="hidden sm:inline">Details</span>
-              </Button>
-            )}
             {presentation === "preview" && !inEditMode && (
               <Button
                 type="button"
@@ -634,13 +645,6 @@ export default function DocumentPage({
                 <span className="hidden lg:inline">Full page</span>
               </Button>
             )}
-            {canDelete && !inEditMode && (
-              <ResourceActionsMenu
-                resourceName={doc.title || fileName}
-                deleteLabel="Delete document"
-                onDelete={() => setDeleteOpen(true)}
-              />
-            )}
             {inEditMode ? (
               <>
                 <Button
@@ -648,7 +652,7 @@ export default function DocumentPage({
                   variant="outline"
                   size="sm"
                   onClick={handleCancelBody}
-                  disabled={savingBody || uploadingImage || !isDirty}
+                  disabled={savingBody}
                 >
                   Cancel
                 </Button>
@@ -664,14 +668,23 @@ export default function DocumentPage({
                   {savingBody ? "Saving…" : "Save changes"}
                 </Button>
               </>
-            ) : canEdit ? (
-              <Button type="button" size="sm" onClick={requestEdit}>
-                <Pencil className="h-4 w-4" aria-hidden />
-                <span className="hidden sm:inline">
-                  {presentation === "preview" ? "Edit" : "Edit body"}
-                </span>
-              </Button>
-            ) : null}
+            ) : (
+              <>
+                {canEdit && (
+                  <Button ref={editButtonRef} type="button" size="sm" onClick={requestEdit}>
+                    <Pencil className="h-4 w-4" aria-hidden />
+                    <span className="hidden sm:inline">Edit</span>
+                  </Button>
+                )}
+                <ResourceActionsMenu
+                  resourceName={doc.title || fileName}
+                  onMoveOrRename={moveDisabledReason ? undefined : () => setMoveOpen(true)}
+                  moveDisabledReason={moveDisabledReason || undefined}
+                  deleteLabel={canDelete ? "Delete document" : undefined}
+                  onDelete={canDelete ? () => setDeleteOpen(true) : undefined}
+                />
+              </>
+            )}
           </div>
         </header>
 
@@ -767,70 +780,42 @@ export default function DocumentPage({
                     <History className="h-3.5 w-3.5" aria-hidden />
                     <span className="hidden sm:inline">History</span>
                   </button>
+                  <button
+                    ref={detailsToggleRef}
+                    type="button"
+                    aria-label={detailsOpen ? "Hide document panel" : "Open document panel"}
+                    title={detailsOpen ? "Hide document panel" : "Open document panel"}
+                    aria-controls="document-details-panel"
+                    aria-expanded={detailsOpen}
+                    onClick={() => {
+                      if (detailsOpen) closeDetails();
+                      else setDetailsOpen(true);
+                    }}
+                    className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-md)] border border-border bg-surface text-foreground-muted transition-token hover:border-border-strong hover:bg-surface-hover hover:text-link focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    {detailsOpen ? (
+                      <PanelRightClose className="h-3.5 w-3.5" aria-hidden />
+                    ) : (
+                      <PanelRightOpen className="h-3.5 w-3.5" aria-hidden />
+                    )}
+                  </button>
                 </div>
               </div>
 
               {inEditMode ? (
                 <section className="overflow-hidden rounded-[var(--radius-lg)] border border-border bg-surface shadow-sm">
                   <div
-                    role="tablist"
-                    aria-label="Document view"
-                    className="flex min-h-11 items-center gap-1 border-b border-border bg-surface-2/60 px-3"
-                    onKeyDown={(event) => {
-                      const buttons = Array.from(
-                        event.currentTarget.querySelectorAll<HTMLButtonElement>('[role="tab"]'),
-                      );
-                      const index = buttons.indexOf(document.activeElement as HTMLButtonElement);
-                      if (index < 0) return;
-                      let next: number;
-                      if (event.key === "ArrowRight") next = (index + 1) % buttons.length;
-                      else if (event.key === "ArrowLeft") next = (index - 1 + buttons.length) % buttons.length;
-                      else if (event.key === "Home") next = 0;
-                      else if (event.key === "End") next = buttons.length - 1;
-                      else return;
-                      event.preventDefault();
-                      buttons[next]?.focus();
-                    }}
+                    className="flex min-h-11 items-center gap-2 border-b border-border bg-surface-2/60 px-3"
                   >
-                    <button
-                      role="tab"
-                      aria-selected={false}
-                      tabIndex={-1}
-                      onClick={() => setView("rendered")}
-                      className="inline-flex items-center gap-1.5 rounded-[var(--radius-sm)] px-3 py-1 text-xs font-medium text-foreground-muted transition-token hover:bg-surface-hover hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                    >
-                      <FileText className="h-3.5 w-3.5" aria-hidden />
-                      Rendered
-                    </button>
-                    <button
-                      role="tab"
-                      aria-selected={false}
-                      tabIndex={-1}
-                      onClick={() => setView("raw")}
-                      className="inline-flex items-center gap-1.5 rounded-[var(--radius-sm)] px-3 py-1 text-xs font-medium text-foreground-muted transition-token hover:bg-surface-hover hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                    >
-                      <Code2 className="h-3.5 w-3.5" aria-hidden />
-                      Raw
-                    </button>
-                    <button
-                      role="tab"
-                      id="doc-tab-edit"
-                      aria-selected={true}
-                      aria-controls="doc-panel-edit"
-                      tabIndex={0}
-                      className="inline-flex items-center gap-1.5 rounded-[var(--radius-sm)] bg-surface-selected px-3 py-1 text-xs font-medium text-surface-selected-foreground"
-                    >
+                    <span className="inline-flex items-center gap-1.5 text-xs font-semibold text-foreground">
                       <Pencil className="h-3.5 w-3.5" aria-hidden />
-                      Edit{isDirty ? "*" : ""}
-                    </button>
-                    <span className="ml-auto text-xs text-foreground-muted">
+                      Editing document
+                    </span>
+                    <span role="status" aria-live="polite" className="ml-auto text-xs text-foreground-muted">
                       {uploadingImage ? "Uploading image…" : isDirty ? "Unsaved changes" : "No changes"}
                     </span>
                   </div>
                   <div
-                    id="doc-panel-edit"
-                    role="tabpanel"
-                    aria-labelledby="doc-tab-edit"
                     className="p-4 sm:p-6"
                   >
                     <Suspense fallback={<MarkdownEditorFallback />}>
@@ -873,14 +858,6 @@ export default function DocumentPage({
                   view={view}
                   onViewChange={(next) => setView(next)}
                   appearance="file"
-                  extraTab={
-                    canEdit
-                      ? {
-                          label: `Edit${isDirty ? "*" : ""}`,
-                          onClick: requestEdit,
-                        }
-                      : undefined
-                  }
                 />
               )}
             </article>
@@ -891,14 +868,14 @@ export default function DocumentPage({
               {detailsOpen && (
                 <button
                   type="button"
-                  aria-label="Close document details"
+                  aria-label="Dismiss document panel"
                   onClick={closeDetails}
                   className="absolute inset-0 z-[var(--z-raised)] bg-black/40 lg:hidden"
                 />
               )}
               <aside
                 id="document-details-panel"
-                aria-label="Document details"
+                aria-label="Document panel"
                 aria-hidden={!detailsOpen}
                 inert={!detailsOpen}
                 className={cn(
@@ -910,15 +887,15 @@ export default function DocumentPage({
               >
               <div className="flex h-14 shrink-0 items-center justify-between border-b border-border px-4">
                 <div>
-                  <h2 className="text-sm font-semibold text-foreground">Document details</h2>
-                  <p className="text-xs text-foreground-muted">Context, links and versions</p>
+                  <h2 className="text-sm font-semibold text-foreground">Document panel</h2>
+                  <p className="text-xs text-foreground-muted">Info, structure, links and versions</p>
                 </div>
                 <Button
                   ref={detailsCloseRef}
                   type="button"
                   variant="ghost"
                   size="icon"
-                  aria-label="Hide document details"
+                  aria-label="Close document panel"
                   onClick={closeDetails}
                 >
                   <PanelRightClose className="h-4 w-4" aria-hidden />
@@ -1100,6 +1077,53 @@ export default function DocumentPage({
         }}
       />
 
+      <DocumentMoveDialog
+        open={moveOpen}
+        onOpenChange={setMoveOpen}
+        vault={name!}
+        path={doc.path}
+        title={doc.title || fileName}
+        onMoved={(result) => {
+          const changedAt = new Date().toISOString();
+          const nextDoc = {
+            ...doc,
+            uri: result.uri,
+            path: result.path,
+            current_commit: result.current_commit ?? result.commit_hash,
+            updated_at: changedAt,
+          };
+          queryClient.setQueryData(
+            ["document", name, result.path, undefined],
+            nextDoc,
+          );
+          setDocOverride(nextDoc);
+          // Sidebar refresh is best-effort after the server has committed the
+          // move. A stale tree must not turn a successful move into a retryable
+          // dialog error (which could cause a second, conflicting request).
+          try {
+            refetchTree();
+          } catch {
+            // intentionally swallowed
+          }
+          const nextCollection = result.path.includes("/")
+            ? result.path.slice(0, result.path.lastIndexOf("/"))
+            : "Vault root";
+          setMoveNotice({ collection: nextCollection, path: result.path });
+
+          const nextSearch = new URLSearchParams(searchParams);
+          nextSearch.delete("commit");
+          const encodedPath = encodeURIComponent(result.path);
+          const search = nextSearch.toString();
+          navigate(
+            {
+              pathname: `/vault/${name}/doc/${encodedPath}`,
+              search: search ? `?${search}` : "",
+            },
+            { replace: true, state: routeLocation.state },
+          );
+        }}
+      />
+
       <PublishOptionsDialog
         open={publishOpen}
         onOpenChange={setPublishOpen}
@@ -1134,13 +1158,70 @@ export default function DocumentPage({
         onConfirm={() => {
           const next = pendingView;
           setEditingContent(originalContent);
+          setEditingAssetIds([]);
           setEditorKey((k) => k + 1);
+          setBodyError("");
           setPendingView(null);
-          if (next) applyView(next);
+          if (next) {
+            restoreEditFocusRef.current = true;
+            applyView(next);
+          }
         }}
       />
+
+      {moveNotice && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="fixed bottom-4 right-4 z-[var(--z-toast)] flex max-w-sm items-start gap-3 rounded-[var(--radius-lg)] border border-success/30 bg-surface px-4 py-3 text-sm text-foreground shadow-lg"
+        >
+          <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-success" aria-hidden />
+          <div className="min-w-0">
+            <p className="font-semibold">Moved to {moveNotice.collection}</p>
+            <code className="mt-0.5 block truncate font-mono text-xs text-foreground-muted" title={moveNotice.path}>
+              {moveNotice.path}
+            </code>
+          </div>
+        </div>
+      )}
     </>
   );
+}
+
+interface DocumentMovePermissionState {
+  path: string;
+  vaultRole: string | null;
+  vaultKind: "normal" | "mirror" | "error" | null;
+  vaultReadOnly: boolean;
+  isHistorical: boolean;
+}
+
+function documentMoveDisabledReason({
+  path,
+  vaultRole,
+  vaultKind,
+  vaultReadOnly,
+  isHistorical,
+}: DocumentMovePermissionState) {
+  if (path === VAULT_SKILL_PATH) {
+    return "The Vault guide has a reserved location and cannot be moved.";
+  }
+  if (isHistorical) {
+    return "Return to the latest version before moving this document.";
+  }
+  if (vaultKind === "error") {
+    return "Permissions could not be verified. Refresh the page and try again.";
+  }
+  if (vaultKind === null || vaultRole === null) {
+    return "Permissions are still loading.";
+  }
+  if (vaultReadOnly || vaultKind === "mirror") {
+    return "This Vault is read-only.";
+  }
+  if (!(["writer", "admin", "owner"] as const).includes(vaultRole as "writer" | "admin" | "owner")) {
+    return "Writer access or higher is required.";
+  }
+  return null;
 }
 
 function DocumentPageLoading({ presentation }: { presentation: "page" | "preview" }) {

--- a/frontend/src/pages/document.tsx
+++ b/frontend/src/pages/document.tsx
@@ -117,6 +117,7 @@ export default function DocumentPage({
   const detailsToggleRef = useRef<HTMLButtonElement | null>(null);
   const detailsCloseRef = useRef<HTMLButtonElement | null>(null);
   const editButtonRef = useRef<HTMLButtonElement | null>(null);
+  const cancelEditButtonRef = useRef<HTMLButtonElement | null>(null);
   const restoreEditFocusRef = useRef(false);
   // Plate manages its own state; we remount via `editorKey` when hydrating
   // a fresh server value rather than treating `value` as controlled.
@@ -648,6 +649,7 @@ export default function DocumentPage({
             {inEditMode ? (
               <>
                 <Button
+                  ref={cancelEditButtonRef}
                   type="button"
                   variant="outline"
                   size="sm"
@@ -1155,6 +1157,7 @@ export default function DocumentPage({
         }
         confirmLabel="Discard changes"
         variant="destructive"
+        returnFocusRef={cancelEditButtonRef}
         onConfirm={() => {
           const next = pendingView;
           setEditingContent(originalContent);


### PR DESCRIPTION
## Summary

- add a permission-aware Move or rename action with destination preview, optional commit message, collision recovery, and server-authoritative navigation
- consolidate Edit and resource actions in the document header and restore focus after discard confirmation
- complete Markdown authoring for links, code blocks, tables, and images
- add table row and column removal plus an explicit Continue below escape route
- add safe link create, edit, and remove flows with URL validation and bare-domain normalization
- add image description editing, in-place replacement, neutral removal controls, and temporary-asset cleanup
- persist new-document drafts locally, including temporary image references, and recover them on re-entry
- prevent editor-only trailing sentinel blocks from leaking into saved Markdown
- add keyboard-roving toolbar navigation and accurate disabled and pressed states

## Compatibility

- frontend-only change; backend code, schemas, environment contracts, and deployment manifests are unchanged
- existing move-capable backends use the current document move endpoint
- older backends that return 404 or 405 show a recoverable not-available-on-this-server-yet message
- the current public-auth and legacy hybrid SSO carriers remain untouched
- tables stay rectangular and GFM-compatible so every edit round-trips to Markdown

## Accessibility and UX

- unavailable actions remain visible in a disabled state with a reason
- toolbar navigation supports Arrow keys, Home, and End with a single tab stop
- link validation is announced inline and returns focus to the invalid field
- table and image actions return focus to the authoring surface
- destructive block controls remain visible without hover
- closing a discard confirmation returns focus to the page-level Cancel action
- read-only mode omits authoring controls

## Verification

- [x] design token check
- [x] TypeScript typecheck
- [x] ESLint: 0 errors
- [x] production frontend build
- [x] frontend unit suite: 669 tests across 96 files
- [x] local frontend-only Docker rebuild
- [x] browser reproduction: safe link validation, creation, normalization, editing, and removal
- [x] browser reproduction: table insertion, row and column removal, continue-below typing
- [x] browser reproduction: edit cancellation and original-content recovery
- [x] locally deployed viewer smoke test with no alert state

## Notes

The implementation follows the installed Plate transforms and the WAI-ARIA toolbar interaction pattern. Production and backend services were not changed.