### PR TITLE
fix(proxy): add modern tools list cache metadata

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,6 +41,12 @@ jobs:
           cache-dependency-path: |
             frontend/pnpm-lock.yaml
             packages/akb-client/pnpm-lock.yaml
+      - name: Install stdio proxy deps
+        working-directory: packages/akb-mcp-client
+        run: npm ci
+      - name: Test stdio proxy
+        working-directory: packages/akb-mcp-client
+        run: npm test
       - name: Install frontend deps
         working-directory: frontend
         # `--ignore-scripts` skips package postinstall hooks. We don't need

--- a/packages/akb-mcp-client/lib/proxy.mjs
+++ b/packages/akb-mcp-client/lib/proxy.mjs
@@ -414,6 +414,14 @@ function modernResult(result) {
   return output;
 }
 
+function modernToolsListResult(result) {
+  return {
+    ...modernResult(result),
+    ttlMs: 0,
+    cacheScope: "private",
+  };
+}
+
 function legacyResult(result) {
   const output = isObject(result) ? { ...result } : {};
   delete output.resultType;
@@ -649,6 +657,12 @@ export class AKBProxy {
     return this._clientGeneration === "modern" ? modernResult(result) : legacyResult(result);
   }
 
+  _clientToolsListResult(result) {
+    return this._clientGeneration === "modern"
+      ? modernToolsListResult(result)
+      : legacyResult(result);
+  }
+
   _vaultSkillCallKey(params) {
     if (!params?.name || !params.arguments || typeof params.arguments !== "object") {
       return null;
@@ -826,11 +840,11 @@ export class AKBProxy {
       return {
         jsonrpc: "2.0",
         id,
-        result: this._clientResult({ tools: this._fileToolsForClient() }),
+        result: this._clientToolsListResult({ tools: this._fileToolsForClient() }),
       };
     }
 
-    return { jsonrpc: "2.0", id, result: this._clientResult(this._decorateTools(resp)) };
+    return { jsonrpc: "2.0", id, result: this._clientToolsListResult(this._decorateTools(resp)) };
   }
 
   // ── File-to-content resolution ─────────────────────────

--- a/packages/akb-mcp-client/package-lock.json
+++ b/packages/akb-mcp-client/package-lock.json
@@ -1,0 +1,175 @@
+{
+  "name": "akb-mcp",
+  "version": "2.3.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "akb-mcp",
+      "version": "2.3.0",
+      "license": "MIT",
+      "bin": {
+        "akb-mcp": "bin/akb-mcp.mjs"
+      },
+      "devDependencies": {
+        "@modelcontextprotocol/client": "2.0.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "jose": "^6.1.3",
+        "pkce-challenge": "^5.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.10",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.10.tgz",
+      "integrity": "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/packages/akb-mcp-client/package.json
+++ b/packages/akb-mcp-client/package.json
@@ -10,6 +10,9 @@
     "test": "node test/contract.test.mjs && node test/reconnect.test.mjs && node test/protocol.test.mjs"
   },
   "type": "module",
+  "devDependencies": {
+    "@modelcontextprotocol/client": "2.0.0"
+  },
   "files": ["bin/", "lib/", "CHANGELOG.md"],
   "keywords": ["mcp", "akb", "knowledge-base", "claude-code", "cursor", "copilot", "ai-agent"],
   "license": "MIT",

--- a/packages/akb-mcp-client/test/protocol.test.mjs
+++ b/packages/akb-mcp-client/test/protocol.test.mjs
@@ -8,6 +8,8 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawn } from "node:child_process";
 import { createInterface } from "node:readline";
+import { Client } from "@modelcontextprotocol/client";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 import { AKBProxy } from "../lib/proxy.mjs";
 
 const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
@@ -18,6 +20,53 @@ const MODERN_META = {
   "io.modelcontextprotocol/clientCapabilities": {},
   "io.modelcontextprotocol/clientInfo": { name: "modern-test", version: "1" },
 };
+const FILE_TOOL_NAMES = [
+  "akb_put_file",
+  "akb_put_image",
+  "akb_discard_image",
+  "akb_get_file",
+  "akb_update_file",
+  "akb_delete_file",
+];
+const DEFAULT_BACKEND_TOOLS = [{
+  name: "akb_search",
+  description: "search",
+  inputSchema: { type: "object", properties: {} },
+}];
+const RICH_BACKEND_TOOLS = [
+  {
+    name: "akb_search",
+    description: "search",
+    inputSchema: {
+      type: "object",
+      properties: { query: { type: "string" } },
+      additionalProperties: false,
+    },
+    annotations: {
+      title: "Search",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  {
+    name: "akb_custom",
+    description: "preserve this tool contract",
+    inputSchema: {
+      type: "object",
+      properties: { mode: { type: "string" } },
+      additionalProperties: false,
+    },
+    annotations: {
+      title: "Custom",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+  },
+];
 
 function waitForLine(lines, id, timeoutMs = 3000) {
   const existing = lines.find((line) => line?.id === id);
@@ -32,7 +81,7 @@ function waitForLine(lines, id, timeoutMs = 3000) {
   });
 }
 
-async function fakeBackend({ legacyOnly = false } = {}) {
+async function fakeBackend({ legacyOnly = false, tools = DEFAULT_BACKEND_TOOLS } = {}) {
   const requests = [];
   const server = createServer(async (req, res) => {
     let raw = "";
@@ -64,13 +113,7 @@ async function fakeBackend({ legacyOnly = false } = {}) {
         capabilities: { tools: { listChanged: true } },
       };
     } else if (body.method === "tools/list") {
-      result = {
-        tools: [{
-          name: "akb_search",
-          description: "search",
-          inputSchema: { type: "object", properties: {} },
-        }],
-      };
+      result = { tools };
     } else {
       result = { content: [{ type: "text", text: "{}" }], isError: false };
     }
@@ -134,6 +177,77 @@ async function runProxy(url, messages) {
   }
 }
 
+async function withExternalModernClient(url, fn, { connectTimeoutMs = 50 } = {}) {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [proxyEntrypoint, "--url", url, "--pat", "akb_test"],
+    cwd: packageRoot,
+    env: {
+      PATH: process.env.PATH || "",
+      AKB_MCP_CONNECT_TIMEOUT_MS: String(connectTimeoutMs),
+    },
+    stderr: "pipe",
+  });
+  transport.stderr?.resume();
+  const client = new Client(
+    { name: "akb-235-external-parser", version: "1" },
+    { versionNegotiation: { mode: { pin: "2026-07-28" } } },
+  );
+
+  try {
+    await client.connect(transport, { timeout: 3000 });
+    return await fn(client);
+  } finally {
+    await client.close().catch(() => {});
+  }
+}
+
+async function testModernDegradedProcessWithExternalParser() {
+  await withExternalModernClient("http://127.0.0.1:1/mcp/", async (client) => {
+    const result = await client.listTools();
+
+    assert.equal(result.ttlMs, 0, "degraded modern tools/list is immediately stale");
+    assert.equal(result.cacheScope, "private", "degraded modern tools/list is private");
+    assert.deepEqual(
+      result.tools.map((tool) => tool.name),
+      FILE_TOOL_NAMES,
+      "degraded catalog still exposes only proxy-local file tools",
+    );
+  });
+}
+
+async function testModernReachableProcessWithExternalParser() {
+  const backend = await fakeBackend({ tools: RICH_BACKEND_TOOLS });
+  try {
+    await withExternalModernClient(backend.url, async (client) => {
+      const result = await client.listTools();
+
+      assert.equal(result.ttlMs, 0, "reachable modern tools/list is immediately stale");
+      assert.equal(result.cacheScope, "private", "reachable modern tools/list is private");
+      assert.deepEqual(
+        result.tools.slice(0, RICH_BACKEND_TOOLS.length),
+        RICH_BACKEND_TOOLS,
+        "backend tool schemas, ordering, and annotations are preserved",
+      );
+      assert.deepEqual(
+        result.tools.map((tool) => tool.name),
+        [...RICH_BACKEND_TOOLS.map((tool) => tool.name), ...FILE_TOOL_NAMES],
+        "proxy-local tools remain appended to the backend catalog",
+      );
+      assert.ok(backend.requests.some((request) => request.body.method === "tools/list"));
+      for (const request of backend.requests) {
+        assert.equal(request.headers.authorization, "Bearer akb_test");
+      }
+
+      const toolResult = await client.callTool({ name: "akb_search", arguments: {} });
+      assert.equal(toolResult.ttlMs, undefined, "cache metadata stays on tools/list only");
+      assert.equal(toolResult.cacheScope, undefined, "cache metadata stays on tools/list only");
+    }, { connectTimeoutMs: 1000 });
+  } finally {
+    await backend.close();
+  }
+}
+
 async function testModernProcess() {
   const backend = await fakeBackend();
   try {
@@ -143,7 +257,11 @@ async function testModernProcess() {
     ]);
     assert.equal(responses[0].result.supportedVersions[0], "2026-07-28");
     assert.equal(responses[0].result.resultType, "complete");
+    assert.equal(responses[0].result.ttlMs, undefined);
+    assert.equal(responses[0].result.cacheScope, undefined);
     assert.equal(responses[1].result.resultType, "complete");
+    assert.equal(responses[1].result.ttlMs, 0);
+    assert.equal(responses[1].result.cacheScope, "private");
     assert.ok(responses[1].result.tools.some((tool) => tool.name === "akb_put_file"));
     assert.ok(responses[1].result._meta["io.modelcontextprotocol/serverInfo"]);
 
@@ -182,6 +300,8 @@ async function testLegacyProcess() {
     assert.equal(responses[0].result.protocolVersion, "2025-06-18");
     assert.equal(responses[1].result.resultType, undefined);
     assert.equal(responses[1].result._meta, undefined);
+    assert.equal(responses[1].result.ttlMs, undefined);
+    assert.equal(responses[1].result.cacheScope, undefined);
     assert.ok(responses[1].result.tools.some((tool) => tool.name === "akb_search"));
 
     for (const request of backend.requests) {
@@ -266,6 +386,8 @@ async function testGenerationMixingIsFailClosed() {
   assert.equal(legacyHandshake.error.code, -32022);
 }
 
+await testModernDegradedProcessWithExternalParser();
+await testModernReachableProcessWithExternalParser();
 await testModernProcess();
 await testLegacyProcess();
 await testLegacyBackendFallback();

--- a/packages/akb-mcp-client/test/reconnect.test.mjs
+++ b/packages/akb-mcp-client/test/reconnect.test.mjs
@@ -176,6 +176,22 @@ itAsync("tools/list serves the full decorated list from cache", async () => {
   );
 });
 
+itAsync("modern tools/list cache metadata covers degraded and cached catalogs", async () => {
+  const proxy = newProxy();
+  proxy._clientGeneration = "modern";
+  proxy._startBackendMonitor = () => {};
+  proxy._ensureBackend = async () => false;
+
+  const degraded = await proxy._toolsList(4, {});
+  assert.equal(degraded.result.ttlMs, 0, "degraded catalog expires immediately");
+  assert.equal(degraded.result.cacheScope, "private", "degraded catalog is private");
+
+  proxy._cachedTools = { tools: [{ name: "akb_search", inputSchema: { type: "object" } }] };
+  const cached = await proxy._toolsList(5, {});
+  assert.equal(cached.result.ttlMs, 0, "cached catalog expires immediately");
+  assert.equal(cached.result.cacheScope, "private", "cached catalog is private");
+});
+
 // ── background monitor recovers the toolset after an outage ──────────
 
 itAsync("monitor emits tools/list_changed after backend recovers from a degraded list", async () => {


### PR DESCRIPTION
## Summary

- Add `ttlMs: 0` and `cacheScope: "private"` to modern stdio `tools/list` results.
- Apply the same modern result contract to both backend-unreachable degraded catalogs and reachable backend catalogs.
- Preserve legacy responses, ordinary tool results, reconnect behavior, and `tools/list_changed` semantics.

## Changes

- Added modern cache metadata stamping dedicated to `tools/list`.
- Added regression coverage through an actually installed `akb-mcp` process and the official `@modelcontextprotocol/client@2.0.0` parser.
- Exact-pinned the parser as a development dependency while keeping the published runtime dependency-free.
- Wired the proxy package tests into the existing pull-request CI workflow.

## Validation

- `npm ci && npm test` — contract 18/18, reconnect 13/13, and the stdio protocol matrix passed.
- Verified degraded and reachable modern responses with the external parser.
- Verified that legacy responses do not acquire modern-only fields and that reconnect behavior remains intact.
- `npm pack --dry-run` — zero bundled runtime dependencies.
- Complete-diff autoreview and over-engineering review reported no actionable findings.
- Hosted CI passed: static analysis, backend unit tests, live PostgreSQL/pgvector tests, and repository-owned shell E2E.

## Scope

This PR is limited to AKB-235. It does not change the backend, direct HTTP router, runtime, or orchestrator validation mapping.