### PR TITLE
fix(admin): align SSO provider catalog contract

### DIFF
--- a/backend/tests/fixtures/admin_sso_provider_catalog_v1.json
+++ b/backend/tests/fixtures/admin_sso_provider_catalog_v1.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "auth_mode": "sso",
+  "control_mode": "direct",
+  "supported_provider_types": [
+    "keycloak-oidc"
+  ],
+  "providers": [
+    {
+      "provider_type": "keycloak-oidc",
+      "alias": "workforce",
+      "display_name": "Company SSO",
+      "state": "configured_disabled",
+      "enabled": false,
+      "issuer": "https://accounts.example.com/realms/workforce",
+      "discovery_url": "https://accounts.example.com/realms/workforce/.well-known/openid-configuration",
+      "client_id": "akb-broker",
+      "client_secret_configured": true,
+      "redirect_uri": "https://auth.akb.example.com/realms/akb/broker/workforce/endpoint",
+      "post_logout_redirect_uri": "https://auth.akb.example.com/realms/akb/broker/workforce/endpoint/logout_response",
+      "capabilities": {
+        "supports_logout": true,
+        "supports_identity_migration": true
+      }
+    }
+  ]
+}

--- a/backend/tests/test_admin_sso_routes_unit.py
+++ b/backend/tests/test_admin_sso_routes_unit.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 import uuid
 
 from fastapi import FastAPI
@@ -26,6 +28,7 @@ from app.sso.models import (
 
 
 _SECRET = "write-only-provider-secret-must-not-leak"  # pragma: allowlist secret
+_CATALOG_FIXTURE = Path(__file__).parent / "fixtures" / "admin_sso_provider_catalog_v1.json"
 
 
 def _admin() -> ProductAdminIdentity:
@@ -127,13 +130,7 @@ def test_admin_catalog_is_versioned_bounded_and_secret_free(monkeypatch):
     response = _client(monkeypatch, Control()).get("/api/v1/admin/sso/providers")
 
     assert response.status_code == 200
-    assert response.json() == {
-        "schema_version": 1,
-        "auth_mode": "sso",
-        "control_mode": "direct",
-        "supported_provider_types": ["keycloak-oidc"],
-        "providers": [_provider().admin_view()],
-    }
+    assert response.json() == json.loads(_CATALOG_FIXTURE.read_text())
     assert _SECRET not in response.text
 
 

--- a/frontend/src/lib/__tests__/admin-sso-config.test.ts
+++ b/frontend/src/lib/__tests__/admin-sso-config.test.ts
@@ -1,6 +1,9 @@
+import { readFileSync } from "node:fs";
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  type AdminSsoCatalog,
   adminLogout,
   configureAdminSsoProvider,
   getAdminSsoCatalog,
@@ -9,30 +12,11 @@ import {
 } from "../api";
 
 
-const provider = {
-  provider_type: "keycloak-oidc",
-  alias: "workforce",
-  display_name: "Company SSO",
-  state: "configured_disabled",
-  enabled: false,
-  issuer: "https://accounts.example.com/realms/workforce",
-  discovery_url: "https://accounts.example.com/realms/workforce/.well-known/openid-configuration",
-  client_id: "akb-broker",
-  client_secret_configured: true,
-  redirect_uri: "https://auth.akb.example.com/realms/akb/broker/workforce/endpoint",
-  capabilities: {
-    supports_logout: true,
-    supports_identity_migration: true,
-  },
-};
-
-const catalog = {
-  schema_version: 1,
-  auth_mode: "sso",
-  control_mode: "direct",
-  supported_provider_types: ["keycloak-oidc"],
-  providers: [provider],
-};
+const catalog = JSON.parse(readFileSync(
+  "../backend/tests/fixtures/admin_sso_provider_catalog_v1.json",
+  "utf8",
+)) as AdminSsoCatalog;
+const provider = catalog.providers[0];
 
 function response(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -74,6 +58,10 @@ describe("admin SSO provider API", () => {
       ...catalog,
       providers: [{ ...provider, display_name: "unsafe\nlabel" }],
     }],
+    ["unsafe post-logout redirect URI", {
+      ...catalog,
+      providers: [{ ...provider, post_logout_redirect_uri: "https://auth.example.com/logout\nunsafe" }],
+    }],
     ["provider secret field", {
       ...catalog,
       providers: [{ ...provider, client_secret: "leaked" }], // pragma: allowlist secret
@@ -90,8 +78,8 @@ describe("admin SSO provider API", () => {
     const result = await configureAdminSsoProvider("workforce", {
       provider_type: "keycloak-oidc",
       display_name: "Company SSO",
-      issuer: provider.issuer,
-      discovery_url: provider.discovery_url,
+      issuer: provider.issuer!,
+      discovery_url: provider.discovery_url!,
       client_id: "akb-broker",
       client_secret: "write-only-secret", // pragma: allowlist secret
     });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -794,6 +794,7 @@ export interface AdminSsoProvider {
   client_id: string | null;
   client_secret_configured: boolean;
   redirect_uri: string;
+  post_logout_redirect_uri: string;
   capabilities: {
     supports_logout: boolean;
     supports_identity_migration: boolean;
@@ -816,7 +817,7 @@ function parseAdminSsoProvider(value: unknown): AdminSsoProvider {
     !hasExactKeys(provider, [
       "provider_type", "alias", "display_name", "state", "enabled", "issuer",
       "discovery_url", "client_id", "client_secret_configured",
-      "redirect_uri", "capabilities",
+      "redirect_uri", "post_logout_redirect_uri", "capabilities",
     ]) ||
     !hasExactKeys(capabilities, ["supports_logout", "supports_identity_migration"]) ||
     typeof provider.provider_type !== "string" ||
@@ -851,6 +852,10 @@ function parseAdminSsoProvider(value: unknown): AdminSsoProvider {
     !provider.redirect_uri ||
     provider.redirect_uri.length > 2048 ||
     hasControlCharacters(provider.redirect_uri) ||
+    typeof provider.post_logout_redirect_uri !== "string" ||
+    !provider.post_logout_redirect_uri ||
+    provider.post_logout_redirect_uri.length > 2048 ||
+    hasControlCharacters(provider.post_logout_redirect_uri) ||
     ((state === "enabled" || state === "configured_disabled") && (
       provider.issuer === null ||
       provider.discovery_url === null ||
@@ -873,6 +878,7 @@ function parseAdminSsoProvider(value: unknown): AdminSsoProvider {
     client_id: provider.client_id as string | null,
     client_secret_configured: provider.client_secret_configured,
     redirect_uri: provider.redirect_uri,
+    post_logout_redirect_uri: provider.post_logout_redirect_uri,
     capabilities: {
       supports_logout: capabilities.supports_logout,
       supports_identity_migration: capabilities.supports_identity_migration,

--- a/frontend/src/pages/__tests__/admin-auth-page.test.tsx
+++ b/frontend/src/pages/__tests__/admin-auth-page.test.tsx
@@ -68,6 +68,7 @@ const provider = {
   client_id: "akb-broker",
   client_secret_configured: true,
   redirect_uri: "https://auth.akb.example.com/realms/akb/broker/workforce/endpoint",
+  post_logout_redirect_uri: "https://auth.akb.example.com/realms/akb/broker/workforce/endpoint/logout_response",
   capabilities: {
     supports_logout: true,
     supports_identity_migration: true,


### PR DESCRIPTION
## Summary

- accept and validate the backend-owned post-logout redirect URI in the admin SSO catalog parser
- preserve strict, secret-free provider response validation
- share one versioned catalog fixture across backend and frontend tests so future contract drift fails CI

## Root cause

The backend provider readback included a supported post-logout redirect field, while the frontend exact-key parser still used the earlier response shape. The API returned success, but the UI rejected the payload and replaced the provider controls with a generic load error.

## Verification

- regression test confirmed RED before the parser change
- backend admin SSO route tests: 33 passed
- focused frontend tests: 23 passed
- repository check gate: passed
- exact-head multi-lens review: no High or Medium findings