### PR TITLE
feat(sso): add generic OIDC upstream provider

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3613
+        "line_number": 3625
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5400,5 +5400,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-28T06:22:51Z"
+  "generated_at": "2026-08-28T08:04:39Z"
 }

--- a/README.md
+++ b/README.md
@@ -391,8 +391,9 @@ its ordinary-login option without redeploying AKB. The option becomes a usable
 button only when the server-side browser-session capability is ready. Client
 secrets are write-only, and an enabled provider must be disabled before
 reconfiguration.
-See the [SSO provider guide](./docs/sso/README.md) and the first reference
-integration, [Keycloak OIDC behind Keycloak](./docs/sso/providers/keycloak-oidc.md).
+See the [SSO provider guide](./docs/sso/README.md), the standards-based
+[generic OIDC integration](./docs/sso/providers/oidc.md), and the stricter
+[Keycloak OIDC reference](./docs/sso/providers/keycloak-oidc.md).
 
 The dedicated admin callback stores no Keycloak access, refresh, or ID token.
 It creates a short-lived opaque HttpOnly admin cookie plus a CSRF token;

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -7,6 +7,18 @@ specifically; the proxy has its own log in
 
 ## Unreleased
 
+### Added standards-based upstream OIDC provider control
+
+Product administrators can now configure a generic `oidc` upstream from its
+exact HTTPS issuer, client ID, and write-only client secret. AKB still asks its
+Keycloak broker to import discovery, but validates the returned issuer and
+HTTPS endpoints, renders only a bounded secure profile, and fingerprints that
+endpoint set so out-of-band drift fails closed. The profile uses authorization
+code flow with PKCE S256, JWKS signature validation, `client_secret_post`, and
+starts disabled. Microsoft Entra ID and distinct upstream Keycloak realms are
+covered as interoperability contracts; the existing Keycloak-specific provider
+remains available for compatibility and its stricter path/claim policy.
+
 ### Made product-admin callback failures recoverable
 
 Expired, malformed, or refused product-admin OIDC callbacks now return the

--- a/backend/app/sso/keycloak_admin.py
+++ b/backend/app/sso/keycloak_admin.py
@@ -645,7 +645,11 @@ class KeycloakProviderControl:
             if definition is None:
                 raise _fail("provider_alias_conflict")
             provider = self._readback(definition, representation)
-            if provider.state == "configuration_error" or provider.issuer is None:
+            if (
+                provider.state == "configuration_error"
+                or provider.issuer is None
+                or not provider.supports_identity_migration
+            ):
                 raise _fail("provider_configuration_invalid")
 
             user_base = (

--- a/backend/app/sso/providers/generic_oidc.py
+++ b/backend/app/sso/providers/generic_oidc.py
@@ -1,0 +1,362 @@
+"""Standards-based OIDC upstream brokered through Keycloak."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import hashlib
+import json
+from urllib.parse import quote, urlsplit
+
+from app.sso.models import ProviderConfigureSpec, ProviderReadback, ProviderState
+from app.sso.providers.keycloak_oidc import (
+    KEYCLOAK_PROVIDER_ID,
+    MARKER_SCHEMA_KEY,
+    MARKER_SCHEMA_VALUE,
+    MARKER_TYPE_KEY,
+    MASKED_SECRET,
+    ProviderDefinitionError,
+    _CLIENT_ID_RE,
+    _clean_text,
+    _config_string,
+    _https_url,
+    _issuer_identity,
+    _opaque_secret,
+    _secret_configured,
+    validate_alias,
+)
+
+
+PROVIDER_TYPE = "oidc"
+DISCOVERY_FINGERPRINT_KEY = "akbDiscoveryFingerprint"
+
+_REQUIRED_ENDPOINT_CODES = {
+    "authorizationUrl": "provider_discovery_authorization_url_invalid",
+    "tokenUrl": "provider_discovery_token_url_invalid",
+    "jwksUrl": "provider_discovery_jwks_url_invalid",
+}
+_OPTIONAL_ENDPOINT_KEYS = (
+    "userInfoUrl",
+    "logoutUrl",
+    "tokenIntrospectionUrl",
+)
+
+
+def _https_endpoint_url(value: str, *, code: str) -> str:
+    """Validate an absolute OIDC endpoint while preserving its query component."""
+
+    cleaned = _clean_text(value, maximum=2048, code=code)
+    try:
+        parsed = urlsplit(cleaned)
+        port = parsed.port
+    except ValueError as exc:
+        raise ProviderDefinitionError(code) from exc
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.fragment
+        or any(character.isspace() for character in cleaned)
+        or (port is not None and not 1 <= port <= 65535)
+    ):
+        raise ProviderDefinitionError(code)
+    return cleaned
+
+
+def validate_spec(
+    spec: ProviderConfigureSpec,
+    *,
+    broker_issuer: str,
+) -> ProviderConfigureSpec:
+    if spec.provider_type != PROVIDER_TYPE:
+        raise ProviderDefinitionError("provider_type_mismatch")
+    alias = validate_alias(spec.alias)
+    display_name = _clean_text(
+        spec.display_name,
+        maximum=80,
+        code="provider_display_name_invalid",
+    )
+    issuer = _https_url(spec.issuer, code="provider_issuer_invalid").rstrip("/")
+    if _issuer_identity(issuer) == _issuer_identity(broker_issuer):
+        raise ProviderDefinitionError("provider_issuer_is_broker")
+    discovery_url = _https_url(
+        spec.discovery_url,
+        code="provider_discovery_url_invalid",
+    )
+    if discovery_url != f"{issuer}/.well-known/openid-configuration":
+        raise ProviderDefinitionError("provider_discovery_url_mismatch")
+    client_id = _clean_text(
+        spec.client_id,
+        maximum=255,
+        code="provider_client_id_invalid",
+    )
+    if not _CLIENT_ID_RE.fullmatch(client_id):
+        raise ProviderDefinitionError("provider_client_id_invalid")
+    secret = spec.client_secret
+    if secret is not None:
+        secret = _opaque_secret(secret, code="provider_client_secret_invalid")
+    return ProviderConfigureSpec(
+        provider_type=PROVIDER_TYPE,
+        alias=alias,
+        display_name=display_name,
+        issuer=issuer,
+        discovery_url=discovery_url,
+        client_id=client_id,
+        client_secret=secret,
+    )
+
+
+def is_managed_representation(value: Mapping[str, object]) -> bool:
+    config = value.get("config")
+    return bool(
+        isinstance(config, dict)
+        and config.get(MARKER_TYPE_KEY) == PROVIDER_TYPE
+        and config.get(MARKER_SCHEMA_KEY) == MARKER_SCHEMA_VALUE
+    )
+
+
+def _validated_endpoints(imported: Mapping[str, object]) -> dict[str, str]:
+    endpoints: dict[str, str] = {}
+    for key, code in _REQUIRED_ENDPOINT_CODES.items():
+        value = imported.get(key)
+        if not isinstance(value, str):
+            raise ProviderDefinitionError(code)
+        endpoints[key] = _https_endpoint_url(value, code=code)
+    for key in _OPTIONAL_ENDPOINT_KEYS:
+        value = imported.get(key)
+        if value is None:
+            continue
+        if not isinstance(value, str):
+            raise ProviderDefinitionError("provider_discovery_optional_url_invalid")
+        endpoints[key] = _https_endpoint_url(
+            value,
+            code="provider_discovery_optional_url_invalid",
+        )
+    return endpoints
+
+
+def _endpoint_fingerprint(
+    *,
+    issuer: str,
+    discovery_url: str,
+    endpoints: Mapping[str, str],
+) -> str:
+    payload = {
+        "discovery_url": discovery_url,
+        "endpoints": dict(sorted(endpoints.items())),
+        "issuer": issuer,
+    }
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def render_representation(
+    spec: ProviderConfigureSpec,
+    imported: Mapping[str, object],
+    *,
+    preserve_secret: bool,
+) -> dict[str, object]:
+    if imported.get("issuer") != spec.issuer:
+        raise ProviderDefinitionError("provider_discovery_issuer_mismatch")
+    endpoints = _validated_endpoints(imported)
+    config: dict[str, str] = {
+        "issuer": spec.issuer,
+        **endpoints,
+        "useJwksUrl": "true",
+        "validateSignature": "true",
+        "clientId": spec.client_id,
+        "clientSecret": MASKED_SECRET if preserve_secret else spec.client_secret or "",
+        # client_secret_post is advertised by Entra and accepted by Keycloak;
+        # it avoids hard-coding a provider family while keeping one bounded
+        # confidential-client profile for the generic contribution.
+        "clientAuthMethod": "client_secret_post",
+        "defaultScope": "openid profile email",
+        "syncMode": "FORCE",
+        "pkceEnabled": "true",
+        "pkceMethod": "S256",
+        "metadataDescriptorUrl": spec.discovery_url,
+        MARKER_TYPE_KEY: PROVIDER_TYPE,
+        MARKER_SCHEMA_KEY: MARKER_SCHEMA_VALUE,
+    }
+    config[DISCOVERY_FINGERPRINT_KEY] = _endpoint_fingerprint(
+        issuer=spec.issuer,
+        discovery_url=spec.discovery_url,
+        endpoints=endpoints,
+    )
+    return {
+        "alias": spec.alias,
+        "displayName": spec.display_name,
+        "providerId": KEYCLOAK_PROVIDER_ID,
+        "enabled": False,
+        # The product administrator explicitly trusts the selected issuer as
+        # the profile authority. AKB still resolves identity only by signed
+        # issuer/subject; email is mutable profile and collision data and can
+        # never adopt an existing account.
+        "trustEmail": True,
+        "storeToken": False,
+        "addReadTokenRoleOnCreate": False,
+        "authenticateByDefault": False,
+        "linkOnly": False,
+        "hideOnLogin": True,
+        "firstBrokerLoginFlowAlias": "first broker login",
+        "config": config,
+    }
+
+
+def with_enabled(
+    representation: Mapping[str, object],
+    *,
+    enabled: bool,
+) -> dict[str, object]:
+    updated = dict(representation)
+    updated["enabled"] = enabled
+    updated["hideOnLogin"] = not enabled
+    return updated
+
+
+def _readback_endpoints(config: Mapping[str, object]) -> dict[str, str]:
+    endpoints: dict[str, str] = {}
+    for key, code in _REQUIRED_ENDPOINT_CODES.items():
+        value = _config_string(config, key)
+        if value is None:
+            raise ProviderDefinitionError(code)
+        endpoints[key] = _https_endpoint_url(value, code=code)
+    for key in _OPTIONAL_ENDPOINT_KEYS:
+        raw = config.get(key)
+        if raw is None:
+            continue
+        if not isinstance(raw, str) or not raw:
+            raise ProviderDefinitionError("provider_discovery_optional_url_invalid")
+        endpoints[key] = _https_endpoint_url(
+            raw,
+            code="provider_discovery_optional_url_invalid",
+        )
+    return endpoints
+
+
+def readback(
+    representation: Mapping[str, object],
+    *,
+    broker_base_url: str,
+    broker_issuer: str,
+    realm: str,
+) -> ProviderReadback:
+    config_value = representation.get("config")
+    config: Mapping[str, object] = config_value if isinstance(config_value, dict) else {}
+    alias_value = representation.get("alias")
+    raw_alias = alias_value if isinstance(alias_value, str) else ""
+    alias_is_valid = True
+    try:
+        alias = validate_alias(raw_alias)
+    except ProviderDefinitionError:
+        alias = ""
+        alias_is_valid = False
+    display_value = representation.get("displayName")
+    display_is_valid = True
+    try:
+        display_name = _clean_text(
+            display_value if isinstance(display_value, str) else "",
+            maximum=80,
+            code="provider_display_name_invalid",
+        )
+    except ProviderDefinitionError:
+        display_name = alias
+        display_is_valid = False
+    secret_configured = _secret_configured(config)
+    raw_issuer = _config_string(config, "issuer")
+    raw_discovery_url = _config_string(config, "metadataDescriptorUrl")
+    raw_client_id = _config_string(config, "clientId")
+    issuer: str | None = None
+    discovery_url: str | None = None
+    client_id: str | None = None
+    supports_logout = False
+    values_are_valid = False
+    if (
+        alias_is_valid
+        and display_is_valid
+        and raw_issuer is not None
+        and raw_discovery_url is not None
+        and raw_client_id is not None
+    ):
+        try:
+            validated = validate_spec(
+                ProviderConfigureSpec(
+                    provider_type=PROVIDER_TYPE,
+                    alias=alias,
+                    display_name=display_name,
+                    issuer=raw_issuer,
+                    discovery_url=raw_discovery_url,
+                    client_id=raw_client_id,
+                    client_secret=MASKED_SECRET,
+                ),
+                broker_issuer=broker_issuer,
+            )
+            endpoints = _readback_endpoints(config)
+            expected_fingerprint = _endpoint_fingerprint(
+                issuer=validated.issuer,
+                discovery_url=validated.discovery_url,
+                endpoints=endpoints,
+            )
+            if config.get(DISCOVERY_FINGERPRINT_KEY) != expected_fingerprint:
+                raise ProviderDefinitionError("provider_readback_url_invalid")
+            issuer = validated.issuer
+            discovery_url = validated.discovery_url
+            client_id = validated.client_id
+            supports_logout = "logoutUrl" in endpoints
+            values_are_valid = True
+        except ProviderDefinitionError:
+            values_are_valid = False
+    common_matches = all(
+        (
+            values_are_valid,
+            representation.get("providerId") == KEYCLOAK_PROVIDER_ID,
+            representation.get("trustEmail") is True,
+            representation.get("storeToken") is False,
+            representation.get("addReadTokenRoleOnCreate") is False,
+            representation.get("authenticateByDefault") is False,
+            representation.get("linkOnly") is False,
+            representation.get("firstBrokerLoginFlowAlias") == "first broker login",
+            config.get(MARKER_TYPE_KEY) == PROVIDER_TYPE,
+            config.get(MARKER_SCHEMA_KEY) == MARKER_SCHEMA_VALUE,
+            config.get("useJwksUrl") == "true",
+            config.get("validateSignature") == "true",
+            config.get("clientAuthMethod") == "client_secret_post",
+            config.get("defaultScope") == "openid profile email",
+            config.get("syncMode") == "FORCE",
+            config.get("pkceEnabled") == "true",
+            config.get("pkceMethod") == "S256",
+            secret_configured,
+        )
+    )
+    enabled = representation.get("enabled") is True
+    hidden = representation.get("hideOnLogin") is True
+    if common_matches and enabled and not hidden:
+        state: ProviderState = "enabled"
+    elif common_matches and not enabled and hidden:
+        state = "configured_disabled"
+    else:
+        state = "configuration_error"
+    redirect_uri = (
+        f"{broker_base_url.rstrip('/')}/realms/{quote(realm, safe='')}/broker/"
+        f"{quote(alias, safe='')}/endpoint"
+    )
+    return ProviderReadback(
+        provider_type=PROVIDER_TYPE,
+        alias=alias,
+        display_name=display_name,
+        state=state,
+        enabled=enabled,
+        issuer=issuer,
+        discovery_url=discovery_url,
+        client_id=client_id,
+        client_secret_configured=secret_configured,
+        redirect_uri=redirect_uri,
+        post_logout_redirect_uri=f"{redirect_uri}/logout_response",
+        supports_logout=supports_logout,
+        supports_identity_migration=False,
+    )

--- a/backend/app/sso/registry.py
+++ b/backend/app/sso/registry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from types import ModuleType
 
-from app.sso.providers import keycloak_oidc
+from app.sso.providers import generic_oidc, keycloak_oidc
 
 
 @dataclass(frozen=True, slots=True)
@@ -18,6 +18,10 @@ _DEFINITIONS = {
     keycloak_oidc.PROVIDER_TYPE: ProviderDefinition(
         provider_type=keycloak_oidc.PROVIDER_TYPE,
         module=keycloak_oidc,
+    ),
+    generic_oidc.PROVIDER_TYPE: ProviderDefinition(
+        provider_type=generic_oidc.PROVIDER_TYPE,
+        module=generic_oidc,
     ),
 }
 

--- a/backend/tests/fixtures/admin_sso_provider_catalog_v1.json
+++ b/backend/tests/fixtures/admin_sso_provider_catalog_v1.json
@@ -3,7 +3,8 @@
   "auth_mode": "sso",
   "control_mode": "direct",
   "supported_provider_types": [
-    "keycloak-oidc"
+    "keycloak-oidc",
+    "oidc"
   ],
   "providers": [
     {

--- a/backend/tests/test_generic_oidc_provider_contract_unit.py
+++ b/backend/tests/test_generic_oidc_provider_contract_unit.py
@@ -1,0 +1,308 @@
+"""Fail-closed contract for standards-based OIDC brokered through Keycloak."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import replace
+
+import pytest
+
+from app.sso.models import ProviderConfigureSpec
+from app.sso.providers import generic_oidc
+from app.sso.providers.keycloak_oidc import ProviderDefinitionError
+
+
+_BROKER_BASE_URL = "https://auth.akb.example.com"
+_BROKER_ISSUER = f"{_BROKER_BASE_URL}/realms/akb"
+_TENANT_ID = "ade9ac17-851e-48d0-ba36-ed99a8d8c07e"
+_UPSTREAM_ISSUER = f"https://login.microsoftonline.com/{_TENANT_ID}/v2.0"
+_CLIENT_ID = "6fd50bdd-9701-4244-a489-0059e8baba49"
+_SECRET = "oidc-client-secret-must-not-leak"  # pragma: allowlist secret
+
+
+def _spec(**changes: object) -> ProviderConfigureSpec:
+    values: dict[str, object] = {
+        "provider_type": "oidc",
+        "alias": "entra-dn",
+        "display_name": "Microsoft Teams",
+        "issuer": _UPSTREAM_ISSUER,
+        "discovery_url": f"{_UPSTREAM_ISSUER}/.well-known/openid-configuration",
+        "client_id": _CLIENT_ID,
+        "client_secret": _SECRET,
+    }
+    values.update(changes)
+    return ProviderConfigureSpec(**values)  # type: ignore[arg-type]
+
+
+def _imported(**changes: object) -> dict[str, object]:
+    values: dict[str, object] = {
+        "issuer": _UPSTREAM_ISSUER,
+        "authorizationUrl": (
+            f"https://login.microsoftonline.com/{_TENANT_ID}/oauth2/v2.0/authorize"
+        ),
+        "tokenUrl": (
+            f"https://login.microsoftonline.com/{_TENANT_ID}/oauth2/v2.0/token"
+        ),
+        "jwksUrl": (
+            f"https://login.microsoftonline.com/{_TENANT_ID}/discovery/v2.0/keys"
+        ),
+        "userInfoUrl": "https://graph.microsoft.com/oidc/userinfo",
+        "logoutUrl": (
+            f"https://login.microsoftonline.com/{_TENANT_ID}/oauth2/v2.0/logout"
+        ),
+    }
+    values.update(changes)
+    return values
+
+
+def _oidc_readback(*, enabled: bool = False) -> dict[str, object]:
+    rendered = generic_oidc.render_representation(
+        _spec(),
+        _imported(untrustedImportedField="must-not-pass-through"),
+        preserve_secret=False,
+    )
+    config = rendered["config"]
+    assert isinstance(config, dict)
+    config["clientSecret"] = generic_oidc.MASKED_SECRET
+    return generic_oidc.with_enabled(rendered, enabled=enabled)
+
+
+def _readback(representation: dict[str, object]):
+    return generic_oidc.readback(
+        representation,
+        broker_base_url=_BROKER_BASE_URL,
+        broker_issuer=_BROKER_ISSUER,
+        realm="akb",
+    )
+
+
+def test_entra_discovery_renders_a_generic_disabled_security_profile():
+    spec = generic_oidc.validate_spec(_spec(), broker_issuer=_BROKER_ISSUER)
+    rendered = generic_oidc.render_representation(
+        spec,
+        _imported(untrustedImportedField="must-not-pass-through"),
+        preserve_secret=False,
+    )
+
+    assert rendered["providerId"] == "oidc"
+    assert rendered["enabled"] is False
+    assert rendered["hideOnLogin"] is True
+    assert rendered["trustEmail"] is True
+    config = rendered["config"]
+    assert isinstance(config, dict)
+    assert config["clientSecret"] == _SECRET
+    assert config["clientAuthMethod"] == "client_secret_post"
+    assert config["validateSignature"] == "true"
+    assert config["useJwksUrl"] == "true"
+    assert config["pkceEnabled"] == "true"
+    assert config["pkceMethod"] == "S256"
+    assert config["syncMode"] == "FORCE"
+    assert config["akbProviderType"] == "oidc"
+    assert config["userInfoUrl"] == "https://graph.microsoft.com/oidc/userinfo"
+    assert "claimFilterName" not in config
+    assert "untrustedImportedField" not in config
+    assert len(config["akbDiscoveryFingerprint"]) == 64
+
+
+def test_generic_oidc_accepts_keycloak_discovery_without_a_provider_branch():
+    issuer = "https://identity.example.com/realms/workforce"
+    spec = generic_oidc.validate_spec(
+        _spec(
+            issuer=issuer,
+            discovery_url=f"{issuer}/.well-known/openid-configuration",
+            client_id="akb-broker",
+        ),
+        broker_issuer=_BROKER_ISSUER,
+    )
+    rendered = generic_oidc.render_representation(
+        spec,
+        {
+            "issuer": issuer,
+            "authorizationUrl": f"{issuer}/protocol/openid-connect/auth",
+            "tokenUrl": f"{issuer}/protocol/openid-connect/token",
+            "jwksUrl": f"{issuer}/protocol/openid-connect/certs",
+            "userInfoUrl": f"{issuer}/protocol/openid-connect/userinfo",
+            "logoutUrl": f"{issuer}/protocol/openid-connect/logout",
+        },
+        preserve_secret=False,
+    )
+
+    assert rendered["enabled"] is False
+    config = rendered["config"]
+    assert isinstance(config, dict)
+    assert config["issuer"] == issuer
+
+
+def test_generic_oidc_preserves_standard_endpoint_query_components():
+    spec = generic_oidc.validate_spec(_spec(), broker_issuer=_BROKER_ISSUER)
+
+    rendered = generic_oidc.render_representation(
+        spec,
+        _imported(
+            authorizationUrl=(
+                f"https://login.microsoftonline.com/{_TENANT_ID}/oauth2/v2.0/authorize"
+                "?slice=workforce"
+            )
+        ),
+        preserve_secret=False,
+    )
+
+    config = rendered["config"]
+    assert isinstance(config, dict)
+    assert config["authorizationUrl"].endswith("?slice=workforce")
+
+
+@pytest.mark.parametrize(
+    ("changes", "code"),
+    [
+        ({"provider_type": "keycloak-oidc"}, "provider_type_mismatch"),
+        ({"issuer": "http://identity.example.com"}, "provider_issuer_invalid"),
+        (
+            {
+                "issuer": f"{_BROKER_ISSUER}/",
+                "discovery_url": f"{_BROKER_ISSUER}/.well-known/openid-configuration",
+            },
+            "provider_issuer_is_broker",
+        ),
+        (
+            {"discovery_url": "https://login.microsoftonline.com/custom"},
+            "provider_discovery_url_mismatch",
+        ),
+        ({"client_id": "client id with spaces"}, "provider_client_id_invalid"),
+    ],
+)
+def test_generic_configuration_rejects_invalid_authority_or_client(changes, code):
+    with pytest.raises(ProviderDefinitionError) as captured:
+        generic_oidc.validate_spec(_spec(**changes), broker_issuer=_BROKER_ISSUER)
+
+    assert captured.value.code == code
+    assert _SECRET not in f"{captured.value!s} {captured.value!r}"
+
+
+@pytest.mark.parametrize(
+    ("changes", "code"),
+    [
+        (
+            {"issuer": "https://different.example.com"},
+            "provider_discovery_issuer_mismatch",
+        ),
+        (
+            {"authorizationUrl": "http://identity.example.com/authorize"},
+            "provider_discovery_authorization_url_invalid",
+        ),
+        (
+            {"tokenUrl": "not-a-url"},
+            "provider_discovery_token_url_invalid",
+        ),
+        (
+            {"jwksUrl": "file:///keys"},
+            "provider_discovery_jwks_url_invalid",
+        ),
+        (
+            {"userInfoUrl": "http://graph.example.com/userinfo"},
+            "provider_discovery_optional_url_invalid",
+        ),
+        (
+            {"userInfoUrl": "https://graph.example.com/user info"},
+            "provider_discovery_optional_url_invalid",
+        ),
+        (
+            {"userInfoUrl": "https://graph.example.com/userinfo#fragment"},
+            "provider_discovery_optional_url_invalid",
+        ),
+        (
+            {"logoutUrl": 7},
+            "provider_discovery_optional_url_invalid",
+        ),
+    ],
+)
+def test_generic_discovery_rejects_mismatched_issuer_or_non_https_endpoints(changes, code):
+    spec = generic_oidc.validate_spec(_spec(), broker_issuer=_BROKER_ISSUER)
+
+    with pytest.raises(ProviderDefinitionError) as captured:
+        generic_oidc.render_representation(
+            spec,
+            _imported(**changes),
+            preserve_secret=False,
+        )
+
+    assert captured.value.code == code
+
+
+def test_generic_readback_detects_endpoint_drift_with_the_discovery_fingerprint():
+    representation = _oidc_readback(enabled=True)
+    config = representation["config"]
+    assert isinstance(config, dict)
+    config["tokenUrl"] = "https://tokens.example.com/oauth/token"
+
+    assert _readback(representation).state == "configuration_error"
+
+
+def test_generic_readback_recognizes_only_exact_disabled_and_enabled_profiles():
+    disabled = _readback(_oidc_readback())
+    enabled = _readback(_oidc_readback(enabled=True))
+
+    assert disabled.state == "configured_disabled"
+    assert enabled.state == "enabled"
+    assert enabled.client_secret_configured is True
+    assert enabled.redirect_uri == (
+        "https://auth.akb.example.com/realms/akb/broker/entra-dn/endpoint"
+    )
+    assert enabled.post_logout_redirect_uri == (
+        "https://auth.akb.example.com/realms/akb/broker/entra-dn/endpoint/logout_response"
+    )
+    assert enabled.supports_logout is True
+    assert enabled.supports_identity_migration is False
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        (("providerId",), "saml"),
+        (("trustEmail",), False),
+        (("config", "clientAuthMethod"), "client_secret_basic"),
+        (("config", "validateSignature"), "false"),
+        (("config", "akbDiscoveryFingerprint"), "0" * 64),
+        (("config", "clientSecret"), ""),
+    ],
+)
+def test_generic_readback_fails_closed_on_profile_drift(path, value):
+    representation = _oidc_readback(enabled=True)
+    target = representation
+    for key in path[:-1]:
+        nested = target[key]
+        assert isinstance(nested, dict)
+        target = nested
+    target[path[-1]] = value
+
+    assert _readback(representation).state == "configuration_error"
+
+
+def test_generic_reconfigure_preserves_only_keycloaks_masked_secret_sentinel():
+    rendered = generic_oidc.render_representation(
+        replace(_spec(), client_secret=None),
+        _imported(),
+        preserve_secret=True,
+    )
+
+    config = rendered["config"]
+    assert isinstance(config, dict)
+    assert config["clientSecret"] == generic_oidc.MASKED_SECRET
+
+
+def test_generic_readback_is_secret_free_and_does_not_mutate_representation():
+    representation = _oidc_readback(enabled=True)
+    before = deepcopy(representation)
+
+    provider = _readback(representation)
+    rendered = repr(
+        (
+            provider.admin_view(),
+            provider.public_view(login_url="/login"),
+            provider.audit_view(),
+        )
+    )
+
+    assert representation == before
+    assert _SECRET not in rendered
+    assert generic_oidc.MASKED_SECRET not in rendered

--- a/backend/tests/test_sso_keycloak_admin_unit.py
+++ b/backend/tests/test_sso_keycloak_admin_unit.py
@@ -23,6 +23,8 @@ _SECRET = "upstream-client-secret-must-not-leak"  # pragma: allowlist secret
 _NEW_SECRET = "rotated-client-secret-must-not-leak"  # pragma: allowlist secret
 _MANAGEMENT_SECRET = "management-secret-must-not-leak"  # pragma: allowlist secret
 _ISSUER = "https://accounts.example.com/realms/workforce"
+_ENTRA_TENANT = "ade9ac17-851e-48d0-ba36-ed99a8d8c07e"
+_ENTRA_ISSUER = f"https://login.microsoftonline.com/{_ENTRA_TENANT}/v2.0"
 
 
 def _config(*, management_secret: str = _MANAGEMENT_SECRET) -> KeycloakAdminConfig:
@@ -44,6 +46,20 @@ def _spec(**changes: object) -> ProviderConfigureSpec:
         "issuer": _ISSUER,
         "discovery_url": f"{_ISSUER}/.well-known/openid-configuration",
         "client_id": "akb-broker",
+        "client_secret": _SECRET,
+    }
+    values.update(changes)
+    return ProviderConfigureSpec(**values)  # type: ignore[arg-type]
+
+
+def _generic_spec(**changes: object) -> ProviderConfigureSpec:
+    values: dict[str, object] = {
+        "provider_type": "oidc",
+        "alias": "entra-dn",
+        "display_name": "Microsoft Teams",
+        "issuer": _ENTRA_ISSUER,
+        "discovery_url": f"{_ENTRA_ISSUER}/.well-known/openid-configuration",
+        "client_id": "6fd50bdd-9701-4244-a489-0059e8baba49",
         "client_secret": _SECRET,
     }
     values.update(changes)
@@ -82,10 +98,32 @@ class KeycloakFixture:
             return httpx.Response(500, text=f"never expose {_SECRET} {_MANAGEMENT_SECRET}")
         if path == "/auth/admin/realms/akb/identity-provider/import-config":
             body = json.loads(request.content)
-            assert body == {
-                "providerId": "oidc",
-                "fromUrl": f"{_ISSUER}/.well-known/openid-configuration",
-            }
+            assert body["providerId"] == "oidc"
+            if body["fromUrl"] == f"{_ENTRA_ISSUER}/.well-known/openid-configuration":
+                return httpx.Response(
+                    200,
+                    json={
+                        "issuer": _ENTRA_ISSUER,
+                        "authorizationUrl": (
+                            f"https://login.microsoftonline.com/{_ENTRA_TENANT}"
+                            "/oauth2/v2.0/authorize"
+                        ),
+                        "tokenUrl": (
+                            f"https://login.microsoftonline.com/{_ENTRA_TENANT}"
+                            "/oauth2/v2.0/token"
+                        ),
+                        "jwksUrl": (
+                            f"https://login.microsoftonline.com/{_ENTRA_TENANT}"
+                            "/discovery/v2.0/keys"
+                        ),
+                        "userInfoUrl": "https://graph.microsoft.com/oidc/userinfo",
+                        "logoutUrl": (
+                            f"https://login.microsoftonline.com/{_ENTRA_TENANT}"
+                            "/oauth2/v2.0/logout"
+                        ),
+                    },
+                )
+            assert body["fromUrl"] == f"{_ISSUER}/.well-known/openid-configuration"
             return httpx.Response(
                 200,
                 json={
@@ -191,6 +229,38 @@ async def test_configure_creates_disabled_then_exactly_reads_back():
     assert isinstance(config, dict)
     assert config["clientSecret"] == _SECRET
     assert "untrustedImportedField" not in config
+
+
+async def test_generic_oidc_configure_accepts_entra_discovery_without_provider_code():
+    fixture = KeycloakFixture()
+    control = _control(fixture)
+
+    provider = (await control.configure(_generic_spec())).after
+
+    assert provider.provider_type == "oidc"
+    assert provider.state == "configured_disabled"
+    assert provider.redirect_uri.endswith("/broker/entra-dn/endpoint")
+    stored = fixture.providers["entra-dn"]
+    config = stored["config"]
+    assert isinstance(config, dict)
+    assert config["clientAuthMethod"] == "client_secret_post"
+    assert config["userInfoUrl"] == "https://graph.microsoft.com/oidc/userinfo"
+
+
+async def test_generic_oidc_does_not_silently_inherit_keycloak_identity_migration():
+    fixture = KeycloakFixture()
+    control = _control(fixture)
+    await control.configure(_generic_spec())
+
+    with pytest.raises(ProviderControlError) as captured:
+        await control.verify_identity_prelink(
+            "entra-dn",
+            broker_subject="22222222-2222-2222-2222-222222222222",
+            upstream_subject="opaque-upstream-subject",
+        )
+
+    assert captured.value.code == "provider_configuration_invalid"
+    assert all("/users/" not in path for _, path in fixture.requests)
 
 
 async def test_configure_rejects_a_valid_but_non_exact_readback():

--- a/backend/tests/test_sso_provider_contract_unit.py
+++ b/backend/tests/test_sso_provider_contract_unit.py
@@ -8,7 +8,7 @@ from dataclasses import replace
 import pytest
 
 from app.sso.models import ProviderConfigureSpec
-from app.sso.providers import keycloak_oidc
+from app.sso.providers import generic_oidc, keycloak_oidc
 from app.sso.providers.keycloak_oidc import ProviderDefinitionError
 from app.sso.registry import provider_definition, provider_types
 
@@ -68,10 +68,14 @@ def _readback(representation: dict[str, object]):
 
 
 def test_registry_is_explicit_and_contains_only_the_reference_provider():
-    assert provider_types() == ("keycloak-oidc",)
+    assert provider_types() == ("keycloak-oidc", "oidc")
     definition = provider_definition("keycloak-oidc")
     assert definition.provider_type == "keycloak-oidc"
     assert definition.module is keycloak_oidc
+
+    oidc_definition = provider_definition("oidc")
+    assert oidc_definition.provider_type == "oidc"
+    assert oidc_definition.module is generic_oidc
 
     with pytest.raises(ValueError, match="unsupported_sso_provider_type"):
         provider_definition("arbitrary-keycloak-json")

--- a/docs/design/accepted/2026-08-28-generic-oidc-provider/README.md
+++ b/docs/design/accepted/2026-08-28-generic-oidc-provider/README.md
@@ -1,0 +1,74 @@
+---
+status: accepted
+stage: implementation
+created: 2026-08-28
+updated: 2026-08-28
+---
+
+# Generic OIDC Provider Control
+
+## Context
+
+AKB's first runtime-managed upstream contribution, `keycloak-oidc`, proves a
+strict Keycloak-to-Keycloak broker profile. Its discovery checks intentionally
+pin Keycloak endpoint paths and verified-email behavior. Applying that provider
+type to another standards-based issuer fails even when Keycloak successfully
+imports the discovery document.
+
+OIDC discovery already supplies the issuer and protocol endpoints. Requiring a
+new vendor-specific provider module for every standards-compatible issuer adds
+product coupling without improving the ordinary configuration workflow.
+
+## Decision
+
+AKB adds a built-in `oidc` provider type for issuer-driven upstreams while
+retaining `keycloak-oidc` unchanged for compatibility and its stricter profile.
+
+The generic contribution:
+
+- requires an exact HTTPS issuer and derives the standard discovery URL;
+- rejects the AKB broker realm as its own upstream;
+- requires the imported discovery issuer to exactly match configuration;
+- accepts only HTTPS authorization, token, JWKS, and optional user-info,
+  logout, and introspection endpoints;
+- renders a bounded authorization-code profile with PKCE S256, JWKS signature
+  validation, `client_secret_post`, fixed scopes, no upstream token storage,
+  and disabled-by-default activation;
+- fingerprints the validated issuer/discovery/endpoint set and fails read-back
+  closed after out-of-band drift; and
+- does not inherit provider-specific identity-migration capability.
+
+The endpoint set may span HTTPS origins because standards-based providers can
+separate identity, token, key, and user-info services. Product-admin authority
+therefore remains identity-network-egress authority; deployments narrow that
+authority with network policy rather than vendor branches in application code.
+
+The generic profile trusts the selected issuer for email profile data. AKB
+continues to resolve identities only by signed broker issuer and subject; email
+and username are mutable profile/collision fields and never adopt or authorize
+an existing account. A provider needing different client-authentication or
+claim-trust semantics remains an explicit provider contribution.
+
+## Compatibility
+
+Existing managed `keycloak-oidc` representations and their marker remain
+unchanged. Editing one preserves its provider type. New admin-form
+configurations use `oidc` when the backend advertises it and fall back to the
+first advertised type during a mixed-version rollout.
+
+A different Keycloak realm is a valid generic upstream. The exact broker realm
+is not, even when it runs on the same server.
+
+## Acceptance criteria
+
+- Microsoft Entra ID discovery configures and reads back disabled without a
+  vendor-specific code branch.
+- A distinct Keycloak realm configures through the same generic contribution.
+- HTTP, malformed, issuer-mismatched, and endpoint-drifted configurations fail
+  closed with value-less errors.
+- Secrets remain write-only and absent from admin, public, audit, test, and log
+  views.
+- Existing Keycloak-specific provider behavior remains green.
+
+Decision history and PM feedback are recorded in [`rounds/`](rounds/README.md)
+and [`feedback/`](feedback/README.md).

--- a/docs/design/accepted/2026-08-28-generic-oidc-provider/feedback/README.md
+++ b/docs/design/accepted/2026-08-28-generic-oidc-provider/feedback/README.md
@@ -1,0 +1,10 @@
+# PM feedback
+
+## 2026-08-28
+
+- Prefer issuer/discovery-driven OIDC configuration over adding a provider
+  implementation for every vendor.
+- Generic OIDC must also support a distinct upstream Keycloak realm.
+- The broker realm must not be allowed to point to itself as an upstream.
+- Keep configuration centered on issuer, client ID, and write-only secret
+  rather than exposing vendor selection as the primary workflow.

--- a/docs/design/accepted/2026-08-28-generic-oidc-provider/rounds/README.md
+++ b/docs/design/accepted/2026-08-28-generic-oidc-provider/rounds/README.md
@@ -1,0 +1,13 @@
+# Decision rounds
+
+## 2026-08-28 — Provider-specific versus issuer-driven control
+
+The initial repair option was a Microsoft Entra-specific contribution with
+tenant-pinned endpoint paths and client authentication. Review rejected that as
+unnecessary vendor coupling for a protocol discovery problem.
+
+The accepted revision adds one standards-based `oidc` contribution, keeps the
+existing strict Keycloak profile intact, and uses Microsoft Entra ID plus a
+distinct Keycloak realm as interoperability fixtures. Provider-specific code is
+reserved for a real client-authentication or claim-policy difference that the
+generic contract cannot state safely.

--- a/docs/sso/README.md
+++ b/docs/sso/README.md
@@ -115,8 +115,12 @@ operator. It does not retain the bootstrap credential.
 
 ## Built-in providers
 
+- [Generic OIDC](providers/oidc.md) configures standards-based upstreams from
+  issuer discovery without a vendor-specific provider branch. Microsoft Entra
+  ID and distinct Keycloak realms are covered compatibility fixtures.
 - [Keycloak OIDC behind Keycloak](providers/keycloak-oidc.md) is the first
-  reference contribution.
+  reference contribution and retains its stricter Keycloak endpoint and
+  verified-email profile for compatibility.
 
 Additional OSS providers should follow [Adding a provider](adding-a-provider.md).
 The registry is explicit and code-reviewed; AKB does not load arbitrary

--- a/docs/sso/providers/oidc.md
+++ b/docs/sso/providers/oidc.md
@@ -1,0 +1,81 @@
+# Generic OIDC behind Keycloak
+
+Provider type: `oidc`
+
+This integration brokers a standards-based OpenID Connect issuer through the
+Keycloak realm owned by an AKB SSO installation. It is issuer-driven rather
+than vendor-driven: Microsoft Entra ID, another Keycloak realm, and other
+compatible providers use the same contribution.
+
+The upstream issuer must be distinct from the AKB broker realm. Another realm
+on the same Keycloak server is valid; pointing the broker realm back at itself
+is rejected because it creates a circular trust and login loop.
+
+## Upstream client
+
+Create a confidential OIDC client with:
+
+- authorization code flow enabled;
+- a client secret and `client_secret_post` token-endpoint authentication;
+- PKCE method `S256`;
+- scopes `openid profile email`;
+- the exact broker redirect URI shown after AKB saves the provider disabled.
+
+The redirect URI has this shape:
+
+```text
+https://<broker-host>/realms/<akb-realm>/broker/<alias>/endpoint
+```
+
+If the upstream supports RP-initiated logout, also register the displayed
+logout response URI where that provider requires an allowlist:
+
+```text
+https://<broker-host>/realms/<akb-realm>/broker/<alias>/endpoint/logout_response
+```
+
+## Configure in AKB
+
+1. Sign in at `/admin` with the product-administrator identity.
+2. Enter a stable alias, the user-facing button label, exact HTTPS issuer,
+   client ID, and client-secret value.
+3. Save the disabled configuration.
+4. Copy the read-back redirect URI into the upstream client registration.
+5. Enable the provider only after the redirect allowlist is exact.
+
+AKB derives `<issuer>/.well-known/openid-configuration` and asks its Keycloak
+broker to import it. The discovery document's issuer must exactly equal the
+configured issuer. Authorization, token, JWKS, and optional user-info, logout,
+and introspection endpoints must be HTTPS. AKB copies only those allowlisted
+fields into a fixed broker profile and stores a SHA-256 fingerprint of the
+validated set; an endpoint changed out of band enters `configuration_error`
+instead of remaining available for login.
+
+Discovery endpoints are allowed to use different HTTPS origins because OIDC
+providers legitimately split services (for example, an identity authority and
+a separate user-info service). Product-admin access therefore includes
+authority to select identity-network egress. Enforce installation-approved
+destinations with DNS, firewall, service mesh, or Kubernetes NetworkPolicy when
+that authority must be narrower.
+
+The generic profile treats the selected issuer as the authority for its email
+profile. AKB still resolves identity only by the signed broker `(issuer, sub)`;
+email and username are mutable profile and collision fields and never select or
+adopt an existing account. Providers used with open enrollment must supply an
+email claim. Use a provider-specific contribution when an organization needs a
+different client-authentication or claim-trust policy rather than making the
+generic profile silently guess.
+
+## Microsoft Entra ID example
+
+For a single-tenant workforce application, use:
+
+```text
+Issuer:    https://login.microsoftonline.com/<tenant-id>/v2.0
+Client ID: <Application (client) ID>
+Secret:    <client secret Value, not Secret ID>
+```
+
+Register the broker endpoint as a **Web** redirect URI. Use the tenant-specific
+issuer rather than `common` or `organizations` when the AKB installation is
+intended for one workforce tenant.

--- a/frontend/src/pages/__tests__/admin-auth-page.test.tsx
+++ b/frontend/src/pages/__tests__/admin-auth-page.test.tsx
@@ -79,7 +79,7 @@ const directCatalog = {
   schema_version: 1 as const,
   auth_mode: "sso" as const,
   control_mode: "direct" as const,
-  supported_provider_types: ["keycloak-oidc"],
+  supported_provider_types: ["keycloak-oidc", "oidc"],
   providers: [provider],
 };
 
@@ -266,12 +266,53 @@ describe("AdminPage mode boundary", () => {
 
     await waitFor(() => {
       expect(configureAdminSsoProvider).toHaveBeenCalledWith("partners", {
-        provider_type: "keycloak-oidc",
+        provider_type: "oidc",
         display_name: "Partner SSO",
         issuer: "https://id.example.com/realms/partners",
         discovery_url: "https://id.example.com/realms/partners/.well-known/openid-configuration",
         client_id: "akb-partners",
         client_secret: "one-time-input", // pragma: allowlist secret
+      });
+    });
+  });
+
+  it("configures Microsoft Entra through the generic OIDC provider", async () => {
+    vi.mocked(getAdminAuthConfig).mockResolvedValue(ssoConfig);
+    vi.mocked(getAdminSession).mockResolvedValue({
+      schema_version: 1,
+      auth_mode: "sso",
+      user: {
+        id: "11111111-1111-1111-1111-111111111111",
+        username: "admin",
+        email: "admin@example.com",
+        display_name: "Admin",
+        is_admin: true,
+      },
+    });
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(await screen.findByLabelText("Alias"), "entra-dn");
+    await user.type(screen.getByLabelText("Button label"), "Microsoft Teams");
+    await user.type(
+      screen.getByLabelText("Upstream issuer"),
+      "https://login.microsoftonline.com/ade9ac17-851e-48d0-ba36-ed99a8d8c07e/v2.0",
+    );
+    await user.type(screen.getByLabelText("Client ID"), "6fd50bdd-9701-4244-a489-0059e8baba49");
+    await user.type(screen.getByLabelText("Client secret"), "one-time-entra-input");
+    await user.click(screen.getByRole("button", { name: /Save disabled configuration/i }));
+
+    await waitFor(() => {
+      expect(configureAdminSsoProvider).toHaveBeenCalledWith("entra-dn", {
+        provider_type: "oidc",
+        display_name: "Microsoft Teams",
+        issuer: "https://login.microsoftonline.com/ade9ac17-851e-48d0-ba36-ed99a8d8c07e/v2.0",
+        discovery_url: (
+          "https://login.microsoftonline.com/ade9ac17-851e-48d0-ba36-ed99a8d8c07e/"
+          + "v2.0/.well-known/openid-configuration"
+        ),
+        client_id: "6fd50bdd-9701-4244-a489-0059e8baba49",
+        client_secret: "one-time-entra-input", // pragma: allowlist secret
       });
     });
   });

--- a/frontend/src/pages/admin.tsx
+++ b/frontend/src/pages/admin.tsx
@@ -193,6 +193,7 @@ export default function AdminPage() {
 }
 
 const EMPTY_PROVIDER_FORM = {
+  providerType: "oidc",
   alias: "",
   displayName: "",
   issuer: "",
@@ -227,6 +228,7 @@ function SsoProviderControl() {
 
   function editProvider(provider: AdminSsoProvider) {
     setForm({
+      providerType: provider.provider_type,
       alias: provider.alias,
       displayName: provider.display_name,
       issuer: provider.issuer || "",
@@ -243,9 +245,12 @@ function SsoProviderControl() {
     setNotice("");
     setSubmitting(true);
     const issuer = form.issuer.trim().replace(/\/+$/, "");
+    const providerType = catalog?.supported_provider_types.includes(form.providerType)
+      ? form.providerType
+      : catalog?.supported_provider_types[0] || form.providerType;
     try {
       await configureAdminSsoProvider(form.alias.trim(), {
-        provider_type: "keycloak-oidc",
+        provider_type: providerType,
         display_name: form.displayName.trim(),
         issuer,
         discovery_url: `${issuer}/.well-known/openid-configuration`,
@@ -348,7 +353,7 @@ function SsoProviderControl() {
       )}
 
       <Panel inset={false} flush>
-        <PanelHeader label="Keycloak OIDC provider" />
+        <PanelHeader label="OIDC provider" />
         <form className="grid gap-4 p-4 sm:grid-cols-2" onSubmit={saveProvider}>
           <AdminField label="Alias" id="sso-alias" value={form.alias} onChange={(value) => setField("alias", value)} pattern="[a-z0-9][a-z0-9._-]{0,62}" autoComplete="off" required />
           <AdminField label="Button label" id="sso-display-name" value={form.displayName} onChange={(value) => setField("displayName", value)} maxLength={80} autoComplete="organization" required />


### PR DESCRIPTION
## Summary

- add a vendor-neutral `oidc` provider driven by exact issuer discovery
- accept Microsoft Entra and distinct upstream Keycloak realms through one bounded profile
- preserve existing `keycloak-oidc` behavior and provider types during edits
- reject broker self-loops, malformed or insecure endpoints, drifted profiles, and unsupported identity migration

## Security profile

- authorization code flow with PKCE S256 and JWKS signature validation
- write-only client secret, disabled by default, no upstream token storage
- exact issuer match, HTTPS endpoints, allowlisted discovery fields, stored endpoint fingerprint

## Verification

- exact reviewed head: `19ad754418aab46e69e10d28f8af5e6b1d437ae7`
- `uv run --project backend --extra dev bash scripts/check.sh`
- backend static analysis and security scan passed
- SDK: 50 tests passed
- frontend: 673 tests passed
- generic OIDC focused contract: 26 tests passed

## Compatibility

Existing `keycloak-oidc` representations are unchanged. New configurations prefer `oidc` when advertised; the mixed-version frontend falls back to the first backend-supported provider type.
