### PR TITLE
feat(mcp): let a rule-driven grantor name the basis it writes

### DIFF
--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -41,6 +41,7 @@ from app.services.uri_service import doc_uri, parse_uri, split_uri
 from app.services.access_service import (
     authorized_vault, authorized_vault_id, check_vault_access, check_vault_scope, grant_access,
     revoke_access, list_vault_members, list_accessible_vaults, get_vault_info,
+    explain_vault_access,
     reset_authorized_vault, search_users, transfer_ownership, archive_vault,
 )
 from app.services.auth_service import resolve_mcp_authorization, token_has_scope
@@ -233,6 +234,9 @@ _TOOL_SCOPES: dict[str, str] = {
     "akb_list_vaults": _READ_SCOPE,
     "akb_vault_info": _READ_SCOPE,
     "akb_vault_members": _READ_SCOPE,
+    # A read: it reports the reasons behind a role, and reporting a reason is
+    # never authority to change one.
+    "akb_explain_access": _READ_SCOPE,
     "akb_search_users": _READ_SCOPE,
     "akb_browse": _READ_SCOPE,
     "akb_get": _READ_SCOPE,
@@ -1383,12 +1387,33 @@ async def _handle_vault_members(args: dict, uid: str, user: _MCPUser) -> dict:
 
 @_h("akb_grant")
 async def _handle_grant(args: dict, uid: str, user: _MCPUser) -> dict:
-    return await grant_access(uid, args["vault"], args["user"], args["role"])
+    # `source_key` is forwarded only when the caller named one, so an agent that
+    # does not know about bases keeps the exact behaviour it had: the service
+    # default is `direct`. Passing None instead would override that default with
+    # a value the service never meant to receive.
+    kwargs: dict = {}
+    if args.get("source_key") is not None:
+        kwargs["source_key"] = args["source_key"]
+    return await grant_access(
+        uid, args["vault"], args["user"], args["role"],
+        revision=args.get("revision"), **kwargs,
+    )
 
 
 @_h("akb_revoke")
 async def _handle_revoke(args: dict, uid: str, user: _MCPUser) -> dict:
-    return await revoke_access(uid, args["vault"], args["user"])
+    # Here the absent key is itself the meaning — no source key is the
+    # administrator's revoke, which removes every basis — so it is passed
+    # straight through rather than being filtered out like the grant default.
+    return await revoke_access(
+        uid, args["vault"], args["user"],
+        source_key=args.get("source_key"), revision=args.get("revision"),
+    )
+
+
+@_h("akb_explain_access")
+async def _handle_explain_access(args: dict, uid: str, user: _MCPUser) -> dict:
+    return await explain_vault_access(uid, args["vault"], args["user"])
 
 
 @_h("akb_search_users")

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -1045,7 +1045,11 @@ TOOLS = [
     ),
     Tool(
         name="akb_grant",
-        description="Grant vault access to a user. You must be owner or admin of the vault.",
+        description=(
+            "Grant vault access to a user. You must be owner or admin of the vault. "
+            "A rule-driven grantor should name its own source_key so it can later "
+            "withdraw its own reason without deleting anybody else's."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
@@ -1056,13 +1060,61 @@ TOOLS = [
                     "description": "Role to grant",
                     "enum": ["reader", "writer", "admin"],
                 },
+                "source_key": {
+                    "type": "string",
+                    "description": (
+                        "The basis on which the role is held, as '<namespace>:<id>'. "
+                        "Omit it and the grant is 'direct', which is what every grant "
+                        "was before bases could coexist."
+                    ),
+                },
+                "revision": {
+                    "type": "integer",
+                    "description": (
+                        "Monotonic per (vault, user, source). A retry carrying a "
+                        "revision no newer than the stored one is a no-op rather "
+                        "than an overwrite."
+                    ),
+                },
             },
             "required": ["vault", "user", "role"],
         },
     ),
     Tool(
         name="akb_revoke",
-        description="Revoke a user's vault access. You must be owner or admin.",
+        description=(
+            "Revoke a user's vault access. You must be owner or admin. "
+            "Omit source_key and the person is out of the vault entirely; name one "
+            "and only that basis is withdrawn, which may downgrade rather than remove."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "vault": {"type": "string", "description": "Vault name"},
+                "user": {"type": "string", "description": "Target username"},
+                "source_key": {
+                    "type": "string",
+                    "description": (
+                        "Withdraw only this basis. Omit it and EVERY basis goes — "
+                        "an administrator's revoke, which must not leave the person "
+                        "holding rule-given access."
+                    ),
+                },
+                "revision": {
+                    "type": "integer",
+                    "description": "Monotonic per (vault, user, source); a stale one is a no-op.",
+                },
+            },
+            "required": ["vault", "user"],
+        },
+    ),
+    Tool(
+        name="akb_explain_access",
+        description=(
+            "Explain why a user holds the role they hold on a vault: every "
+            "independent basis, and the effective role derived from them. "
+            "A member list shows the result, never the reasons."
+        ),
         inputSchema={
             "type": "object",
             "properties": {

--- a/backend/tests/test_mcp_access_basis_unit.py
+++ b/backend/tests/test_mcp_access_basis_unit.py
@@ -1,0 +1,109 @@
+"""MCP must be able to name the basis a grant is held on.
+
+REST learned this when bases were introduced; MCP did not. That asymmetry is
+not cosmetic: a rule-driven grantor reaching AKB over MCP could only ever write
+`direct`, so its later revoke would delete reasons that were never its to
+remove — the exact defect source keys exist to prevent.
+
+Two halves are asserted separately because they fail separately. A schema that
+advertises `source_key` while the handler drops it accepts the argument and
+ignores it; a handler that forwards `source_key` while the schema omits it is
+rejected by `_dispatch`'s unknown-argument check before it runs. Either alone
+reads as "MCP supports bases" and neither is.
+
+The grant and revoke defaults are deliberately different, and that difference is
+asserted rather than assumed: an omitted key on grant means `direct` (the
+service's own default, so the argument must not be forwarded as None), while an
+omitted key on revoke means EVERY basis (so it must be forwarded).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from mcp_server import server as mcp_server
+from mcp_server.tools import TOOLS
+
+
+def _schema(name: str) -> dict:
+    for tool in TOOLS:
+        if tool.name == name:
+            return tool.inputSchema
+    raise AssertionError(f"{name} is not advertised at all")
+
+
+# ── the advertised surface ────────────────────────────────────
+
+
+@pytest.mark.parametrize("tool", ["akb_grant", "akb_revoke"])
+def test_basis_arguments_are_advertised(tool):
+    props = _schema(tool)["properties"]
+    assert "source_key" in props, f"{tool} cannot be told which basis it writes"
+    assert "revision" in props, f"{tool} cannot carry a monotonic revision"
+    # Neither is required: an agent that knows nothing about bases keeps working.
+    assert "source_key" not in _schema(tool).get("required", [])
+
+
+def test_explanation_is_reachable_over_mcp():
+    props = _schema("akb_explain_access")["properties"]
+    assert {"vault", "user"} <= set(props)
+
+
+# ── what the handler actually forwards ────────────────────────
+
+
+class _Spy:
+    def __init__(self):
+        self.kwargs = None
+        self.args = None
+
+    async def __call__(self, *args, **kwargs):
+        self.args, self.kwargs = args, kwargs
+        return {"ok": True}
+
+
+def _run(handler, args):
+    return asyncio.run(handler(args, "uid-1", None))
+
+
+def test_grant_forwards_a_named_basis(monkeypatch):
+    spy = _Spy()
+    monkeypatch.setattr(mcp_server, "grant_access", spy)
+    _run(mcp_server._HANDLERS["akb_grant"],
+         {"vault": "v", "user": "u", "role": "reader",
+          "source_key": "team:abc", "revision": 7})
+    assert spy.kwargs["source_key"] == "team:abc"
+    assert spy.kwargs["revision"] == 7
+
+
+def test_grant_without_a_basis_leaves_the_service_default_alone(monkeypatch):
+    spy = _Spy()
+    monkeypatch.setattr(mcp_server, "grant_access", spy)
+    _run(mcp_server._HANDLERS["akb_grant"], {"vault": "v", "user": "u", "role": "reader"})
+    # Not `source_key=None` — that would override `direct` with a value the
+    # service never meant to receive.
+    assert "source_key" not in spy.kwargs
+
+
+def test_revoke_forwards_a_named_basis(monkeypatch):
+    spy = _Spy()
+    monkeypatch.setattr(mcp_server, "revoke_access", spy)
+    _run(mcp_server._HANDLERS["akb_revoke"],
+         {"vault": "v", "user": "u", "source_key": "team:abc"})
+    assert spy.kwargs["source_key"] == "team:abc"
+
+
+def test_revoke_without_a_basis_still_means_every_basis(monkeypatch):
+    spy = _Spy()
+    monkeypatch.setattr(mcp_server, "revoke_access", spy)
+    _run(mcp_server._HANDLERS["akb_revoke"], {"vault": "v", "user": "u"})
+    # Absent here is a meaning, not a gap: the administrator's revoke.
+    assert spy.kwargs["source_key"] is None
+
+
+def test_explain_handler_reaches_the_service(monkeypatch):
+    spy = _Spy()
+    monkeypatch.setattr(mcp_server, "explain_vault_access", spy)
+    _run(mcp_server._HANDLERS["akb_explain_access"], {"vault": "v", "user": "u"})
+    assert spy.args == ("uid-1", "v", "u")


### PR DESCRIPTION
## What this fixes

Grant contributions arrived on REST in #415. MCP was not extended with them.
`akb_grant` and `akb_revoke` advertised `vault` / `user` / `role` only, and the
handlers called the service without a source key — so **every grant arriving
over MCP is `direct`**.

That is a backward-compatible default, not a bug on its own. It becomes one for
the population the feature exists for: an automated, rule-driven grantor cannot
name its own basis over MCP, so when its rule stops applying its revoke either
names nothing (removing every reason the person holds, including a direct grant
somebody made deliberately) or it cannot withdraw at all. That is precisely the
defect source keys were introduced to prevent, still reachable through the
surface an automated consumer actually uses.

## What changes

- `source_key` and `revision` on `akb_grant` and `akb_revoke`. Neither is
  required: a caller that knows nothing about bases keeps its exact previous
  behaviour.
- `akb_explain_access`, exposing the explanation route over MCP. A member list
  reports the result and never the reasons, so it reads as the audience when it
  is not — the same argument that put the route on REST applies unchanged here,
  and MCP had no way to ask.

Scoped `akb:vault:read`: reporting why a role is held is not authority to change
it.

### The two defaults are deliberately different

```
grant,  no source_key  ->  "direct"        the argument is NOT forwarded,
                                           so the service default stands
revoke, no source_key  ->  EVERY basis     None IS forwarded, because the
                                           absence is the meaning
```

Filtering `None` on the revoke path the way the grant path does would leave an
administrator's revoke silently ineffective against a rule-given role: the call
would return success and the person would keep the access. The test suite
asserts both directions, and a mutation that makes revoke behave like grant
turns exactly that case red.

## Verification

Ran in a container at the repo's pinned interpreter (3.14), not a host Python.

```
new file backend/tests/test_mcp_access_basis_unit.py     8 cases
mutation control                                          4 / 4 red, restore green
adjacent suites (-k "mcp or access")                    159 passed, 29 skipped, 0 failed
```

The mutations, each turning exactly one case red and nothing else:

1. drop `source_key` from the grant schema
2. drop `source_key` in the grant handler
3. make revoke filter `None` the way grant does
4. remove `akb_explain_access` from the advertised tools

The schema half and the handler half are asserted separately because they fail
separately. An advertised argument the handler drops is accepted and ignored; a
forwarded argument the schema omits is rejected by `_dispatch`'s
unknown-argument check before the handler runs. Either alone reads as "MCP
supports bases" and neither is.

## A gate caught this change

`test_every_registered_tool_has_an_explicit_scope_mapping` failed on the first
run, because the new tool had no OAuth scope. That is the gate working, and the
mapping was added rather than the gate relaxed.
