### PR TITLE
design(accepted): say what a floor policy does about a downgrade

### DIFF
--- a/docs/design/accepted/2026-08-26-source-keyed-grant-contributions/README.md
+++ b/docs/design/accepted/2026-08-26-source-keyed-grant-contributions/README.md
@@ -343,6 +343,31 @@ and §4.7 should be read:
   both directions. Granting `reader` to somebody a rule already made a `writer`
   must not demote them in the database, and a surviving basis after a revoke is
   a downgrade rather than a removal.
+- **An administrator's *downgrade* is not a revoke, and against a stronger rule
+  basis it does nothing.** Setting somebody to `reader` writes the `direct`
+  basis; the effective role is the strongest basis; a rule holding `writer`
+  still wins. The call returns 200 and nothing moves. This is intended — a floor
+  policy says rules may raise and never lower, and an explicit *revoke* wins,
+  but a downgrade is not a revoke. Making `direct` a ceiling instead was
+  rejected: with two rule-driven grantors a ceiling from one silently caps the
+  other, which is the original defect wearing a new face, and it turns "the
+  strongest applicable basis" into an ordered policy evaluation that §1's worked
+  example no longer satisfies.
+
+  The write already reports it. `grant_access` returns the requested `role`
+  beside `effective_role`, and they differ exactly in this case. **A consumer
+  that compares against the effective role alone cannot see it** — every such
+  comparison says the rule is satisfied — so a consumer must compare *bases*
+  and say so, rather than reporting the state as in sync.
+
+  What this leaves genuinely missing is the administrator's intent: "this one
+  person is an exception to that rule" has no representation. Lowering the
+  rule's role or removing the person from its subject both change more than the
+  one person, and revoking then re-granting is undone by the next membership
+  event. A suppression basis is the primitive that would express it, and it is
+  a new axis rather than a new value — `role` admits only `reader`, `writer`
+  and `admin`. Deferred until a concrete request for a per-person exception
+  exists.
 
 **What acceptance rests on.** The seven gates of §6 as executable tests against
 live PostgreSQL, each verified to turn red when the guard it names is removed.

--- a/docs/design/accepted/2026-08-26-source-keyed-grant-contributions/feedback/README.md
+++ b/docs/design/accepted/2026-08-26-source-keyed-grant-contributions/feedback/README.md
@@ -1,7 +1,8 @@
 # Feedback
 
-Three corrections shaped this record. Two were self-corrections made before
-acceptance, and one was published after it.
+Four corrections shaped this record. Two were self-corrections made before
+acceptance, one was published after it, and the fourth came from the first
+consumer running against a real deployment.
 
 **The cost argument did not decide what it claimed to.** The proposal argued
 for a materialized effective row from the eleven modules that read
@@ -31,3 +32,14 @@ ground — something notices within an hour, which is not what "expired" means f
 a security control — and the correction strengthens the case for a materialized
 row, because the layer below it is watched continuously rather than only on
 request.
+
+**The floor policy covered revocation and said nothing about downgrade.** Found
+by the first rule-driven consumer, against a live deployment, after acceptance.
+An administrator lowering somebody who also holds a stronger rule basis gets a
+200 and no change, and the consumer reported that as in sync — a green tick
+telling an administrator their decision took effect. The semantics are right and
+the reporting was wrong, but the gap was in this record too: "an explicit human
+revoke wins" was written as though it covered every explicit human decision, and
+a downgrade is not a revoke. §8 now says so, along with why a ceiling is the
+wrong repair and what is actually missing. It was invisible to every comparison
+against the effective role, which is why no test found it and a person did.


### PR DESCRIPTION
## What was missing

The accepted record settled revocation and said nothing about downgrade. "An
explicit human revoke wins" was written as though it covered every explicit
human decision, and it does not.

An administrator setting somebody to `reader` writes the `direct` basis. The
effective role is the strongest basis. A rule holding `writer` still wins. So
the call returns 200 and nothing moves.

That behaviour is intended — a floor policy is exactly "rules may raise and
never lower" — but nothing said so, and the consequence is not academic: the
first rule-driven consumer reported the result as in sync, which is a green tick
telling an administrator their decision took effect.

## What this records

A third settled contract point in §8, and a fourth entry in `feedback/`.

- **Why the semantics stand.** Making `direct` a ceiling was considered and
  rejected. With two rule-driven grantors, a ceiling from one silently caps the
  other — the original defect wearing a new face. It also turns "the strongest
  currently applicable basis" into an ordered policy evaluation, which §1's
  worked example (`reader(team:a) + writer(team:b) -> writer`) no longer
  satisfies.
- **The write already reports it.** `grant_access` returns the requested `role`
  beside `effective_role`, and they differ in exactly this case.
- **Why a consumer cannot see it by looking at the effective role.** Every
  comparison against the effective role says the rule is satisfied. A consumer
  has to compare *bases* and report the difference in words.
- **What is genuinely missing**, named rather than papered over: "this one
  person is an exception to that rule" has no representation. Lowering the
  rule's role or removing the person from its subject both change more than the
  one person; revoking and re-granting is undone by the next membership event. A
  suppression basis would express it, and that is a new axis rather than a new
  value — `role` admits only `reader`, `writer` and `admin`. Deferred until a
  concrete request for a per-person exception exists.

## How it was found

Against a live deployment, after acceptance, by a consumer — not by a test.
No comparison against the effective role can see it, which is why the gates
were green and a person was not.

Documentation only. No behaviour changes.
