### PR TITLE
feat(events): add authenticated Vault event tail

### DIFF
--- a/backend/app/api/routes/events.py
+++ b/backend/app/api/routes/events.py
@@ -1,0 +1,81 @@
+"""REST route for the authenticated Vault Change Event Tail."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from fastapi import APIRouter, Depends, Header, Query, Request
+from starlette.responses import StreamingResponse
+
+from app.api.deps import get_current_user
+from app.exceptions import AKBError
+from app.services import event_tail_service
+from app.services.access_service import check_vault_access
+from app.services.auth_service import AuthenticatedUser
+
+
+router = APIRouter()
+
+
+@router.get(
+    "/events/{vault}",
+    summary="Tail retained Vault Change Events",
+    operation_id="eventsTail",
+    response_class=StreamingResponse,
+    responses={
+        200: {
+            "description": "Authenticated Server-Sent Events stream.",
+            "content": {
+                "text/event-stream": {
+                    "schema": {
+                        "type": "string",
+                        "description": "SSE frames carrying change or checkpoint JSON data.",
+                    },
+                    "x-event-schemas": {
+                        "change": {"$ref": "#/components/schemas/ChangeEventEnvelopeV1"},
+                        "checkpoint": {"$ref": "#/components/schemas/TailCheckpointV1"},
+                    },
+                }
+            },
+        }
+    },
+)
+async def events_tail(
+    vault: str,
+    request: Request,
+    cursor: str | None = Query(None, description="Opaque Event Cursor to resume after."),
+    start: Literal["earliest"] | None = Query(
+        None,
+        description="Replay from the earliest retained Vault event; mutually exclusive with a cursor.",
+    ),
+    kind: list[str] | None = Query(
+        None,
+        description="Repeat for exact Event Kind filters; omitted means all Vault-scoped kinds.",
+    ),
+    last_event_id: str | None = Header(
+        None,
+        alias="Last-Event-ID",
+        description="Opaque Event Cursor; takes precedence over the cursor query parameter.",
+    ),
+    user: AuthenticatedUser = Depends(get_current_user),
+) -> StreamingResponse:
+    """Open a reader-gated stream whose source of truth is PostgreSQL."""
+    access = await check_vault_access(user.user_id, vault, required_role="reader")
+    try:
+        return await event_tail_service.open_tail(
+            # The access check intentionally precedes all event queries.
+            request=request,
+            user_id=user.user_id,
+            vault=vault,
+            vault_id=access["vault_id"],
+            last_event_id=last_event_id,
+            cursor=cursor,
+            start=start,
+            kinds=kind,
+        )
+    except event_tail_service.EventCursorError as exc:
+        raise AKBError(
+            "Invalid Event Cursor",
+            status_code=400,
+            code="invalid_event_cursor",
+        ) from exc

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,6 +29,7 @@ from app.api.routes import (
     auth,
     collections,
     documents,
+    events,
     files,
     help as help_routes,
     knowledge,
@@ -341,6 +342,7 @@ app.include_router(app_legacy_adoptions.router, prefix="/api/v1", tags=["app-leg
 app.include_router(app_rollouts.router, prefix="/api/v1", tags=["app-rollouts"])
 app.include_router(access.router, prefix="/api/v1", tags=["access"])
 app.include_router(documents.router, prefix="/api/v1", tags=["documents"])
+app.include_router(events.router, prefix="/api/v1", tags=["events"])
 app.include_router(search.router, prefix="/api/v1", tags=["search"])
 app.include_router(collections.router, prefix="/api/v1")
 app.include_router(knowledge.router, prefix="/api/v1")

--- a/backend/app/models/events.py
+++ b/backend/app/models/events.py
@@ -1,0 +1,34 @@
+"""Public models for the authenticated Vault Change Event Tail."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict
+
+
+EventCursor = str
+EventKind = str
+
+
+class EventTailModel(BaseModel):
+    """Reject accidental fields in the wire-level event records."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ChangeEventEnvelopeV1(EventTailModel):
+    version: Literal[1]
+    cursor: str
+    occurred_at: datetime
+    vault: str
+    kind: str
+    resource_uri: str | None = None
+    actor: str | None = None
+    payload: dict[str, Any]
+
+
+class TailCheckpointV1(EventTailModel):
+    version: Literal[1]
+    cursor: str

--- a/backend/app/models/events.py
+++ b/backend/app/models/events.py
@@ -8,10 +8,6 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict
 
 
-EventCursor = str
-EventKind = str
-
-
 class EventTailModel(BaseModel):
     """Reject accidental fields in the wire-level event records."""
 

--- a/backend/app/openapi_contract.py
+++ b/backend/app/openapi_contract.py
@@ -138,6 +138,7 @@ OPERATION_TAG_OVERRIDES = {
     ("get", "/api/v1/history/{vault}/{doc_id}"): ["documents"],
     ("get", "/api/v1/diff/{vault}/{doc_id}"): ["documents"],
 }
+EVENT_TAIL_PATH = "/api/v1/events/{vault}"
 NO_SUCCESS_RESPONSE_OPERATIONS = {
     ("get", "/api/v1/auth/keycloak/login"),
     ("get", "/api/v1/auth/keycloak/logout"),
@@ -214,8 +215,27 @@ def _normalize_api_operations(schema: dict[str, Any]) -> None:
             else:
                 operation.setdefault("tags", [_namespace_for_path(path)])
             operation.setdefault("operationId", _operation_id_from_schema(path, method, operation))
+            if method == "get" and path == EVENT_TAIL_PATH:
+                _normalize_event_tail_parameters(operation)
             _ensure_success_response(path, method, operation)
             _ensure_error_responses(operation)
+
+
+def _normalize_event_tail_parameters(operation: dict[str, Any]) -> None:
+    """Point Event Tail inputs at the public cursor/kind components."""
+    for parameter in operation.get("parameters", []):
+        if parameter.get("name") in {"cursor", "Last-Event-ID"}:
+            parameter["schema"] = {"$ref": "#/components/schemas/EventCursor"}
+        elif parameter.get("name") == "kind":
+            parameter["schema"] = {
+                "anyOf": [
+                    {
+                        "type": "array",
+                        "items": {"$ref": "#/components/schemas/EventKind"},
+                    },
+                    {"type": "null"},
+                ]
+            }
 
 
 def _ensure_success_response(path: str, method: str, operation: dict[str, Any]) -> None:
@@ -295,6 +315,38 @@ def _error_description(status: str) -> str:
 
 def _success_envelope_schemas() -> dict[str, dict[str, Any]]:
     return {
+        "EventCursor": {
+            "type": "string",
+            "pattern": r"^ec1\.[A-Za-z0-9_-]+$",
+            "description": "Opaque signed cursor bound to a Vault and exact Event Kind filter set.",
+        },
+        "EventKind": {
+            "type": "string",
+            "pattern": r"^[A-Za-z][A-Za-z0-9]*(?:[._:-][A-Za-z0-9]+)*$",
+            "description": "Stable exact Event Kind identifier.",
+        },
+        "ChangeEventEnvelopeV1": {
+            "type": "object",
+            "required": ["version", "cursor", "occurred_at", "vault", "kind", "payload"],
+            "properties": {
+                "version": {"type": "integer", "enum": [1]},
+                "cursor": {"$ref": "#/components/schemas/EventCursor"},
+                "occurred_at": {"type": "string", "format": "date-time"},
+                "vault": {"type": "string"},
+                "kind": {"$ref": "#/components/schemas/EventKind"},
+                "resource_uri": _nullable_string(),
+                "actor": _nullable_string(),
+                "payload": {"$ref": "#/components/schemas/AkbJsonObject"},
+            },
+        },
+        "TailCheckpointV1": {
+            "type": "object",
+            "required": ["version", "cursor"],
+            "properties": {
+                "version": {"type": "integer", "enum": [1]},
+                "cursor": {"$ref": "#/components/schemas/EventCursor"},
+            },
+        },
         "AkbCollectionSummary": {
             "type": "object",
             "required": ["path", "name", "summary", "doc_count"],

--- a/backend/app/repositories/events_repo.py
+++ b/backend/app/repositories/events_repo.py
@@ -64,6 +64,57 @@ async def emit_event(
     )
 
 
+async def get_vault_event_bounds(
+    conn,
+    vault_id: uuid.UUID | str,
+) -> tuple[int | None, int | None]:
+    """Return the retained ``events.id`` range for one Vault.
+
+    The range deliberately ignores kind filters. A filtered consumer still
+    advances across every retained event, emitting checkpoints for kinds it
+    did not select, so retention-gap validation must use the complete Vault
+    tail rather than only the selected subset.
+    """
+    row = await conn.fetchrow(
+        """
+        SELECT MIN(id) AS earliest_id, MAX(id) AS latest_id
+          FROM events
+         WHERE vault_id = $1
+        """,
+        _to_uuid_or_none(vault_id),
+    )
+    return (
+        int(row["earliest_id"]) if row["earliest_id"] is not None else None,
+        int(row["latest_id"]) if row["latest_id"] is not None else None,
+    )
+
+
+async def list_vault_events(
+    conn,
+    vault_id: uuid.UUID | str,
+    *,
+    after_id: int,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Read retained Vault events in their monotonic database order."""
+    if limit < 1:
+        raise ValueError("event batch limit must be positive")
+
+    vault_uuid = _to_uuid_or_none(vault_id)
+    rows = await conn.fetch(
+        """
+        SELECT id, occurred_at, vault_id, kind, resource_uri, actor_id, payload
+          FROM events
+         WHERE vault_id = $1
+           AND id > $2
+         ORDER BY id ASC
+         LIMIT $3
+        """,
+        vault_uuid, after_id, limit,
+    )
+    return [dict(row) for row in rows]
+
+
 def _to_uuid_or_none(v: uuid.UUID | str | None) -> uuid.UUID | None:
     if v is None:
         return None

--- a/backend/app/services/event_tail_service.py
+++ b/backend/app/services/event_tail_service.py
@@ -1,0 +1,387 @@
+"""Authenticated PostgreSQL-backed Vault Change Event Tail."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import re
+from typing import Any, AsyncIterator, Mapping
+from uuid import UUID
+
+from cryptography.hazmat.primitives.ciphers.aead import AESSIV
+from fastapi import Request
+from starlette.responses import StreamingResponse
+
+from app.config import settings
+from app.db.postgres import get_pool
+from app.exceptions import AKBError
+from app.models.events import ChangeEventEnvelopeV1, TailCheckpointV1
+from app.repositories.events_repo import get_vault_event_bounds, list_vault_events
+from app.services.access_service import check_vault_access
+
+
+EVENT_CHANNEL = "akb_events"
+EVENT_BATCH_SIZE = 100
+HEARTBEAT_INTERVAL_SECONDS = 15.0
+_CURSOR_PREFIX = "ec1."
+_CURSOR_AAD = b"akb-event-cursor-v1"
+_KIND_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9]*(?:[._:-][A-Za-z0-9]+)*$")
+
+
+class EventCursorError(ValueError):
+    """A malformed, unauthenticated, or wrongly scoped Event Cursor."""
+
+
+class EventGapError(AKBError):
+    """The requested cursor is older than the retained Vault tail."""
+
+    def __init__(self, *, earliest_cursor: str, latest_cursor: str):
+        super().__init__(
+            "Event cursor is outside the retained Vault tail",
+            status_code=410,
+            code="event_gap",
+            details={
+                "earliest_cursor": earliest_cursor,
+                "latest_cursor": latest_cursor,
+            },
+        )
+
+
+@dataclass(frozen=True)
+class EventBounds:
+    """The retained event-id range for one Vault."""
+
+    earliest_id: int | None
+    latest_id: int | None
+
+
+@dataclass(frozen=True)
+class TailStart:
+    """Resolved last-inspected position for a tail connection."""
+
+    position: int
+
+
+def _canonical_uuid(value: UUID | str) -> UUID:
+    try:
+        return value if isinstance(value, UUID) else UUID(str(value))
+    except (AttributeError, ValueError, TypeError) as exc:
+        raise EventCursorError("invalid event cursor") from exc
+
+
+def _canonical_kinds(values: tuple[str, ...] | list[str]) -> tuple[str, ...]:
+    if not isinstance(values, (tuple, list)):
+        raise EventCursorError("invalid event cursor")
+    canonical: set[str] = set()
+    for value in values:
+        if not isinstance(value, str) or not _KIND_PATTERN.fullmatch(value):
+            raise EventCursorError("invalid event cursor")
+        canonical.add(value)
+    return tuple(sorted(canonical))
+
+
+def normalize_kind_filter(values: list[str] | tuple[str, ...] | None) -> tuple[str, ...]:
+    """Normalize a repeated exact-kind query into its cursor scope."""
+    if values is None:
+        return ()
+    return _canonical_kinds(values)
+
+
+class EventCursorCodec:
+    """Encode and authenticate opaque cursors with the system HMAC secret.
+
+    AES-SIV uses a key derived from ``system_hmac_secret_effective``. Its
+    authentication tag provides the signature/integrity guarantee while the
+    encrypted payload keeps the database position, Vault identity, and kind
+    filter set out of the public cursor. Deterministic encryption keeps the
+    same logical position stable across at-least-once redelivery.
+    """
+
+    def __init__(self, secret: str | None = None):
+        effective = settings.system_hmac_secret_effective if secret is None else secret
+        if not isinstance(effective, str) or not effective:
+            raise ValueError("system HMAC secret is required for Event Cursors")
+        self._key = hashlib.sha512(_CURSOR_AAD + b"\0" + effective.encode("utf-8")).digest()
+
+    def encode(
+        self,
+        vault_id: UUID | str,
+        kinds: tuple[str, ...] | list[str],
+        position: int,
+    ) -> str:
+        vault_uuid = _canonical_uuid(vault_id)
+        if isinstance(position, bool) or not isinstance(position, int) or position < 0:
+            raise EventCursorError("invalid event cursor")
+        canonical_kinds = _canonical_kinds(kinds)
+        payload = json.dumps(
+            {
+                "kinds": list(canonical_kinds),
+                "position": position,
+                "vault": str(vault_uuid),
+                "version": 1,
+            },
+            ensure_ascii=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        encrypted = AESSIV(self._key).encrypt(payload, [_CURSOR_AAD])
+        return _CURSOR_PREFIX + _encode_bytes(encrypted)
+
+    def decode(self, token: str) -> tuple[UUID, tuple[str, ...], int]:
+        if not isinstance(token, str) or not token.startswith(_CURSOR_PREFIX) or len(token) > 4096:
+            raise EventCursorError("invalid event cursor")
+        encoded = token[len(_CURSOR_PREFIX) :]
+        try:
+            raw = _decode_bytes(encoded)
+            if len(raw) <= 16:
+                raise ValueError("cursor payload is empty")
+            payload = AESSIV(self._key).decrypt(raw, [_CURSOR_AAD])
+            decoded = json.loads(payload)
+            if not isinstance(decoded, dict) or set(decoded) != {"kinds", "position", "vault", "version"}:
+                raise ValueError("cursor payload shape is invalid")
+            if decoded["version"] != 1:
+                raise ValueError("cursor version is unsupported")
+            vault_uuid = _canonical_uuid(decoded["vault"])
+            position = decoded["position"]
+            if isinstance(position, bool) or not isinstance(position, int) or position < 0:
+                raise ValueError("cursor position is invalid")
+            kinds = _canonical_kinds(decoded["kinds"])
+            if list(kinds) != decoded["kinds"]:
+                raise ValueError("cursor kind scope is not canonical")
+            return vault_uuid, kinds, position
+        except EventCursorError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - all decode failures are one public error
+            raise EventCursorError("invalid event cursor") from exc
+
+
+def _encode_bytes(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
+
+
+def _decode_bytes(value: str) -> bytes:
+    if not value or not re.fullmatch(r"[A-Za-z0-9_-]+", value):
+        raise ValueError("cursor encoding is invalid")
+    padding = "=" * (-len(value) % 4)
+    return base64.b64decode(value + padding, altchars=b"-_", validate=True)
+
+
+def resolve_start_position(
+    codec: EventCursorCodec,
+    vault_id: UUID | str,
+    kinds: tuple[str, ...],
+    bounds: EventBounds,
+    *,
+    last_event_id: str | None,
+    cursor: str | None,
+    start: str | None,
+) -> TailStart:
+    """Resolve the connection position using the public start precedence."""
+    if start not in (None, "earliest"):
+        raise EventCursorError("invalid event cursor")
+    selected = last_event_id if last_event_id is not None else cursor
+    if start == "earliest" and selected is not None:
+        raise EventCursorError("invalid event cursor")
+
+    if selected is not None:
+        decoded_vault, decoded_kinds, position = codec.decode(selected)
+        if decoded_vault != _canonical_uuid(vault_id) or decoded_kinds != kinds:
+            raise EventCursorError("invalid event cursor")
+        return TailStart(position=position)
+
+    if start == "earliest":
+        return TailStart(
+            position=max(0, (bounds.earliest_id or 1) - 1),
+        )
+    return TailStart(position=bounds.latest_id or 0)
+
+
+def validate_event_gap(
+    codec: EventCursorCodec,
+    vault_id: UUID | str,
+    kinds: tuple[str, ...],
+    *,
+    position: int,
+    bounds: EventBounds,
+) -> None:
+    """Reject a cursor that cannot reach the retained head without a gap."""
+    earliest = bounds.earliest_id
+    if earliest is None or position >= earliest - 1:
+        return
+    latest_position = bounds.latest_id if bounds.latest_id is not None else position
+    raise EventGapError(
+        earliest_cursor=codec.encode(vault_id, kinds, max(0, earliest - 1)),
+        latest_cursor=codec.encode(vault_id, kinds, latest_position),
+    )
+
+
+def _as_utc(value: datetime | str) -> datetime:
+    if isinstance(value, str):
+        value = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _event_envelope(row: Mapping[str, Any], *, cursor: str, vault: str) -> dict[str, Any]:
+    payload = row.get("payload")
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except json.JSONDecodeError:
+            payload = {}
+    if not isinstance(payload, dict):
+        payload = {}
+    envelope = ChangeEventEnvelopeV1(
+        version=1,
+        cursor=cursor,
+        occurred_at=_as_utc(row["occurred_at"]),
+        vault=vault,
+        kind=str(row["kind"]),
+        resource_uri=row.get("resource_uri"),
+        actor=str(row["actor_id"]) if row.get("actor_id") is not None else None,
+        payload=payload,
+    )
+    return envelope.model_dump(mode="json", exclude_none=True)
+
+
+def format_sse(event_type: str, cursor: str, data: Mapping[str, Any]) -> str:
+    """Render one SSE record with a JSON data line."""
+    return (
+        f"event: {event_type}\n"
+        f"id: {cursor}\n"
+        f"data: {json.dumps(dict(data), ensure_ascii=False, separators=(',', ':'))}\n\n"
+    )
+
+
+def format_heartbeat() -> str:
+    """Render an SSE comment, which carries no Event Cursor."""
+    return ": heartbeat\n\n"
+
+
+async def open_tail(
+    request: Request,
+    *,
+    user_id: str,
+    vault: str,
+    vault_id: UUID | str,
+    last_event_id: str | None,
+    cursor: str | None,
+    start: str | None,
+    kinds: list[str] | None,
+) -> StreamingResponse:
+    """Preflight and return a streaming response for one authorized Vault."""
+    normalized_kinds = normalize_kind_filter(kinds)
+    codec = EventCursorCodec()
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        earliest_id, latest_id = await get_vault_event_bounds(conn, vault_id)
+    bounds = EventBounds(earliest_id=earliest_id, latest_id=latest_id)
+    resolved = resolve_start_position(
+        codec,
+        vault_id,
+        normalized_kinds,
+        bounds,
+        last_event_id=last_event_id,
+        cursor=cursor,
+        start=start,
+    )
+    validate_event_gap(
+        codec,
+        vault_id,
+        normalized_kinds,
+        position=resolved.position,
+        bounds=bounds,
+    )
+    stream = _stream_events(
+        request,
+        user_id=user_id,
+        vault=vault,
+        vault_id=vault_id,
+        kinds=normalized_kinds,
+        position=resolved.position,
+        codec=codec,
+    )
+    return StreamingResponse(
+        stream,
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+async def _stream_events(
+    request: Request,
+    *,
+    user_id: str,
+    vault: str,
+    vault_id: UUID | str,
+    kinds: tuple[str, ...],
+    position: int,
+    codec: EventCursorCodec,
+) -> AsyncIterator[str]:
+    async def still_authorized() -> bool:
+        try:
+            access = await check_vault_access(user_id, vault, required_role="reader")
+            return str(access.get("vault_id")) == str(vault_id)
+        except Exception:  # noqa: BLE001 - a revoked stream closes silently
+            return False
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        wakeup = asyncio.Event()
+
+        def on_notify(*_args: Any) -> None:
+            wakeup.set()
+
+        await conn.add_listener(EVENT_CHANNEL, on_notify)
+        try:
+            current_position = position
+            while True:
+                if await request.is_disconnected():
+                    return
+                if not await still_authorized():
+                    return
+
+                wakeup.clear()
+                rows = await list_vault_events(
+                    conn,
+                    vault_id,
+                    after_id=current_position,
+                    limit=EVENT_BATCH_SIZE,
+                )
+                if rows:
+                    for row in rows:
+                        if await request.is_disconnected():
+                            return
+                        if not await still_authorized():
+                            return
+                        current_position = int(row["id"])
+                        event_cursor = codec.encode(vault_id, kinds, current_position)
+                        if not kinds or row["kind"] in kinds:
+                            yield format_sse(
+                                "change",
+                                event_cursor,
+                                _event_envelope(row, cursor=event_cursor, vault=vault),
+                            )
+                        else:
+                            checkpoint = TailCheckpointV1(version=1, cursor=event_cursor)
+                            yield format_sse(
+                                "checkpoint",
+                                event_cursor,
+                                checkpoint.model_dump(mode="json", exclude_none=True),
+                            )
+                    continue
+
+                try:
+                    await asyncio.wait_for(wakeup.wait(), timeout=HEARTBEAT_INTERVAL_SECONDS)
+                except TimeoutError:
+                    yield format_heartbeat()
+        finally:
+            await conn.remove_listener(EVENT_CHANNEL, on_notify)

--- a/backend/app/services/event_tail_service.py
+++ b/backend/app/services/event_tail_service.py
@@ -59,13 +59,6 @@ class EventBounds:
     latest_id: int | None
 
 
-@dataclass(frozen=True)
-class TailStart:
-    """Resolved last-inspected position for a tail connection."""
-
-    position: int
-
-
 def _canonical_uuid(value: UUID | str) -> UUID:
     try:
         return value if isinstance(value, UUID) else UUID(str(value))
@@ -178,7 +171,7 @@ def resolve_start_position(
     last_event_id: str | None,
     cursor: str | None,
     start: str | None,
-) -> TailStart:
+) -> int:
     """Resolve the connection position using the public start precedence."""
     if start not in (None, "earliest"):
         raise EventCursorError("invalid event cursor")
@@ -190,13 +183,11 @@ def resolve_start_position(
         decoded_vault, decoded_kinds, position = codec.decode(selected)
         if decoded_vault != _canonical_uuid(vault_id) or decoded_kinds != kinds:
             raise EventCursorError("invalid event cursor")
-        return TailStart(position=position)
+        return position
 
     if start == "earliest":
-        return TailStart(
-            position=max(0, (bounds.earliest_id or 1) - 1),
-        )
-    return TailStart(position=bounds.latest_id or 0)
+        return max(0, (bounds.earliest_id or 1) - 1)
+    return bounds.latest_id or 0
 
 
 def validate_event_gap(
@@ -293,7 +284,7 @@ async def open_tail(
         codec,
         vault_id,
         normalized_kinds,
-        position=resolved.position,
+        position=resolved,
         bounds=bounds,
     )
     stream = _stream_events(
@@ -302,7 +293,7 @@ async def open_tail(
         vault=vault,
         vault_id=vault_id,
         kinds=normalized_kinds,
-        position=resolved.position,
+        position=resolved,
         codec=codec,
     )
     return StreamingResponse(

--- a/backend/scripts/ci/e2e_suite_runner.py
+++ b/backend/scripts/ci/e2e_suite_runner.py
@@ -46,6 +46,7 @@ CURATED_SUITES: tuple[str, ...] = (
     "test_okf_export_import_e2e.sh",
     "test_resource_hash_e2e.sh",
     "test_events_emit_e2e.sh",
+    "test_event_tail_e2e.sh",
     "test_s3_delete_outbox_e2e.sh",
     "test_publication_resolution_e2e.sh",
     "test_publications_e2e.sh",

--- a/backend/tests/test_e2e_runtime_unit.py
+++ b/backend/tests/test_e2e_runtime_unit.py
@@ -345,7 +345,7 @@ def test_suite_summary_uses_last_complete_line_and_fails_closed():
     assert SuiteResult("suite.sh", 0, 0, 0, None, "").gate_failed
     assert SuiteResult("suite.sh", 0, 2, 0, "Results: 2 passed, 0 failed", "").gate_failed is False
     assert SuiteResult("suite.sh", -4, 0, 0, None, "").signal == 4
-    assert len(CURATED_SUITES) == 25
+    assert len(CURATED_SUITES) == 26
 
 
 def test_shell_e2e_manifest_classifies_every_suite_exactly_once():

--- a/backend/tests/test_event_tail_e2e.sh
+++ b/backend/tests/test_event_tail_e2e.sh
@@ -1,0 +1,223 @@
+#!/bin/bash
+#
+# AKB REST/SSE Event Tail E2E.
+# Exercises the public reader surface against PostgreSQL-backed events without
+# knowing or invoking the internal Redis fan-out.
+#
+set -uo pipefail
+
+BASE_URL="${AKB_URL:-http://localhost:8000}"
+PASS=0
+FAIL=0
+ERRORS=()
+TMP_DIR=$(mktemp -d)
+VAULT="event-tail-$(date +%s)-$RANDOM"
+USER="event-tail-user-$(date +%s)-$RANDOM"
+OTHER="event-tail-other-$(date +%s)-$RANDOM"
+
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); ERRORS+=("$1: $2"); echo "  ✗ $1 — $2"; }
+cleanup() {
+  if [ -n "${TOKEN:-}" ]; then
+    curl -sk -X DELETE "$BASE_URL/api/v1/vaults/$VAULT" \
+      -H "Authorization: Bearer $TOKEN" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+json_field() { python3 -c "import json,sys; print(json.load(sys.stdin).get('$1',''))" 2>/dev/null; }
+
+echo "╔══════════════════════════════════════════╗"
+echo "║       REST/SSE Event Tail E2E             ║"
+echo "║       Target: $BASE_URL"
+echo "╚══════════════════════════════════════════╝"
+echo ""
+
+echo "▸ 0. Setup"
+curl -sk -X POST "$BASE_URL/api/v1/auth/register" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$USER\",\"email\":\"$USER@test.dev\",\"password\":\"test1234\"}" >/dev/null 2>&1
+TOKEN=$(curl -sk -X POST "$BASE_URL/api/v1/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$USER\",\"password\":\"test1234\"}" | json_field token)
+
+curl -sk -X POST "$BASE_URL/api/v1/auth/register" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$OTHER\",\"email\":\"$OTHER@test.dev\",\"password\":\"test1234\"}" >/dev/null 2>&1
+OTHER_TOKEN=$(curl -sk -X POST "$BASE_URL/api/v1/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$OTHER\",\"password\":\"test1234\"}" | json_field token)
+
+[ -n "$TOKEN" ] && [ -n "$OTHER_TOKEN" ] && pass "two authenticated users" || { fail "setup" "could not obtain both tokens"; exit 1; }
+
+VAULT_RESPONSE=$(curl -sk -X POST "$BASE_URL/api/v1/vaults?name=$VAULT" \
+  -H "Authorization: Bearer $TOKEN")
+VAULT_ID=$(echo "$VAULT_RESPONSE" | json_field vault_id)
+[ -n "$VAULT_ID" ] && pass "private Vault created" || { fail "vault" "$VAULT_RESPONSE"; exit 1; }
+
+DOC_RESPONSE=$(curl -sk -X POST "$BASE_URL/api/v1/documents" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "{\"vault\":\"$VAULT\",\"collection\":\"tail\",\"title\":\"First document\",\"slug\":\"first\",\"content\":\"first\",\"status\":\"active\"}")
+[ "$(echo "$DOC_RESPONSE" | json_field kind)" = "document_write" ] && pass "document producer event" || fail "document" "$DOC_RESPONSE"
+
+TABLE_RESPONSE=$(curl -sk -X POST "$BASE_URL/api/v1/tables/$VAULT" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"items","columns":[{"name":"sku","type":"text"}]}')
+[ "$(echo "$TABLE_RESPONSE" | json_field kind)" = "table" ] && pass "table producer event" || fail "table" "$TABLE_RESPONSE"
+
+ROW_RESPONSE=$(curl -sk -X POST "$BASE_URL/api/v1/tables/$VAULT/items/rows" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Prefer: return=representation' \
+  -H 'Content-Type: application/json' \
+  -d '[{"sku":"one"}]')
+[ "$(echo "$ROW_RESPONSE" | json_field kind)" = "table_query" ] && pass "table.rows_changed producer event" || fail "rows_changed" "$ROW_RESPONSE"
+
+echo ""
+echo "▸ 1. start=earliest and exact kind checkpoint"
+FILTERED="$TMP_DIR/filtered.sse"
+curl -sk --no-buffer --max-time 2 \
+  "$BASE_URL/api/v1/events/$VAULT?start=earliest&kind=table.rows_changed" \
+  -H "Authorization: Bearer $TOKEN" >"$FILTERED" 2>/dev/null || true
+
+python3 - "$FILTERED" <<'PY'
+import json
+import sys
+
+text = open(sys.argv[1], encoding="utf-8").read()
+frames = []
+current = {}
+for line in text.splitlines():
+    if not line:
+        if current:
+            frames.append(current)
+            current = {}
+        continue
+    if line.startswith("event: "):
+        current["event"] = line[7:]
+    elif line.startswith("id: "):
+        current["id"] = line[4:]
+    elif line.startswith("data: "):
+        current["data"] = json.loads(line[6:])
+if current:
+    frames.append(current)
+
+changes = [frame for frame in frames if frame.get("event") == "change"]
+checkpoints = [frame for frame in frames if frame.get("event") == "checkpoint"]
+assert len(changes) == 1, (frames, "expected exactly one selected change")
+assert checkpoints, (frames, "excluded producer events must advance by checkpoint")
+change = changes[0]
+assert change["id"] == change["data"]["cursor"]
+assert change["data"]["version"] == 1
+assert change["data"]["vault"].startswith("event-tail-")
+assert change["data"]["kind"] == "table.rows_changed"
+assert "vault_id" not in change["data"]
+assert "redis" not in text.lower()
+PY
+[ $? -eq 0 ] && pass "exact filter emits change plus checkpoint" || fail "filter/checkpoint" "unexpected SSE frames"
+
+echo ""
+echo "▸ 2. unfiltered retained order and cursor resume"
+ALL_EVENTS="$TMP_DIR/all.sse"
+curl -sk --no-buffer --max-time 2 \
+  "$BASE_URL/api/v1/events/$VAULT?start=earliest" \
+  -H "Authorization: Bearer $TOKEN" >"$ALL_EVENTS" 2>/dev/null || true
+
+python3 - "$ALL_EVENTS" <<'PY'
+import json
+import sys
+
+text = open(sys.argv[1], encoding="utf-8").read()
+events = []
+for block in text.split("\n\n"):
+    rows = dict(line.split(": ", 1) for line in block.splitlines() if ": " in line)
+    if rows.get("event") == "change":
+        events.append(json.loads(rows["data"]))
+assert len(events) >= 3, events
+assert {item["kind"] for item in events} >= {"document.put", "table.create", "table.rows_changed"}
+assert all(item["cursor"] for item in events)
+assert "redis" not in text.lower()
+PY
+[ $? -eq 0 ] && pass "all Vault kinds are ordered and Redis-free" || fail "all events" "retained event envelope mismatch"
+
+LAST_CURSOR=$(awk '/^id: / {cursor=$2} END {print cursor}' "$ALL_EVENTS")
+[ -n "$LAST_CURSOR" ] && pass "opaque cursor captured" || fail "cursor" "no SSE id"
+
+curl -sk -X POST "$BASE_URL/api/v1/documents" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "{\"vault\":\"$VAULT\",\"collection\":\"tail\",\"title\":\"Second document\",\"slug\":\"second\",\"content\":\"second\",\"status\":\"active\"}" >/dev/null
+RESUMED="$TMP_DIR/resumed.sse"
+curl -sk --no-buffer --max-time 2 \
+  "$BASE_URL/api/v1/events/$VAULT" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Last-Event-ID: $LAST_CURSOR" >"$RESUMED" 2>/dev/null || true
+
+python3 - "$RESUMED" <<'PY'
+import json
+import sys
+
+text = open(sys.argv[1], encoding="utf-8").read()
+changes = []
+for block in text.split("\n\n"):
+    rows = dict(line.split(": ", 1) for line in block.splitlines() if ": " in line)
+    if rows.get("event") == "change":
+        changes.append(json.loads(rows["data"]))
+assert changes, text
+assert all(item["kind"] == "document.put" for item in changes), changes
+assert "Second document" in text
+assert "redis" not in text.lower()
+PY
+[ $? -eq 0 ] && pass "Last-Event-ID resumes after the retained cursor" || fail "resume" "new event was not delivered"
+
+RESUME_CURSOR=$(awk '/^id: / {cursor=$2} END {print cursor}' "$RESUMED")
+curl -sk -X POST "$BASE_URL/api/v1/documents" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "{\"vault\":\"$VAULT\",\"collection\":\"tail\",\"title\":\"Third document\",\"slug\":\"third\",\"content\":\"third\",\"status\":\"active\"}" >/dev/null
+QUERY_RESUMED="$TMP_DIR/query-resumed.sse"
+curl -sk --no-buffer --max-time 2 \
+  "$BASE_URL/api/v1/events/$VAULT?cursor=$RESUME_CURSOR" \
+  -H "Authorization: Bearer $TOKEN" >"$QUERY_RESUMED" 2>/dev/null || true
+grep -q 'Third document' "$QUERY_RESUMED" && pass "cursor query resumes the same tail" || fail "query resume" "new event was not delivered"
+
+echo ""
+echo "▸ 3. start-at-tail, invalid cursor, and access isolation"
+LIVE="$TMP_DIR/live.sse"
+curl -sk --no-buffer --max-time 4 \
+  "$BASE_URL/api/v1/events/$VAULT" \
+  -H "Authorization: Bearer $TOKEN" >"$LIVE" 2>/dev/null &
+LIVE_PID=$!
+sleep 0.3
+curl -sk -X POST "$BASE_URL/api/v1/documents" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "{\"vault\":\"$VAULT\",\"collection\":\"tail\",\"title\":\"Live document\",\"slug\":\"live\",\"content\":\"live\",\"status\":\"active\"}" >/dev/null
+wait "$LIVE_PID" 2>/dev/null || true
+grep -q 'Live document' "$LIVE" && pass "cursor-free connection waits for new tail" || fail "live tail" "post-connect event missing"
+
+INVALID_CODE=$(curl -sk -o "$TMP_DIR/invalid.json" -w '%{http_code}' \
+  "$BASE_URL/api/v1/events/$VAULT?cursor=invalid" \
+  -H "Authorization: Bearer $TOKEN")
+INVALID_BODY=$(cat "$TMP_DIR/invalid.json")
+[ "$INVALID_CODE" = "400" ] && echo "$INVALID_BODY" | grep -q 'invalid_event_cursor' \
+  && pass "malformed cursor returns standard 400" || fail "invalid cursor" "code=$INVALID_CODE body=$INVALID_BODY"
+
+UNAUTHORIZED_CODE=$(curl -sk -o "$TMP_DIR/unauthorized.json" -w '%{http_code}' \
+  "$BASE_URL/api/v1/events/$VAULT?start=earliest" \
+  -H "Authorization: Bearer $OTHER_TOKEN")
+UNAUTHORIZED_BODY=$(cat "$TMP_DIR/unauthorized.json")
+[ "$UNAUTHORIZED_CODE" = "403" ] && ! echo "$UNAUTHORIZED_BODY" | grep -q 'document.put' \
+  && pass "non-member cannot observe the tail" || fail "access isolation" "code=$UNAUTHORIZED_CODE body=$UNAUTHORIZED_BODY"
+
+echo ""
+echo "═══════════════════════════════════════════"
+echo "  Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  echo "  Failures:"
+  printf '    - %s\n' "${ERRORS[@]}"
+  exit 1
+fi
+exit 0

--- a/backend/tests/test_event_tail_postgres.py
+++ b/backend/tests/test_event_tail_postgres.py
@@ -1,0 +1,205 @@
+"""PostgreSQL proof for retained event ordering and Vault isolation."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock
+import uuid
+
+import asyncpg
+import pytest
+
+from app.repositories.events_repo import get_vault_event_bounds, list_vault_events
+from app.services.event_tail_service import EventBounds, EventCursorCodec, EventGapError, validate_event_gap
+
+
+pytestmark = pytest.mark.asyncio
+
+_DSN = os.environ.get("AKB_TEST_DSN", "postgresql://akb:akb@localhost:15432/akb")
+
+
+async def _can_connect(dsn: str) -> bool:
+    try:
+        conn = await asyncpg.connect(dsn, timeout=2)
+    except OSError, asyncpg.PostgresError:
+        return False
+    await conn.close()
+    return True
+
+
+def _database_dsn(name: str) -> str:
+    base, _ = _DSN.rsplit("/", 1)
+    return f"{base}/{name}"
+
+
+@contextlib.asynccontextmanager
+async def _fresh_database():
+    if not await _can_connect(_DSN):
+        if os.environ.get("REQUIRE_REAL_PG") == "1":
+            pytest.fail(f"Required PostgreSQL is not reachable at {_DSN}")
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+
+    admin = await asyncpg.connect(_DSN)
+    name = f"akb_event_tail_{uuid.uuid4().hex[:12]}"
+    await admin.execute(f'CREATE DATABASE "{name}"')
+    pool = await asyncpg.create_pool(_database_dsn(name), min_size=1, max_size=4)
+    previous_pool = None
+    try:
+        init_sql = (Path(__file__).resolve().parents[1] / "app" / "db" / "init.sql").read_text()
+        async with pool.acquire() as conn:
+            await conn.execute(init_sql)
+        from app.db import postgres as postgres_module
+
+        previous_pool = postgres_module._pool
+        postgres_module._pool = pool
+        await postgres_module._apply_migrations()
+        yield pool
+    finally:
+        from app.db import postgres as postgres_module
+
+        postgres_module._pool = previous_pool
+        await pool.close()
+        await admin.execute(f'DROP DATABASE "{name}" WITH (FORCE)')
+        await admin.close()
+
+
+async def _make_vault(pool: asyncpg.Pool, name: str) -> uuid.UUID:
+    async with pool.acquire() as conn:
+        return await conn.fetchval(
+            "INSERT INTO vaults (name, git_path) VALUES ($1, $2) RETURNING id",
+            name,
+            f"/tmp/{name}.git",
+        )
+
+
+async def _insert_event(
+    pool: asyncpg.Pool,
+    vault_id: uuid.UUID,
+    kind: str,
+    actor: str,
+) -> int:
+    async with pool.acquire() as conn:
+        return await conn.fetchval(
+            """
+            INSERT INTO events (vault_id, kind, resource_uri, actor_id, payload)
+            VALUES ($1, $2, $3, $4, $5::jsonb)
+            RETURNING id
+            """,
+            vault_id,
+            kind,
+            f"akb://event-test/{kind}",
+            actor,
+            json.dumps({"kind": kind}),
+        )
+
+
+async def test_event_repository_orders_and_isolates_vault_rows():
+    async with _fresh_database() as pool:
+        vault_id = await _make_vault(pool, "event-tail-a")
+        other_vault_id = await _make_vault(pool, "event-tail-b")
+        first_id = await _insert_event(pool, vault_id, "document.put", "alice")
+        second_id = await _insert_event(pool, other_vault_id, "document.put", "bob")
+        third_id = await _insert_event(pool, vault_id, "table.rows_changed", "alice")
+
+        async with pool.acquire() as conn:
+            assert await get_vault_event_bounds(conn, vault_id) == (first_id, third_id)
+            rows = await list_vault_events(conn, vault_id, after_id=0)
+            assert [row["id"] for row in rows] == [first_id, third_id]
+            assert all(row["vault_id"] == vault_id for row in rows)
+
+        assert second_id not in {first_id, third_id}
+
+
+async def test_retention_bounds_drive_gap_recovery_without_skipping():
+    async with _fresh_database() as pool:
+        vault_id = await _make_vault(pool, "event-gap")
+        first_id = await _insert_event(pool, vault_id, "document.put", "alice")
+        second_id = await _insert_event(pool, vault_id, "document.update", "alice")
+        latest_id = await _insert_event(pool, vault_id, "document.delete", "alice")
+
+        async with pool.acquire() as conn:
+            await conn.execute("DELETE FROM events WHERE id = $1", first_id)
+            earliest_id, current_latest_id = await get_vault_event_bounds(conn, vault_id)
+
+        assert earliest_id == second_id
+        assert current_latest_id == latest_id
+        codec = EventCursorCodec("cursor-secret")
+        with pytest.raises(EventGapError) as exc_info:
+            validate_event_gap(
+                codec,
+                vault_id,
+                (),
+                position=first_id - 1,
+                bounds=EventBounds(earliest_id, current_latest_id),
+            )
+        assert exc_info.value.details["earliest_cursor"]
+        assert exc_info.value.details["latest_cursor"]
+
+
+async def test_postgres_tail_stream_preserves_order_filter_checkpoints_and_resume(monkeypatch):
+    from app.services import event_tail_service
+
+    class _Request:
+        async def is_disconnected(self) -> bool:
+            return False
+
+    async with _fresh_database() as pool:
+        vault_id = await _make_vault(pool, "event-stream")
+        first_id = await _insert_event(pool, vault_id, "document.put", "alice")
+        selected_id = await _insert_event(pool, vault_id, "table.rows_changed", "alice")
+        skipped_id = await _insert_event(pool, vault_id, "document.update", "alice")
+        codec = EventCursorCodec("cursor-secret")
+
+        async def get_pool():
+            return pool
+
+        monkeypatch.setattr(event_tail_service, "get_pool", get_pool)
+        monkeypatch.setattr(
+            event_tail_service,
+            "check_vault_access",
+            AsyncMock(return_value={"vault_id": vault_id}),
+        )
+
+        stream = event_tail_service._stream_events(
+            _Request(),
+            user_id="user",
+            vault="event-stream",
+            vault_id=vault_id,
+            kinds=("table.rows_changed",),
+            position=first_id - 1,
+            codec=codec,
+        )
+        first_frame = await anext(stream)
+        selected_frame = await anext(stream)
+        skipped_frame = await anext(stream)
+        await stream.aclose()
+
+        assert first_frame.startswith("event: checkpoint\n")
+        assert selected_frame.startswith("event: change\n")
+        assert skipped_frame.startswith("event: checkpoint\n")
+        assert codec.decode(first_frame.splitlines()[1][4:])[2] == first_id
+        assert codec.decode(selected_frame.splitlines()[1][4:])[2] == selected_id
+        assert codec.decode(skipped_frame.splitlines()[1][4:])[2] == skipped_id
+        selected_body = json.loads(selected_frame.split("data: ", 1)[1])
+        assert selected_body["kind"] == "table.rows_changed"
+        assert "vault_id" not in selected_body
+
+        resumed_id = await _insert_event(pool, vault_id, "table.rows_changed", "alice")
+        resumed = event_tail_service._stream_events(
+            _Request(),
+            user_id="user",
+            vault="event-stream",
+            vault_id=vault_id,
+            kinds=("table.rows_changed",),
+            position=selected_id,
+            codec=codec,
+        )
+        checkpoint_after_resume = await anext(resumed)
+        next_change = await anext(resumed)
+        await resumed.aclose()
+        assert checkpoint_after_resume.startswith("event: checkpoint\n")
+        assert next_change.startswith("event: change\n")
+        assert codec.decode(next_change.splitlines()[1][4:])[2] == resumed_id

--- a/backend/tests/test_event_tail_routes_unit.py
+++ b/backend/tests/test_event_tail_routes_unit.py
@@ -1,0 +1,123 @@
+"""Unit coverage for the authenticated Event Tail route boundary."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID
+
+import pytest
+from starlette.responses import StreamingResponse
+
+
+class _User:
+    user_id = "00000000-0000-0000-0000-000000000001"
+
+
+@pytest.mark.asyncio
+async def test_route_authorizes_before_opening_the_event_stream(monkeypatch) -> None:
+    from app.api.routes import events
+
+    access = AsyncMock(return_value={"vault_id": UUID("11111111-1111-4111-8111-111111111111")})
+    opened = AsyncMock(return_value=StreamingResponse(iter(()), media_type="text/event-stream"))
+    monkeypatch.setattr(events, "check_vault_access", access)
+    monkeypatch.setattr(events.event_tail_service, "open_tail", opened)
+
+    request = MagicMock()
+    result = await events.events_tail(
+        "vault",
+        request,
+        cursor=None,
+        start=None,
+        kind=None,
+        last_event_id=None,
+        user=_User(),  # type: ignore[arg-type]
+    )
+
+    assert result is opened.return_value
+    access.assert_awaited_once_with(_User.user_id, "vault", required_role="reader")
+    opened.assert_awaited_once_with(
+        request=request,
+        user_id=_User.user_id,
+        vault="vault",
+        vault_id=UUID("11111111-1111-4111-8111-111111111111"),
+        last_event_id=None,
+        cursor=None,
+        start=None,
+        kinds=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_invalid_cursor_is_the_standard_400_error(monkeypatch) -> None:
+    from app.api.routes import events
+    from app.services.event_tail_service import EventCursorError
+
+    monkeypatch.setattr(
+        events,
+        "check_vault_access",
+        AsyncMock(return_value={"vault_id": UUID("11111111-1111-4111-8111-111111111111")}),
+    )
+    monkeypatch.setattr(
+        events.event_tail_service,
+        "open_tail",
+        AsyncMock(side_effect=EventCursorError("invalid")),
+    )
+
+    with pytest.raises(events.AKBError) as exc_info:
+        await events.events_tail(
+            "vault",
+            MagicMock(),
+            cursor="bad",
+            start=None,
+            kind=None,
+            last_event_id=None,
+            user=_User(),  # type: ignore[arg-type]
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.code == "invalid_event_cursor"
+
+
+@pytest.mark.asyncio
+async def test_open_tail_preflights_retention_gap_before_returning_stream(monkeypatch) -> None:
+    from app.config import settings
+    from app.services import event_tail_service
+
+    class _Connection:
+        async def fetchrow(self, *_args):
+            return {"earliest_id": 10, "latest_id": 20}
+
+    class _Acquire:
+        async def __aenter__(self):
+            return _Connection()
+
+        async def __aexit__(self, *_args):
+            return None
+
+    class _Pool:
+        def acquire(self):
+            return _Acquire()
+
+    monkeypatch.setattr(settings, "system_hmac_secret", "cursor-secret")
+
+    async def get_pool():
+        return _Pool()
+
+    monkeypatch.setattr(event_tail_service, "get_pool", get_pool)
+    codec = event_tail_service.EventCursorCodec("cursor-secret")
+
+    with pytest.raises(event_tail_service.EventGapError) as exc_info:
+        await event_tail_service.open_tail(
+            MagicMock(),
+            user_id="user",
+            vault="vault",
+            vault_id=UUID("11111111-1111-4111-8111-111111111111"),
+            last_event_id=None,
+            cursor=codec.encode(UUID("11111111-1111-4111-8111-111111111111"), (), 8),
+            start=None,
+            kinds=None,
+        )
+
+    assert exc_info.value.status_code == 410
+    assert exc_info.value.code == "event_gap"
+    assert set(exc_info.value.details) == {"earliest_cursor", "latest_cursor"}

--- a/backend/tests/test_event_tail_unit.py
+++ b/backend/tests/test_event_tail_unit.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 import json
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID
 
 import pytest
@@ -24,6 +24,20 @@ from app.services.event_tail_service import (
 
 
 VAULT_ID = UUID("11111111-1111-4111-8111-111111111111")
+
+
+def _stream_test_doubles() -> tuple[MagicMock, MagicMock, MagicMock]:
+    connection = MagicMock()
+    connection.add_listener = AsyncMock()
+    connection.remove_listener = AsyncMock()
+    acquire = MagicMock()
+    acquire.__aenter__ = AsyncMock(return_value=connection)
+    acquire.__aexit__ = AsyncMock(return_value=None)
+    pool = MagicMock()
+    pool.acquire.return_value = acquire
+    request = MagicMock()
+    request.is_disconnected = AsyncMock(return_value=False)
+    return pool, connection, request
 
 
 def test_cursor_is_opaque_authenticated_and_scope_bound() -> None:
@@ -64,66 +78,51 @@ def test_start_position_matrix_obeys_header_priority_and_earliest_exclusion() ->
     query = codec.encode(VAULT_ID, (), 7)
     bounds = EventBounds(earliest_id=3, latest_id=20)
 
-    assert (
-        resolve_start_position(
-            codec,
-            VAULT_ID,
-            (),
-            bounds,
-            last_event_id=header,
-            cursor=query,
-            start=None,
-        ).position
-        == 12
-    )
-    assert (
-        resolve_start_position(
-            codec,
-            VAULT_ID,
-            (),
-            bounds,
-            last_event_id=header,
-            cursor="not-a-cursor",
-            start=None,
-        ).position
-        == 12
-    )
-    assert (
-        resolve_start_position(
-            codec,
-            VAULT_ID,
-            (),
-            bounds,
-            last_event_id=None,
-            cursor=query,
-            start=None,
-        ).position
-        == 7
-    )
-    assert (
-        resolve_start_position(
-            codec,
-            VAULT_ID,
-            (),
-            bounds,
-            last_event_id=None,
-            cursor=None,
-            start="earliest",
-        ).position
-        == 2
-    )
-    assert (
-        resolve_start_position(
-            codec,
-            VAULT_ID,
-            (),
-            bounds,
-            last_event_id=None,
-            cursor=None,
-            start=None,
-        ).position
-        == 20
-    )
+    assert resolve_start_position(
+        codec,
+        VAULT_ID,
+        (),
+        bounds,
+        last_event_id=header,
+        cursor=query,
+        start=None,
+    ) == 12
+    assert resolve_start_position(
+        codec,
+        VAULT_ID,
+        (),
+        bounds,
+        last_event_id=header,
+        cursor="not-a-cursor",
+        start=None,
+    ) == 12
+    assert resolve_start_position(
+        codec,
+        VAULT_ID,
+        (),
+        bounds,
+        last_event_id=None,
+        cursor=query,
+        start=None,
+    ) == 7
+    assert resolve_start_position(
+        codec,
+        VAULT_ID,
+        (),
+        bounds,
+        last_event_id=None,
+        cursor=None,
+        start="earliest",
+    ) == 2
+    assert resolve_start_position(
+        codec,
+        VAULT_ID,
+        (),
+        bounds,
+        last_event_id=None,
+        cursor=None,
+        start=None,
+    ) == 20
 
     with pytest.raises(EventCursorError):
         resolve_start_position(
@@ -193,37 +192,6 @@ def test_public_envelopes_require_version_and_reject_internal_fields() -> None:
 async def test_stream_emits_checkpoint_for_skipped_event_and_change_envelope(monkeypatch) -> None:
     from app.services import event_tail_service
 
-    class _Connection:
-        def __init__(self) -> None:
-            self.listeners: list[tuple[str, object]] = []
-
-        async def add_listener(self, channel: str, callback: object) -> None:
-            self.listeners.append((channel, callback))
-
-        async def remove_listener(self, channel: str, callback: object) -> None:
-            self.listeners.remove((channel, callback))
-
-    class _Acquire:
-        def __init__(self, connection: _Connection) -> None:
-            self.connection = connection
-
-        async def __aenter__(self) -> _Connection:
-            return self.connection
-
-        async def __aexit__(self, *_args: object) -> None:
-            return None
-
-    class _Pool:
-        def __init__(self, connection: _Connection) -> None:
-            self.connection = connection
-
-        def acquire(self) -> _Acquire:
-            return _Acquire(self.connection)
-
-    class _Request:
-        async def is_disconnected(self) -> bool:
-            return False
-
     rows = [
         {
             "id": 10,
@@ -242,18 +210,14 @@ async def test_stream_emits_checkpoint_for_skipped_event_and_change_envelope(mon
             "payload": {"operation": "insert"},
         },
     ]
-    connection = _Connection()
-
-    async def get_pool() -> _Pool:
-        return _Pool(connection)
-
-    monkeypatch.setattr(event_tail_service, "get_pool", get_pool)
+    pool, connection, request = _stream_test_doubles()
+    monkeypatch.setattr(event_tail_service, "get_pool", AsyncMock(return_value=pool))
     monkeypatch.setattr(event_tail_service, "list_vault_events", AsyncMock(return_value=rows))
     access = AsyncMock(return_value={"vault_id": VAULT_ID})
     monkeypatch.setattr(event_tail_service, "check_vault_access", access)
 
     stream = event_tail_service._stream_events(
-        _Request(),
+        request,
         user_id="user",
         vault="vault",
         vault_id=VAULT_ID,
@@ -277,7 +241,7 @@ async def test_stream_emits_checkpoint_for_skipped_event_and_change_envelope(mon
     assert change_body["payload"] == {"operation": "insert"}
     assert "id" not in change_body
     assert "vault_id" not in change_body
-    assert not connection.listeners
+    connection.remove_listener.assert_awaited_once()
     assert access.await_count >= 2
 
 
@@ -286,32 +250,8 @@ async def test_stream_closes_without_emitting_after_access_is_revoked(monkeypatc
     from app.exceptions import ForbiddenError
     from app.services import event_tail_service
 
-    class _Connection:
-        async def add_listener(self, *_args: object) -> None:
-            return None
-
-        async def remove_listener(self, *_args: object) -> None:
-            return None
-
-    class _Acquire:
-        async def __aenter__(self) -> _Connection:
-            return _Connection()
-
-        async def __aexit__(self, *_args: object) -> None:
-            return None
-
-    class _Pool:
-        def acquire(self) -> _Acquire:
-            return _Acquire()
-
-    class _Request:
-        async def is_disconnected(self) -> bool:
-            return False
-
-    async def get_pool() -> _Pool:
-        return _Pool()
-
-    monkeypatch.setattr(event_tail_service, "get_pool", get_pool)
+    pool, _connection, request = _stream_test_doubles()
+    monkeypatch.setattr(event_tail_service, "get_pool", AsyncMock(return_value=pool))
     monkeypatch.setattr(
         event_tail_service,
         "list_vault_events",
@@ -335,7 +275,7 @@ async def test_stream_closes_without_emitting_after_access_is_revoked(monkeypatc
     )
 
     stream = event_tail_service._stream_events(
-        _Request(),
+        request,
         user_id="user",
         vault="vault",
         vault_id=VAULT_ID,

--- a/backend/tests/test_event_tail_unit.py
+++ b/backend/tests/test_event_tail_unit.py
@@ -1,0 +1,347 @@
+"""Unit contracts for the PostgreSQL-backed event tail."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+from pydantic import ValidationError
+
+from app.services.event_tail_service import (
+    EventBounds,
+    EventCursorCodec,
+    EventCursorError,
+    EventGapError,
+    format_heartbeat,
+    format_sse,
+    normalize_kind_filter,
+    resolve_start_position,
+    validate_event_gap,
+)
+
+
+VAULT_ID = UUID("11111111-1111-4111-8111-111111111111")
+
+
+def test_cursor_is_opaque_authenticated_and_scope_bound() -> None:
+    codec = EventCursorCodec("cursor-secret")
+
+    token = codec.encode(VAULT_ID, ("document.put", "table.rows_changed"), 42)
+
+    assert token.startswith("ec1.")
+    assert "42" not in token
+    assert str(VAULT_ID) not in token
+    assert "document.put" not in token
+    assert codec.decode(token) == (VAULT_ID, ("document.put", "table.rows_changed"), 42)
+    assert codec.encode(VAULT_ID, ("table.rows_changed", "document.put"), 42) == token
+    assert EventCursorCodec("cursor-secret").encode(VAULT_ID, ("document.put", "table.rows_changed"), 42) == token
+    assert EventCursorCodec("cursor-secret").encode(VAULT_ID, (), 42) != token
+
+    tamper_at = len("ec1.") + 8
+    replacement = "A" if token[tamper_at] != "A" else "B"
+    tampered = token[:tamper_at] + replacement + token[tamper_at + 1 :]
+    with pytest.raises(EventCursorError):
+        codec.decode(tampered)
+
+
+def test_kind_filter_is_exact_sorted_deduplicated_and_rejects_wildcards() -> None:
+    assert normalize_kind_filter(["table.rows_changed", "document.put", "table.rows_changed"]) == (
+        "document.put",
+        "table.rows_changed",
+    )
+    assert normalize_kind_filter(None) == ()
+
+    with pytest.raises(EventCursorError):
+        normalize_kind_filter(["document.*"])
+
+
+def test_start_position_matrix_obeys_header_priority_and_earliest_exclusion() -> None:
+    codec = EventCursorCodec("cursor-secret")
+    header = codec.encode(VAULT_ID, (), 12)
+    query = codec.encode(VAULT_ID, (), 7)
+    bounds = EventBounds(earliest_id=3, latest_id=20)
+
+    assert (
+        resolve_start_position(
+            codec,
+            VAULT_ID,
+            (),
+            bounds,
+            last_event_id=header,
+            cursor=query,
+            start=None,
+        ).position
+        == 12
+    )
+    assert (
+        resolve_start_position(
+            codec,
+            VAULT_ID,
+            (),
+            bounds,
+            last_event_id=header,
+            cursor="not-a-cursor",
+            start=None,
+        ).position
+        == 12
+    )
+    assert (
+        resolve_start_position(
+            codec,
+            VAULT_ID,
+            (),
+            bounds,
+            last_event_id=None,
+            cursor=query,
+            start=None,
+        ).position
+        == 7
+    )
+    assert (
+        resolve_start_position(
+            codec,
+            VAULT_ID,
+            (),
+            bounds,
+            last_event_id=None,
+            cursor=None,
+            start="earliest",
+        ).position
+        == 2
+    )
+    assert (
+        resolve_start_position(
+            codec,
+            VAULT_ID,
+            (),
+            bounds,
+            last_event_id=None,
+            cursor=None,
+            start=None,
+        ).position
+        == 20
+    )
+
+    with pytest.raises(EventCursorError):
+        resolve_start_position(
+            codec,
+            VAULT_ID,
+            (),
+            bounds,
+            last_event_id=header,
+            cursor=None,
+            start="earliest",
+        )
+
+
+def test_cursor_scope_and_retention_gap_fail_closed_with_recovery_cursors() -> None:
+    codec = EventCursorCodec("cursor-secret")
+    bounds = EventBounds(earliest_id=10, latest_id=25)
+
+    with pytest.raises(EventCursorError):
+        resolve_start_position(
+            codec,
+            UUID("22222222-2222-4222-8222-222222222222"),
+            (),
+            bounds,
+            last_event_id=codec.encode(VAULT_ID, (), 9),
+            cursor=None,
+            start=None,
+        )
+
+    with pytest.raises(EventGapError) as exc_info:
+        validate_event_gap(codec, VAULT_ID, (), position=8, bounds=bounds)
+
+    assert codec.decode(exc_info.value.details["earliest_cursor"]) == (VAULT_ID, (), 9)
+    assert codec.decode(exc_info.value.details["latest_cursor"]) == (VAULT_ID, (), 25)
+
+    # A cursor immediately before the retained head is a valid way to request
+    # that first retained event, and a cursor at the current tail waits.
+    validate_event_gap(codec, VAULT_ID, (), position=9, bounds=bounds)
+    validate_event_gap(codec, VAULT_ID, (), position=25, bounds=bounds)
+
+
+def test_sse_records_and_heartbeat_keep_control_data_distinct() -> None:
+    frame = format_sse("checkpoint", "ec1.cursor", {"version": 1, "cursor": "ec1.cursor"})
+
+    assert frame == ('event: checkpoint\nid: ec1.cursor\ndata: {"version":1,"cursor":"ec1.cursor"}\n\n')
+    assert format_heartbeat() == ": heartbeat\n\n"
+
+
+def test_public_envelopes_require_version_and_reject_internal_fields() -> None:
+    from app.models.events import ChangeEventEnvelopeV1, TailCheckpointV1
+
+    with pytest.raises(ValidationError):
+        ChangeEventEnvelopeV1.model_validate(
+            {
+                "cursor": "ec1.cursor",
+                "occurred_at": "2026-08-28T08:00:00Z",
+                "vault": "vault",
+                "kind": "document.put",
+                "payload": {},
+            }
+        )
+    checkpoint = TailCheckpointV1(version=1, cursor="ec1.cursor")
+    with pytest.raises(ValidationError):
+        checkpoint.model_validate({"version": 1, "cursor": "ec1.cursor", "id": 4})
+
+
+@pytest.mark.asyncio
+async def test_stream_emits_checkpoint_for_skipped_event_and_change_envelope(monkeypatch) -> None:
+    from app.services import event_tail_service
+
+    class _Connection:
+        def __init__(self) -> None:
+            self.listeners: list[tuple[str, object]] = []
+
+        async def add_listener(self, channel: str, callback: object) -> None:
+            self.listeners.append((channel, callback))
+
+        async def remove_listener(self, channel: str, callback: object) -> None:
+            self.listeners.remove((channel, callback))
+
+    class _Acquire:
+        def __init__(self, connection: _Connection) -> None:
+            self.connection = connection
+
+        async def __aenter__(self) -> _Connection:
+            return self.connection
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+    class _Pool:
+        def __init__(self, connection: _Connection) -> None:
+            self.connection = connection
+
+        def acquire(self) -> _Acquire:
+            return _Acquire(self.connection)
+
+    class _Request:
+        async def is_disconnected(self) -> bool:
+            return False
+
+    rows = [
+        {
+            "id": 10,
+            "occurred_at": datetime(2026, 8, 28, 8, 0, tzinfo=timezone.utc),
+            "kind": "document.update",
+            "resource_uri": "akb://vault/doc/a.md",
+            "actor_id": "alice",
+            "payload": {"changed": True},
+        },
+        {
+            "id": 11,
+            "occurred_at": datetime(2026, 8, 28, 8, 1, tzinfo=timezone.utc),
+            "kind": "table.rows_changed",
+            "resource_uri": "akb://vault/table/items",
+            "actor_id": "alice",
+            "payload": {"operation": "insert"},
+        },
+    ]
+    connection = _Connection()
+
+    async def get_pool() -> _Pool:
+        return _Pool(connection)
+
+    monkeypatch.setattr(event_tail_service, "get_pool", get_pool)
+    monkeypatch.setattr(event_tail_service, "list_vault_events", AsyncMock(return_value=rows))
+    access = AsyncMock(return_value={"vault_id": VAULT_ID})
+    monkeypatch.setattr(event_tail_service, "check_vault_access", access)
+
+    stream = event_tail_service._stream_events(
+        _Request(),
+        user_id="user",
+        vault="vault",
+        vault_id=VAULT_ID,
+        kinds=("table.rows_changed",),
+        position=9,
+        codec=EventCursorCodec("cursor-secret"),
+    )
+    checkpoint = await anext(stream)
+    change = await anext(stream)
+    await stream.aclose()
+
+    assert checkpoint.startswith("event: checkpoint\nid: ec1.")
+    assert change.startswith("event: change\nid: ec1.")
+    checkpoint_body = json.loads(checkpoint.split("data: ", 1)[1])
+    change_body = json.loads(change.split("data: ", 1)[1])
+    assert checkpoint_body["version"] == 1
+    assert checkpoint_body["cursor"] == checkpoint.split("\n", 2)[1][4:]
+    assert change_body["version"] == 1
+    assert change_body["cursor"] == change.split("\n", 2)[1][4:]
+    assert change_body["kind"] == "table.rows_changed"
+    assert change_body["payload"] == {"operation": "insert"}
+    assert "id" not in change_body
+    assert "vault_id" not in change_body
+    assert not connection.listeners
+    assert access.await_count >= 2
+
+
+@pytest.mark.asyncio
+async def test_stream_closes_without_emitting_after_access_is_revoked(monkeypatch) -> None:
+    from app.exceptions import ForbiddenError
+    from app.services import event_tail_service
+
+    class _Connection:
+        async def add_listener(self, *_args: object) -> None:
+            return None
+
+        async def remove_listener(self, *_args: object) -> None:
+            return None
+
+    class _Acquire:
+        async def __aenter__(self) -> _Connection:
+            return _Connection()
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+    class _Pool:
+        def acquire(self) -> _Acquire:
+            return _Acquire()
+
+    class _Request:
+        async def is_disconnected(self) -> bool:
+            return False
+
+    async def get_pool() -> _Pool:
+        return _Pool()
+
+    monkeypatch.setattr(event_tail_service, "get_pool", get_pool)
+    monkeypatch.setattr(
+        event_tail_service,
+        "list_vault_events",
+        AsyncMock(
+            return_value=[
+                {
+                    "id": 1,
+                    "occurred_at": datetime(2026, 8, 28, 8, 0, tzinfo=timezone.utc),
+                    "kind": "document.put",
+                    "resource_uri": None,
+                    "actor_id": "alice",
+                    "payload": {},
+                }
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        event_tail_service,
+        "check_vault_access",
+        AsyncMock(side_effect=[{"vault_id": VAULT_ID}, ForbiddenError("revoked")]),
+    )
+
+    stream = event_tail_service._stream_events(
+        _Request(),
+        user_id="user",
+        vault="vault",
+        vault_id=VAULT_ID,
+        kinds=(),
+        position=0,
+        codec=EventCursorCodec("cursor-secret"),
+    )
+    with pytest.raises(StopAsyncIteration):
+        await anext(stream)

--- a/backend/tests/test_rest_openapi_contract_unit.py
+++ b/backend/tests/test_rest_openapi_contract_unit.py
@@ -996,3 +996,57 @@ def test_non_json_success_operations_keep_their_media_types():
     help_content = schema["paths"]["/api/v1/help/skill-template"]["get"]["responses"]["200"]["content"]
     assert "text/markdown" in help_content
     assert "application/json" not in help_content
+
+
+def test_event_tail_openapi_contract_is_authenticated_typed_sse():
+    operation = app.openapi()["paths"]["/api/v1/events/{vault}"]["get"]
+
+    assert operation["operationId"] == "eventsTail"
+    assert operation["tags"] == ["events"]
+    assert operation["security"] == [{"bearerAuth": []}]
+    assert set(operation["responses"]) >= {"200", "400", "401", "403", "404", "410", "422", "500", "503"}
+    content = operation["responses"]["200"]["content"]
+    assert set(content) == {"text/event-stream"}
+    assert content["text/event-stream"]["schema"] == {
+        "type": "string",
+        "description": "SSE frames carrying change or checkpoint JSON data.",
+    }
+    assert content["text/event-stream"]["x-event-schemas"] == {
+        "change": {"$ref": "#/components/schemas/ChangeEventEnvelopeV1"},
+        "checkpoint": {"$ref": "#/components/schemas/TailCheckpointV1"},
+    }
+
+    params = {(parameter["name"], parameter["in"]): parameter for parameter in operation["parameters"]}
+    assert ("cursor", "query") in params
+    assert ("start", "query") in params
+    assert ("kind", "query") in params
+    assert ("Last-Event-ID", "header") in params
+    assert params[("cursor", "query")]["schema"] == {
+        "$ref": "#/components/schemas/EventCursor",
+    }
+    start_schema = params[("start", "query")]["schema"]
+    start_variants = start_schema.get("anyOf", [start_schema])
+    assert {"const": "earliest", "type": "string"} in start_variants
+    kind_schema = params[("kind", "query")]["schema"]
+    kind_variants = kind_schema.get("anyOf", [kind_schema])
+    assert {
+        "type": "array",
+        "items": {"$ref": "#/components/schemas/EventKind"},
+    } in kind_variants
+    assert params[("Last-Event-ID", "header")]["schema"] == {
+        "$ref": "#/components/schemas/EventCursor",
+    }
+    assert params[("Last-Event-ID", "header")]["required"] is False
+
+    schemas = app.openapi()["components"]["schemas"]
+    assert schemas["EventCursor"]["type"] == "string"
+    assert schemas["EventKind"]["type"] == "string"
+    assert schemas["ChangeEventEnvelopeV1"]["required"] == [
+        "version",
+        "cursor",
+        "occurred_at",
+        "vault",
+        "kind",
+        "payload",
+    ]
+    assert schemas["TailCheckpointV1"]["required"] == ["version", "cursor"]


### PR DESCRIPTION
## Summary

- Adds an authenticated SSE endpoint at `GET /api/v1/events/{vault}` so Vault readers and higher roles can subscribe to PostgreSQL outbox-backed Change Events.
- Adds a deterministic opaque cursor bound to the Vault, the normalized exact Kind filter set, and the Tail position.
- Aligns the resume precedence, retained-gap handling, checkpoints, heartbeats, mid-stream permission revocation, and Redis non-disclosure contracts across OpenAPI and runtime behavior.
- Adds the endpoint E2E suite to the curated hosted gate.

## Verification

- Backend pytest: 2,419 passed, 648 skipped
- Focused event/OpenAPI/runtime tests: 40 passed, 3 skipped
- Ruff, mypy, E2E manifest, and shell syntax checks passed
- Branch-aware P0 review: no actionable findings
- Exact-head hosted CI passed: static analysis, backend unit tests, live PostgreSQL tests, and repository-owned shell E2E
- Independent source-blind REST/SSE behavior validation passed: Vault isolation, starting positions, query/header resume, cursor tampering and scope binding, exact filters and checkpoints, multiple producers, Redis non-disclosure, heartbeats, and mid-stream revocation