### PR TITLE
feat(mcp): serve modern and legacy protocol generations

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3593
+        "line_number": 3601
       }
     ],
     "backend/mcp_server/help.py": [
@@ -201,28 +201,28 @@
         "filename": "backend/scripts/ci/e2e_runtime.py",
         "hashed_secret": "f017223a0417e247cdef8c5c3e5681c6d5439219",
         "is_verified": false,
-        "line_number": 63
+        "line_number": 69
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/scripts/ci/e2e_runtime.py",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 796
+        "line_number": 812
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/scripts/ci/e2e_runtime.py",
         "hashed_secret": "7bd173a7d5330a38f4e220b20348085e38bf232b",
         "is_verified": false,
-        "line_number": 1132
+        "line_number": 1148
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/scripts/ci/e2e_runtime.py",
         "hashed_secret": "ea67b3a75dccf0e8c1d6058e060151a3c5ed90a8",
         "is_verified": false,
-        "line_number": 1134
+        "line_number": 1150
       }
     ],
     "backend/tests/bench/sparse_shape_bench.py": [
@@ -270,7 +270,7 @@
         "filename": "backend/tests/test_e2e_runtime_unit.py",
         "hashed_secret": "e4b2fc073450eb73ac13305ba129b049865f69e2",
         "is_verified": false,
-        "line_number": 125
+        "line_number": 127
       }
     ],
     "backend/tests/test_publications_e2e.sh": [

--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ the AS — see [`docs/mcp-clients/web-connectors.md`](./docs/mcp-clients/web-con
 also accept Claude Code's `mcp add --transport http` + `mcp login` flow
 end-to-end, without a PAT.
 
+### MCP protocol compatibility
+
+The backend release `0.15.0` and `akb-mcp` proxy `2.3.0` expose one shared
+tool and authorization core through both generations:
+
+| Transport | Modern contract | Legacy contract |
+|-----------|-----------------|-----------------|
+| Direct HTTP `/mcp/` | `2026-07-28` stateless `server/discover` and per-request metadata | `2024-11-05`, `2025-03-26`, `2025-06-18`, `2025-11-25` initialize/session lifecycle |
+| `akb-mcp` stdio | `2026-07-28` discovery and request metadata | `2025-06-18` initialize/session surface |
+
+Deploy the backend with both generations before publishing or installing the
+proxy. Existing legacy clients continue using initialize/session, while modern
+clients use stateless requests. Unsupported revisions, generation mixing,
+principal mismatches, and conflicting routing metadata fail closed; the proxy
+does not silently downgrade a modern client.
+
 ## Plugins
 
 Beyond raw MCP access, AKB ships ready-made **agent plugins** for **Claude Code**
@@ -155,7 +171,7 @@ letting the indexing worker re-populate.
 | `akb_list_vaults` / `akb_create_vault` | Vault management |
 | `akb_put` / `akb_get` / `akb_update` / `akb_delete` | Document CRUD (Git commit + indexing) |
 | `akb_put_file` / `akb_get_file` / `akb_update_file` / `akb_delete_file` | File attachments — proxy-side (requires local filesystem) |
-| `akb_put_image` / `akb_discard_image` | Validated inline Markdown images — proxy-side in `akb-mcp` 2.2+ |
+| `akb_put_image` / `akb_discard_image` | Validated inline Markdown images — proxy-side in `akb-mcp` 2.3+ |
 | `akb_create_table` / `akb_alter_table` / `akb_drop_table` / `akb_sql` | Tabular content — per-doc tables + SQL |
 | `akb_browse` | Tree traversal (collection → docs) |
 | `akb_search` / `akb_grep` | Hybrid search (dense + BM25) / literal grep |
@@ -201,7 +217,7 @@ Markdown reference. Remove an image by deleting its Markdown expression; use
 `akb_discard_image` only for an upload that never reached a successful document
 commit. Run `akb_help(topic="images")` for retention and publication behavior.
 
-The image tools require both the matching backend release and `akb-mcp` 2.2 or
+The image tools require both the matching backend release and `akb-mcp` 2.3 or
 newer. For upgrades, deploy the backend first, then publish/install the proxy
 and restart existing MCP processes so they load the updated tool list.
 
@@ -543,6 +559,8 @@ provision with Object Lock and a write-only key for a true immutable trail);
 the local buffer is pruned only after a confirmed upload. Capture is
 best-effort and never raises into the serving path. See
 `config/app.yaml.example` for the full `audit:` block.
+MCP tool lines include the protocol generation, exact revision, and auth
+method; raw credentials, session IDs, and client metadata are not retained.
 
 ### Production deployment
 

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -28,6 +28,14 @@ and tables in both resource viewers and the Vault explorer. Table deletion
 requires exact-name confirmation and identifies affected rows, while every
 successful deletion refreshes the explorer and returns the user to the Vault.
 
+## 0.15.0 — 2026-08-27  *(feat — dual-generation MCP transport)*
+
+The backend now serves the `2026-07-28` stateless MCP envelope alongside the
+allowlisted legacy initialize/session revisions through the exact-pinned MCP
+SDK `2.1.0` and one shared tool/auth core. Legacy sessions are bound to their
+authenticated account principal; generation, revision, and routing mismatches
+fail closed.
+
 ### Fixed repeated production-scale BM25 rebuilds and bounded rebuild memory
 
 The BM25 refresher no longer compares all non-null chunks with the smaller set

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -107,6 +107,7 @@ async def lifespan(app: FastAPI):
         )
     storage_initialized = False
     runtime_started = False
+    mcp_started = False
     try:
         await init_storage()
         storage_initialized = True
@@ -142,8 +143,12 @@ async def lifespan(app: FastAPI):
             start_workers()
         else:
             start_api_runtime()
+        await mcp_app.start()
+        mcp_started = True
         yield
     finally:
+        if mcp_started:
+            await mcp_app.stop()
         if runtime_started:
             if role == "all":
                 await stop_workers()

--- a/backend/app/services/audit_log.py
+++ b/backend/app/services/audit_log.py
@@ -355,7 +355,12 @@ def _grep_replace_meta(args: dict, result) -> dict | None:
     }
 
 
-def _record_grep_replace_receipts(args: dict, user, result) -> None:
+def _record_grep_replace_receipts(
+    args: dict,
+    user,
+    result,
+    protocol_metadata: dict[str, str] | None = None,
+) -> None:
     """Emit one compact recovery receipt per committed grep replacement.
 
     The summary tool record cannot identify every document without becoming one
@@ -375,6 +380,11 @@ def _record_grep_replace_receipts(args: dict, user, result) -> None:
         target = f"uri={replacement['uri']}"
         if len(target) > _TARGET_MAX:
             target = target[:_TARGET_MAX] + "…"
+        meta: dict[str, object] = dict(protocol_metadata or {})
+        meta.update({
+            "commit": replacement.get("commit"),
+            "previous_commit": replacement.get("previous_commit"),
+        })
         record(
             action="akb_grep.replace",
             actor=getattr(user, "username", None),
@@ -382,14 +392,19 @@ def _record_grep_replace_receipts(args: dict, user, result) -> None:
             vault=(args.get("vault") if isinstance(args, dict) else None),
             target=target,
             outcome="ok",
-            meta={
-                "commit": replacement.get("commit"),
-                "previous_commit": replacement.get("previous_commit"),
-            },
+            meta=meta,
         )
 
 
-def record_tool(name: str, args: dict, user, result, *, is_write: bool = False) -> None:
+def record_tool(
+    name: str,
+    args: dict,
+    user,
+    result,
+    *,
+    is_write: bool = False,
+    protocol_metadata: dict[str, str] | None = None,
+) -> None:
     """Audit one MCP tool call from the dispatch chokepoint. ``user`` is the
     resolved _MCPUser; ``result`` is the handler's return envelope (or the
     final error envelope) — outcome is derived from it.
@@ -403,7 +418,9 @@ def record_tool(name: str, args: dict, user, result, *, is_write: bool = False) 
     compliance SIEM. A canonical `resource_uri` can't be formed reliably
     from raw dispatch args (e.g. `akb_search` has no resource), so we keep
     an honest, lossy `target` rather than fake a URI. The divergence is
-    intentional; do not try to unify the two."""
+    intentional; do not try to unify the two. ``protocol_metadata`` carries
+    only the generation, exact revision, and authentication method; client
+    metadata and session identifiers are intentionally excluded."""
     if not settings.audit.enabled:
         return
     # Skip reads only when the operator opted out of read logging; unknown
@@ -417,7 +434,11 @@ def record_tool(name: str, args: dict, user, result, *, is_write: bool = False) 
         outcome = "error"
         code = result.get("code")
     if name == "akb_grep" and is_write:
-        _record_grep_replace_receipts(args, user, result)
+        _record_grep_replace_receipts(args, user, result, protocol_metadata)
+    meta = dict(protocol_metadata or {})
+    grep_meta = _grep_replace_meta(args, result) if name == "akb_grep" and is_write else None
+    if grep_meta:
+        meta.update(grep_meta)
     record(
         action=name,
         actor=getattr(user, "username", None),
@@ -426,7 +447,7 @@ def record_tool(name: str, args: dict, user, result, *, is_write: bool = False) 
         target=(_target_of(args) if isinstance(args, dict) else None),
         outcome=outcome,
         code=code,
-        meta=(_grep_replace_meta(args, result) if name == "akb_grep" and is_write else None),
+        meta=meta or None,
     )
 
 

--- a/backend/mcp_server/help.py
+++ b/backend/mcp_server/help.py
@@ -1548,7 +1548,7 @@ Permissions: SELECT=reader, INSERT/UPDATE/DELETE=writer""",
     "images": """# Inline Document Images
 
 Availability: `akb_put_image` and `akb_discard_image` are local-filesystem
-tools supplied by the `akb-mcp` stdio proxy version 2.2 or newer. Use this
+tools supplied by the `akb-mcp` stdio proxy version 2.3 or newer. Use this
 workflow only when those names are present in the client's tool list.
 
 Use `akb_put_image` when a local raster image should render inside an AKB
@@ -1642,7 +1642,7 @@ permanent image archive.
 
     "akb_put_image": """# akb_put_image — Upload an Inline Document Image
 
-Availability: proxy-local in `akb-mcp` 2.2 or newer; it is not exposed by a
+Availability: proxy-local in `akb-mcp` 2.3 or newer; it is not exposed by a
 direct connection to the backend MCP endpoint.
 
 Reads a local PNG, JPEG, GIF, or WebP through the akb-mcp stdio proxy and
@@ -1687,7 +1687,7 @@ fails, pass `image.url` to `akb_discard_image`.""",
 
     "akb_discard_image": """# akb_discard_image — Clean Up an Uncommitted Image
 
-Availability: proxy-local in `akb-mcp` 2.2 or newer; it is not exposed by a
+Availability: proxy-local in `akb-mcp` 2.3 or newer; it is not exposed by a
 direct connection to the backend MCP endpoint.
 
 Deletes a caller-owned image upload only when no document commit has claimed

--- a/backend/mcp_server/http_app.py
+++ b/backend/mcp_server/http_app.py
@@ -1,99 +1,158 @@
-"""MCP Streamable HTTP — mounts MCP server as ASGI app at /mcp.
+"""Authenticated MCP Streamable HTTP entrypoint.
 
-Each authenticated session gets its own transport + server loop.
-Agents connect via one of:
-  POST http://localhost:8000/mcp/
-  Authorization: Bearer akb_<pat-or-service>   # token-store credential
-  Authorization: Bearer <rs256-access-token>   # keycloak-access-v1 only when
-                                               # mcp_oauth_enabled=true
+The pinned MCP SDK owns the transport split: handshake-era requests use a
+stateful session and 2026-07-28 requests use a fresh stateless exchange. This
+module owns only the AKB authentication boundary and supplies the SDK with a
+stable account principal for legacy-session binding.
 """
 
 from __future__ import annotations
 
-import asyncio
-import logging
-import uuid
+import json
+from contextlib import AsyncExitStack
+from typing import Any
 
+from mcp.server.transport_security import DEFAULT_MAX_REQUEST_BODY_SIZE
+from mcp.server.auth.middleware.bearer_auth import (
+    AuthenticatedUser as MCPAuthenticatedUser,
+)
+from mcp.server.auth.provider import AccessToken as MCPAccessToken
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from starlette.requests import Request
-from starlette.responses import JSONResponse
-from starlette.types import Receive, Scope, Send
-
-from mcp.server.streamable_http import StreamableHTTPServerTransport
+from starlette.responses import JSONResponse, Response
+from starlette.types import Message, Receive, Scope, Send
 
 from app.config import settings
-from app.services.auth_service import resolve_mcp_authorization
-
-logger = logging.getLogger("akb.mcp")
+from app.services.auth_service import AuthenticatedUser, resolve_mcp_authorization
+from mcp_server.protocol import (
+    MCP_LEGACY_PROTOCOL_VERSIONS,
+    MCP_MODERN_PROTOCOL_VERSION,
+)
 
 
 def _www_authenticate_header() -> str:
-    """Build the RFC 9728 §5 `WWW-Authenticate` header value for 401s.
-
-    When MCP-OAuth is enabled the header carries a `resource_metadata`
-    parameter pointing the client at the protected-resource metadata
-    document, so a standards-compliant MCP client (Claude Code,
-    claude.ai, ChatGPT) can autodiscover the authorization server and
-    initiate DCR + the auth-code flow. When disabled (PAT-only), we
-    emit the plain `Bearer` challenge — there is no AS to discover.
-    """
+    """Build the RFC 9728 §5 ``WWW-Authenticate`` header for 401s."""
     base = 'Bearer realm="akb-mcp"'
     if settings.mcp_oauth_enabled and settings.public_base_url:
-        meta_url = (
-            f"{settings.public_base_url.rstrip('/')}"
-            "/.well-known/oauth-protected-resource"
-        )
+        meta_url = f"{settings.public_base_url.rstrip('/')}/.well-known/oauth-protected-resource"
         return f'{base}, resource_metadata="{meta_url}"'
     return base
 
-# Active transports keyed by session ID
-_transports: dict[str, StreamableHTTPServerTransport] = {}
-_server_tasks: dict[str, asyncio.Task] = {}
-# Authenticated user per session (used by tool handlers)
-_session_users: dict[str, object] = {}
+
+def _sdk_principal(user: AuthenticatedUser) -> MCPAuthenticatedUser:
+    """Project an AKB account onto the SDK's legacy-session identity type.
+
+    The SDK compares ``client_id``, issuer, and subject when a stateful
+    session is reused. AKB authorizes the account returned by its own auth
+    service, so the account UUID is the stable principal across PAT/OIDC
+    credentials for that account. The credential value is deliberately not
+    copied into this in-memory adapter.
+    """
+    access_token = MCPAccessToken(
+        token="akb-session-principal",
+        client_id=f"akb-user:{user.user_id}",
+        scopes=[],
+        subject=user.user_id,
+        claims={"iss": "akb"},
+    )
+    return MCPAuthenticatedUser(access_token)
 
 
-def get_session_user(session_id: str):
-    """Get authenticated user for a session. Called by tool handlers."""
-    return _session_users.get(session_id)
+def _request_id(decoded: Any) -> int | str | None:
+    if not isinstance(decoded, dict):
+        return None
+    value = decoded.get("id")
+    return value if isinstance(value, (int, str)) and not isinstance(value, bool) else None
 
 
-async def _ensure_server_running(session_id: str, transport: StreamableHTTPServerTransport) -> None:
-    """Ensure the MCP server loop is running for this transport."""
-    if session_id in _server_tasks and not _server_tasks[session_id].done():
-        return
+def _protocol_error(
+    *,
+    request_id: int | str | None,
+    message: str,
+    code: int = -32600,
+    data: Any = None,
+) -> JSONResponse:
+    error: dict[str, Any] = {"code": code, "message": message}
+    if data is not None:
+        error["data"] = data
+    return JSONResponse(
+        {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": error,
+        },
+        status_code=400,
+    )
 
-    from mcp_server.server import server
 
-    async def run():
-        try:
-            async with transport.connect() as (read_stream, write_stream):
-                await server.run(read_stream, write_stream, server.create_initialization_options())
-        except Exception:
-            logger.exception("MCP server loop error for session %s", session_id)
-        finally:
-            _transports.pop(session_id, None)
-            _session_users.pop(session_id, None)
-            _server_tasks.pop(session_id, None)
+async def _read_body_for_routing(request: Request, receive: Receive) -> tuple[bytes, Any]:
+    """Read a POST body once and provide the SDK a replayable receive."""
+    body = await request.body()
+    decoded: Any = None
+    try:
+        decoded = json.loads(body)
+    except (ValueError, RecursionError):
+        pass
 
-    _server_tasks[session_id] = asyncio.create_task(run())
-    await asyncio.sleep(0.05)
+    sent = False
+
+    async def replay() -> Message:
+        nonlocal sent
+        if not sent:
+            sent = True
+            return {"type": "http.request", "body": body, "more_body": False}
+        return await receive()
+
+    return body, (decoded, replay)
 
 
 class MCPApp:
-    """ASGI app that handles MCP Streamable HTTP authorization."""
+    """Authenticate each request before the SDK's mixed-generation manager."""
+
+    def __init__(self) -> None:
+        self._manager: StreamableHTTPSessionManager | None = None
+        self._exit_stack: AsyncExitStack | None = None
+        self._session_revisions: dict[str, str] = {}
+
+    async def start(self) -> None:
+        """Start the process-scoped SDK manager and shared server lifespan."""
+        if self._manager is not None:
+            return
+
+        from mcp_server.server import server
+
+        manager = StreamableHTTPSessionManager(
+            app=server,
+            json_response=True,
+            # The SDK's 2.1 manager routes modern requests to its stateless
+            # driver while keeping the stateful driver for handshake-era
+            # revisions. One manager therefore serves both generations.
+            stateless=False,
+        )
+        exit_stack = AsyncExitStack()
+        try:
+            await exit_stack.enter_async_context(manager.run())
+        except BaseException:
+            await exit_stack.aclose()
+            raise
+        self._manager = manager
+        self._exit_stack = exit_stack
+
+    async def stop(self) -> None:
+        """Stop the manager and release legacy session tasks."""
+        exit_stack = self._exit_stack
+        self._manager = None
+        self._exit_stack = None
+        self._session_revisions.clear()
+        if exit_stack is not None:
+            await exit_stack.aclose()
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
             return
 
         request = Request(scope, receive, send)
-
-        # Auth check. The MCP capability accepts only namespaced token-store
-        # credentials and, when enabled, keycloak-access-v1 for the MCP
-        # audience. Local human sessions are never MCP credentials. 401s carry
-        # an RFC 9728 WWW-Authenticate
-        # header so a standards-compliant MCP client can autodiscover
-        # the AS and complete OAuth without an out-of-band tip-off.
+        response: Response
         auth_header = request.headers.get("authorization", "")
         www_auth = _www_authenticate_header()
         if not auth_header:
@@ -120,50 +179,165 @@ class MCPApp:
             await response(scope, receive, send)
             return
 
-        session_id = request.headers.get("mcp-session-id")
+        # StreamableHTTPSessionManager binds stateful sessions to this
+        # principal and returns the same opaque session-not-found response for
+        # a different account. The application handler still resolves the
+        # real AKB user from the Authorization header on every tool call.
+        scope["user"] = _sdk_principal(user)
 
-        if request.method == "DELETE":
-            if session_id and session_id in _transports:
-                transport = _transports.pop(session_id)
-                _session_users.pop(session_id, None)
-                await transport.terminate()
-                task = _server_tasks.pop(session_id, None)
-                if task:
-                    task.cancel()
-                logger.info("MCP session terminated: %s", session_id[:8])
-            response = JSONResponse({"terminated": True})
+        manager = self._manager
+        if manager is None:
+            response = Response(status_code=503)
             await response(scope, receive, send)
             return
 
-        if request.method == "POST":
-            if session_id and session_id in _transports:
-                transport = _transports[session_id]
-            else:
-                session_id = str(uuid.uuid4())
-                transport = StreamableHTTPServerTransport(
-                    mcp_session_id=session_id,
-                    is_json_response_enabled=True,
-                )
-                _transports[session_id] = transport
-                _session_users[session_id] = user
-                await _ensure_server_running(session_id, transport)
-                logger.info("MCP session started: %s (user: %s)", session_id[:8], user.username)
-
-            # Delegate to transport's ASGI handler
-            await transport.handle_request(scope, receive, send)
+        protocol_header = request.headers.get("mcp-protocol-version")
+        modern_header = protocol_header == MCP_MODERN_PROTOCOL_VERSION
+        if modern_header and request.method != "POST":
+            response = _protocol_error(
+                request_id=None,
+                message="The stateless 2026-07-28 protocol only accepts POST requests",
+            )
+            await response(scope, receive, send)
             return
 
-        if request.method == "GET":
-            if not session_id or session_id not in _transports:
-                response = JSONResponse({"error": "Invalid session"}, status_code=404)
+        decoded: Any = None
+        replay: Receive = receive
+        negotiated_revision: str | None = None
+        delete_messages: list[Message] | None = [] if request.method == "DELETE" else None
+        if request.method == "POST":
+            body, routing = await _read_body_for_routing(request, receive)
+            decoded, replay = routing
+            if len(body) > DEFAULT_MAX_REQUEST_BODY_SIZE:
+                response = Response(status_code=413)
                 await response(scope, receive, send)
                 return
-            transport = _transports[session_id]
-            await transport.handle_request(scope, receive, send)
-            return
 
-        response = JSONResponse({"error": "Method not allowed"}, status_code=405)
-        await response(scope, receive, send)
+            body_meta: dict[str, Any] | None = None
+            if isinstance(decoded, dict):
+                params = decoded.get("params")
+                if isinstance(params, dict):
+                    meta = params.get("_meta")
+                    if isinstance(meta, dict):
+                        body_meta = meta
+            body_modern_version = body_meta.get("io.modelcontextprotocol/protocolVersion") if body_meta else None
+            method = decoded.get("method") if isinstance(decoded, dict) else None
+            if body_modern_version is not None and (
+                protocol_header is None
+                or protocol_header in MCP_LEGACY_PROTOCOL_VERSIONS
+                or protocol_header != body_modern_version
+            ):
+                response = _protocol_error(
+                    request_id=_request_id(decoded),
+                    message="Modern request metadata requires the 2026-07-28 protocol header",
+                    code=-32020,
+                )
+                await response(scope, receive, send)
+                return
+            if method == "server/discover" and not modern_header:
+                response = _protocol_error(
+                    request_id=_request_id(decoded),
+                    message="server/discover requires the 2026-07-28 stateless protocol",
+                    code=-32022,
+                    data={
+                        "supported": [MCP_MODERN_PROTOCOL_VERSION],
+                        "requested": str(body_modern_version or protocol_header or ""),
+                    },
+                )
+                await response(scope, receive, send)
+                return
+            if method == "initialize" and modern_header:
+                params = decoded.get("params") if isinstance(decoded, dict) else None
+                requested = params.get("protocolVersion") if isinstance(params, dict) else ""
+                response = _protocol_error(
+                    request_id=_request_id(decoded),
+                    message="initialize is only valid for the legacy initialize/session protocol",
+                    code=-32022,
+                    data={
+                        "supported": list(MCP_LEGACY_PROTOCOL_VERSIONS),
+                        "requested": str(requested or ""),
+                    },
+                )
+                await response(scope, receive, send)
+                return
+            if method == "initialize" and isinstance(decoded, dict):
+                params = decoded.get("params")
+                requested = params.get("protocolVersion") if isinstance(params, dict) else None
+                negotiated_revision = requested or MCP_LEGACY_PROTOCOL_VERSIONS[-1]
+                if protocol_header is not None and protocol_header != negotiated_revision:
+                    response = _protocol_error(
+                        request_id=_request_id(decoded),
+                        message="Mcp-Protocol-Version header does not match initialize protocolVersion",
+                        code=-32020,
+                    )
+                    await response(scope, receive, send)
+                    return
+                if requested is not None and requested not in MCP_LEGACY_PROTOCOL_VERSIONS:
+                    response = _protocol_error(
+                        request_id=_request_id(decoded),
+                        message="Unsupported protocol version",
+                        code=-32022,
+                        data={
+                            "supported": list(MCP_LEGACY_PROTOCOL_VERSIONS),
+                            "requested": str(requested),
+                        },
+                    )
+                    await response(scope, receive, send)
+                    return
+            if modern_header:
+                if request.headers.get("mcp-session-id") is not None:
+                    response = _protocol_error(
+                        request_id=_request_id(decoded),
+                        message="Mcp-Session-Id is not supported by the stateless 2026-07-28 protocol",
+                    )
+                    await response(scope, receive, send)
+                    return
+                if isinstance(decoded, dict) and decoded.get("method") == "notifications/initialized":
+                    response = _protocol_error(
+                        request_id=_request_id(decoded),
+                        message="notifications/initialized is only valid for the legacy initialize/session protocol",
+                    )
+                    await response(scope, receive, send)
+                    return
+            receive = replay
+
+        session_id = request.headers.get("mcp-session-id")
+        if session_id is not None and protocol_header in MCP_LEGACY_PROTOCOL_VERSIONS:
+            expected_revision = self._session_revisions.get(session_id)
+            if expected_revision is not None and protocol_header != expected_revision:
+                response = _protocol_error(
+                    request_id=_request_id(decoded),
+                    message="Mcp-Protocol-Version does not match the negotiated legacy session revision",
+                    code=-32020,
+                )
+                await response(scope, receive, send)
+                return
+
+        async def capture_response(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = dict(message.get("headers", []))
+                response_session = headers.get(b"mcp-session-id")
+                if response_session is not None and negotiated_revision is not None:
+                    self._session_revisions[response_session.decode("latin-1")] = negotiated_revision
+            if delete_messages is not None:
+                delete_messages.append(message)
+            else:
+                await send(message)
+
+        await manager.handle_request(scope, receive, capture_response)
+        if delete_messages is not None:
+            response_start = next(
+                (message for message in delete_messages if message["type"] == "http.response.start"),
+                None,
+            )
+            status = response_start["status"] if response_start is not None else 500
+            if status == 200:
+                await JSONResponse({"terminated": True})(scope, receive, send)
+            else:
+                for message in delete_messages:
+                    await send(message)
+            if session_id is not None:
+                self._session_revisions.pop(session_id, None)
 
 
 mcp_app = MCPApp()

--- a/backend/mcp_server/instructions.py
+++ b/backend/mcp_server/instructions.py
@@ -19,7 +19,7 @@ When writing into a vault:
 4. Never inline secrets in document bodies — use ${{secrets.X}} placeholders.
 5. Destructive tools (akb_delete_vault, akb_delete_collection) require explicit user confirmation.
 6. Reference resources by the akb:// URIs returned by tool calls — do not reassemble paths yourself.
-7. If listed, use proxy-local akb_put_image and insert its returned `markdown`. For existing documents use targeted akb_edit: akb_update(content=...) replaces the entire body. On write failure call akb_discard_image. If absent, use akb-mcp 2.2+.
+7. If listed, use proxy-local akb_put_image and insert its returned `markdown`. For existing documents use targeted akb_edit: akb_update(content=...) replaces the entire body. On write failure call akb_discard_image. If absent, use akb-mcp 2.3+.
 8. For other surfaces (akb_publish, akb_activity, akb_history), call akb_help() for an overview.
 
 Agent memory is managed outside this tool loop by lifecycle plugins. Find your accessible memory vault with akb_list_vaults; use normal akb_search / akb_browse / akb_get tools rather than reconstructing its name.

--- a/backend/mcp_server/protocol.py
+++ b/backend/mcp_server/protocol.py
@@ -1,0 +1,20 @@
+"""AKB's public MCP protocol matrix."""
+
+from mcp_types.version import HANDSHAKE_PROTOCOL_VERSIONS, MODERN_PROTOCOL_VERSIONS
+
+MCP_LEGACY_PROTOCOL_VERSIONS = (
+    "2024-11-05",
+    "2025-03-26",
+    "2025-06-18",
+    "2025-11-25",
+)
+MCP_MODERN_PROTOCOL_VERSION = "2026-07-28"
+
+if tuple(HANDSHAKE_PROTOCOL_VERSIONS) != MCP_LEGACY_PROTOCOL_VERSIONS:
+    raise RuntimeError(
+        "The pinned MCP SDK handshake versions do not match the AKB legacy allowlist"
+    )
+if tuple(MODERN_PROTOCOL_VERSIONS) != (MCP_MODERN_PROTOCOL_VERSION,):
+    raise RuntimeError(
+        "The pinned MCP SDK must expose exactly the AKB modern protocol revision"
+    )

--- a/backend/mcp_server/server.py
+++ b/backend/mcp_server/server.py
@@ -13,11 +13,14 @@ Provides MCP tools for:
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import sys
 import time
 import uuid
+from contextvars import ContextVar
+from importlib.metadata import version as package_version
 from pathlib import Path
 from typing import Any
 
@@ -26,9 +29,10 @@ from app.util.git_refs import HEX_COMMIT_RE
 # Add backend to path so we can import app modules
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from mcp.server import Server
+from mcp.server import CacheHint, Server
+from mcp.server.context import ServerRequestContext
 from mcp.server.stdio import stdio_server
-from mcp.types import TextContent
+from mcp.types import CallToolResult, ListToolsResult, TextContent
 
 from app.db.postgres import get_pool, init_db, close_pool
 from app.exceptions import ConflictError, NotFoundError, ValidationError, WriteBusyError
@@ -70,6 +74,7 @@ from mcp_server.tools import TOOLS
 from mcp_server.response_projection import browse_payload
 from mcp_server.help import _resolve_help
 from mcp_server.instructions import INSTRUCTIONS
+from mcp_server.protocol import MCP_MODERN_PROTOCOL_VERSION
 from mcp_server.vault_contract import project_accessible_vault
 from app.services import audit_log, tool_usage
 
@@ -83,11 +88,17 @@ VAULT_SKILL_PREFLIGHT_CAPABILITY = "io.dnotitia.akb/vault-skill-preflight"
 VAULT_SKILL_ACK_ARGUMENT = "_vault_skill_ack"
 
 
+_REQUEST_CONTEXT: ContextVar[ServerRequestContext[Any, Any] | None] = ContextVar(
+    "akb_mcp_request_context", default=None
+)
+
+
 def _vault_skill_preflight_version() -> int | None:
-    """Negotiated retry-contract version for this MCP session, if any."""
+    """Negotiated retry-contract version for the current MCP request."""
+    context = _REQUEST_CONTEXT.get()
     try:
-        params = server.request_context.session.client_params
-        experimental = params.capabilities.experimental if params else None
+        capabilities = context.session.client_capabilities if context else None
+        experimental = capabilities.experimental if capabilities else None
         advertised = (experimental or {}).get(VAULT_SKILL_PREFLIGHT_CAPABILITY)
         if not isinstance(advertised, dict):
             return None
@@ -118,9 +129,6 @@ async def _find_doc(vault_name: str, doc_ref: str) -> dict | None:
 
 
 
-server = Server("akb", instructions=INSTRUCTIONS)
-
-
 class _MCPUser:
     """Resolved user from MCP request context."""
     def __init__(
@@ -131,6 +139,7 @@ class _MCPUser:
         oauth_scopes: list[str] | None = None,
         token_scopes: frozenset[str] | None = None,
         key_class: str | None = None,
+        auth_method: str = "unknown",
     ):
         self.user_id = user_id
         self.username = username
@@ -143,6 +152,7 @@ class _MCPUser:
         self.oauth_scopes = oauth_scopes
         self.token_scopes = token_scopes
         self.key_class = key_class
+        self.auth_method = auth_method
 
 _FALLBACK_USER = _MCPUser()
 
@@ -150,13 +160,13 @@ _FALLBACK_USER = _MCPUser()
 async def _get_user() -> _MCPUser:
     """Get authenticated user from MCP request context.
 
-    Uses the standard MCP SDK mechanism: server.request_context.request
-    contains the original HTTP Request, from which we extract the
-    Authorization header and apply the MCP credential capability.
+    The pinned MCP SDK passes the original HTTP Request through the
+    per-request ``ServerRequestContext``. Authentication is therefore resolved
+    independently for every request, including legacy session requests.
     """
     try:
-        ctx = server.request_context
-        request = ctx.request  # Starlette Request object
+        context = _REQUEST_CONTEXT.get()
+        request = context.request if context else None
         if request:
             auth_header = request.headers.get("authorization", "")
             if auth_header:
@@ -169,6 +179,7 @@ async def _get_user() -> _MCPUser:
                         oauth_scopes=user.oauth_scopes,
                         token_scopes=user.token_scopes,
                         key_class=user.key_class,
+                        auth_method=user.auth_method,
                     )
                 # A credential was presented and rejected — that's a
                 # security-relevant event, so audit the denial. No token material
@@ -185,20 +196,47 @@ async def _get_user() -> _MCPUser:
 
 
 def _session_id() -> str | None:
-    """The caller's MCP session id, for correlating a conversation's tool calls.
+    """Return the legacy transport id for usage correlation, when present.
 
-    Same source as `_get_user()` — the SDK stashes the originating HTTP request
-    on the request context. Absent for stdio/CLI callers and for the very first
-    POST of a session (the server mints the id during `initialize`), so this is
-    nullable by construction and must never be treated as a required key.
+    Modern stateless and stdio requests have no session id. The raw value is
+    never placed in audit metadata; the usage sink applies its own bounded
+    representation at the dispatch boundary.
     """
     try:
-        request = server.request_context.request
+        context = _REQUEST_CONTEXT.get()
+        request = context.request if context else None
         if request:
             return request.headers.get("mcp-session-id")
     except (LookupError, AttributeError):
         pass
     return None
+
+
+def _protocol_metadata(user: _MCPUser) -> dict[str, str] | None:
+    """Return bounded protocol facts for audit, without client metadata."""
+    context = _REQUEST_CONTEXT.get()
+    if context is None:
+        return None
+    revision = context.protocol_version
+    generation = "modern" if revision == MCP_MODERN_PROTOCOL_VERSION else "legacy"
+    return {
+        "protocol_generation": generation,
+        "protocol_revision": revision,
+        "auth_method": user.auth_method,
+    }
+
+
+def _usage_session_id(protocol_metadata: dict[str, str] | None) -> str | None:
+    """Keep legacy session correlation opaque in the usage table."""
+    raw = _session_id()
+    if raw is None or protocol_metadata is None:
+        return raw
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    return (
+        f"{protocol_metadata['protocol_generation']}"
+        f":{protocol_metadata['protocol_revision']}"
+        f":{protocol_metadata['auth_method']}:{digest}"
+    )
 revision_backend = get_revision_backend()
 doc_service = revision_backend.document_service
 search_service = SearchService()
@@ -347,7 +385,7 @@ def _required_scope(name: str, args: dict) -> str:
 # time from the same TOOLS list returned via list_tools, so the
 # "what the agent saw" and "what we accept" can't drift.
 _TOOL_ARG_NAMES: dict[str, set[str]] = {
-    t.name: set((t.inputSchema or {}).get("properties", {}).keys())
+    t.name: set((t.input_schema or {}).get("properties", {}).keys())
     for t in TOOLS
 }
 
@@ -1574,14 +1612,10 @@ async def _handle_set_public(args: dict, uid: str, user: _MCPUser) -> dict:
 
 # ── Tool Handlers ────────────────────────────────────────────
 
-@server.list_tools()
 async def list_tools():
-    if _vault_skill_preflight_version() != 2:
-        return TOOLS
-
-    # Capability v2 makes acknowledgement explicit.  Advertise the reserved
-    # retry argument only to clients that negotiated that contract; older
-    # clients keep the byte-for-byte schemas they already understand.
+    # Keep one canonical catalog for both protocol generations. The reserved
+    # acknowledgement argument is optional, so advertising it does not alter
+    # the legacy response shape or business-tool semantics.
     decorated = []
     for tool in TOOLS:
         may_write = (
@@ -1592,7 +1626,7 @@ async def list_tools():
             decorated.append(tool)
             continue
         copied = tool.model_copy(deep=True)
-        copied.inputSchema.setdefault("properties", {})[
+        copied.input_schema.setdefault("properties", {})[
             VAULT_SKILL_ACK_ARGUMENT
         ] = {
             "type": "string",
@@ -1606,8 +1640,27 @@ async def list_tools():
         decorated.append(copied)
     return decorated
 
+async def _handle_list_tools(
+    context: ServerRequestContext[Any, Any], _params: Any
+) -> ListToolsResult:
+    token = _REQUEST_CONTEXT.set(context)
+    try:
+        return ListToolsResult(tools=await list_tools())
+    finally:
+        _REQUEST_CONTEXT.reset(token)
 
-@server.call_tool()
+
+async def _handle_call_tool(
+    context: ServerRequestContext[Any, Any], params: Any
+) -> CallToolResult:
+    token = _REQUEST_CONTEXT.set(context)
+    try:
+        content = await call_tool(params.name, params.arguments or {})
+        return CallToolResult(content=content)
+    finally:
+        _REQUEST_CONTEXT.reset(token)
+
+
 async def call_tool(name: str, arguments: dict):
     # Capability-v2 acknowledgement is transport metadata expressed as a
     # reserved tool argument so generic MCP clients can send it through their
@@ -1624,6 +1677,7 @@ async def call_tool(name: str, arguments: dict):
     # Resolve the actor once and reuse it for both dispatch and the audit
     # line so the two can't disagree on who made the call.
     user = await _get_user()
+    protocol_metadata = _protocol_metadata(user)
     started = time.perf_counter()
     # Guards the two exits against recording the SAME invocation twice. The
     # encode below sits inside this `try`, so a `json.dumps` failure falls to
@@ -1689,13 +1743,20 @@ async def call_tool(name: str, arguments: dict):
         # lock on the event loop, and neither touches the shared to_thread pool
         # — a stalled audit disk can't freeze the loop or starve bcrypt /
         # document reads.
-        audit_log.record_tool(name, arguments, user, result, is_write=is_write)
+        audit_log.record_tool(
+            name,
+            arguments,
+            user,
+            result,
+            is_write=is_write,
+            protocol_metadata=protocol_metadata,
+        )
         # Independent sink: usage analytics go to PG so they can be grouped, and
         # must NOT inherit the audit flags (audit is off by default and
         # `log_reads` would drop most tool calls).
         tool_usage.record(
             name, arguments, user, result,
-            session_id=_session_id(),
+            session_id=_usage_session_id(protocol_metadata),
             duration_ms=int((time.perf_counter() - started) * 1000),
             is_write=is_write,
         )
@@ -1760,10 +1821,17 @@ async def call_tool(name: str, arguments: dict):
         # failure lands here after a handler that actually succeeded).
         if not recorded:
             is_write = _required_scope(name, arguments) == _WRITE_SCOPE
-            audit_log.record_tool(name, arguments, user, envelope, is_write=is_write)
+            audit_log.record_tool(
+                name,
+                arguments,
+                user,
+                envelope,
+                is_write=is_write,
+                protocol_metadata=protocol_metadata,
+            )
             tool_usage.record(
                 name, arguments, user, envelope,
-                session_id=_session_id(),
+                session_id=_usage_session_id(protocol_metadata),
                 duration_ms=int((time.perf_counter() - started) * 1000),
                 is_write=is_write,
             )
@@ -1842,6 +1910,22 @@ async def _dispatch(name: str, args: dict, user: "_MCPUser"):
             hint="The vault is under heavy write load. Wait a few seconds and retry; no partial write occurred.",
             retry_after_secs=e.retry_after_secs,
         )
+
+
+# One process-scoped server and one exact-pinned SDK release serve both the
+# handshake-era and 2026-07-28 request envelopes. The HTTP session manager
+# selects the transport generation; the handlers below remain shared.
+server = Server(
+    "akb",
+    version=package_version("akb"),
+    instructions=INSTRUCTIONS,
+    cache_hints={
+        "server/discover": CacheHint(ttl_ms=300_000, scope="public"),
+        "tools/list": CacheHint(ttl_ms=300_000, scope="public"),
+    },
+    on_list_tools=_handle_list_tools,
+    on_call_tool=_handle_call_tool,
+)
 
 
 # ── Entry point ──────────────────────────────────────────────

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -60,7 +60,7 @@ TOOLS = [
             "- limit / offset: pagination when there are many matches.\n"
             "- include_archived: include archived vaults (default false)."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "filter": {"type": "string", "description": "Substring filter against name+description (case-insensitive)."},
@@ -77,7 +77,7 @@ TOOLS = [
             "Pass `external_git` to instead create a read-only mirror of an upstream git repo — the vault "
             "tracks the remote on a polling schedule and rejects user writes."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "name": {"type": "string", "description": "Vault name (lowercase, hyphens allowed)"},
@@ -115,7 +115,7 @@ TOOLS = [
             "that URI to address the document from every other tool. Automatically "
             "chunked and indexed for semantic search."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "parent": {
@@ -173,7 +173,7 @@ TOOLS = [
             "Use akb_browse or akb_search first to obtain the URI. "
             "Optionally pass a commit hash (from akb_history) to read a previous version."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Document URI — akb://{vault}[/coll/{coll_path}]/doc/{filename}"},
@@ -190,7 +190,7 @@ TOOLS = [
             "partial fragment such as a newly uploaded image. Use a targeted "
             "akb_edit for inline insertion or replacement."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Document URI"},
@@ -224,7 +224,7 @@ TOOLS = [
             "resending the complete document body. For find-and-replace across many "
             "documents, use akb_grep with replace instead."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Document URI"},
@@ -259,7 +259,7 @@ TOOLS = [
             "rewritten. Provide collection and/or slug (at least one must change). "
             "The title is unchanged; use akb_update to change the displayed title."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Document URI to move"},
@@ -279,7 +279,7 @@ TOOLS = [
     Tool(
         name="akb_delete",
         description="Delete a document. Removes from Git, search index, and knowledge graph.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Document URI"},
@@ -306,7 +306,7 @@ TOOLS = [
             "vaults fit in the agent's context window. Returns "
             "{vault, path, context, items, total, returned, truncated?, hint?}."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {
@@ -393,7 +393,7 @@ TOOLS = [
             "genuine zero-match; `degradation_reason` names the cause. Retry shortly, or fall "
             "back to akb_grep for a literal search."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "query": {"type": "string", "description": "Natural language search query"},
@@ -448,7 +448,7 @@ TOOLS = [
             "safety bounds truncate snippets, the `truncation` object names the applied "
             "resource, match, and byte limits; use count_only for exact counts without snippets."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "pattern": {"type": "string", "minLength": 1, "description": "Non-empty search pattern. By default matched as literal text (ILIKE) — metacharacters like |, ., *, (), [], +, ? are treated as literal characters. Set regex=true to enable PostgreSQL regex (required for alternation and wildcards)."},
@@ -504,7 +504,7 @@ TOOLS = [
             "deciding which section to read.\n"
             "Returns {uri, sections|outline, returned, total?, truncated?, hint?}."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Document URI"},
@@ -527,7 +527,7 @@ TOOLS = [
             "Returns Git commit history with changed file list. "
             "Use akb_diff to see the actual content changes for a specific commit."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault name"},
@@ -546,7 +546,7 @@ TOOLS = [
             "Shows what was added/removed/modified. "
             "Use akb_history or akb_activity to find commit hashes first."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Document URI"},
@@ -562,7 +562,7 @@ TOOLS = [
             "Shows same-vault cross-type connections: doc→table, doc→file, table→file, etc. "
             "Each row identifies whether it is an explicit link or implicit document-derived edge."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Resource URI (akb://vault/doc/path, akb://vault/table/name, akb://vault/file/uuid)"},
@@ -579,7 +579,7 @@ TOOLS = [
             "Provide `uri` to get a subgraph centered on any resource with BFS traversal. "
             "Provide `vault` (without uri) to get the full vault graph."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Center resource URI (omit + pass vault for full vault graph)"},
@@ -607,7 +607,7 @@ TOOLS = [
             f"Relation types: {_REL_LIST}. "
             "Example: link a design doc to its data table, or attach a diagram file to a spec."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "source": {"type": "string", "description": "Source resource URI (e.g. akb://vault/doc/specs/api.md)"},
@@ -628,7 +628,7 @@ TOOLS = [
             "Implicit relations are removed by editing their source document. "
             "If relation type is omitted, removes all explicit relations between the two resources."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "source": {"type": "string", "description": "Source resource URI"},
@@ -648,7 +648,7 @@ TOOLS = [
             "Get provenance for a document — who created it, when, which entities were "
             "extracted, and its visible same-vault relations."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Document URI"},
@@ -668,7 +668,7 @@ TOOLS = [
             "groups the table under that collection so it appears beside the documents "
             "and files there in akb_browse; omit for vault root."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "parent": {
@@ -786,7 +786,7 @@ TOOLS = [
             "returned (nothing is silently truncated), so an unbounded SELECT on a large table "
             "can send back a very large response."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "sql": {"type": "string", "description": "SQL query to execute. For large tables, add a LIMIT to cap the rows returned unless you need the full set."},
@@ -803,7 +803,7 @@ TOOLS = [
     Tool(
         name="akb_drop_table",
         description="Permanently delete a table and all its rows. Cannot be undone. Requires admin role on the vault.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Table URI — akb://{vault}[/coll/{coll_path}]/table/{name}"},
@@ -814,7 +814,7 @@ TOOLS = [
     Tool(
         name="akb_alter_table",
         description="Modify a table's schema — add, remove, or rename columns via ALTER TABLE DDL. Requires admin role.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Table URI — akb://{vault}[/coll/{coll_path}]/table/{name}"},
@@ -937,7 +937,7 @@ TOOLS = [
             "Returns the canonical publication dict — `slug` is the only identifier "
             "you need; `share_url` is always an absolute URL ready to paste."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Resource URI to publish — required when resource_type is document or file. Omit for table_query."},
@@ -988,7 +988,7 @@ TOOLS = [
             "(handy when re-publishing). table_query publications have no resource "
             "URI, so remove them by slug. Returns {deleted: N}."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "slug": {"type": "string", "description": "Publication slug — remove exactly this publication."},
@@ -1002,7 +1002,7 @@ TOOLS = [
             "List every publication in a vault. Each item is the canonical "
             "publication dict (same shape as `akb_publish` returns)."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault name"},
@@ -1023,7 +1023,7 @@ TOOLS = [
             "Identified by `slug` alone — the vault is resolved from the publication. "
             "Returns the updated publication dict."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "slug": {"type": "string", "description": "Publication slug"},
@@ -1034,7 +1034,7 @@ TOOLS = [
     Tool(
         name="akb_vault_info",
         description="Get detailed vault information: owner, member count, document/table/file/edge counts, last activity.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault name"},
@@ -1045,7 +1045,7 @@ TOOLS = [
     Tool(
         name="akb_vault_members",
         description="List all members of a vault with their roles (owner, admin, writer, reader).",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault name"},
@@ -1060,7 +1060,7 @@ TOOLS = [
             "A rule-driven grantor should name its own source_key so it can later "
             "withdraw its own reason without deleting anybody else's."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault name"},
@@ -1097,7 +1097,7 @@ TOOLS = [
             "Omit source_key and the person is out of the vault entirely; name one "
             "and only that basis is withdrawn, which may downgrade rather than remove."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault name"},
@@ -1125,7 +1125,7 @@ TOOLS = [
             "independent basis, and the effective role derived from them. "
             "A member list shows the result, never the reasons."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault name"},
@@ -1137,7 +1137,7 @@ TOOLS = [
     Tool(
         name="akb_search_users",
         description="Search for users by username, display name, or email. Use this to find users before granting vault access.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "query": {"type": "string", "description": "Search query (name, email, etc.)"},
@@ -1148,7 +1148,7 @@ TOOLS = [
     Tool(
         name="akb_whoami",
         description="Get your current profile — username, email, display name, role. Use this to check who you are authenticated as.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {},
         },
@@ -1159,7 +1159,7 @@ TOOLS = [
             "Transfer vault ownership to another user. The current owner or "
             "a system admin can do this."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault name"},
@@ -1171,7 +1171,7 @@ TOOLS = [
     Tool(
         name="akb_archive_vault",
         description="Archive a vault (makes it read-only). Only the owner can do this.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault name"},
@@ -1185,7 +1185,7 @@ TOOLS = [
             "Permanently delete a vault and ALL its data — documents, chunks, tables, files, edges, Git repo. "
             "This cannot be undone. Owner or admin only."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault name to delete"},
@@ -1199,7 +1199,7 @@ TOOLS = [
             "Create an empty collection (folder) inside a vault. Idempotent — "
             "returns {created: false} if the collection already exists. Writer or higher role."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault name"},
@@ -1217,7 +1217,7 @@ TOOLS = [
             "Cascade emits one git commit for the document batch. Writer or higher role; "
             "admin or higher when any table is included."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault name"},
@@ -1234,7 +1234,7 @@ TOOLS = [
     Tool(
         name="akb_set_public",
         description="Set vault public access level. Owner only. 'none'=private, 'reader'=public read, 'writer'=public read+write.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault name"},
@@ -1249,7 +1249,7 @@ TOOLS = [
             "Get version history of a document — who changed it, when, and why. "
             "Each entry is a Git commit. Use the commit hash with akb_get to read a previous version."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "uri": {"type": "string", "description": "Document URI"},
@@ -1266,7 +1266,7 @@ TOOLS = [
             "Drill down into categories or specific tools for details and examples. "
             "START HERE if you're new to AKB."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "topic": {
@@ -1296,7 +1296,7 @@ TOOLS = [
             "`resource` pointer — the rows/bytes stay in AKB). Reader role required. "
             "For a downloadable zip, use the REST endpoint GET /api/v1/vaults/{vault}/export."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Vault to export"},
@@ -1322,7 +1322,7 @@ TOOLS = [
             "'overview' collection or carrying type='skill' are skipped per-record and "
             "reported in the response's 'reserved' list. Writer role required."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "vault": {"type": "string", "description": "Target vault"},

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.14.2"
+version = "0.15.0"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
 license = "BUSL-1.1"
@@ -20,7 +20,7 @@ dependencies = [
     "gitpython==3.1.50",
     "python-frontmatter==1.3.0",
     "httpx==0.28.1",
-    "mcp[cli]==1.27.2",
+    "mcp[cli]==2.1.0",
     "pyyaml==6.0.3",
     "python-multipart==0.0.32",
     "pyjwt==2.13.0",

--- a/backend/scripts/ci/README.md
+++ b/backend/scripts/ci/README.md
@@ -112,9 +112,10 @@ For a selected transport profile the supervisor mints one candidate-bound PAT
 in memory, passes it to the real proxy only as the `AKB_PAT` child environment
 value, and exposes only the configured PAT environment-name in descriptor and
 discovery. The private discovery `runtime` object records the exact source
-revision, backend/proxy artifact versions, protocol revision, transport,
-selected capabilities, tool-case coordinates, fixture reset, and whether the
-stdio initialize/tools-list/read probes crossed the process boundary. The
+revision, backend/proxy artifact versions, the modern and allowlisted legacy
+protocol revisions, transport, selected capabilities, tool-case coordinates,
+fixture reset, and whether the separate legacy and modern stdio
+initialize/discover/tools-list/read probes crossed the process boundary. The
 OIDC discovery object exposes issuer/JWKS/token coordinates and variant names,
 never an access token or signing key.
 

--- a/backend/scripts/ci/e2e_runtime.py
+++ b/backend/scripts/ci/e2e_runtime.py
@@ -51,7 +51,13 @@ from oidc_fixture import OIDCFixture
 
 LOGGER = logging.getLogger("akb.e2e_runtime")
 SCHEMA_VERSION = 2
-PROTOCOL_REVISION = "2025-06-18"
+PROTOCOL_REVISION = "2026-07-28"
+LEGACY_PROTOCOL_REVISIONS = (
+    "2024-11-05",
+    "2025-03-26",
+    "2025-06-18",
+    "2025-11-25",
+)
 Scenario = Literal[
     "empty",
     "app-installation-lifecycle",
@@ -379,8 +385,11 @@ class E2ERuntime:
         self._candidate_revision: str | None = None
         self._proxy_version: str | None = None
         self._stdio_initialize_observed = False
+        self._stdio_discover_observed = False
         self._stdio_tools_list_observed = False
+        self._stdio_modern_tools_list_observed = False
         self._stdio_read_call_observed = False
+        self._stdio_modern_read_call_observed = False
         self._stdio_next_id = 2
         self.oidc_fixture: OIDCFixture | None = (
             OIDCFixture(
@@ -459,6 +468,10 @@ class E2ERuntime:
             "source_revision": self._source_revision(),
             "backend_artifact_version": self._backend_version(),
             "protocol_revision": PROTOCOL_REVISION,
+            "protocol_matrix": {
+                "modern": PROTOCOL_REVISION,
+                "legacy": list(LEGACY_PROTOCOL_REVISIONS),
+            },
             "transport": ["http", "stdio"] if self.profile.needs_stdio else ["http"],
             "selected_capabilities": list(self.selected_capabilities),
             "tool_cases": {
@@ -509,8 +522,11 @@ class E2ERuntime:
                     "AKB_PAT": self.config.credentials.pat_env,
                 },
                 "initialize_observed": self._stdio_initialize_observed,
+                "discover_observed": self._stdio_discover_observed,
                 "tools_list_observed": getattr(self, "_stdio_tools_list_observed", False),
+                "modern_tools_list_observed": getattr(self, "_stdio_modern_tools_list_observed", False),
                 "read_call_observed": getattr(self, "_stdio_read_call_observed", False),
+                "modern_read_call_observed": getattr(self, "_stdio_modern_read_call_observed", False),
             }
         if self.oidc_fixture is not None:
             oidc_evidence = self.oidc_fixture.discovery()
@@ -1461,9 +1477,11 @@ class E2ERuntime:
         self._proxy_version = self._artifact_version(self.config.proxy_package_dir)
         return executable
 
-    async def _start_stdio_proxy(self) -> None:
+    async def _start_stdio_proxy(self, generation: Literal["legacy", "modern"] = "legacy") -> None:
         if not self._pat_value:
             raise BlockedRuntimeConfig("stdio capability requires a runtime PAT")
+        if generation not in {"legacy", "modern"}:
+            raise BlockedRuntimeConfig("unsupported stdio protocol generation")
         executable = await self._install_stdio_proxy()
         node = shutil.which("node")
         if node is None:
@@ -1479,17 +1497,34 @@ class E2ERuntime:
         )
         if managed.stdin is None or managed.stdout is None:
             raise BlockedRuntimeConfig("stdio proxy did not expose stdin/stdout pipes")
-        initialize = {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "initialize",
-            "params": {
-                "protocolVersion": PROTOCOL_REVISION,
-                "capabilities": {},
-                "clientInfo": {"name": "akb-e2e-runtime", "version": "1"},
-            },
-        }
-        managed.stdin.write((json.dumps(initialize, separators=(",", ":")) + "\n").encode())
+        if generation == "legacy":
+            first_request = {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": {"name": "akb-e2e-runtime", "version": "1"},
+                },
+            }
+        else:
+            first_request = {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "server/discover",
+                "params": {
+                    "_meta": {
+                        "io.modelcontextprotocol/protocolVersion": PROTOCOL_REVISION,
+                        "io.modelcontextprotocol/clientCapabilities": {},
+                        "io.modelcontextprotocol/clientInfo": {
+                            "name": "akb-e2e-runtime",
+                            "version": "1",
+                        },
+                    }
+                },
+            }
+        managed.stdin.write((json.dumps(first_request, separators=(",", ":")) + "\n").encode())
         await managed.stdin.drain()
         try:
             for _ in range(8):
@@ -1503,19 +1538,22 @@ class E2ERuntime:
                     continue
                 if "error" in response:
                     raise ValueError
-                self._stdio_initialize_observed = True
-                initialized = {
-                    "jsonrpc": "2.0",
-                    "method": "notifications/initialized",
-                    "params": {},
-                }
-                managed.stdin.write((json.dumps(initialized, separators=(",", ":")) + "\n").encode())
-                await managed.stdin.drain()
+                if generation == "legacy":
+                    self._stdio_initialize_observed = True
+                    initialized = {
+                        "jsonrpc": "2.0",
+                        "method": "notifications/initialized",
+                        "params": {},
+                    }
+                    managed.stdin.write((json.dumps(initialized, separators=(",", ":")) + "\n").encode())
+                    await managed.stdin.drain()
+                else:
+                    self._stdio_discover_observed = True
                 return
         except (asyncio.TimeoutError, ValueError, json.JSONDecodeError):
             pass
         await self._stop_named_process("stdio")
-        raise BlockedRuntimeConfig("stdio proxy initialize did not cross the process boundary")
+        raise BlockedRuntimeConfig(f"stdio proxy {generation} handshake did not cross the process boundary")
 
     async def _stdio_response(self, expected_id: int) -> dict[str, object]:
         managed = self._children.get("stdio")
@@ -1588,6 +1626,49 @@ class E2ERuntime:
         if not isinstance(read_result, dict) or "error" in read_response:
             raise ProductAssertionFailure("stdio read tool call was not accepted")
         self._stdio_read_call_observed = True
+
+        # A process cannot switch protocol generations after its first
+        # request. Start a fresh installed proxy for the modern arm so the
+        # two observations remain independent and source-comparable.
+        await self._stop_named_process("stdio")
+        self._stdio_next_id = 2
+        await self._start_stdio_proxy("modern")
+        modern_meta = {
+            "io.modelcontextprotocol/protocolVersion": PROTOCOL_REVISION,
+            "io.modelcontextprotocol/clientCapabilities": {},
+            "io.modelcontextprotocol/clientInfo": {
+                "name": "akb-e2e-runtime",
+                "version": "1",
+            },
+        }
+        modern_response = await self._stdio_request(
+            "tools/list",
+            {"_meta": modern_meta},
+        )
+        modern_result = modern_response.get("result")
+        if not isinstance(modern_result, dict) or not isinstance(modern_result.get("tools"), list):
+            raise ProductAssertionFailure("modern stdio tools/list returned an invalid result")
+        modern_names = {
+            item.get("name")
+            for item in modern_result["tools"]
+            if isinstance(item, dict) and isinstance(item.get("name"), str)
+        }
+        if modern_names != names:
+            raise ProductAssertionFailure("legacy and modern stdio catalogs differ")
+        self._stdio_modern_tools_list_observed = True
+
+        modern_read_response = await self._stdio_request(
+            "tools/call",
+            {
+                "name": "akb_list_vaults",
+                "arguments": {},
+                "_meta": modern_meta,
+            },
+        )
+        modern_read_result = modern_read_response.get("result")
+        if not isinstance(modern_read_result, dict) or "error" in modern_read_response:
+            raise ProductAssertionFailure("modern stdio read tool call was not accepted")
+        self._stdio_modern_read_call_observed = True
 
     @staticmethod
     def _ready_response(status: int, body: bytes) -> bool:
@@ -3041,8 +3122,11 @@ class E2ERuntime:
                 self._fixture_controls.clear()
                 await self._stop_named_process("stdio")
                 self._stdio_initialize_observed = False
+                self._stdio_discover_observed = False
                 self._stdio_tools_list_observed = False
+                self._stdio_modern_tools_list_observed = False
                 self._stdio_read_call_observed = False
+                self._stdio_modern_read_call_observed = False
                 self._stdio_next_id = 2
                 await self._stop_named_process("backend")
                 await self._stop_named_process("embed")

--- a/backend/tests/mcp_modern.sh
+++ b/backend/tests/mcp_modern.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# Shared test-only caller for AKB's 2026-07-28 stateless HTTP surface.
+# It deliberately has no initialize/session fallback so endpoint suites
+# exercise the modern contract directly.
+
+MCP_MODERN_PROTOCOL_VERSION="2026-07-28"
+
+mcp_modern_request() {
+  local pat=$1
+  local request_id=$2
+  local method=$3
+  local params_json="${4-}"
+  if [ -z "$params_json" ]; then params_json='{}'; fi
+  local name=${5:-}
+  local client_name=${6:-mcp-e2e}
+  local body
+
+  body=$(python3 - "$request_id" "$method" "$params_json" "$client_name" <<'PY'
+import json
+import sys
+
+request_id = int(sys.argv[1])
+method = sys.argv[2]
+params = json.loads(sys.argv[3])
+client_name = sys.argv[4]
+if not isinstance(params, dict):
+    raise SystemExit("MCP params must be a JSON object")
+params = dict(params)
+params["_meta"] = {
+    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+    "io.modelcontextprotocol/clientCapabilities": {},
+    "io.modelcontextprotocol/clientInfo": {"name": client_name, "version": "1"},
+}
+print(json.dumps({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}, separators=(",", ":")))
+PY
+  )
+
+  local -a headers=(
+    -H "Authorization: Bearer $pat"
+    -H "Content-Type: application/json"
+    -H "Accept: application/json"
+    -H "Mcp-Protocol-Version: $MCP_MODERN_PROTOCOL_VERSION"
+    -H "Mcp-Method: $method"
+  )
+  if [ -n "$name" ]; then
+    headers+=(-H "Mcp-Name: $name")
+  fi
+  curl -sk -X POST "${BASE_URL}/mcp/" "${headers[@]}" -d "$body" 2>&1
+}
+
+mcp_modern_discover() {
+  mcp_modern_request "$1" 1 server/discover '{}' '' "${2:-mcp-e2e}"
+}
+
+mcp_modern_list() {
+  mcp_modern_request "$1" "${2:-2}" tools/list '{}'
+}
+
+mcp_modern_call() {
+  local pat=$1
+  local tool=$2
+  local args=$3
+  local request_id=${4:-$RANDOM}
+  local client_name=${5:-mcp-e2e}
+  mcp_modern_request "$pat" "$request_id" tools/call \
+    "$(python3 - "$tool" "$args" <<'PY'
+import json
+import sys
+print(json.dumps({"name": sys.argv[1], "arguments": json.loads(sys.argv[2])}, separators=(",", ":")))
+PY
+)" "$tool" "$client_name"
+}

--- a/backend/tests/test_akb_put_slug_unit.py
+++ b/backend/tests/test_akb_put_slug_unit.py
@@ -63,7 +63,7 @@ def _dict_value(node: ast.expr, key: str) -> ast.expr:
 def _akb_put_schema_property_names() -> set[str]:
     tree = ast.parse((_MCP / "tools.py").read_text())
     call = _tool_call(tree, "akb_put")
-    schema = _kwarg_value(call, "inputSchema")
+    schema = _kwarg_value(call, "input_schema")
     props = _dict_value(schema, "properties")
     assert isinstance(props, ast.Dict)
     return {k.value for k in props.keys if isinstance(k, ast.Constant)}

--- a/backend/tests/test_audit_log.py
+++ b/backend/tests/test_audit_log.py
@@ -214,6 +214,32 @@ def test_record_tool_marks_error_outcome(audit_dir):
     assert row["code"] == "NOT_FOUND"
 
 
+def test_record_tool_keeps_protocol_facts_without_client_or_session_metadata(audit_dir):
+    class _U:
+        username, user_id = "bob", "u2"
+
+    audit_log.record_tool(
+        "akb_help",
+        {"topic": "quickstart"},
+        _U(),
+        {"help": "ok"},
+        protocol_metadata={
+            "protocol_generation": "modern",
+            "protocol_revision": "2026-07-28",
+            "auth_method": "pat",
+        },
+    )
+
+    row = json.loads(_read_lines(audit_dir / f"akb-audit-{_today()}.jsonl")[0])
+    assert row["meta"] == {
+        "protocol_generation": "modern",
+        "protocol_revision": "2026-07-28",
+        "auth_method": "pat",
+    }
+    assert "topic" not in json.dumps(row)
+    assert "session" not in json.dumps(row).lower()
+
+
 def test_never_raises_on_unwritable_dir(tmp_path, monkeypatch):
     blocker = tmp_path / "afile"
     blocker.write_text("not a dir")

--- a/backend/tests/test_e2e_runtime_unit.py
+++ b/backend/tests/test_e2e_runtime_unit.py
@@ -22,7 +22,9 @@ from e2e_runtime import (  # noqa: E402
     CapabilityProfile,
     CredentialNames,
     E2ERuntime,
+    LEGACY_PROTOCOL_REVISIONS,
     ManagedProcess,
+    PROTOCOL_REVISION,
     RuntimeConfig,
     _parse_args,
     prepare_private_runtime_root,
@@ -1054,6 +1056,12 @@ def test_transport_profile_exposes_real_proxy_boundary_without_secret(tmp_path):
     assert "akb_runtime_secret" not in serialized
     assert "AKB_E2E_PAT" in serialized
     assert descriptor["evidence"]["transport"] == ["http", "stdio"]
+    assert descriptor["evidence"]["protocol_matrix"] == {
+        "modern": PROTOCOL_REVISION,
+        "legacy": list(LEGACY_PROTOCOL_REVISIONS),
+    }
+    assert descriptor["evidence"]["stdio"]["initialize_observed"] is False
+    assert descriptor["evidence"]["stdio"]["discover_observed"] is False
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_mcp_access_basis_unit.py
+++ b/backend/tests/test_mcp_access_basis_unit.py
@@ -29,7 +29,7 @@ from mcp_server.tools import TOOLS
 def _schema(name: str) -> dict:
     for tool in TOOLS:
         if tool.name == name:
-            return tool.inputSchema
+            return tool.input_schema
     raise AssertionError(f"{name} is not advertised at all")
 
 

--- a/backend/tests/test_mcp_compatibility_unit.py
+++ b/backend/tests/test_mcp_compatibility_unit.py
@@ -1,0 +1,478 @@
+"""Focused contract checks for the dual-generation MCP surface."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import re
+import subprocess
+import tempfile
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import httpx
+import pytest
+
+from app.config import settings
+
+settings.git_storage_path = tempfile.mkdtemp(prefix="akb-mcp-compatibility-vaults-")
+
+from mcp_server import http_app  # noqa: E402
+from mcp_server import server as server_mod  # noqa: E402
+from mcp_server.protocol import (  # noqa: E402
+    MCP_LEGACY_PROTOCOL_VERSIONS,
+    MCP_MODERN_PROTOCOL_VERSION,
+)
+
+
+def test_public_protocol_matrix_is_explicit_and_ordered():
+    assert MCP_MODERN_PROTOCOL_VERSION == "2026-07-28"
+    assert MCP_LEGACY_PROTOCOL_VERSIONS == (
+        "2024-11-05",
+        "2025-03-26",
+        "2025-06-18",
+        "2025-11-25",
+    )
+
+
+def test_legacy_usage_correlation_does_not_store_the_raw_session_id(monkeypatch):
+    raw_session_id = "opaque-session-from-wire"
+    monkeypatch.setattr(server_mod, "_session_id", lambda: raw_session_id)
+
+    stored = server_mod._usage_session_id({
+        "protocol_generation": "legacy",
+        "protocol_revision": "2025-06-18",
+        "auth_method": "pat",
+    })
+
+    assert stored is not None
+    assert raw_session_id not in stored
+    assert stored.startswith("legacy:2025-06-18:pat:")
+
+
+def test_protocol_release_metadata_is_aligned():
+    root = Path(__file__).resolve().parents[2]
+    pyproject = (root / "backend" / "pyproject.toml").read_text()
+    package = json.loads((root / "packages" / "akb-mcp-client" / "package.json").read_text())
+    registry = json.loads((root / "server.json").read_text())
+    proxy_source = (root / "packages" / "akb-mcp-client" / "lib" / "proxy.mjs").read_text()
+
+    assert '"mcp[cli]==2.1.0"' in pyproject
+    assert re.search(r'^version\s*=\s*"0\.15\.0"$', pyproject, re.MULTILINE)
+    assert package["version"] == "2.3.0"
+    assert registry["version"] == package["version"]
+    assert registry["packages"][0]["version"] == package["version"]
+    assert f'const PROXY_VERSION = "{package["version"]}";' in proxy_source
+
+
+def test_modern_shell_helper_emits_valid_default_params():
+    root = Path(__file__).resolve().parents[2]
+    command = r'''
+curl() {
+    while [ "$#" -gt 0 ]; do
+        if [ "$1" = "-d" ]; then
+            printf '%s\n' "$2"
+            return 0
+        fi
+        shift
+    done
+}
+source backend/tests/mcp_modern.sh
+mcp_modern_discover fake
+'''
+    completed = subprocess.run(
+        ["bash", "-c", command],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    request = json.loads(completed.stdout)
+    assert request["method"] == "server/discover"
+    assert request["params"]["_meta"]["io.modelcontextprotocol/protocolVersion"] == "2026-07-28"
+
+
+class _User:
+    def __init__(self, user_id: str, username: str):
+        self.user_id = user_id
+        self.username = username
+        self.email = f"{username}@example.test"
+        self.display_name = username
+        self.is_admin = True
+        self.auth_method = "pat"
+        self.account_kind = "human"
+        self.oauth_scopes = None
+        self.token_scopes = None
+        self.key_class = "pat"
+
+
+_USERS = {
+    "Bearer alpha": _User("00000000-0000-0000-0000-000000000001", "alpha"),
+    "Bearer beta": _User("00000000-0000-0000-0000-000000000002", "beta"),
+}
+
+
+@asynccontextmanager
+async def running_mcp(monkeypatch):
+    async def resolve(authorization: str):
+        return _USERS.get(authorization)
+
+    monkeypatch.setattr(http_app, "resolve_mcp_authorization", resolve)
+    monkeypatch.setattr(server_mod, "resolve_mcp_authorization", resolve)
+    app = http_app.MCPApp()
+    await app.start()
+    transport = httpx.ASGITransport(app=app)
+    try:
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            yield app, client
+    finally:
+        await app.stop()
+
+
+def _modern_meta(version: str = MCP_MODERN_PROTOCOL_VERSION) -> dict:
+    return {
+        "io.modelcontextprotocol/protocolVersion": version,
+        "io.modelcontextprotocol/clientCapabilities": {},
+        "io.modelcontextprotocol/clientInfo": {"name": "compatibility-test", "version": "1"},
+    }
+
+
+def _modern_headers(
+    method: str,
+    *,
+    name: str | None = None,
+    version: str = MCP_MODERN_PROTOCOL_VERSION,
+) -> dict[str, str]:
+    headers = {
+        "Authorization": "Bearer alpha",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "Mcp-Protocol-Version": version,
+        "Mcp-Method": method,
+    }
+    if name is not None:
+        headers["Mcp-Name"] = name
+    return headers
+
+
+def _legacy_headers(
+    *,
+    session_id: str | None = None,
+    version: str | None = None,
+    authorization: str = "Bearer alpha",
+) -> dict[str, str]:
+    headers = {
+        "Authorization": authorization,
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+    if session_id is not None:
+        headers["Mcp-Session-Id"] = session_id
+    if version is not None:
+        headers["Mcp-Protocol-Version"] = version
+    return headers
+
+
+def _modern_request(
+    request_id: int,
+    method: str,
+    params: dict | None = None,
+    *,
+    meta: dict | None = None,
+) -> dict:
+    body = dict(params or {})
+    body["_meta"] = meta or _modern_meta()
+    return {"jsonrpc": "2.0", "id": request_id, "method": method, "params": body}
+
+
+@pytest.mark.asyncio
+async def test_modern_discover_and_repeated_requests_are_stateless(monkeypatch):
+    async with running_mcp(monkeypatch) as (_, client):
+        discover = await client.post(
+            "/",
+            headers=_modern_headers("server/discover"),
+            json=_modern_request(1, "server/discover"),
+        )
+        assert discover.status_code == 200
+        assert discover.headers.get("mcp-session-id") is None
+        assert discover.json()["result"]["supportedVersions"] == [MCP_MODERN_PROTOCOL_VERSION]
+
+        for request_id in (2, 3):
+            listing = await client.post(
+                "/",
+                headers=_modern_headers("tools/list"),
+                json=_modern_request(request_id, "tools/list"),
+            )
+            assert listing.status_code == 200
+            assert listing.headers.get("mcp-session-id") is None
+            assert listing.json()["result"]["resultType"] == "complete"
+            assert listing.json()["result"]["cacheScope"] == "public"
+
+
+@pytest.mark.asyncio
+async def test_legacy_initialize_tools_call_get_and_delete_keep_session_contract(monkeypatch):
+    async with running_mcp(monkeypatch) as (app, client):
+        initialize = await client.post(
+            "/",
+            headers=_legacy_headers(),
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": {"name": "legacy-test", "version": "1"},
+                },
+            },
+        )
+        assert initialize.status_code == 200
+        session_id = initialize.headers.get("mcp-session-id")
+        assert session_id
+        assert initialize.json()["result"]["protocolVersion"] == "2025-06-18"
+
+        initialized = await client.post(
+            "/",
+            headers=_legacy_headers(session_id=session_id, version="2025-06-18"),
+            json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        )
+        assert initialized.status_code == 202
+
+        listing = await client.post(
+            "/",
+            headers=_legacy_headers(session_id=session_id, version="2025-06-18"),
+            json={"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+        )
+        assert listing.status_code == 200
+        assert "tools" in listing.json()["result"]
+        assert listing.json()["result"].get("resultType") is None
+        assert listing.json()["result"].get("cacheScope") is None
+
+        call = await client.post(
+            "/",
+            headers=_legacy_headers(session_id=session_id, version="2025-06-18"),
+            json={
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {"name": "akb_help", "arguments": {"topic": "quickstart"}},
+            },
+        )
+        assert call.status_code == 200
+        assert call.json()["result"]["content"]
+
+        events: list[dict] = []
+        started = asyncio.Event()
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.3"},
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": "http",
+            "path": "/",
+            "raw_path": b"/",
+            "query_string": b"",
+            "headers": [
+                (key.lower().encode(), value.encode())
+                for key, value in _legacy_headers(session_id=session_id, version="2025-06-18").items()
+            ],
+            "client": ("testclient", 50000),
+            "server": ("testserver", 80),
+            "root_path": "",
+        }
+
+        async def receive():
+            await asyncio.sleep(0)
+            return {"type": "http.disconnect"}
+
+        async def send(message):
+            events.append(message)
+            if message["type"] == "http.response.start":
+                started.set()
+
+        get_task = asyncio.create_task(app(scope, receive, send))
+        try:
+            await asyncio.wait_for(started.wait(), timeout=1)
+        finally:
+            get_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await get_task
+        response_start = next(message for message in events if message["type"] == "http.response.start")
+        assert response_start["status"] == 200
+
+        terminated = await client.delete(
+            "/",
+            headers=_legacy_headers(session_id=session_id, version="2025-06-18"),
+        )
+        assert terminated.status_code == 200
+        assert terminated.json() == {"terminated": True}
+        after_delete = await client.post(
+            "/",
+            headers=_legacy_headers(session_id=session_id, version="2025-06-18"),
+            json={"jsonrpc": "2.0", "id": 4, "method": "tools/list", "params": {}},
+        )
+        assert after_delete.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_every_allowlisted_http_legacy_revision_negotiates(monkeypatch):
+    async with running_mcp(monkeypatch) as (_, client):
+        for request_id, revision in enumerate(MCP_LEGACY_PROTOCOL_VERSIONS, start=50):
+            initialize = await client.post(
+                "/",
+                headers=_legacy_headers(),
+                json={
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": revision,
+                        "capabilities": {},
+                        "clientInfo": {"name": "legacy-test", "version": "1"},
+                    },
+                },
+            )
+            assert initialize.status_code == 200
+            assert initialize.json()["result"]["protocolVersion"] == revision
+            session_id = initialize.headers["mcp-session-id"]
+            terminated = await client.delete(
+                "/",
+                headers=_legacy_headers(session_id=session_id, version=revision),
+            )
+            assert terminated.status_code == 200
+            assert terminated.json() == {"terminated": True}
+
+
+@pytest.mark.asyncio
+async def test_legacy_session_is_bound_to_the_authenticated_account(monkeypatch):
+    async with running_mcp(monkeypatch) as (_, client):
+        initialize = await client.post(
+            "/",
+            headers=_legacy_headers(),
+            json={
+                "jsonrpc": "2.0",
+                "id": 20,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": {"name": "legacy-test", "version": "1"},
+                },
+            },
+        )
+        session_id = initialize.headers["mcp-session-id"]
+        mismatch = await client.post(
+            "/",
+            headers=_legacy_headers(
+                session_id=session_id,
+                version="2025-06-18",
+                authorization="Bearer beta",
+            ),
+            json={"jsonrpc": "2.0", "id": 21, "method": "tools/list", "params": {}},
+        )
+        assert mismatch.status_code == 404
+        assert "alpha" not in mismatch.text
+        assert "beta" not in mismatch.text
+
+
+@pytest.mark.asyncio
+async def test_legacy_session_revision_cannot_change_after_initialize(monkeypatch):
+    async with running_mcp(monkeypatch) as (_, client):
+        initialize = await client.post(
+            "/",
+            headers=_legacy_headers(),
+            json={
+                "jsonrpc": "2.0",
+                "id": 22,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {"name": "legacy-test", "version": "1"},
+                },
+            },
+        )
+        session_id = initialize.headers["mcp-session-id"]
+        mismatch = await client.post(
+            "/",
+            headers=_legacy_headers(session_id=session_id, version="2025-06-18"),
+            json={"jsonrpc": "2.0", "id": 23, "method": "tools/list", "params": {}},
+        )
+        assert mismatch.status_code == 400
+        assert mismatch.json()["error"]["code"] == -32020
+
+
+@pytest.mark.asyncio
+async def test_protocol_generation_mixing_and_routing_mismatch_fail_closed(monkeypatch):
+    async with running_mcp(monkeypatch) as (_, client):
+        dispatches = 0
+        original_help = server_mod._HANDLERS["akb_help"]
+
+        async def counted_help(*args, **kwargs):
+            nonlocal dispatches
+            dispatches += 1
+            return await original_help(*args, **kwargs)
+
+        monkeypatch.setitem(server_mod._HANDLERS, "akb_help", counted_help)
+        modern_with_session = await client.post(
+            "/",
+            headers={**_modern_headers("tools/list"), "Mcp-Session-Id": "legacy-session"},
+            json=_modern_request(30, "tools/list"),
+        )
+        assert modern_with_session.status_code == 400
+        assert modern_with_session.json()["error"]["code"] == -32600
+
+        legacy_with_modern_header = await client.post(
+            "/",
+            headers=_modern_headers("initialize"),
+            json={
+                "jsonrpc": "2.0",
+                "id": 31,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": {"name": "legacy-test", "version": "1"},
+                },
+            },
+        )
+        assert legacy_with_modern_header.status_code == 400
+        assert legacy_with_modern_header.json()["error"]["code"] in {-32022, -32602}
+
+        mismatch = await client.post(
+            "/",
+            headers=_modern_headers("tools/list"),
+            json=_modern_request(32, "tools/call", {"name": "akb_help", "arguments": {}}),
+        )
+        assert mismatch.status_code == 400
+        assert mismatch.json()["error"]["code"] != 0
+
+        name_mismatch = await client.post(
+            "/",
+            headers=_modern_headers("tools/call", name="akb_put"),
+            json=_modern_request(33, "tools/call", {"name": "akb_help", "arguments": {}}),
+        )
+        assert name_mismatch.status_code == 400
+        assert name_mismatch.json()["error"]["code"] == -32020
+
+        unsupported = await client.post(
+            "/",
+            headers=_modern_headers("tools/list", version="2099-01-01"),
+            json=_modern_request(34, "tools/list", meta=_modern_meta("2099-01-01")),
+        )
+        assert unsupported.status_code == 400
+        assert unsupported.json()["error"]["code"] == -32022
+        assert dispatches == 0
+
+
+@pytest.mark.asyncio
+async def test_backend_auth_failure_is_not_hidden_by_protocol_adapter(monkeypatch):
+    async with running_mcp(monkeypatch) as (_, client):
+        response = await client.post(
+            "/",
+            headers={**_modern_headers("server/discover"), "Authorization": "Bearer invalid"},
+            json=_modern_request(40, "server/discover"),
+        )
+        assert response.status_code == 401
+        assert "WWW-Authenticate" in response.headers

--- a/backend/tests/test_mcp_e2e.sh
+++ b/backend/tests/test_mcp_e2e.sh
@@ -39,6 +39,23 @@ PAT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/tokens" \
 
 [ -n "$PAT" ] && pass "PAT acquired" || { fail "PAT" "could not get PAT"; exit 1; }
 
+# ── 0b. Modern stateless HTTP surface ───────────────────────
+echo ""
+echo "▸ 0b. MCP 2026-07-28 stateless protocol"
+source "$(dirname "${BASH_SOURCE[0]}")/mcp_modern.sh"
+
+MODERN_DISCOVER=$(mcp_modern_discover "$PAT")
+MODERN_VERSIONS=$(echo "$MODERN_DISCOVER" | python3 -c 'import sys,json; print(",".join(json.load(sys.stdin)["result"]["supportedVersions"]))' 2>/dev/null)
+[ "$MODERN_VERSIONS" = "2026-07-28" ] && pass "modern server/discover: $MODERN_VERSIONS" || fail "modern discover" "expected 2026-07-28, got $MODERN_VERSIONS"
+
+MODERN_LIST=$(mcp_modern_list "$PAT" 2)
+MODERN_TOOL_COUNT=$(echo "$MODERN_LIST" | python3 -c 'import sys,json; print(len(json.load(sys.stdin)["result"]["tools"]))' 2>/dev/null)
+[ "$MODERN_TOOL_COUNT" -ge 22 ] 2>/dev/null && pass "modern tools/list returns $MODERN_TOOL_COUNT tools" || fail "modern tools/list" "expected >=22, got $MODERN_TOOL_COUNT"
+
+MODERN_CALL=$(mcp_modern_call "$PAT" akb_help '{"topic":"quickstart"}' 3)
+MODERN_CALL_OK=$(echo "$MODERN_CALL" | python3 -c 'import sys,json; print(bool(json.load(sys.stdin)["result"]["content"]))' 2>/dev/null)
+[ "$MODERN_CALL_OK" = "True" ] && pass "modern tools/call uses shared tool core" || fail "modern tools/call" "missing result content"
+
 # ── 1. MCP Initialize ───────────────────────────────────────
 echo ""
 echo "▸ 1. MCP Protocol"

--- a/backend/tests/test_mcp_grep_text_files_unit.py
+++ b/backend/tests/test_mcp_grep_text_files_unit.py
@@ -17,17 +17,17 @@ def test_akb_grep_schema_exposes_guarded_text_file_measurement_argument():
     from mcp_server.tools import TOOLS
 
     grep = next(tool for tool in TOOLS if tool.name == "akb_grep")
-    argument = grep.inputSchema["properties"]["measurement_include_text_files"]
+    argument = grep.input_schema["properties"]["measurement_include_text_files"]
 
-    assert grep.inputSchema["properties"]["pattern"]["minLength"] == 1
-    replacement_budget = grep.inputSchema["properties"]["max_replacements"]
+    assert grep.input_schema["properties"]["pattern"]["minLength"] == 1
+    replacement_budget = grep.input_schema["properties"]["max_replacements"]
     assert replacement_budget["default"] == 50
     assert replacement_budget["maximum"] == 1000
     assert (
         "treated literally"
-        in grep.inputSchema["properties"]["replace"]["description"].lower()
+        in grep.input_schema["properties"]["replace"]["description"].lower()
     )
-    assert "does not limit replacement writes" in grep.inputSchema["properties"]["limit"]["description"]
+    assert "does not limit replacement writes" in grep.input_schema["properties"]["limit"]["description"]
     assert argument["type"] == "boolean"
     assert argument["default"] is False
     assert "guarded native" in argument["description"].lower()

--- a/backend/tests/test_mcp_tool_validation_unit.py
+++ b/backend/tests/test_mcp_tool_validation_unit.py
@@ -88,7 +88,7 @@ def test_relation_tool_descriptions_match_the_vault_boundary():
     tools = {tool.name: tool for tool in TOOLS}
 
     for tool_name in ("akb_put", "akb_update"):
-        properties = tools[tool_name].inputSchema["properties"]
+        properties = tools[tool_name].input_schema["properties"]
         for field in ("depends_on", "related_to"):
             description = properties[field]["description"].lower()
             assert "same-vault" in description

--- a/backend/tests/test_skill_injection_dispatch_unit.py
+++ b/backend/tests/test_skill_injection_dispatch_unit.py
@@ -298,15 +298,15 @@ async def test_v2_tool_list_advertises_ack_only_on_possible_writes(monkeypatch):
     by_name = {tool.name: tool for tool in tools}
 
     assert server_mod.VAULT_SKILL_ACK_ARGUMENT in (
-        by_name["akb_update"].inputSchema["properties"]
+        by_name["akb_update"].input_schema["properties"]
     )
     # akb_grep is normally read-only but becomes a writer when `replace` is
     # present, so its schema must carry the acknowledgement too.
     assert server_mod.VAULT_SKILL_ACK_ARGUMENT in (
-        by_name["akb_grep"].inputSchema["properties"]
+        by_name["akb_grep"].input_schema["properties"]
     )
     assert server_mod.VAULT_SKILL_ACK_ARGUMENT not in (
-        by_name["akb_get"].inputSchema["properties"]
+        by_name["akb_get"].input_schema["properties"]
     )
 
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "akb"
-version = "0.14.2"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },
@@ -60,7 +60,7 @@ requires-dist = [
     { name = "hypothesis", marker = "extra == 'dev'", specifier = "==6.155.7" },
     { name = "kiwipiepy", specifier = "==0.23.1" },
     { name = "markdown-it-py", specifier = "==4.1.0" },
-    { name = "mcp", extras = ["cli"], specifier = "==1.27.2" },
+    { name = "mcp", extras = ["cli"], specifier = "==2.1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==2.1.0" },
     { name = "pgvector", specifier = "==0.4.2" },
     { name = "pillow", specifier = "==12.3.0" },
@@ -499,6 +499,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -541,12 +554,28 @@ http2 = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -572,11 +601,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -701,15 +730,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.2"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -719,15 +748,28 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/3b/3acf4897b934ceeb8d22df7309a435a76c34f94be936b36eee8bb57b29a3/mcp-2.1.0.tar.gz", hash = "sha256:b4407b2890238248795d03e8c17d02d311c600ca9272d023ab12dbfa6ad21c70", size = 3983282, upload-time = "2026-08-24T19:04:32.671Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
+    { url = "https://files.pythonhosted.org/packages/88/67/b2160b6cf138872860d2552cca2894dbe4d29da7f1c6fae0c21d22782838/mcp-2.1.0-py3-none-any.whl", hash = "sha256:b8acaed6ca4b9376801377463e44246395749363b1c34467ec6243a50be5ed28", size = 357320, upload-time = "2026-08-24T19:04:29.909Z" },
 ]
 
 [package.optional-dependencies]
 cli = [
     { name = "python-dotenv" },
     { name = "typer" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/97/5b1c2e40d6121172c97638a0f1d6240526f5aeebdc9ebea11ddcf2139249/mcp_types-2.1.0.tar.gz", hash = "sha256:16f91064ce33d7ee7a75a7e198a437172215180c16d4bbcfa0e61488ede92c54", size = 66679, upload-time = "2026-08-24T19:04:34.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/99/f9041368b5af773de32af6192ff0627a71368c240123e57262439ae5b594/mcp_types-2.1.0-py3-none-any.whl", hash = "sha256:6a65bfb7d057ceaf2418781ee61b3041e1f4b5418199297f8939a4b4ed334c3a", size = 69654, upload-time = "2026-08-24T19:04:31.327Z" },
 ]
 
 [[package]]
@@ -805,6 +847,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ed/ad/483d9e262f4b831000062e5d8a45e342166ec8aaa1195264982bca267e62/numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871", size = 6155500, upload-time = "2026-03-29T13:21:28.205Z" },
     { url = "https://files.pythonhosted.org/packages/c7/03/2fc4e14c7bd4ff2964b74ba90ecb8552540b6315f201df70f137faa5c589/numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e", size = 12637755, upload-time = "2026-03-29T13:21:31.107Z" },
     { url = "https://files.pythonhosted.org/packages/58/78/548fb8e07b1a341746bfbecb32f2c268470f45fa028aacdbd10d9bc73aab/numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7", size = 10566643, upload-time = "2026-03-29T13:21:34.339Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -1008,20 +1062,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
     { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
     { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
-]
-
-[[package]]
-name = "pydantic-settings"
-version = "2.14.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
 ]
 
 [[package]]
@@ -1360,6 +1400,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]

--- a/docs/mcp-clients/web-connectors.md
+++ b/docs/mcp-clients/web-connectors.md
@@ -5,7 +5,27 @@ This guide is for connecting AKB to an MCP client that speaks the
 claude.ai Custom Connectors, and ChatGPT Custom Connectors. For
 stdio-based clients (Claude Desktop, Codex CLI via `akb-mcp`,
 Claude Code via the stdio proxy), see the project README: the PAT
-flow there is unchanged.
+flow there supports both the established legacy handshake and the modern
+stateless proxy surface.
+
+## Protocol compatibility
+
+The backend's `/mcp/` endpoint supports modern `2026-07-28` stateless
+requests and the production legacy revisions `2024-11-05`, `2025-03-26`,
+`2025-06-18`, and `2025-11-25`. Modern requests carry
+`Mcp-Protocol-Version`, `Mcp-Method`, and per-request `_meta`; they never carry
+`Mcp-Session-Id`. Legacy clients continue with `initialize`,
+`notifications/initialized`, and the session-bound POST/GET/DELETE lifecycle.
+
+The `akb-mcp` 2.3 proxy exposes `2026-07-28` through `server/discover` and
+keeps its public legacy stdio contract at `2025-06-18`. It converts either
+stdio generation to the backend's modern request envelope while preserving
+the same tool catalog, authentication, vault RBAC, and side effects.
+
+For a rolling upgrade, deploy backend `0.15.0` first and then install proxy
+`2.3.0`. Requests that mix generations, revisions, routing metadata, or
+session principals are rejected before tool dispatch; the proxy distinguishes
+these protocol errors from reconnectable backend transport outages.
 
 ## What you need
 

--- a/llms-install.md
+++ b/llms-install.md
@@ -8,6 +8,11 @@ MCP client.
 agent to an **AKB backend**, which speaks MCP over Streamable HTTP. So you
 need two values:
 
+The current proxy supports both the legacy `2025-06-18` initialize/session
+stdio contract and the modern `2026-07-28` stateless discovery/request
+contract. It selects the generation from the first client request and rejects
+mixed or unsupported revisions instead of silently downgrading.
+
 - **`AKB_MCP_URL`** — the AKB backend's MCP endpoint, e.g.
   `https://akb.example.com/mcp/`
 - **`AKB_PAT`** — an AKB Personal Access Token (looks like `akb_...`)

--- a/packages/akb-mcp-client/CHANGELOG.md
+++ b/packages/akb-mcp-client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.3.0 — dual-generation MCP transport
+
+The proxy now serves the established `2025-06-18` initialize/session stdio
+contract and the `2026-07-28` stateless discovery/request contract, selected by
+the first client request. Backend calls use the modern stateless envelope and
+protocol errors are kept separate from reconnectable transport failures.
+
 ## 2.2.2 — strict MCP protocol boundary
 
 The stdio proxy now rejects an `initialize` request that names an unsupported

--- a/packages/akb-mcp-client/lib/proxy.mjs
+++ b/packages/akb-mcp-client/lib/proxy.mjs
@@ -366,11 +366,11 @@ const FILE_WRITE_TOOL_NAMES = new Set([
 // Tools where proxy injects a `file` param as alternative to `content`
 const FILE_CONTENT_TOOLS = new Set(["akb_put", "akb_update"]);
 
-// Kept in sync with package.json `version`. Reported to the client in the
-// local `initialize` response, so it must not silently drift on a proxy
-// behaviour change. There is no import of package.json here to keep lib/
-// zero-dependency and load-safe across Node versions.
-const PROXY_VERSION = "2.2.2";
+// Kept in sync with package.json `version`. Reported in both the legacy
+// initialize result and the modern discover metadata, so it must not silently
+// drift on a proxy behaviour change. There is no import of package.json here
+// to keep lib/ zero-dependency and load-safe across Node versions.
+const PROXY_VERSION = "2.3.0";
 const VAULT_SKILL_PREFLIGHT_CAPABILITY =
   "io.dnotitia.akb/vault-skill-preflight";
 const PROXY_INSTRUCTIONS =
@@ -384,26 +384,58 @@ const PROXY_INSTRUCTIONS =
   "the entire document body. If the document write fails, clean up the uncommitted " +
   "upload with akb_discard_image.";
 
-// Fallback MCP protocol version echoed to the client when its `initialize`
-// request omits one. We otherwise echo the client's requested version.
-const MCP_PROTOCOL_VERSION = "2025-06-18";
+// The proxy's public stdio matrix has one modern envelope and one legacy
+// handshake revision. Backend legacy revisions are accepted directly by the
+// HTTP server, but the proxy keeps its established 2025-06-18 surface stable.
+const MCP_PROTOCOL_VERSION = "2026-07-28";
+const MCP_LEGACY_PROTOCOL_VERSION = "2025-06-18";
+const PROTOCOL_VERSION_META_KEY = "io.modelcontextprotocol/protocolVersion";
+const CLIENT_CAPABILITIES_META_KEY = "io.modelcontextprotocol/clientCapabilities";
+const CLIENT_INFO_META_KEY = "io.modelcontextprotocol/clientInfo";
+const SERVER_INFO_META_KEY = "io.modelcontextprotocol/serverInfo";
+const UNSUPPORTED_PROTOCOL_VERSION = -32022;
+const INVALID_PARAMS = -32602;
+const INVALID_REQUEST = -32600;
+
+class MCPProtocolError extends Error {
+  constructor(error) {
+    super(`MCP error ${error?.code}: ${error?.message || "protocol failure"}`);
+    this.rpcError = error;
+  }
+
+  static invalid(id, message, code = INVALID_REQUEST, data) {
+    const error = { code, message };
+    if (data !== undefined) error.data = data;
+    return {
+      jsonrpc: "2.0",
+      id: id ?? null,
+      error,
+    };
+  }
+}
+
+function encodeRoutingHeader(value) {
+  if (/^[\x20-\x7e]*$/.test(value) && value === value.trim()) return value;
+  return `=?base64?${Buffer.from(value, "utf8").toString("base64")}?=`;
+}
 
 export class AKBProxy {
   constructor({ url, pat, insecure = false }) {
     this.url = new URL(url);
     this.pat = pat;
     this.insecure = insecure;
-    this.sessionId = null;
     this.msgId = 0;
     this._initialized = false;
+    this._protocolGeneration = null; // "legacy" or "modern"
     // ── Backend-liveness state (decoupled from client liveness) ──────
     // The client's view of this server must NOT depend on backend
     // reachability: a stdio MCP server that fails `initialize` is dropped
     // by the client for the whole session (the VPN-down-at-startup bug).
-    // So we answer `initialize` locally and manage the backend session
+    // So we answer `initialize` locally and manage backend reachability
     // out of band via a background monitor.
-    this._clientInitParams = null; // client initialize params, replayed to backend
-    this._backendReady = false; // backend MCP session established
+    this._clientInitParams = null; // legacy client params, projected into modern metadata
+    this._clientMeta = null; // modern request metadata, projected per backend request
+    this._backendReady = false; // backend modern contract reachable
     this._connecting = null; // in-flight backend-connect promise (single-flight lock)
     this._cachedTools = null; // last successful backend tools/list result (raw)
     this._servedDegraded = false; // client was handed a fallback (file-tools-only) list
@@ -458,6 +490,77 @@ export class AKBProxy {
     this._closed = true;
   }
 
+  _unsupportedVersion(id, requested, supported = [MCP_PROTOCOL_VERSION]) {
+    return MCPProtocolError.invalid(
+      id,
+      "Unsupported protocol version",
+      UNSUPPORTED_PROTOCOL_VERSION,
+      { supported, requested: String(requested || "") },
+    );
+  }
+
+  _validateModernRequest(msg) {
+    const { id, method, params } = msg || {};
+    if (method === "initialize") {
+      return this._unsupportedVersion(id, params?.protocolVersion || "", [
+        MCP_LEGACY_PROTOCOL_VERSION,
+      ]);
+    }
+    const meta = params && typeof params === "object" ? params._meta : null;
+    if (!meta || typeof meta !== "object" || Array.isArray(meta)) {
+      return MCPProtocolError.invalid(
+        id,
+        "params._meta must be an object carrying the required protocol version and client capabilities",
+        INVALID_PARAMS,
+      );
+    }
+    if (meta[PROTOCOL_VERSION_META_KEY] !== MCP_PROTOCOL_VERSION) {
+      return this._unsupportedVersion(id, meta[PROTOCOL_VERSION_META_KEY]);
+    }
+    if (!(CLIENT_CAPABILITIES_META_KEY in meta)) {
+      return MCPProtocolError.invalid(
+        id,
+        `params._meta is missing the required envelope key ${CLIENT_CAPABILITIES_META_KEY}`,
+        INVALID_PARAMS,
+      );
+    }
+    if (
+      !meta[CLIENT_CAPABILITIES_META_KEY] ||
+      typeof meta[CLIENT_CAPABILITIES_META_KEY] !== "object" ||
+      Array.isArray(meta[CLIENT_CAPABILITIES_META_KEY])
+    ) {
+      return MCPProtocolError.invalid(
+        id,
+        `${CLIENT_CAPABILITIES_META_KEY} must be an object`,
+        INVALID_PARAMS,
+      );
+    }
+    if (method === "notifications/initialized") {
+      return MCPProtocolError.invalid(
+        id,
+        "notifications/initialized is only valid for the legacy initialize/session protocol",
+      );
+    }
+    return null;
+  }
+
+  _validateLegacyRequest(msg) {
+    const { id, method, params } = msg || {};
+    if (method === "server/discover") {
+      return this._unsupportedVersion(id, MCP_PROTOCOL_VERSION, [
+        MCP_LEGACY_PROTOCOL_VERSION,
+      ]);
+    }
+    const meta = params && typeof params === "object" ? params._meta : null;
+    if (meta && typeof meta === "object" && meta[PROTOCOL_VERSION_META_KEY]) {
+      return MCPProtocolError.invalid(
+        id,
+        "modern request metadata cannot be mixed with the legacy initialize/session protocol",
+      );
+    }
+    return null;
+  }
+
   async _handle(msg) {
     // Normalize every inbound string to NFC before anything else sees it.
     // macOS-sourced paths enter here as NFD; letting them reach the
@@ -466,14 +569,44 @@ export class AKBProxy {
       msg = { ...msg, params: nfcDeep(msg.params) };
     }
 
-    const { method, id, params } = msg;
+    if (!msg || typeof msg !== "object" || Array.isArray(msg) || typeof msg.method !== "string") {
+      return MCPProtocolError.invalid(msg?.id, "JSON-RPC request must name a protocol method");
+    }
 
-    if (method === "initialize") {
-      return await this._initialize(id, params);
+    const { method, id, params } = msg;
+    if (this._protocolGeneration === null) {
+      if (method === "initialize") {
+        return await this._initialize(id, params);
+      }
+      if (method === "server/discover") {
+        const protocolError = this._validateModernRequest(msg);
+        if (protocolError) return protocolError;
+        this._protocolGeneration = "modern";
+        this._clientMeta = { ...params._meta };
+      } else {
+        return MCPProtocolError.invalid(
+          id,
+          "The first request must be legacy initialize or modern server/discover",
+        );
+      }
+    } else if (this._protocolGeneration === "legacy") {
+      if (method === "initialize") {
+        return MCPProtocolError.invalid(id, "The protocol generation is already fixed to legacy");
+      }
+      const protocolError = this._validateLegacyRequest(msg);
+      if (protocolError) return protocolError;
+    } else {
+      const protocolError = this._validateModernRequest(msg);
+      if (protocolError) return protocolError;
+      this._clientMeta = { ...params._meta };
     }
 
     if (id === undefined || id === null) {
       return null;
+    }
+
+    if (method === "server/discover") {
+      return await this._discover(id, msg);
     }
 
     if (method === "tools/list") {
@@ -567,34 +700,28 @@ export class AKBProxy {
   }
 
   async _initialize(id, params) {
-    // Answer the handshake LOCALLY — never round-trip to the backend here.
-    // This is the crux of the reconnect fix: the client considers this MCP
-    // server initialized (and keeps it registered for the whole session)
-    // regardless of whether the backend is reachable right now. If the VPN
-    // is down at startup, the server still registers; tools recover once
-    // connectivity returns (see the monitor + tools/list_changed path).
+    if (this._protocolGeneration !== null) {
+      return MCPProtocolError.invalid(id, "The protocol generation is already fixed");
+    }
     const requestedProtocol =
       params && typeof params.protocolVersion === "string" && params.protocolVersion;
-    if (requestedProtocol && requestedProtocol !== MCP_PROTOCOL_VERSION) {
-      // Never claim success by echoing a protocol revision this proxy does
-      // not implement.  A client can retry with the explicit supported
-      // revision; there is no fallback or downgrade path here.
-      return {
-        jsonrpc: "2.0",
+    if (requestedProtocol && requestedProtocol !== MCP_LEGACY_PROTOCOL_VERSION) {
+      return this._unsupportedVersion(
         id,
-        error: {
-          code: -32602,
-          message: "Unsupported protocol version",
-          data: { supported: [MCP_PROTOCOL_VERSION] },
-        },
-      };
+        requestedProtocol,
+        [MCP_LEGACY_PROTOCOL_VERSION],
+      );
     }
+    // Answer the legacy handshake LOCALLY — never round-trip to the backend.
+    // The client remains registered while the modern backend adapter reconnects
+    // independently, including when the backend is down at startup.
+    this._protocolGeneration = "legacy";
+    const protocolVersion = requestedProtocol || MCP_LEGACY_PROTOCOL_VERSION;
     this._clientInitParams = params || null;
     this._initialized = true;
-    // Kick off the backend session + tool prefetch in the background.
+    // Kick off backend reachability + tool prefetch in the background.
     this._startBackendMonitor();
 
-    const protocolVersion = requestedProtocol || MCP_PROTOCOL_VERSION;
     return {
       jsonrpc: "2.0",
       id,
@@ -607,6 +734,86 @@ export class AKBProxy {
         instructions: PROXY_INSTRUCTIONS,
       },
     };
+  }
+
+  async _discover(id, msg) {
+    let response;
+    try {
+      response = await this._forward(msg);
+    } catch (err) {
+      if (!this._isConnError(err)) throw err;
+      response = this._localDiscover(id);
+    }
+    if (response.error) return response;
+    return {
+      ...response,
+      result: this._decorateDiscover(response.result),
+    };
+  }
+
+  _decorateDiscover(result = {}) {
+    return {
+      ...result,
+      supportedVersions: [MCP_PROTOCOL_VERSION],
+      instructions: PROXY_INSTRUCTIONS,
+      resultType: "complete",
+      _meta: {
+        ...(result._meta || {}),
+        [SERVER_INFO_META_KEY]: { name: "akb-mcp", version: PROXY_VERSION },
+      },
+    };
+  }
+
+  _localDiscover(id) {
+    return {
+      jsonrpc: "2.0",
+      id,
+      result: {
+        capabilities: { tools: { listChanged: true } },
+        ttlMs: 300000,
+        cacheScope: "public",
+      },
+    };
+  }
+
+  _backendMeta(meta = null) {
+    const legacyCapabilities = this._clientInitParams?.capabilities;
+    const legacyInfo = this._clientInitParams?.clientInfo;
+    const source = this._clientMeta || {
+      [PROTOCOL_VERSION_META_KEY]: MCP_PROTOCOL_VERSION,
+      [CLIENT_CAPABILITIES_META_KEY]: legacyCapabilities || {},
+      [CLIENT_INFO_META_KEY]: legacyInfo || {
+        name: "akb-mcp-client",
+        version: PROXY_VERSION,
+      },
+    };
+    const provided = meta && typeof meta === "object" ? meta : {};
+    const sourceCapabilities = source[CLIENT_CAPABILITIES_META_KEY];
+    const providedCapabilities = provided[CLIENT_CAPABILITIES_META_KEY];
+    return {
+      ...source,
+      ...provided,
+      [PROTOCOL_VERSION_META_KEY]: MCP_PROTOCOL_VERSION,
+      [CLIENT_CAPABILITIES_META_KEY]: {
+        ...(sourceCapabilities && typeof sourceCapabilities === "object"
+          ? sourceCapabilities
+          : {}),
+        ...(providedCapabilities && typeof providedCapabilities === "object"
+          ? providedCapabilities
+          : {}),
+        experimental: {
+          ...(sourceCapabilities?.experimental || {}),
+          ...(providedCapabilities?.experimental || {}),
+          [VAULT_SKILL_PREFLIGHT_CAPABILITY]: { version: 2 },
+        },
+      },
+    };
+  }
+
+  _legacyToolsResult(result) {
+    const legacy = { tools: result.tools || [] };
+    if (result.nextCursor !== undefined) legacy.nextCursor = result.nextCursor;
+    return legacy;
   }
 
   // Decorate a raw backend tools/list result with the proxy-local file
@@ -633,7 +840,16 @@ export class AKBProxy {
       return { ...t };
     });
     tools.push(...this._fileToolsForClient());
-    return { ...resp, tools };
+    tools.sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0));
+    return {
+      ...resp,
+      resultType: "complete",
+      tools,
+      _meta: {
+        ...(resp._meta || {}),
+        [SERVER_INFO_META_KEY]: { name: "akb-mcp", version: PROXY_VERSION },
+      },
+    };
   }
 
   _fileToolsForClient() {
@@ -660,11 +876,18 @@ export class AKBProxy {
     // the whole tools/list on backend unreachability.
     let resp = this._cachedTools;
     if (!resp) {
-      const ok = await this._ensureBackend();
+      let ok;
+      try {
+        ok = await this._ensureBackend();
+      } catch (err) {
+        if (err?.rpcError) return { jsonrpc: "2.0", id, error: err.rpcError };
+        throw err;
+      }
       if (ok) {
         try {
           resp = await this._syncTools();
-        } catch {
+        } catch (err) {
+          if (err?.rpcError) return { jsonrpc: "2.0", id, error: err.rpcError };
           resp = null;
         }
       }
@@ -676,10 +899,22 @@ export class AKBProxy {
       process.stderr.write(
         "[akb-mcp] backend unreachable — serving file tools only; will re-list on recovery\n",
       );
-      return { jsonrpc: "2.0", id, result: { tools: this._fileToolsForClient() } };
+      const degraded = this._decorateTools({ tools: [] });
+      return {
+        jsonrpc: "2.0",
+        id,
+        result: this._protocolGeneration === "legacy" ? this._legacyToolsResult(degraded) : degraded,
+      };
     }
 
-    return { jsonrpc: "2.0", id, result: this._decorateTools(resp) };
+    const decorated = this._decorateTools(resp);
+    return {
+      jsonrpc: "2.0",
+      id,
+      result: this._protocolGeneration === "legacy"
+        ? this._legacyToolsResult(decorated)
+        : decorated,
+    };
   }
 
   // ── File-to-content resolution ─────────────────────────
@@ -795,12 +1030,12 @@ export class AKBProxy {
   }
 
   /**
-   * Touch the backend MCP session before a proxy-local file operation.
+   * Touch the backend MCP endpoint before a proxy-local file operation.
    *
    * Local tools bypass the backend `call_tool` dispatcher, so without this
-   * bridge their first write could commit before the session received the
+   * bridge their first write could commit before the backend received the
    * vault guide. `akb_help` is a reader-authorized, mirror-aware backend call
-   * and therefore reuses the same version/session gate as every native tool.
+   * and therefore reuses the same version/protocol gate as every native tool.
    * A write-only credential receives no payload and remains usable.
    */
   async _fileToolSkillPreflight(vault, acknowledgement = null) {
@@ -1296,51 +1531,50 @@ export class AKBProxy {
     });
   }
 
-  // ── Backend session + reconnect monitor ───────────────────
+  // ── Backend reachability + reconnect monitor ──────────────
 
-  // A connection/session failure that a background reconnect can recover
-  // from — as opposed to a genuine application error we must surface.
-  _isConnError(message) {
-    return /session|404|ECONNREFUSED|ECONNRESET|socket hang up|ETIMEDOUT|EHOSTUNREACH|ENETUNREACH|ENETDOWN|ENOTFOUND|EPIPE|timeout|unreachable/i.test(
-      message || "",
+  // A transport failure that a background reconnect can recover from — as
+  // opposed to a protocol or application error that must be surfaced.
+  _isConnError(error) {
+    if (error?.rpcError) return false;
+    if ([502, 503, 504].includes(error?.statusCode)) return true;
+    return /ECONNREFUSED|ECONNRESET|socket hang up|ETIMEDOUT|EHOSTUNREACH|ENETUNREACH|ENETDOWN|ENOTFOUND|EPIPE|timeout|unreachable/i.test(
+      error?.message || String(error || ""),
     );
   }
 
-  // Establish the backend MCP session (the `initialize` handshake that
-  // yields an mcp-session-id) if not already up. Single-flight: concurrent
-  // callers share one in-flight attempt. Returns true on success, false on
-  // failure — never throws — so callers can degrade gracefully.
+  // Probe the backend's modern stateless contract if not already reachable.
+  // Single-flight: concurrent callers share one in-flight attempt. Protocol
+  // errors propagate so callers never confuse an incompatible backend with
+  // a recoverable transport outage.
   async _ensureBackend() {
     if (this._backendReady) return true;
     if (this._connecting) return this._connecting;
     this._connecting = (async () => {
       try {
-        const sourceParams = this._clientInitParams || {
-          protocolVersion: MCP_PROTOCOL_VERSION,
-          capabilities: {},
-          clientInfo: { name: "akb-mcp-client", version: PROXY_VERSION },
-        };
-        // Strict vault-guide preflight changes a successful write into a
-        // retry envelope. Advertise support on behalf of this proxy version;
-        // raw/older MCP clients that do not opt in retain additive injection.
-        // Merge rather than replace client capabilities so roots/sampling and
-        // unrelated experimental features survive the bridge unchanged.
-        const sourceCapabilities = sourceParams.capabilities || {};
-        const initParams = {
-          ...sourceParams,
-          capabilities: {
-            ...sourceCapabilities,
-            experimental: {
-              ...(sourceCapabilities.experimental || {}),
-              [VAULT_SKILL_PREFLIGHT_CAPABILITY]: { version: 2 },
+        const discovered = await this._rpc(
+          "server/discover",
+          {},
+          { timeoutMs: this._probeTimeoutMs() },
+        );
+        if (
+          !Array.isArray(discovered.supportedVersions) ||
+          !discovered.supportedVersions.includes(MCP_PROTOCOL_VERSION)
+        ) {
+          throw new MCPProtocolError({
+            code: UNSUPPORTED_PROTOCOL_VERSION,
+            message: "Backend does not advertise the required protocol revision",
+            data: {
+              supported: discovered.supportedVersions || [],
+              requested: MCP_PROTOCOL_VERSION,
             },
-          },
-        };
-        await this._rpc("initialize", initParams, { timeoutMs: this._probeTimeoutMs() });
+          });
+        }
         this._backendReady = true;
         return true;
-      } catch {
+      } catch (err) {
         this._backendReady = false;
+        if (err?.rpcError) throw err;
         return false;
       } finally {
         this._connecting = null;
@@ -1350,19 +1584,19 @@ export class AKBProxy {
   }
 
   // Fetch and cache the backend tool list. Caller is responsible for having
-  // an established session. Uses the short probe timeout.
+  // a reachable backend. Uses the short probe timeout.
   async _syncTools() {
     const resp = await this._rpc("tools/list", {}, { timeoutMs: this._probeTimeoutMs() });
     this._cachedTools = resp;
     return resp;
   }
 
-  // Background loop that keeps trying to (re)establish the backend session
-  // with exponential backoff — effectively forever while the client is
+  // Background loop that keeps trying to reach the backend with exponential
+  // backoff — effectively forever while the client is
   // connected. On (re)connect it refreshes the tool cache and, if the
   // client was previously handed a degraded list, pushes a
   // tools/list_changed notification so the full toolset reappears WITHOUT a
-  // session restart. Idempotent: at most one loop runs at a time.
+  // client session restart. Idempotent: at most one loop runs at a time.
   _startBackendMonitor() {
     if (this._monitorRunning || this._closed) return;
     this._monitorRunning = true;
@@ -1382,8 +1616,8 @@ export class AKBProxy {
             }
             break; // connected + synced; idle until a forward detects a drop
           } catch {
-            // initialize succeeded but tools/list failed — treat as not
-            // ready and keep retrying.
+            // discover succeeded but tools/list failed — treat the backend as
+            // not ready and keep retrying.
             this._backendReady = false;
           }
         }
@@ -1412,12 +1646,14 @@ export class AKBProxy {
         const resp = await this._rpc(msg.method, msg.params || {});
         return { jsonrpc: "2.0", id: msg.id, result: resp };
       } catch (err) {
-        if (this._isConnError(err.message)) {
-          // Drop the dead session and let the background monitor restore
+        if (err?.rpcError) {
+          return { jsonrpc: "2.0", id: msg.id, error: err.rpcError };
+        }
+        if (this._isConnError(err)) {
+          // Mark the backend unavailable and let the background monitor restore
           // it. The proxy process and the client-visible server stay
           // alive, so calls recover once connectivity returns.
           this._backendReady = false;
-          this.sessionId = null;
           this._startBackendMonitor();
 
           if (attempt < maxRetries) {
@@ -1434,20 +1670,26 @@ export class AKBProxy {
 
   async _rpc(method, params, rpcOpts = {}) {
     this.msgId++;
+    const requestParams = {
+      ...(params || {}),
+      _meta: this._backendMeta(params?._meta),
+    };
     const body = JSON.stringify({
       jsonrpc: "2.0",
       id: this.msgId,
       method,
-      params,
+      params: requestParams,
     });
 
     const headers = {
       Authorization: `Bearer ${this.pat}`,
       "Content-Type": "application/json",
       Accept: "application/json, text/event-stream",
+      "mcp-protocol-version": MCP_PROTOCOL_VERSION,
+      "mcp-method": method,
     };
-    if (this.sessionId) {
-      headers["mcp-session-id"] = this.sessionId;
+    if (method === "tools/call" && typeof requestParams.name === "string") {
+      headers["mcp-name"] = encodeRoutingHeader(requestParams.name);
     }
 
     const resp = await this._http(
@@ -1458,10 +1700,6 @@ export class AKBProxy {
       { timeoutMs: rpcOpts.timeoutMs },
     );
 
-    if (resp.headers["mcp-session-id"]) {
-      this.sessionId = resp.headers["mcp-session-id"];
-    }
-
     let parsed;
     try {
       parsed = JSON.parse(resp.text);
@@ -1469,11 +1707,8 @@ export class AKBProxy {
       throw new Error(`Invalid JSON response: ${resp.text.slice(0, 200)}`);
     }
 
-    if (parsed._sessionId) {
-      this.sessionId = parsed._sessionId;
-    }
     if (parsed.error) {
-      throw new Error(`MCP error ${parsed.error.code}: ${parsed.error.message}`);
+      throw new MCPProtocolError(parsed.error);
     }
     return parsed.result || {};
   }

--- a/packages/akb-mcp-client/package.json
+++ b/packages/akb-mcp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akb-mcp",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "mcpName": "io.github.dnotitia/akb",
   "description": "AKB MCP stdio client — connect any AI agent to AKB knowledge base. Zero dependencies, auto-reconnect.",
   "bin": {

--- a/packages/akb-mcp-client/test/contract.test.mjs
+++ b/packages/akb-mcp-client/test/contract.test.mjs
@@ -122,6 +122,130 @@ it("envelope adds kind without breaking legacy fields", () => {
   }
 });
 
+const modernMeta = {
+  "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+  "io.modelcontextprotocol/clientCapabilities": {},
+  "io.modelcontextprotocol/clientInfo": { name: "modern-test", version: "1" },
+};
+
+function modernRequest(id, method, params = {}) {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method,
+    params: { ...params, _meta: modernMeta },
+  };
+}
+
+itAsync("modern discover fixes the proxy generation and advertises stateless support", async () => {
+  const proxy = new AKBProxy({ url: "http://akb.test/mcp", pat: "test" });
+  proxy._forward = async (msg) => ({
+    jsonrpc: "2.0",
+    id: msg.id,
+    result: { supportedVersions: ["2026-07-28"], capabilities: { tools: {} } },
+  });
+
+  const response = await proxy._handle(modernRequest(1, "server/discover"));
+
+  assert.equal(proxy._protocolGeneration, "modern");
+  assert.equal(response.result.supportedVersions[0], "2026-07-28");
+  assert.equal(response.result._meta["io.modelcontextprotocol/serverInfo"].name, "akb-mcp");
+});
+
+itAsync("modern backend requests carry exact routing headers and request metadata", async () => {
+  const proxy = new AKBProxy({ url: "http://akb.test/mcp", pat: "test" });
+  proxy._protocolGeneration = "modern";
+  proxy._clientMeta = modernMeta;
+  let request;
+  proxy._http = async (method, path, body, headers) => {
+    request = { method, path, body: JSON.parse(body.toString()), headers };
+    return { text: JSON.stringify({ jsonrpc: "2.0", id: 1, result: { ok: true } }), headers: {} };
+  };
+
+  const result = await proxy._rpc("tools/call", { name: "akb_help", arguments: {} });
+
+  assert.deepEqual(result, { ok: true });
+  assert.equal(request.headers["mcp-protocol-version"], "2026-07-28");
+  assert.equal(request.headers["mcp-method"], "tools/call");
+  assert.equal(request.headers["mcp-name"], "akb_help");
+  assert.equal(request.body.params._meta["io.modelcontextprotocol/protocolVersion"], "2026-07-28");
+  assert.deepEqual(
+    request.body.params._meta["io.modelcontextprotocol/clientCapabilities"].experimental[
+      "io.dnotitia.akb/vault-skill-preflight"
+    ],
+    { version: 2 },
+  );
+});
+
+itAsync("legacy initialize remains local and rejects modern discovery mixing", async () => {
+  const proxy = new AKBProxy({ url: "http://akb.test/mcp", pat: "test" });
+  proxy._startBackendMonitor = () => {};
+
+  const initialized = await proxy._handle({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "legacy-test", version: "1" },
+    },
+  });
+  const mixed = await proxy._handle(modernRequest(2, "server/discover"));
+
+  assert.equal(initialized.result.protocolVersion, "2025-06-18");
+  assert.equal(initialized.result.serverInfo.version, "2.3.0");
+  assert.equal(mixed.error.code, -32022);
+});
+
+itAsync("modern clients cannot send initialize or initialized notifications", async () => {
+  const proxy = new AKBProxy({ url: "http://akb.test/mcp", pat: "test" });
+  const modern = modernRequest(1, "server/discover");
+  proxy._forward = async (msg) => ({
+    jsonrpc: "2.0",
+    id: msg.id,
+    result: { supportedVersions: ["2026-07-28"] },
+  });
+  await proxy._handle(modern);
+
+  const initialize = await proxy._handle({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "initialize",
+    params: { protocolVersion: "2025-06-18", capabilities: {} },
+  });
+  const initialized = await proxy._handle(modernRequest(3, "notifications/initialized"));
+
+  assert.equal(initialize.error.code, -32022);
+  assert.equal(initialized.error.code, -32600);
+});
+
+itAsync("legacy and modern tool catalogs share tools but keep modern cache metadata private", async () => {
+  const cached = {
+    tools: [{ name: "akb_help", inputSchema: { type: "object", properties: {} } }],
+    resultType: "complete",
+    ttlMs: 300000,
+    cacheScope: "public",
+  };
+  const modern = new AKBProxy({ url: "http://akb.test/mcp", pat: "test" });
+  modern._protocolGeneration = "modern";
+  modern._cachedTools = cached;
+  modern._startBackendMonitor = () => {};
+  const legacy = new AKBProxy({ url: "http://akb.test/mcp", pat: "test" });
+  legacy._protocolGeneration = "legacy";
+  legacy._cachedTools = cached;
+  legacy._startBackendMonitor = () => {};
+
+  const modernList = await modern._toolsList(1, { _meta: modernMeta });
+  const legacyList = await legacy._toolsList(1, {});
+
+  assert.deepEqual(modernList.result.tools, legacyList.result.tools);
+  assert.equal(modernList.result.cacheScope, "public");
+  assert.equal(legacyList.result.cacheScope, undefined);
+  assert.equal(legacyList.result.resultType, undefined);
+  assert.equal(legacyList.result._meta, undefined);
+});
+
 itAsync("_putFile omits initiate hash, uploads bytes, and returns the canonical confirm shape", async () => {
   const directory = await mkdtemp(join(tmpdir(), "akb-mcp-contract-"));
   const filePath = join(directory, "proxy.bin");
@@ -472,6 +596,13 @@ itAsync("proxy-local exact retry acknowledges the guide before writing", async (
     name: "akb_put_image",
     arguments: { vault: "myvault", file_path: "/tmp/example.png" },
   };
+
+  proxy._startBackendMonitor = () => {};
+  await proxy._initialize(0, {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "legacy-test", version: "1" },
+  });
 
   const first = await proxy._handle({
     jsonrpc: "2.0", id: 1, method: "tools/call", params,

--- a/packages/akb-mcp-client/test/reconnect.test.mjs
+++ b/packages/akb-mcp-client/test/reconnect.test.mjs
@@ -34,6 +34,14 @@ const tick = (ms = 10) => new Promise((r) => setTimeout(r, ms));
 function newProxy() {
   return new AKBProxy({ url: "http://akb.test/mcp", pat: "test-pat" });
 }
+async function initializeLegacy(proxy) {
+  proxy._startBackendMonitor = () => {};
+  return proxy._initialize(0, {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "legacy-test", version: "1" },
+  });
+}
 const fileToolNames = [
   "akb_put_file",
   "akb_put_image",
@@ -81,13 +89,13 @@ itAsync("initialize rejects an unsupported protocol version instead of echoing i
     capabilities: {},
   });
 
-  assert.equal(res.error.code, -32602);
+  assert.equal(res.error.code, -32022);
   assert.deepEqual(res.error.data.supported, ["2025-06-18"]);
   assert.equal(res.result, undefined);
   assert.equal(proxy._initialized, false);
 });
 
-itAsync("backend initialize negotiates vault-guide preflight without dropping client capabilities", async () => {
+itAsync("backend modern discover carries legacy client capabilities", async () => {
   const proxy = newProxy();
   const original = {
     protocolVersion: "2025-06-18",
@@ -98,21 +106,30 @@ itAsync("backend initialize negotiates vault-guide preflight without dropping cl
     clientInfo: { name: "client", version: "1" },
   };
   proxy._clientInitParams = original;
+  proxy._protocolGeneration = "legacy";
   let forwarded;
-  proxy._rpc = async (method, params) => {
-    assert.equal(method, "initialize");
-    forwarded = params;
-    return {};
+  proxy._http = async (method, path, body) => {
+    assert.equal(method, "POST");
+    assert.equal(path, "/mcp");
+    forwarded = JSON.parse(body.toString()).params;
+    return {
+      text: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        result: { supportedVersions: ["2026-07-28"] },
+      }),
+      headers: {},
+    };
   };
 
   assert.equal(await proxy._ensureBackend(), true);
-  assert.deepEqual(forwarded.capabilities.roots, { listChanged: true });
+  assert.deepEqual(forwarded._meta["io.modelcontextprotocol/clientCapabilities"].roots, { listChanged: true });
   assert.deepEqual(
-    forwarded.capabilities.experimental["example.test/feature"],
+    forwarded._meta["io.modelcontextprotocol/clientCapabilities"].experimental["example.test/feature"],
     { version: 2 },
   );
   assert.deepEqual(
-    forwarded.capabilities.experimental["io.dnotitia.akb/vault-skill-preflight"],
+    forwarded._meta["io.modelcontextprotocol/clientCapabilities"].experimental["io.dnotitia.akb/vault-skill-preflight"],
     { version: 2 },
   );
   assert.equal(
@@ -208,6 +225,7 @@ itAsync("monitor stays silent on recovery when the list was never degraded", asy
 
 itAsync("vault-guide acknowledgement is attached only to the exact backend retry", async () => {
   const proxy = newProxy();
+  await initializeLegacy(proxy);
   const forwarded = [];
   const challenge = {
     error: "Apply the vault instructions",
@@ -252,6 +270,7 @@ itAsync("vault-guide acknowledgement is attached only to the exact backend retry
 
 itAsync("vault-guide acknowledgement never authorizes an unrelated queued write", async () => {
   const proxy = newProxy();
+  await initializeLegacy(proxy);
   const forwarded = [];
   proxy._forward = async (msg) => {
     forwarded.push(msg);
@@ -304,6 +323,30 @@ itAsync("_forward retries a connection error then surfaces it (process survives)
   assert.equal(proxy._backendReady, false, "marks backend not-ready");
   assert.ok(restarts >= 1, "kicks the reconnect monitor");
   assert.ok(calls >= 3, "attempted the initial call plus retries");
+});
+
+itAsync("_forward surfaces protocol errors without reconnect retries", async () => {
+  const proxy = newProxy();
+  proxy._backendReady = true;
+  let calls = 0;
+  let monitorStarts = 0;
+  proxy._startBackendMonitor = () => { monitorStarts++; };
+  proxy._rpc = async () => {
+    calls++;
+    const error = new Error("MCP protocol error");
+    error.rpcError = {
+      code: -32022,
+      message: "Unsupported protocol version",
+      data: { supported: ["2026-07-28"], requested: "2099-01-01" },
+    };
+    throw error;
+  };
+
+  const response = await proxy._forward({ method: "tools/list", id: 8, params: {} });
+
+  assert.equal(response.error.code, -32022);
+  assert.equal(calls, 1);
+  assert.equal(monitorStarts, 0);
 });
 
 itAsync("_forward recovers on a later attempt once the backend returns", async () => {

--- a/server.json
+++ b/server.json
@@ -1,18 +1,18 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.dnotitia/akb",
-  "description": "Git-backed org memory for AI agents — hybrid search, tables, files & a URI graph over MCP.",
+  "description": "Git-backed org memory for AI agents — hybrid search, tables, files & a URI graph over MCP, with 2026-07-28 stateless and legacy compatibility.",
   "repository": {
     "url": "https://github.com/dnotitia/akb",
     "source": "github"
   },
-  "version": "2.1.0",
+  "version": "2.3.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "akb-mcp",
-      "version": "2.1.0",
+      "version": "2.3.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

This draft PR delivers AKB-178's dual-generation MCP transport contract for the backend HTTP server and the akb-mcp stdio proxy.

Modern clients can use the stateless MCP 2026-07-28 request contract, while existing HTTP and stdio clients retain the supported legacy initialize/session flows. Routing, authentication, tool dispatch, authorization, audit, and side effects remain shared across both generations.

## Scope

- Add explicit modern/legacy protocol routing and fail-closed mismatch handling at the authenticated MCP boundary.
- Bind legacy sessions to the authenticated principal and keep modern requests independent of session state.
- Normalize proxy backend calls onto the modern stateless contract while preserving legacy client behavior and degraded/reconnect behavior.
- Keep the canonical tool catalog and authorization semantics unchanged across generations.
- Update protocol metadata, runtime descriptor coverage, changelogs, README/connector guidance, and compatibility tests.

## Verification (exact head)

- Candidate: 47bbc2044f0230d50c91c9a659bbbc1a84785f33
- Base: 636cfe7fbcd9724e8514d111d561696372657697
- Backend MCP compatibility and runtime-descriptor focused tests: 123 passed.
- akb-mcp contract and reconnect tests: 23 + 13 passed.
- Local repository contributor gate scripts/check.sh: passed, including 329-source mypy, bandit, frontend tests (669), SDK/package checks (50), generated-type checks, and detect-secrets.
- Hosted check #1012: passed.
- Hosted backend tests #1005: passed.
- Hosted endpoint behavior gate e2e #670: passed.
- Shell syntax and diff checks: passed.
- Hidden over-engineering review: findings were checked; legacy compatibility, exact allowlist, deterministic catalog, and protocol boundary invariants were preserved, with only the verified dead connectionError branch removed.
- Final correctness review on this exact head: no findings, patch correct, confidence 0.95, no P0.

The hosted endpoint E2E is the repository-policy-equivalent source-blind behavior gate for the HTTP surface; proxy contract/reconnect and child-process probes cover the stdio surface. A mapped Crabbox runtime attempt was stopped and excluded from proof because its SSH execution path exposed fixture credential values in process arguments.

This pull request remains a draft for review. Relates to AKB-178.