### PR TITLE
fix(sso): preserve selected upstream broker login

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3625
+        "line_number": 3632
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5400,5 +5400,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-28T08:04:39Z"
+  "generated_at": "2026-08-28T08:43:34Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3632
+        "line_number": 3634
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5400,5 +5400,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-28T08:43:34Z"
+  "generated_at": "2026-08-28T09:48:16Z"
 }

--- a/README.md
+++ b/README.md
@@ -393,7 +393,10 @@ secrets are write-only, and an enabled provider must be disabled before
 reconfiguration.
 See the [SSO provider guide](./docs/sso/README.md), the standards-based
 [generic OIDC integration](./docs/sso/providers/oidc.md), and the stricter
-[Keycloak OIDC reference](./docs/sso/providers/keycloak-oidc.md).
+[Keycloak OIDC reference](./docs/sso/providers/keycloak-oidc.md). Existing
+Kubernetes installations should also follow the
+[local-to-SSO cutover runbook](./docs/sso/kubernetes-cutover.md) instead of
+treating `auth_mode` as a rolling one-line configuration change.
 
 The dedicated admin callback stores no Keycloak access, refresh, or ID token.
 It creates a short-lived opaque HttpOnly admin cookie plus a CSRF token;

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -9,10 +9,12 @@ specifically; the proxy has its own log in
 
 ### Fixed upstream provider selection with an existing Keycloak session
 
-Ordinary browser login now requires a fresh authentication ceremony in
-addition to its signed `kc_idp_hint`. A native Keycloak session left by the
+Ordinary browser login now requires a fresh Keycloak authentication ceremony
+in addition to its signed `kc_idp_hint`. A native Keycloak session left by the
 separate product-admin surface can no longer satisfy an upstream-provider
-request and cause the selected broker alias to be skipped.
+request and cause the selected broker alias to be skipped. The request does
+not send `prompt=login`, so the upstream provider can still use its own SSO
+session.
 
 ### Added standards-based upstream OIDC provider control
 

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -7,6 +7,13 @@ specifically; the proxy has its own log in
 
 ## Unreleased
 
+### Fixed upstream provider selection with an existing Keycloak session
+
+Ordinary browser login now requires a fresh authentication ceremony in
+addition to its signed `kc_idp_hint`. A native Keycloak session left by the
+separate product-admin surface can no longer satisfy an upstream-provider
+request and cause the selected broker alias to be skipped.
+
 ### Added standards-based upstream OIDC provider control
 
 Product administrators can now configure a generic `oidc` upstream from its

--- a/backend/app/services/keycloak_oidc.py
+++ b/backend/app/services/keycloak_oidc.py
@@ -245,6 +245,12 @@ class KeycloakOIDC:
             "code_challenge": self._make_code_challenge(verifier),
             "code_challenge_method": "S256",
             "kc_idp_hint": provider_alias,
+            # The browser can carry a native Keycloak session from the
+            # separate product-admin surface.  Without forced reauthentication
+            # Keycloak may satisfy this request from that session and ignore
+            # the selected upstream broker alias.
+            "prompt": "login",
+            "max_age": "0",
         }
         await _store_issue(
             state,

--- a/backend/app/services/keycloak_oidc.py
+++ b/backend/app/services/keycloak_oidc.py
@@ -246,10 +246,9 @@ class KeycloakOIDC:
             "code_challenge_method": "S256",
             "kc_idp_hint": provider_alias,
             # The browser can carry a native Keycloak session from the
-            # separate product-admin surface.  Without forced reauthentication
-            # Keycloak may satisfy this request from that session and ignore
-            # the selected upstream broker alias.
-            "prompt": "login",
+            # separate product-admin surface.  Force Keycloak to run the
+            # selected broker ceremony again without forwarding prompt=login
+            # and unnecessarily defeating the upstream provider's own SSO.
             "max_age": "0",
         }
         await _store_issue(

--- a/backend/tests/test_keycloak_companion_client_unit.py
+++ b/backend/tests/test_keycloak_companion_client_unit.py
@@ -40,6 +40,10 @@ async def test_begin_browser_login_is_nonce_pkce_and_browser_bound(monkeypatch):
     assert query["response_type"] == ["code"]
     assert query["scope"] == ["openid profile email"]
     assert query["kc_idp_hint"] == ["workforce"]
+    # Provider selection must win over any native/broker session already in
+    # the browser (for example, the separate product-admin login).
+    assert query["prompt"] == ["login"]
+    assert query["max_age"] == ["0"]
     assert query["code_challenge_method"] == ["S256"]
     assert len(query["code_challenge"][0]) >= 43
     assert len(query["nonce"][0]) >= 20

--- a/backend/tests/test_keycloak_companion_client_unit.py
+++ b/backend/tests/test_keycloak_companion_client_unit.py
@@ -41,9 +41,10 @@ async def test_begin_browser_login_is_nonce_pkce_and_browser_bound(monkeypatch):
     assert query["scope"] == ["openid profile email"]
     assert query["kc_idp_hint"] == ["workforce"]
     # Provider selection must win over any native/broker session already in
-    # the browser (for example, the separate product-admin login).
-    assert query["prompt"] == ["login"]
+    # the browser (for example, the separate product-admin login), without
+    # forcing the upstream provider to discard its own SSO session.
     assert query["max_age"] == ["0"]
+    assert "prompt" not in query
     assert query["code_challenge_method"] == ["S256"]
     assert len(query["code_challenge"][0]) >= 43
     assert len(query["nonce"][0]) >= 20

--- a/deploy/k8s/standalone-sso/README.md
+++ b/deploy/k8s/standalone-sso/README.md
@@ -5,6 +5,12 @@ database to the standalone AKB stack. It owns exactly one AKB realm and is not
 the deployment shape for a managed tenant that reuses a platform-owned
 Keycloak.
 
+For a customized existing namespace, first follow the
+[local-to-SSO cutover runbook](../../../docs/sso/kubernetes-cutover.md). This
+directory is a reference resource set, not an in-place migration patch: review
+resource names, selectors, StatefulSets, PVCs, Ingress, and retained companion
+workloads before applying a target-specific overlay.
+
 The bundle implements the product-administrator bootstrap and recovery slice:
 
 1. Keycloak creates one temporary master-realm service account on its first

--- a/docs/design/accepted/2026-08-13-authentication-mode-boundary/README.md
+++ b/docs/design/accepted/2026-08-13-authentication-mode-boundary/README.md
@@ -2,7 +2,7 @@
 status: accepted
 stage: implementation
 created: 2026-08-13
-updated: 2026-08-14
+updated: 2026-08-28
 ---
 
 # Authentication Mode Boundary
@@ -170,6 +170,9 @@ and policy surfaces.
 - In `sso` mode, ordinary login exposes only enabled, configured OIDC login
   options. Local login, registration, password recovery, and hidden local
   escape paths remain unavailable in both UI and backend policy.
+- Selecting an ordinary upstream provider starts a fresh authentication
+  ceremony. A native Keycloak session from the separate product-admin surface
+  must not satisfy that request or bypass the selected broker alias.
 - If public login options cannot be loaded or validated, ordinary login is
   unavailable; it is not guessed to be local.
 - Product-admin access uses a mode-appropriate bootstrap and recovery path

--- a/docs/sso/README.md
+++ b/docs/sso/README.md
@@ -126,6 +126,12 @@ Additional OSS providers should follow [Adding a provider](adding-a-provider.md)
 The registry is explicit and code-reviewed; AKB does not load arbitrary
 Keycloak JSON or runtime Python plugins.
 
+For an existing Kubernetes installation, use the
+[local-to-SSO cutover runbook](kubernetes-cutover.md). It separates broker
+topology, account continuity, the stop-the-world session-epoch bridge,
+provider activation, acceptance gates, and prepared rollback; do not treat
+`auth_mode` as an isolated rolling configuration toggle.
+
 Ordinary browser sessions are server-custodied. The browser receives an opaque
 HttpOnly AKB handle and a readable double-submit CSRF cookie; it never receives
 a Keycloak access, refresh, or ID token and SSO never mints an AKB user JWT.

--- a/docs/sso/README.md
+++ b/docs/sso/README.md
@@ -136,7 +136,9 @@ The ordinary `akb-web` client maps Keycloak's `identity_provider` user-session
 note into both token profiles. AKB requires that signed alias to equal the
 provider selected in its one-time state, then retains and rechecks the alias in
 the encrypted session envelope; `kc_idp_hint` alone is never an authorization
-boundary.
+boundary. Ordinary provider selection also requests a fresh Keycloak
+authentication ceremony, so a native session left by the separate
+product-admin surface cannot bypass the selected upstream broker.
 An invalid refresh deletes the session; a
 transient Keycloak outage rolls back without converting it into a revocation.
 Production HTTPS uses `__Host-` cookie names with `Secure`, no `Domain`, and

--- a/docs/sso/kubernetes-cutover.md
+++ b/docs/sso/kubernetes-cutover.md
@@ -1,0 +1,185 @@
+# Existing Kubernetes installation: local to SSO cutover
+
+This runbook plans a mode-exclusive `auth_mode: local` to `auth_mode: sso`
+transition for an existing standalone Kubernetes installation. It complements
+the resource definitions in
+[`deploy/k8s/standalone-sso`](../../deploy/k8s/standalone-sso/README.md); it is
+not permission to apply that reference overlay unchanged to a customized live
+namespace.
+
+SSO is a human-login boundary. AKB continues to own users, administrator
+status, Vault grants, PATs, service identities, and application credentials.
+Switching the mode removes local login, registration, password recovery, and
+local product-admin login from the browser. It does not convert existing local
+accounts into upstream identities and it does not revoke PATs automatically.
+
+## 1. Freeze the target and choose a broker topology
+
+Record the exact current and candidate image digests, database migration
+ledger, PostgreSQL backup, storage snapshots, public AKB origin, TLS names,
+Ingress ownership, and every component that authenticates to AKB. Do not use a
+mutable image tag as either the candidate or rollback artifact.
+
+Choose one topology before rendering resources:
+
+- **Installation-owned Keycloak (`direct`)**: deploy the standalone bundle's
+  dedicated Keycloak database, realm, `akb-web`, `akb-admin`, and
+  `akb-sso-manager` clients. AKB `/admin` can manage its own upstream provider
+  instances. This is the reference standalone shape.
+- **Shared or platform-owned Keycloak (`delegated`)**: the realm owner creates
+  and proves the required client profiles and configures upstream providers
+  out of band. AKB must not receive broader realm authority merely to make the
+  admin form writable.
+
+Changing the public Keycloak issuer or its local subject values changes the
+exact identity AKB sees. Treat that as an account migration, not a DNS change.
+
+## 2. Audit account continuity before disabling local login
+
+Inventory, without exporting credentials:
+
+- total human users and administrators;
+- users already bound to the candidate broker issuer and subject;
+- local-only users that still need browser access;
+- active PATs, service identities, and machine consumers;
+- Vault grants owned by accounts that would otherwise be replaced;
+- companion products that still depend on a legacy token-exchange contract.
+
+Email and username are not identity keys. A first Entra login must not adopt
+an existing AKB account merely because profile fields match. Pre-bind an exact
+verified identity to the intended existing account, use an approved explicit
+identity-migration operation, or accept a newly created account and re-grant
+its authorization deliberately. `keycloak_enrollment_mode: invite_only`
+fails closed until exact bindings exist; `open` permits new accounts but does
+not preserve old account ownership.
+
+At least one recovery administrator must be usable after the cutover. For a
+shared broker, pre-provision the exact administrator issuer and subject with
+`python -m app.cli provision-recovery-admin sso`. For the installation-owned
+bundle, prove the native Keycloak product-administrator bootstrap and AKB
+projection before retiring one-time material. Do not assume that an existing
+local `is_admin` row can sign in after local mode is disabled.
+
+## 3. Build a target-specific overlay
+
+Start from the standalone SSO bundle, but preserve the live installation's
+existing PostgreSQL storage, Vault Git storage, object storage, derived
+indexes, Services, Ingress routes, NetworkPolicies, collectors, and companion
+applications. A reference manifest may use the same resource names with
+different selectors, StatefulSet definitions, or PVC contracts; an
+unreviewed `kubectl apply` can replace those resources.
+
+The rendered `app.yaml` must include a coherent SSO profile:
+
+```yaml
+auth_mode: sso
+auth_runtime_generation: <positive monotonic integer>
+keycloak_enabled: true
+keycloak_server_url: https://<public-broker-host>
+keycloak_internal_url: http://<in-cluster-keycloak-service>:8080
+keycloak_backchannel_logout_uri: http://<backend-service>:8000/api/v1/auth/keycloak/backchannel-logout
+keycloak_realm: akb
+keycloak_client_id: akb-web
+keycloak_public_client: false
+keycloak_admin_client_id: akb-admin
+keycloak_management_client_id: akb-sso-manager
+keycloak_enrollment_mode: invite_only
+keycloak_require_verified_email: true
+keycloak_verify_ssl: true
+public_base_url: https://<public-akb-host>
+```
+
+Use `open` only after account-admission behavior has been approved. The Secret
+must provide an installation-owned UUID `sso_session_epoch`, an independent
+32-byte unpadded base64url `sso_browser_session_encryption_key`, and the three
+independent confidential-client secrets described by the standalone bundle.
+Keep the generation/mode/epoch tuple stable for ordinary restarts; advance the
+generation for every later mode or epoch change.
+
+Render, schema-check, and diff the target-specific overlay against the live
+objects before the maintenance window. A client-side dry run does not prove
+selector, PVC, Ingress, or database compatibility; review those explicitly.
+
+## 4. Rehearse the database transition
+
+Restore a current production backup into an isolated candidate environment
+and run the exact candidate image. Verify the migration ledger and execute the
+session-epoch preflight there before attempting the live database.
+
+An installation first upgrading from a pre-epoch build requires the explicit
+stop-the-world bridge:
+
+1. Stop every backend replica and every other direct client of the AKB
+   PostgreSQL database.
+2. Configure the desired positive generation and SSO epoch, plus the temporary
+   `sso_session_epoch_upgrade: stop-the-world-v1` acknowledgement.
+3. From the candidate image run
+   `python scripts/sso_session_epoch_preflight.py status`; a legacy database
+   reports `migration_pending`.
+4. Run `python scripts/sso_session_epoch_preflight.py prepare-upgrade`. It
+   refuses concurrent database clients, applies the compatible migration set,
+   purges pre-epoch browser authority, and enables the legacy-write guard.
+5. Require `state=enforced` and `legacy_rows_present=false`, then remove the
+   temporary acknowledgement before starting the application.
+
+The ordinary backend startup is not a substitute for `prepare-upgrade`.
+
+## 5. Cut over in a maintenance window
+
+1. Quiesce writes and capture both a logical PostgreSQL backup and the
+   installation's storage snapshots. Record the rollback image digests and
+   configuration revision.
+2. Scale every backend/API/worker process that connects directly to the AKB
+   database to zero. Confirm `pg_stat_activity` has no other client backend.
+3. Deploy or verify the selected Keycloak topology, its database, TLS,
+   hostname, clients, signing profile, and back-channel route.
+4. Run the rehearsed `prepare-upgrade` job with the candidate image and exact
+   mounted configuration. Remove the temporary acknowledgement after success.
+5. Start one backend replica. Require its bootstrap/read-back gate, `/livez`,
+   `/readyz`, migration ledger, and authentication runtime boundary to be
+   healthy before starting more replicas or dependent components.
+6. Verify `/admin` through the recovery administrator. Save the generic OIDC
+   upstream disabled, register AKB's displayed broker endpoint as an upstream
+   Web redirect URI, then enable it.
+7. Start ordinary login only from AKB `/auth`. Complete one canary identity
+   before restoring full traffic.
+
+## 6. Acceptance gates
+
+The cutover is incomplete until all of these pass against the immutable
+candidate:
+
+- `/api/v1/auth/config` advertises only enabled SSO providers and no local
+  login, registration, password-reset, or hidden fallback route is usable;
+- product-admin login succeeds through `akb-admin` and a brokered ordinary
+  user is rejected from that admin ceremony;
+- Entra login reaches the exact Keycloak broker callback, AKB callback, and
+  `/api/v1/auth/me` without exposing provider tokens to the browser;
+- the canary resolves to the intended existing account or to an explicitly
+  approved new account, with expected Vault roles;
+- logout, refresh, idle/absolute expiry, back-channel logout, wrong
+  issuer/audience, copied callback, and stale state behave fail-closed;
+- representative existing PAT and service consumers still work, while local
+  human credentials no longer do;
+- collectors and companion products complete their own read/write smoke tests.
+
+## 7. Rollback
+
+To run a pre-epoch rollback image, stop every current backend and database
+client and use the current image/config to run:
+
+```text
+python scripts/sso_session_epoch_preflight.py prepare-rollback
+```
+
+Only after that succeeds may the operator restore the old configuration
+without `auth_runtime_generation`, `sso_session_epoch_upgrade`, and
+`sso_session_epoch`, then start the frozen rollback image. No current browser
+session survives. Retain the generation floor: a later re-upgrade must use a
+greater generation.
+
+Prefer this prepared application rollback over restoring a database snapshot
+after post-cutover writes. Scale an installation-owned Keycloak down only
+after AKB has returned to the old authority. Newly created SSO accounts are
+not converted into local-password accounts by rollback; record and reconcile
+them explicitly.

--- a/docs/sso/providers/oidc.md
+++ b/docs/sso/providers/oidc.md
@@ -34,6 +34,31 @@ logout response URI where that provider requires an allowlist:
 https://<broker-host>/realms/<akb-realm>/broker/<alias>/endpoint/logout_response
 ```
 
+### Redirect-registration ownership
+
+AKB and its Keycloak broker derive and display the callback, but they do not
+modify the upstream client registration. Registering that URI remains an
+upstream-application administrator action. Automatic registration would
+require provider-management credentials that are unrelated to OIDC login and
+would make the generic provider depend on a vendor control plane.
+
+One upstream client may allow several exact Web redirect URIs. Register one
+for every public broker host, realm, and provider alias that will use that
+client; a Kubernetes namespace name by itself does not determine the URI.
+For example, a test and production installation can coexist in one client:
+
+```text
+https://<test-broker-host>/realms/<realm>/broker/<alias>/endpoint
+https://<production-broker-host>/realms/<realm>/broker/<alias>/endpoint
+```
+
+The same client ID and credential then authorize every listed environment.
+Separate upstream clients are preferred when test and production should have
+independent credentials, consent, ownership, rotation, and incident scope.
+Remove retired-environment URIs promptly. Wildcards, a guessed AKB API
+callback, and a URI copied from another alias are not substitutes for the
+displayed value.
+
 ## Configure in AKB
 
 1. Sign in at `/admin` with the product-administrator identity.
@@ -76,6 +101,46 @@ Client ID: <Application (client) ID>
 Secret:    <client secret Value, not Secret ID>
 ```
 
-Register the broker endpoint as a **Web** redirect URI. Use the tenant-specific
-issuer rather than `common` or `organizations` when the AKB installation is
-intended for one workforce tenant.
+Use the tenant-specific issuer rather than `common` or `organizations` when
+the AKB installation is intended for one workforce tenant.
+
+In the Microsoft Entra admin center:
+
+1. Open **Identity → Applications → App registrations**, then select the
+   application whose Application (client) ID is configured in AKB.
+2. Open **Authentication → Add a platform → Web**. Do not register the
+   Keycloak server callback as a Single-page application.
+3. Paste the exact redirect URI shown by AKB after the provider is saved
+   disabled, then save the platform configuration. Additional environments
+   are additional Web redirect URIs on the same application, or separate app
+   registrations when isolation is required.
+4. Under **Certificates & secrets**, give AKB the client secret **Value** at
+   creation time. The Secret ID is metadata and cannot authenticate a client.
+5. Ensure the workforce profile supplies an email claim before using open
+   enrollment. Email is profile/admission data only; AKB still keys identity
+   by the signed broker issuer and subject and never adopts an existing user
+   from an email match.
+
+The standard `openid profile email` login does not require AKB to hold a
+Microsoft Graph management credential. Tenant policy may still require an
+administrator to grant consent for the application's requested scopes.
+
+After Entra has accepted the redirect URI, return to AKB `/auth` and start the
+login from the rendered provider button. Opening the Microsoft authorize URL
+or the Keycloak broker callback directly does not create AKB's one-time state.
+
+Common diagnostics:
+
+- `AADSTS900971: No reply address provided` means the app registration has no
+  usable Web reply address for this flow. Add the displayed broker endpoint.
+- `AADSTS50011` means the request's redirect URI does not exactly match a URI
+  registered on that application. Compare scheme, host, realm, alias, path,
+  and trailing slash.
+- `Missing state parameter in response from identity provider` usually means
+  a callback or authorize endpoint was opened directly. Restart at AKB
+  `/auth`; do not reuse an old callback URL.
+
+Microsoft references:
+
+- [Register an application and configure a Web redirect URI](https://learn.microsoft.com/en-us/graph/auth-register-app-v2)
+- [Redirect URI restrictions and multiple-environment guidance](https://learn.microsoft.com/en-us/entra/identity-platform/reply-url)


### PR DESCRIPTION
## Summary

- force ordinary browser login to rerun the selected Keycloak broker ceremony even when the browser carries a native product-admin Keycloak session
- use `max_age=0` without `prompt=login`, preserving the upstream provider's own SSO session
- document generic OIDC/Entra redirect-registration ownership, multiple exact Web redirect URIs, diagnostics, and an existing-Kubernetes local-to-SSO cutover runbook

## Root cause

`kc_idp_hint` selects an Identity Provider Redirector only when Keycloak executes the browser authentication flow. A valid native Keycloak cookie could satisfy the request earlier, skip the broker alias, and return the product-admin identity to AKB's ordinary callback. `max_age=0` invalidates that Keycloak shortcut; omitting `prompt=login` avoids forcing the same reauthentication policy onto Entra or another upstream OIDC provider.

## Validation

- reviewed exact head: `6d4a3e0aadd5c9f1cc76bf8bd62831fd636b3c5f`
- focused auth/provider contracts: 73 passed
- `scripts/check.sh`: backend ruff/mypy/bandit green; SDK 50 passed; frontend 673 passed; tracked-file secret scan green
- public-doc diff contains no internal fresh-environment host, tenant ID, client ID, or credential value

## Operations

No existing `akb` namespace resource is changed by this PR. Post-merge deployment and Entra E2E are limited to the disposable `akb-sso-fresh-260824` namespace.
