### PR TITLE
fix(auth): return admin callback failures to sign-in page

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3605
+        "line_number": 3613
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5400,5 +5400,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-27T14:08:54Z"
+  "generated_at": "2026-08-28T06:22:51Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -7,6 +7,14 @@ specifically; the proxy has its own log in
 
 ## Unreleased
 
+### Made product-admin callback failures recoverable
+
+Expired, malformed, or refused product-admin OIDC callbacks now return the
+browser to `/admin` with a fixed, non-disclosing retry message instead of
+rendering a serialized API error. The one-time browser-binding cookie is
+cleared on failure, while successful callbacks retain the existing short,
+opaque admin session behavior.
+
 ### Added dual-era MCP protocol support
 
 The backend now uses the pinned MCP 2.1.0 SDK and serves the 2026-07-28

--- a/backend/app/api/routes/admin_auth.py
+++ b/backend/app/api/routes/admin_auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 from urllib.parse import urlsplit
 
@@ -9,7 +10,7 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from fastapi.responses import JSONResponse, RedirectResponse
 
 from app.config import settings
-from app.exceptions import AuthenticationError
+from app.exceptions import AKBError, AuthenticationError
 from app.services.admin_auth_service import (
     ProductAdminIdentity,
     authenticate_local_product_admin,
@@ -26,6 +27,7 @@ from app.util.text import NFCModel
 
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 _ADMIN_SESSION_COOKIE = "__Host-akb_admin_session"
 _ADMIN_CSRF_COOKIE = "__Host-akb_admin_csrf"
@@ -203,6 +205,22 @@ def _clear_admin_oidc_binding_cookie(response: RedirectResponse) -> None:
     )
 
 
+def _admin_sign_in_failed(reason: str) -> RedirectResponse:
+    """Return a browser to a safe retry surface after any admin refusal."""
+    # `reason` is always selected by this module, never copied from the IdP or
+    # query string. Keep enough signal for operations without disclosing it to
+    # the browser.
+    logger.warning("Product-admin browser sign-in returned to retry page: %s", reason)
+    response = RedirectResponse(
+        "/admin?auth_error=sign_in_failed",
+        status_code=status.HTTP_303_SEE_OTHER,
+    )
+    _clear_admin_oidc_binding_cookie(response)
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["Pragma"] = "no-cache"
+    return response
+
+
 @router.get("/admin/auth/config", summary="Public product-admin login configuration")
 async def admin_auth_config():
     mode = settings.require_auth_mode()
@@ -259,26 +277,32 @@ async def admin_keycloak_callback(
 ):
     _require_admin_sso()
     if error is not None or not code or not state:
-        raise AuthenticationError("Product-admin sign-in failed")
-    oidc = get_keycloak_oidc()
-    browser_binding = request.cookies.get(_admin_oidc_binding_cookie_name(), "")
-    transient = await oidc.consume_admin_state(state, browser_binding)
-    if not isinstance(transient, dict) or set(transient) != {
-        "code_verifier",
-        "nonce",
-    }:
-        raise AuthenticationError("Product-admin sign-in failed")
-    verifier = transient.get("code_verifier")
-    nonce = transient.get("nonce")
-    if not isinstance(verifier, str) or not isinstance(nonce, str):
-        raise AuthenticationError("Product-admin sign-in failed")
-    tokens = await oidc.exchange_admin_code(code, verifier)
-    id_token = tokens.get("id_token")
-    if tokens.get("token_type") != "Bearer" or not isinstance(id_token, str):
-        raise AuthenticationError("Product-admin sign-in failed")
-    claims = await oidc.verify_admin_id_token(id_token, expected_nonce=nonce)
-    identity = await resolve_prebound_sso_product_admin(claims)
-    issued = await create_sso_admin_browser_session(identity, claims)
+        return _admin_sign_in_failed("authorization_error_or_missing_parameters")
+    try:
+        oidc = get_keycloak_oidc()
+        browser_binding = request.cookies.get(_admin_oidc_binding_cookie_name(), "")
+        transient = await oidc.consume_admin_state(state, browser_binding)
+        if not isinstance(transient, dict) or set(transient) != {
+            "code_verifier",
+            "nonce",
+        }:
+            return _admin_sign_in_failed("state_missing_or_expired")
+        verifier = transient.get("code_verifier")
+        nonce = transient.get("nonce")
+        if not isinstance(verifier, str) or not isinstance(nonce, str):
+            return _admin_sign_in_failed("transient_profile_invalid")
+        tokens = await oidc.exchange_admin_code(code, verifier)
+        id_token = tokens.get("id_token")
+        if tokens.get("token_type") != "Bearer" or not isinstance(id_token, str):
+            return _admin_sign_in_failed("token_profile_invalid")
+        claims = await oidc.verify_admin_id_token(id_token, expected_nonce=nonce)
+        identity = await resolve_prebound_sso_product_admin(claims)
+        issued = await create_sso_admin_browser_session(identity, claims)
+    except AKBError as exc:
+        # The callback is a browser page, so expected application refusals must
+        # not become a serialized API error. The fixed query code deliberately
+        # discloses neither identity state nor the upstream failure detail.
+        return _admin_sign_in_failed(f"application_refusal:{type(exc).__name__}")
     response = RedirectResponse("/admin", status_code=status.HTTP_303_SEE_OTHER)
     _set_admin_cookies(
         response,

--- a/backend/tests/test_admin_callback_answers_with_a_page_unit.py
+++ b/backend/tests/test_admin_callback_answers_with_a_page_unit.py
@@ -1,0 +1,94 @@
+"""Product-admin browser callback failures return a recoverable page."""
+
+from __future__ import annotations
+
+import inspect
+import tempfile
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.config import settings
+from app.exceptions import ForbiddenError
+
+_STORAGE = tempfile.mkdtemp(prefix="admin-callback-page-")
+object.__setattr__(settings, "git_storage_path", _STORAGE)
+
+from app.api.routes import admin_auth  # noqa: E402
+
+
+def _configure_admin_sso(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "auth_mode", "sso", raising=False)
+    monkeypatch.setattr(settings, "keycloak_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "keycloak_admin_client_id", "akb-admin", raising=False)
+    monkeypatch.setattr(settings, "keycloak_admin_client_secret", "secret", raising=False)
+    monkeypatch.setattr(settings, "public_base_url", "https://akb.example", raising=False)
+
+
+def _callback_client() -> TestClient:
+    app = FastAPI()
+    app.include_router(admin_auth.router, prefix="/api/v1")
+    client = TestClient(app)
+    client.cookies.set(
+        "__Host-akb_admin_oidc_binding",
+        "browser-binding-value-that-is-long-enough",
+        path="/",
+    )
+    return client
+
+
+def _assert_recoverable_failure(response) -> None:
+    assert response.status_code == 303
+    assert response.headers["location"] == "/admin?auth_error=sign_in_failed"
+    cookies = response.headers.get_list("set-cookie")
+    assert any(
+        value.startswith("__Host-akb_admin_oidc_binding=") and "Max-Age=0" in value and "Path=/" in value
+        for value in cookies
+    )
+    assert "Product-admin sign-in failed" not in response.text
+
+
+def test_expired_admin_state_returns_to_the_admin_page(monkeypatch, caplog) -> None:
+    class ExpiredOIDC:
+        async def consume_admin_state(self, state: str, browser_binding: str):
+            return None
+
+    _configure_admin_sso(monkeypatch)
+    monkeypatch.setattr(admin_auth, "get_keycloak_oidc", lambda: ExpiredOIDC())
+
+    response = _callback_client().get(
+        "/api/v1/admin/auth/keycloak/callback",
+        params={"code": "one-time-code", "state": "expired-state"},
+        follow_redirects=False,
+    )
+
+    _assert_recoverable_failure(response)
+    assert "state_missing_or_expired" in caplog.text
+    assert "expired-state" not in caplog.text
+
+
+def test_downstream_admin_refusal_returns_to_the_admin_page(monkeypatch) -> None:
+    class RefusedOIDC:
+        async def consume_admin_state(self, state: str, browser_binding: str):
+            return {"code_verifier": "verifier", "nonce": "nonce"}
+
+        async def exchange_admin_code(self, code: str, verifier: str):
+            raise ForbiddenError("sensitive internal refusal")
+
+    _configure_admin_sso(monkeypatch)
+    monkeypatch.setattr(admin_auth, "get_keycloak_oidc", lambda: RefusedOIDC())
+
+    response = _callback_client().get(
+        "/api/v1/admin/auth/keycloak/callback",
+        params={"code": "one-time-code", "state": "one-time-state"},
+        follow_redirects=False,
+    )
+
+    _assert_recoverable_failure(response)
+    assert "sensitive internal refusal" not in response.text
+
+
+def test_admin_callback_never_raises_application_refusals() -> None:
+    source = inspect.getsource(admin_auth.admin_keycloak_callback)
+    assert "raise AuthenticationError" not in source
+    assert "except AKBError" in source

--- a/frontend/src/pages/__tests__/admin-auth-page.test.tsx
+++ b/frontend/src/pages/__tests__/admin-auth-page.test.tsx
@@ -82,13 +82,13 @@ const directCatalog = {
   providers: [provider],
 };
 
-function renderPage() {
+function renderPage(initialEntry = "/admin") {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
   return render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={["/admin"]}>
+      <MemoryRouter initialEntries={[initialEntry]}>
         <AdminPage />
       </MemoryRouter>
     </QueryClientProvider>,
@@ -128,6 +128,25 @@ describe("AdminPage mode boundary", () => {
     expect(await screen.findByRole("button", { name: /keycloak/i })).toBeInTheDocument();
     expect(screen.queryByLabelText("Username")).toBeNull();
     expect(screen.queryByRole("button", { name: /local/i })).toBeNull();
+  });
+
+  it("turns a failed callback into a clear retry path", async () => {
+    vi.mocked(getAdminAuthConfig).mockResolvedValue(ssoConfig);
+    renderPage("/admin?auth_error=sign_in_failed");
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "The product-admin sign-in expired or could not be completed. Start a new sign-in.",
+    );
+    expect(screen.getByRole("button", { name: /keycloak/i })).toBeInTheDocument();
+  });
+
+  it("does not echo an arbitrary callback error into the page", async () => {
+    vi.mocked(getAdminAuthConfig).mockResolvedValue(ssoConfig);
+    renderPage("/admin?auth_error=%3Cscript%3Ealert(1)%3C%2Fscript%3E");
+
+    expect(await screen.findByRole("button", { name: /keycloak/i })).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.queryByText(/script/i)).toBeNull();
   });
 
   it("submits local credentials from the user action and stores the RS256 session", async () => {

--- a/frontend/src/pages/admin.tsx
+++ b/frontend/src/pages/admin.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 
 import { Alert } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -25,6 +25,7 @@ import {
 
 
 export default function AdminPage() {
+  const location = useLocation();
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -45,6 +46,8 @@ export default function AdminPage() {
     sessionQuery.data?.auth_mode === config?.auth_mode
       ? sessionQuery.data
       : undefined;
+  const callbackFailed =
+    new URLSearchParams(location.search).get("auth_error") === "sign_in_failed";
 
   async function submitLocal(event: React.FormEvent) {
     event.preventDefault();
@@ -163,6 +166,11 @@ export default function AdminPage() {
 
           {!session && sessionQuery.isSuccess && config?.available && config.auth_mode === "sso" && config.keycloak.enabled && (
             <div className="space-y-4">
+              {callbackFailed && (
+                <Alert variant="destructive">
+                  The product-admin sign-in expired or could not be completed. Start a new sign-in.
+                </Alert>
+              )}
               {error && <Alert variant="destructive">{error}</Alert>}
               <Button type="button" size="lg" className="w-full" onClick={startKeycloak}>
                 Sign in with Keycloak


### PR DESCRIPTION
## Summary

- redirect expired, malformed, and refused product-admin OIDC callbacks to the admin sign-in page
- clear the one-time browser binding and expose only a fixed, allowlisted error code
- show a retryable admin-page alert and retain a value-free server-side diagnostic reason

## Root cause

The product-admin callback raised application exceptions. Because this endpoint is reached by a browser redirect, FastAPI serialized the exception as a raw JSON page. The observed callback arrived after its 10-minute one-time state had expired.

## Verification

- focused admin callback and auth boundary tests: 19 passed
- frontend design check, typecheck, lint, and unit tests: 96 files / 671 tests passed
- repository scripts/check.sh: passed
- exact-head review receipt: 62ff879eb262d35c9c582c153cfd86570b80f1f8; correctness, security, architecture, tests, and silent-failure lenses; no remaining High or Medium findings