### PR TITLE
feat(frontend): add file and table publication flows

### DIFF
--- a/frontend/src/components/__tests__/publish-options-dialog.test.tsx
+++ b/frontend/src/components/__tests__/publish-options-dialog.test.tsx
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PublishOptionsDialog } from "@/components/publish-options-dialog";
+
+vi.mock("@/lib/api", () => ({
+  createPublication: vi.fn(),
+  getDocument: vi.fn(),
+  listPublications: vi.fn(),
+}));
+
+import { createPublication, getDocument, listPublications } from "@/lib/api";
+
+const createPublicationMock = createPublication as unknown as ReturnType<typeof vi.fn>;
+const getDocumentMock = getDocument as unknown as ReturnType<typeof vi.fn>;
+const listPublicationsMock = listPublications as unknown as ReturnType<typeof vi.fn>;
+
+const FILE_PUBLICATION = {
+  slug: "diagram-public",
+  share_url: "https://example.test/p/diagram-public",
+  resource_type: "file",
+  resource_uri: "akb://demo/coll/design/file/11111111-1111-1111-1111-111111111111",
+  vault: "demo",
+  title: "diagram.png",
+  mode: "live",
+  expires_at: null,
+  max_views: null,
+  view_count: 0,
+  allow_embed: true,
+  section_filter: null,
+  password_protected: false,
+  created_at: "2026-08-31T00:00:00Z",
+  snapshot_at: null,
+} as const;
+
+const DOCUMENT_PUBLICATION = {
+  ...FILE_PUBLICATION,
+  slug: "guide-public",
+  share_url: "https://example.test/p/guide-public",
+  resource_type: "document",
+  resource_uri: "akb://demo/coll/docs/doc/guide.md",
+  title: "Guide",
+} as const;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getDocumentMock.mockResolvedValue({
+    uri: DOCUMENT_PUBLICATION.resource_uri,
+    title: "Guide",
+    path: "docs/guide.md",
+  });
+  listPublicationsMock.mockResolvedValue({ publications: [] });
+  createPublicationMock.mockResolvedValue(FILE_PUBLICATION);
+});
+
+afterEach(cleanup);
+
+describe("PublishOptionsDialog file flow", () => {
+  it("publishes a canonical file URI with the shared access controls", async () => {
+    const user = userEvent.setup();
+    const onPublished = vi.fn();
+    const onOpenChange = vi.fn();
+    render(
+      <PublishOptionsDialog
+        open
+        onOpenChange={onOpenChange}
+        vault="demo"
+        resourceType="file"
+        resourceUri={FILE_PUBLICATION.resource_uri}
+        resourceName="diagram.png"
+        onPublished={onPublished}
+      />,
+    );
+
+    await user.click(screen.getByRole("checkbox", { name: /Require password/i }));
+    await user.type(screen.getByLabelText("Publication password"), "strong-passphrase");
+    await user.click(screen.getByRole("button", { name: "7 days" }));
+    await user.type(screen.getByLabelText("Max views"), "25");
+    await user.click(screen.getByRole("button", { name: "Publish" }));
+
+    await waitFor(() => {
+      expect(createPublicationMock).toHaveBeenCalledWith("demo", {
+        resource_type: "file",
+        uri: FILE_PUBLICATION.resource_uri,
+        title: "diagram.png",
+        password: "strong-passphrase", // pragma: allowlist secret — synthetic test value
+        expires_in: "7d",
+        max_views: 25,
+      });
+    });
+    expect(onPublished).toHaveBeenCalledWith("diagram-public", FILE_PUBLICATION);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("creates a distinct link when the same file already has a publication", async () => {
+    listPublicationsMock.mockResolvedValue({ publications: [FILE_PUBLICATION] });
+    const user = userEvent.setup();
+    const onPublished = vi.fn();
+    render(
+      <PublishOptionsDialog
+        open
+        onOpenChange={vi.fn()}
+        vault="demo"
+        resourceType="file"
+        resourceUri={FILE_PUBLICATION.resource_uri}
+        resourceName="diagram.png"
+        onPublished={onPublished}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Publish" }));
+
+    await waitFor(() => expect(onPublished).toHaveBeenCalledWith("diagram-public", FILE_PUBLICATION));
+    expect(createPublicationMock).toHaveBeenCalledTimes(1);
+    expect(listPublicationsMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps an invalid access limit inline and blocks submission", async () => {
+    const user = userEvent.setup();
+    render(
+      <PublishOptionsDialog
+        open
+        onOpenChange={vi.fn()}
+        vault="demo"
+        resourceType="file"
+        resourceUri={FILE_PUBLICATION.resource_uri}
+        resourceName="diagram.png"
+        onPublished={vi.fn()}
+      />,
+    );
+
+    await user.type(screen.getByLabelText("Max views"), "0");
+    expect(screen.getByText("Enter a positive whole number.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Publish" })).toBeDisabled();
+    expect(createPublicationMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("PublishOptionsDialog document compatibility", () => {
+  it("keeps the document viewer's singular-link reuse contract", async () => {
+    listPublicationsMock.mockResolvedValue({ publications: [DOCUMENT_PUBLICATION] });
+    const user = userEvent.setup();
+    const onPublished = vi.fn();
+    render(
+      <PublishOptionsDialog
+        open
+        onOpenChange={vi.fn()}
+        vault="demo"
+        docId="docs/guide.md"
+        onPublished={onPublished}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Publish" }));
+
+    await waitFor(() => {
+      expect(onPublished).toHaveBeenCalledWith("guide-public", DOCUMENT_PUBLICATION);
+    });
+    expect(getDocumentMock).toHaveBeenCalledWith("demo", "docs/guide.md");
+    expect(listPublicationsMock).toHaveBeenCalledWith("demo", "document");
+    expect(createPublicationMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/__tests__/table-publish-dialog.test.tsx
+++ b/frontend/src/components/__tests__/table-publish-dialog.test.tsx
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TablePublishDialog } from "@/components/table-publish-dialog";
+import { buildTablePublicationQuery } from "@/lib/table-publication";
+
+vi.mock("@/lib/api", () => ({
+  createPublication: vi.fn(),
+  createPublicationSnapshot: vi.fn(),
+  deletePublication: vi.fn(),
+  getDocument: vi.fn(),
+  previewTablePublicationQuery: vi.fn(),
+}));
+
+import {
+  createPublication,
+  createPublicationSnapshot,
+  deletePublication,
+  previewTablePublicationQuery,
+} from "@/lib/api";
+
+const createPublicationMock = createPublication as unknown as ReturnType<typeof vi.fn>;
+const snapshotMock = createPublicationSnapshot as unknown as ReturnType<typeof vi.fn>;
+const deletePublicationMock = deletePublication as unknown as ReturnType<typeof vi.fn>;
+const previewMock = previewTablePublicationQuery as unknown as ReturnType<typeof vi.fn>;
+
+const COLUMNS = [
+  { name: "ticket_id", type: "uuid", primary_key: true },
+  { name: "title", type: "text" },
+  { name: "internal_note", type: "text" },
+];
+
+const LIVE_PUBLICATION = {
+  slug: "tickets-live",
+  share_url: "https://example.test/p/tickets-live",
+  resource_type: "table_query",
+  resource_uri: null,
+  vault: "demo",
+  title: "tickets",
+  mode: "live",
+  expires_at: null,
+  max_views: null,
+  view_count: 0,
+  allow_embed: true,
+  section_filter: null,
+  password_protected: false,
+  created_at: "2026-08-31T00:00:00Z",
+  snapshot_at: null,
+  query_sql: "SELECT ticket_id, title FROM tickets ORDER BY ticket_id LIMIT 100",
+  query_vault_names: ["demo"],
+  query_params: {},
+} as const;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  previewMock.mockResolvedValue({
+    kind: "table_query",
+    columns: ["ticket_id", "title"],
+    items: [{ ticket_id: "t-1", title: "First" }],
+    total: 1,
+  });
+  createPublicationMock.mockResolvedValue(LIVE_PUBLICATION);
+  snapshotMock.mockResolvedValue({
+    ...LIVE_PUBLICATION,
+    mode: "snapshot",
+    snapshot_at: "2026-08-31T01:00:00Z",
+  });
+  deletePublicationMock.mockResolvedValue({ deleted: 1 });
+});
+
+afterEach(cleanup);
+
+describe("table publication query builder", () => {
+  it("keeps catalog order, adds deterministic primary-key ordering, and bounds rows", () => {
+    expect(
+      buildTablePublicationQuery({
+        table: "tickets",
+        columns: COLUMNS,
+        selectedColumns: ["title", "ticket_id"],
+        rowLimit: 250,
+      }),
+    ).toBe("SELECT ticket_id, title FROM tickets ORDER BY ticket_id LIMIT 250");
+  });
+
+  it("rejects malformed identifiers and unbounded selections", () => {
+    expect(() =>
+      buildTablePublicationQuery({
+        table: "tickets;drop",
+        columns: COLUMNS,
+        selectedColumns: ["ticket_id"],
+        rowLimit: 100,
+      }),
+    ).toThrow(/cannot be published safely/i);
+    expect(() =>
+      buildTablePublicationQuery({
+        table: "tickets",
+        columns: COLUMNS,
+        selectedColumns: [],
+        rowLimit: 100,
+      }),
+    ).toThrow(/select at least one column/i);
+  });
+});
+
+describe("TablePublishDialog", () => {
+  it("requires a current server preview before publishing selected columns", async () => {
+    const user = userEvent.setup();
+    const onPublished = vi.fn();
+    render(
+      <TablePublishDialog
+        open
+        onOpenChange={vi.fn()}
+        vault="demo"
+        table="tickets"
+        columns={COLUMNS}
+        onPublished={onPublished}
+      />,
+    );
+
+    const publish = screen.getByRole("button", { name: "Publish live table" });
+    expect(publish).toBeDisabled();
+    await user.click(screen.getByRole("checkbox", { name: /internal_note/i }));
+    await user.click(screen.getByRole("button", { name: "Preview query" }));
+
+    const sql = "SELECT ticket_id, title FROM tickets ORDER BY ticket_id LIMIT 100";
+    await waitFor(() => expect(previewMock).toHaveBeenCalledWith("demo", sql));
+    expect(await screen.findByText("Verified")).toBeInTheDocument();
+    expect(publish).toBeEnabled();
+
+    await user.click(publish);
+    await waitFor(() => {
+      expect(createPublicationMock).toHaveBeenCalledWith("demo", {
+        resource_type: "table_query",
+        query_sql: sql,
+        query_vault_names: ["demo"],
+        title: "tickets",
+        password: undefined,
+        expires_in: undefined,
+        max_views: undefined,
+      });
+    });
+    expect(onPublished).toHaveBeenCalledWith(LIVE_PUBLICATION);
+  });
+
+  it("turns a newly-created live link into a snapshot", async () => {
+    const user = userEvent.setup();
+    const onPublished = vi.fn();
+    render(
+      <TablePublishDialog
+        open
+        onOpenChange={vi.fn()}
+        vault="demo"
+        table="tickets"
+        columns={COLUMNS.slice(0, 2)}
+        onPublished={onPublished}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /^Snapshot/i }));
+    await user.click(screen.getByRole("button", { name: "Preview query" }));
+    await screen.findByText("Verified");
+    await user.click(screen.getByRole("button", { name: "Publish snapshot" }));
+
+    await waitFor(() => expect(snapshotMock).toHaveBeenCalledWith("demo", "tickets-live"));
+    expect(onPublished).toHaveBeenCalledWith(
+      expect.objectContaining({ slug: "tickets-live", mode: "snapshot" }),
+    );
+  });
+
+  it("revokes the temporary live link when snapshot creation fails", async () => {
+    snapshotMock.mockRejectedValue(new Error("Snapshot storage unavailable"));
+    const user = userEvent.setup();
+    render(
+      <TablePublishDialog
+        open
+        onOpenChange={vi.fn()}
+        vault="demo"
+        table="tickets"
+        columns={COLUMNS.slice(0, 2)}
+        onPublished={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /^Snapshot/i }));
+    await user.click(screen.getByRole("button", { name: "Preview query" }));
+    await screen.findByText("Verified");
+    await user.click(screen.getByRole("button", { name: "Publish snapshot" }));
+
+    expect(
+      await screen.findByText(/Snapshot storage unavailable.*temporary live link was removed/i),
+    ).toBeInTheDocument();
+    expect(deletePublicationMock).toHaveBeenCalledWith("demo", "tickets-live");
+  });
+
+  it("surfaces a direct recovery path when snapshot cleanup also fails", async () => {
+    snapshotMock.mockRejectedValue(new Error("Snapshot storage unavailable"));
+    deletePublicationMock.mockRejectedValue(new Error("Revocation unavailable"));
+    const user = userEvent.setup();
+    render(
+      <TablePublishDialog
+        open
+        onOpenChange={vi.fn()}
+        vault="demo"
+        table="tickets"
+        columns={COLUMNS.slice(0, 2)}
+        onPublished={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /^Snapshot/i }));
+    await user.click(screen.getByRole("button", { name: "Preview query" }));
+    await screen.findByText("Verified");
+    await user.click(screen.getByRole("button", { name: "Publish snapshot" }));
+
+    expect(
+      await screen.findByText(/could not be removed; revoke it from Publish immediately/i),
+    ).toBeInTheDocument();
+    expect(deletePublicationMock).toHaveBeenCalledWith("demo", "tickets-live");
+  });
+});

--- a/frontend/src/components/publication-success-banner.tsx
+++ b/frontend/src/components/publication-success-banner.tsx
@@ -1,0 +1,51 @@
+import { Link } from "react-router-dom";
+import { ExternalLink, X } from "lucide-react";
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import type { Publication } from "@/lib/api";
+
+export function PublicationSuccessBanner({
+  vault,
+  publication,
+  resourceLabel,
+  onDismiss,
+}: {
+  vault: string;
+  publication: Publication;
+  resourceLabel: "File" | "Table";
+  onDismiss: () => void;
+}) {
+  return (
+    <div className="flex shrink-0 flex-col gap-2 border-b border-border bg-surface px-3 py-2 sm:flex-row sm:items-center sm:px-4 lg:px-5">
+      <Alert
+        variant="success"
+        title={`${resourceLabel} published`}
+        className="min-w-0 flex-1 border-0 bg-transparent p-0"
+      >
+        Anyone with the link can open the public, read-only view.
+      </Alert>
+      <div className="flex shrink-0 items-center gap-1 self-end sm:self-auto">
+        <Button asChild variant="outline" size="sm">
+          <a href={publication.share_url} target="_blank" rel="noreferrer">
+            Open public link
+            <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+          </a>
+        </Button>
+        <Button asChild variant="ghost" size="sm">
+          <Link to={`/vault/${encodeURIComponent(vault)}/publications`}>
+            Manage links
+          </Link>
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label="Dismiss publication notice"
+          onClick={onDismiss}
+        >
+          <X className="h-4 w-4" aria-hidden />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/publish-options-dialog.tsx
+++ b/frontend/src/components/publish-options-dialog.tsx
@@ -1,6 +1,17 @@
-import { useEffect, useState } from "react";
-import { Eye, EyeOff } from "lucide-react";
-import { createPublication, getDocument, listPublications } from "@/lib/api";
+import { useEffect, useRef, useState, type FormEvent } from "react";
+import { Eye, EyeOff, Globe2 } from "lucide-react";
+import {
+  createPublication,
+  getDocument,
+  listPublications,
+  type Publication,
+} from "@/lib/api";
+import {
+  emptyPublicationAccessOptions,
+  publicationAccessError,
+  publicationAccessPayload,
+  type PublicationAccessOptions,
+} from "@/lib/publication-options";
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -18,9 +29,14 @@ interface PublishOptionsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   vault: string;
-  docId: string;
-  /** Called with the created publication's slug after success. */
-  onPublished: (slug: string) => void;
+  /** Required for the existing document publication flow. */
+  docId?: string;
+  /** File publications pass their canonical URI directly. Defaults to document. */
+  resourceType?: "document" | "file";
+  resourceUri?: string;
+  resourceName?: string;
+  /** Called with the ready public link after success or exact-URI reuse. */
+  onPublished: (slug: string, publication?: Publication) => void;
 }
 
 const EXPIRY_PRESETS: Array<{ value: string; label: string }> = [
@@ -31,207 +47,284 @@ const EXPIRY_PRESETS: Array<{ value: string; label: string }> = [
   { value: "90d", label: "90 days" },
 ];
 
+export function PublicationAccessFields({
+  value,
+  onChange,
+  idPrefix,
+  disabled = false,
+}: {
+  value: PublicationAccessOptions;
+  onChange: (next: PublicationAccessOptions) => void;
+  idPrefix: string;
+  disabled?: boolean;
+}) {
+  const [showPassword, setShowPassword] = useState(false);
+  const passwordId = `${idPrefix}-password`;
+  const passwordHelpId = `${idPrefix}-password-help`;
+  const maxViewsId = `${idPrefix}-max-views`;
+  const maxViewsHelpId = `${idPrefix}-max-views-help`;
+  const passwordInvalid =
+    value.requirePassword && value.password.length > 0 && value.password.trim().length < 8;
+  const max = value.maxViews.trim();
+  const maxViewsInvalid = Boolean(
+    max && (!/^\d+$/.test(max) || !Number.isSafeInteger(Number(max)) || Number(max) < 1),
+  );
+
+  useEffect(() => {
+    if (!value.requirePassword) setShowPassword(false);
+  }, [value.requirePassword]);
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-[var(--radius-md)] border border-border p-3">
+        <label className="flex min-h-9 cursor-pointer items-center gap-2">
+          <input
+            type="checkbox"
+            checked={value.requirePassword}
+            disabled={disabled}
+            onChange={(event) =>
+              onChange({ ...value, requirePassword: event.target.checked })
+            }
+            className="h-4 w-4 shrink-0 cursor-pointer rounded-[var(--radius-sm)] accent-[var(--color-primary)] focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:cursor-not-allowed"
+          />
+          <span className="min-w-0 flex-1">
+            <span className="block text-sm font-medium text-foreground">Require password</span>
+            <span className="block text-xs text-foreground-muted">
+              Viewers enter a shared password before access.
+            </span>
+          </span>
+        </label>
+        {value.requirePassword && (
+          <div className="mt-3">
+            <Label htmlFor={passwordId} className="mb-1.5 block text-xs text-foreground">
+              Publication password
+            </Label>
+            <div className="relative">
+              <Input
+                id={passwordId}
+                type={showPassword ? "text" : "password"}
+                autoComplete="new-password"
+                value={value.password}
+                disabled={disabled}
+                onChange={(event) => onChange({ ...value, password: event.target.value })}
+                placeholder="At least 8 characters"
+                aria-invalid={passwordInvalid || undefined}
+                aria-describedby={passwordHelpId}
+                className="pr-11 font-mono"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((current) => !current)}
+                aria-label={showPassword ? "Hide password" : "Show password"}
+                disabled={disabled}
+                className="absolute right-1 top-1/2 inline-flex h-9 w-9 -translate-y-1/2 cursor-pointer items-center justify-center rounded-[var(--radius-sm)] text-foreground-muted transition-token hover:bg-surface-hover hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {showPassword ? (
+                  <EyeOff className="h-4 w-4" aria-hidden />
+                ) : (
+                  <Eye className="h-4 w-4" aria-hidden />
+                )}
+              </button>
+            </div>
+            <p
+              id={passwordHelpId}
+              className={passwordInvalid ? "mt-1 text-xs text-destructive" : "mt-1 text-xs text-foreground-muted"}
+            >
+              {passwordInvalid ? "Use at least 8 characters." : "Store this password somewhere safe; AKB cannot reveal it later."}
+            </p>
+          </div>
+        )}
+      </div>
+
+      <fieldset disabled={disabled}>
+        <legend className="mb-1.5 text-xs font-medium text-foreground">Expires</legend>
+        <div className="grid grid-cols-2 gap-px overflow-hidden rounded-[var(--radius-md)] border border-border bg-border sm:grid-cols-5">
+          {EXPIRY_PRESETS.map((preset) => {
+            const active = value.expiresIn === preset.value;
+            return (
+              <button
+                key={preset.label}
+                type="button"
+                onClick={() => onChange({ ...value, expiresIn: preset.value })}
+                aria-pressed={active}
+                className={`min-h-9 cursor-pointer px-2 py-2 text-xs font-medium transition-token focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 ${
+                  active
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-surface text-foreground hover:bg-surface-hover"
+                }`}
+              >
+                {preset.label}
+              </button>
+            );
+          })}
+        </div>
+        <p className="mt-1.5 text-xs text-foreground-muted">
+          Expired links stop responding and must be recreated.
+        </p>
+      </fieldset>
+
+      <div>
+        <Label htmlFor={maxViewsId} className="mb-1.5 block text-xs text-foreground">
+          Max views
+        </Label>
+        <Input
+          id={maxViewsId}
+          type="number"
+          min={1}
+          step={1}
+          inputMode="numeric"
+          value={value.maxViews}
+          disabled={disabled}
+          onChange={(event) => onChange({ ...value, maxViews: event.target.value })}
+          placeholder="Unlimited"
+          aria-invalid={maxViewsInvalid || undefined}
+          aria-describedby={maxViewsHelpId}
+        />
+        <p
+          id={maxViewsHelpId}
+          className={maxViewsInvalid ? "mt-1.5 text-xs text-destructive" : "mt-1.5 text-xs text-foreground-muted"}
+        >
+          {maxViewsInvalid
+            ? "Enter a positive whole number."
+            : "Each public view counts toward this limit."}
+        </p>
+      </div>
+    </div>
+  );
+}
+
 export function PublishOptionsDialog({
   open,
   onOpenChange,
   vault,
   docId,
+  resourceType = "document",
+  resourceUri,
+  resourceName,
   onPublished,
 }: PublishOptionsDialogProps) {
-  const [password, setPassword] = useState("");
-  const [showPw, setShowPw] = useState(false);
-  const [requirePassword, setRequirePassword] = useState(false);
-  const [expiresIn, setExpiresIn] = useState("");
-  const [maxViews, setMaxViews] = useState("");
+  const [access, setAccess] = useState<PublicationAccessOptions>(
+    emptyPublicationAccessOptions,
+  );
   const [working, setWorking] = useState(false);
   const [error, setError] = useState("");
-
-  // A shared publication password is a real secret — require a floor length so
-  // a one-character "password" can't be set by accident.
-  const pwTooShort =
-    requirePassword && password.length > 0 && password.length < 8;
-  const cannotPublish = working || (requirePassword && password.trim().length < 8);
+  const errorRef = useRef<HTMLDivElement | null>(null);
+  const accessError = publicationAccessError(access);
+  const resourceLabel = resourceType === "file" ? "file" : "document";
 
   useEffect(() => {
     if (!open) {
-      setPassword("");
-      setShowPw(false);
-      setRequirePassword(false);
-      setExpiresIn("");
-      setMaxViews("");
+      setAccess(emptyPublicationAccessOptions());
       setError("");
     }
   }, [open]);
 
-  async function handlePublish() {
+  useEffect(() => {
+    if (error) errorRef.current?.focus();
+  }, [error]);
+
+  async function handlePublish(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (accessError) {
+      setError(accessError);
+      return;
+    }
+
     setWorking(true);
     setError("");
     try {
-      // Idempotency: if a publication for this doc already exists, surface
-      // it without creating another. The doc page treats publication as
-      // singular ("/p/<slug>"); avoiding duplicates keeps that contract.
-      // The two reads are independent — run them concurrently.
-      const [doc, { publications }] = await Promise.all([
-        getDocument(vault, docId),
-        listPublications(vault, "document"),
-      ]);
-      const existing = publications.find((p: any) => p.resource_uri === doc.uri);
-      if (existing) {
-        onPublished(existing.slug);
-        onOpenChange(false);
-        return;
+      let uri = resourceUri;
+      let title = resourceName;
+      if (resourceType === "document") {
+        if (!docId) throw new Error("Document identity is unavailable.");
+        // Documents expose one representative /p/ link from their viewer, so
+        // keep the existing singular/idempotent contract. File publications
+        // intentionally do not reuse: the same file can have multiple links
+        // with different passwords, expiry dates, and view limits.
+        const [document, { publications }] = await Promise.all([
+          getDocument(vault, docId),
+          listPublications(vault, "document"),
+        ]);
+        uri = document.uri;
+        title = document.title || document.path;
+        const existing = publications.find(
+          (publication) => publication.resource_uri === uri,
+        );
+        if (existing) {
+          onPublished(existing.slug, existing);
+          onOpenChange(false);
+          return;
+        }
       }
+      if (!uri) throw new Error(`${resourceLabel} identity is unavailable.`);
 
-      const max = maxViews.trim();
       const result = await createPublication(vault, {
-        resource_type: "document",
-        uri: doc.uri,
-        password: requirePassword && password ? password : undefined,
-        expires_in: expiresIn || undefined,
-        max_views: max ? Number(max) : undefined,
+        resource_type: resourceType,
+        uri,
+        title: title || undefined,
+        ...publicationAccessPayload(access),
       });
-      onPublished(result.slug);
+      onPublished(result.slug, result);
       onOpenChange(false);
-    } catch (e: any) {
-      setError(e?.message || "Failed to publish");
+    } catch (caught: unknown) {
+      setError(caught instanceof Error ? caught.message : `Failed to publish ${resourceLabel}.`);
     } finally {
       setWorking(false);
     }
   }
 
   return (
-    <Dialog open={open} onOpenChange={(o) => !working && onOpenChange(o)}>
+    <Dialog open={open} onOpenChange={(next) => !working && onOpenChange(next)}>
       <DialogContent className="max-w-xl">
-        <DialogHeader>
-          <DialogTitle>Publish to /p/…</DialogTitle>
-          <DialogDescription>
-            Create a public, read-only link. Optionally lock it down with a
-            password, expiry, or view limit.
-          </DialogDescription>
-        </DialogHeader>
+        <form onSubmit={handlePublish} className="contents">
+          <DialogHeader>
+            <DialogTitle>Publish {resourceLabel}</DialogTitle>
+            <DialogDescription>
+              Create a public, read-only link with optional access limits.
+            </DialogDescription>
+          </DialogHeader>
 
-        <div className="space-y-4">
-          {/* Password gate */}
-          <div className="rounded-[var(--radius-md)] border border-border p-3">
-            <label className="flex items-baseline gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={requirePassword}
-                onChange={(e) => setRequirePassword(e.target.checked)}
-                className="cursor-pointer accent-[var(--color-primary)] focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface rounded-[var(--radius-sm)]"
-              />
-              <div className="flex-1 min-w-0">
-                <div className="text-sm font-medium">Require password</div>
-                <div className="coord">Viewers must enter this before reading</div>
-              </div>
-            </label>
-            {requirePassword && (
-              <div className="mt-3">
-                <Label htmlFor="pub-pw" className="coord-ink mb-1.5 block">
-                  Publication password
-                </Label>
-                <div className="relative">
-                  <Input
-                    id="pub-pw"
-                    type={showPw ? "text" : "password"}
-                    autoComplete="new-password"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    placeholder="Set a strong shared password"
-                    aria-invalid={pwTooShort ? true : undefined}
-                    aria-describedby={pwTooShort ? "pub-pw-help" : undefined}
-                    className="pr-10 font-mono"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowPw((s) => !s)}
-                    aria-label={showPw ? "Hide password" : "Show password"}
-                    className="absolute right-2 top-1/2 -translate-y-1/2 inline-flex items-center justify-center h-7 w-7 text-foreground-muted hover:text-primary cursor-pointer rounded-[var(--radius-sm)] focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  >
-                    {showPw ? (
-                      <EyeOff className="h-4 w-4" aria-hidden />
-                    ) : (
-                      <Eye className="h-4 w-4" aria-hidden />
-                    )}
-                  </button>
-                </div>
-                {pwTooShort && (
-                  <p id="pub-pw-help" className="text-destructive text-xs mt-1">
-                    Use at least 8 characters.
-                  </p>
-                )}
-              </div>
-            )}
-          </div>
+          <Alert variant="info" title="Public link">
+            <span className="inline-flex items-start gap-2">
+              <Globe2 className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
+              Anyone with the link can open this {resourceLabel} without signing in.
+            </span>
+          </Alert>
 
-          {/* Expiry */}
-          <div>
-            <Label className="coord-ink mb-1.5 block">Expires</Label>
-            <div className="grid grid-cols-5 gap-px border border-border bg-border rounded-[var(--radius-md)] overflow-hidden">
-              {EXPIRY_PRESETS.map((p) => {
-                const active = expiresIn === p.value;
-                return (
-                  <button
-                    key={p.label}
-                    type="button"
-                    onClick={() => setExpiresIn(p.value)}
-                    aria-pressed={active}
-                    className={`px-2 py-2 text-xs font-medium transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset ${
-                      active
-                        ? "bg-primary text-primary-foreground"
-                        : "bg-surface text-foreground hover:bg-surface-hover"
-                    }`}
-                  >
-                    {p.label}
-                  </button>
-                );
-              })}
+          {error && (
+            <div ref={errorRef} tabIndex={-1}>
+              <Alert variant="destructive" title="Publication failed">
+                {error}
+              </Alert>
             </div>
-            <p className="text-xs text-foreground-muted mt-1.5">
-              After expiry the link returns 410. Recreate to extend.
-            </p>
-          </div>
+          )}
 
-          {/* Max views */}
-          <div>
-            <Label htmlFor="pub-max" className="coord-ink mb-1.5 block">
-              Max views
-            </Label>
-            <Input
-              id="pub-max"
-              type="number"
-              min={1}
-              value={maxViews}
-              onChange={(e) => setMaxViews(e.target.value)}
-              placeholder="Unlimited"
-            />
-            <p className="text-xs text-foreground-muted mt-1.5">
-              Optional. After this many views the link returns 410.
-            </p>
-          </div>
-
-          {error && <Alert variant="destructive" className="text-xs">{error}</Alert>}
-        </div>
-
-        <DialogFooter>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => onOpenChange(false)}
+          <PublicationAccessFields
+            value={access}
+            onChange={setAccess}
+            idPrefix={`${resourceType}-publication`}
             disabled={working}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            variant="accent"
-            onClick={handlePublish}
-            loading={working}
-            disabled={cannotPublish}
-          >
-            {working ? "Publishing…" : "Publish"}
-          </Button>
-        </DialogFooter>
+          />
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={working}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="accent"
+              loading={working}
+              disabled={Boolean(accessError)}
+            >
+              {working ? "Publishing…" : "Publish"}
+            </Button>
+          </DialogFooter>
+        </form>
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/components/resource-actions-menu.tsx
+++ b/frontend/src/components/resource-actions-menu.tsx
@@ -1,5 +1,5 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
-import { FilePenLine, MoreHorizontal, Trash2 } from "lucide-react";
+import { FilePenLine, MoreHorizontal, Share2, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -7,6 +7,8 @@ interface ResourceActionsMenuProps {
   resourceName: string;
   deleteLabel?: string;
   onDelete?: () => void;
+  publishLabel?: string;
+  onPublish?: () => void;
   onMoveOrRename?: () => void;
   moveDisabledReason?: string;
   className?: string;
@@ -24,6 +26,8 @@ export function ResourceActionsMenu({
   resourceName,
   deleteLabel,
   onDelete,
+  publishLabel,
+  onPublish,
   onMoveOrRename,
   moveDisabledReason,
   className,
@@ -31,8 +35,9 @@ export function ResourceActionsMenu({
   align = "end",
 }: ResourceActionsMenuProps) {
   const showMoveAction = Boolean(onMoveOrRename || moveDisabledReason);
+  const showPublishAction = Boolean(publishLabel && onPublish);
   const showDeleteAction = Boolean(deleteLabel && onDelete);
-  if (!showMoveAction && !showDeleteAction) return null;
+  if (!showMoveAction && !showPublishAction && !showDeleteAction) return null;
 
   return (
     <DropdownMenu.Root>
@@ -81,7 +86,16 @@ export function ResourceActionsMenu({
               </span>
             </DropdownMenu.Item>
           )}
-          {showMoveAction && showDeleteAction && (
+          {showPublishAction && (
+            <DropdownMenu.Item
+              onSelect={onPublish}
+              className="flex cursor-pointer select-none items-center gap-2 rounded-[var(--radius-sm)] px-2.5 py-2 text-sm text-foreground outline-none data-[highlighted]:bg-surface-hover"
+            >
+              <Share2 className="h-4 w-4 text-link" aria-hidden />
+              {publishLabel}
+            </DropdownMenu.Item>
+          )}
+          {(showMoveAction || showPublishAction) && showDeleteAction && (
             <DropdownMenu.Separator className="my-1 h-px bg-border" />
           )}
           {showDeleteAction && (

--- a/frontend/src/components/table-publish-dialog.tsx
+++ b/frontend/src/components/table-publish-dialog.tsx
@@ -1,0 +1,575 @@
+import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import { Camera, Columns3, Database, Globe2, RefreshCw, Rows3 } from "lucide-react";
+import {
+  PublicationAccessFields,
+} from "@/components/publish-options-dialog";
+import {
+  emptyPublicationAccessOptions,
+  publicationAccessError,
+  publicationAccessPayload,
+  type PublicationAccessOptions,
+} from "@/lib/publication-options";
+import { Alert } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  createPublication,
+  createPublicationSnapshot,
+  deletePublication,
+  previewTablePublicationQuery,
+  type Publication,
+  type TablePublicationPreview,
+} from "@/lib/api";
+import {
+  buildTablePublicationQuery,
+  DEFAULT_TABLE_PUBLICATION_ROWS,
+  isPublishableTableIdentifier,
+  MAX_TABLE_PUBLICATION_ROWS,
+  type PublishableTableColumn,
+} from "@/lib/table-publication";
+
+type PublicationMode = "live" | "snapshot";
+
+const PREVIEW_ROW_LIMIT = 5;
+
+export function TablePublishDialog({
+  open,
+  onOpenChange,
+  vault,
+  table,
+  columns,
+  onPublished,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  vault: string;
+  table: string;
+  columns: PublishableTableColumn[];
+  onPublished: (publication: Publication) => void;
+}) {
+  const safeColumnNames = useMemo(
+    () =>
+      columns
+        .filter((column) => isPublishableTableIdentifier(column.name))
+        .map((column) => column.name),
+    [columns],
+  );
+  const [title, setTitle] = useState(table);
+  const [mode, setMode] = useState<PublicationMode>("live");
+  const [selectedColumns, setSelectedColumns] = useState<string[]>(safeColumnNames);
+  const [rowLimit, setRowLimit] = useState(String(DEFAULT_TABLE_PUBLICATION_ROWS));
+  const [access, setAccess] = useState<PublicationAccessOptions>(
+    emptyPublicationAccessOptions,
+  );
+  const [preview, setPreview] = useState<TablePublicationPreview | null>(null);
+  const [previewSql, setPreviewSql] = useState("");
+  const [previewing, setPreviewing] = useState(false);
+  const [publishing, setPublishing] = useState(false);
+  const [error, setError] = useState("");
+  const errorRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setTitle(table);
+    setMode("live");
+    setSelectedColumns(safeColumnNames);
+    setRowLimit(String(DEFAULT_TABLE_PUBLICATION_ROWS));
+    setAccess(emptyPublicationAccessOptions());
+    setPreview(null);
+    setPreviewSql("");
+    setError("");
+  }, [open, safeColumnNames, table]);
+
+  useEffect(() => {
+    if (error) errorRef.current?.focus();
+  }, [error]);
+
+  const parsedLimit = Number(rowLimit);
+  const rowLimitError =
+    !/^\d+$/.test(rowLimit.trim()) ||
+    !Number.isInteger(parsedLimit) ||
+    parsedLimit < 1 ||
+    parsedLimit > MAX_TABLE_PUBLICATION_ROWS
+      ? `Enter a whole number from 1 to ${MAX_TABLE_PUBLICATION_ROWS.toLocaleString()}.`
+      : null;
+  const titleError = title.trim() ? null : "Enter a title for the public link.";
+  const accessError = publicationAccessError(access);
+
+  const query = useMemo(() => {
+    if (rowLimitError) return { sql: "", error: rowLimitError };
+    try {
+      return {
+        sql: buildTablePublicationQuery({
+          table,
+          columns,
+          selectedColumns,
+          rowLimit: parsedLimit,
+        }),
+        error: null,
+      };
+    } catch (caught: unknown) {
+      return {
+        sql: "",
+        error: caught instanceof Error ? caught.message : "The query cannot be generated.",
+      };
+    }
+  }, [columns, parsedLimit, rowLimitError, selectedColumns, table]);
+
+  const previewIsCurrent = Boolean(preview && query.sql && previewSql === query.sql);
+  const busy = previewing || publishing;
+  const publishDisabled = Boolean(
+    busy || titleError || accessError || query.error || !previewIsCurrent,
+  );
+
+  function invalidatePreview() {
+    setPreview(null);
+    setPreviewSql("");
+    setError("");
+  }
+
+  async function handlePreview() {
+    if (query.error || !query.sql) {
+      setError(query.error || "The preview query is unavailable.");
+      return;
+    }
+    setPreviewing(true);
+    setError("");
+    try {
+      const result = await previewTablePublicationQuery(vault, query.sql);
+      setPreview(result);
+      setPreviewSql(query.sql);
+    } catch (caught: unknown) {
+      setPreview(null);
+      setPreviewSql("");
+      setError(caught instanceof Error ? caught.message : "The preview query failed.");
+    } finally {
+      setPreviewing(false);
+    }
+  }
+
+  async function handlePublish(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const validationError = titleError || accessError || query.error;
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    if (!previewIsCurrent || !query.sql) {
+      setError("Preview the current column and row selection before publishing.");
+      return;
+    }
+
+    setPublishing(true);
+    setError("");
+    try {
+      const normalizedTitle = title.trim();
+      // Table links are intentionally multi-instance. Reusing a matching SQL
+      // string could silently discard a newly requested password, expiry, or
+      // view limit, so every confirmed submission creates a distinct link.
+      const created = await createPublication(vault, {
+        resource_type: "table_query",
+        query_sql: query.sql,
+        query_vault_names: [vault],
+        title: normalizedTitle,
+        ...publicationAccessPayload(access),
+      });
+      let ready = created;
+      if (mode === "snapshot") {
+        try {
+          ready = await createPublicationSnapshot(vault, created.slug);
+        } catch (caught: unknown) {
+          let cleanupFailed = false;
+          try {
+            await deletePublication(vault, created.slug);
+          } catch {
+            cleanupFailed = true;
+          }
+          const reason = caught instanceof Error ? caught.message : "Snapshot creation failed.";
+          throw new Error(
+            cleanupFailed
+              ? `${reason} The temporary live link could not be removed; revoke it from Publish immediately.`
+              : `${reason} The temporary live link was removed.`,
+            { cause: caught },
+          );
+        }
+      }
+      onPublished(ready);
+      onOpenChange(false);
+    } catch (caught: unknown) {
+      setError(caught instanceof Error ? caught.message : "Failed to publish the table.");
+    } finally {
+      setPublishing(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !busy && onOpenChange(next)}>
+      <DialogContent className="max-w-5xl">
+        <form onSubmit={handlePublish} className="contents">
+          <DialogHeader>
+            <DialogTitle>Publish table</DialogTitle>
+            <DialogDescription>
+              Choose exactly what becomes public, verify the server result, then create the link.
+            </DialogDescription>
+          </DialogHeader>
+
+          <Alert variant="warning" title="No sign-in required">
+            The selected columns and rows become available to anyone with the link. Table writes are never allowed.
+          </Alert>
+
+          {error && (
+            <div ref={errorRef} tabIndex={-1}>
+              <Alert variant="destructive" title="Publication failed">
+                {error}
+              </Alert>
+            </div>
+          )}
+
+          <div className="grid min-h-0 gap-4 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+            <div className="space-y-4 rounded-[var(--radius-lg)] border border-border bg-surface p-4">
+              <div>
+                <Label htmlFor="table-publication-title" className="mb-1.5 block text-xs text-foreground">
+                  Public title
+                </Label>
+                <Input
+                  id="table-publication-title"
+                  value={title}
+                  disabled={busy}
+                  onChange={(event) => setTitle(event.target.value)}
+                  aria-invalid={Boolean(titleError) || undefined}
+                  aria-describedby={titleError ? "table-publication-title-error" : undefined}
+                />
+                {titleError && (
+                  <p id="table-publication-title-error" className="mt-1.5 text-xs text-destructive">
+                    {titleError}
+                  </p>
+                )}
+              </div>
+
+              <fieldset disabled={busy}>
+                <legend className="mb-1.5 text-xs font-medium text-foreground">Delivery</legend>
+                <div className="grid grid-cols-2 gap-px overflow-hidden rounded-[var(--radius-md)] border border-border bg-border">
+                  <ModeButton
+                    active={mode === "live"}
+                    icon={Globe2}
+                    label="Live"
+                    description="Current rows on each visit"
+                    onClick={() => setMode("live")}
+                  />
+                  <ModeButton
+                    active={mode === "snapshot"}
+                    icon={Camera}
+                    label="Snapshot"
+                    description="Frozen at publish time"
+                    onClick={() => setMode("snapshot")}
+                  />
+                </div>
+              </fieldset>
+
+              <div>
+                <div className="mb-1.5 flex items-center justify-between gap-3">
+                  <Label className="text-xs text-foreground">Public columns</Label>
+                  <span className="text-xs tabular-nums text-foreground-muted">
+                    {selectedColumns.length} of {safeColumnNames.length}
+                  </span>
+                </div>
+                <div className="max-h-48 overflow-y-auto rounded-[var(--radius-md)] border border-border rail-scroll">
+                  {columns.map((column) => {
+                    const safe = isPublishableTableIdentifier(column.name);
+                    const checked = selectedColumns.includes(column.name);
+                    return (
+                      <label
+                        key={column.name}
+                        className="flex min-h-9 items-center gap-2 border-b border-border px-3 py-2 last:border-b-0 hover:bg-surface-hover"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          disabled={busy || !safe}
+                          onChange={(event) => {
+                            invalidatePreview();
+                            setSelectedColumns((current) =>
+                              event.target.checked
+                                ? [...current, column.name]
+                                : current.filter((name) => name !== column.name),
+                            );
+                          }}
+                          className="h-4 w-4 shrink-0 cursor-pointer rounded-[var(--radius-sm)] accent-[var(--color-primary)] focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:cursor-not-allowed disabled:opacity-50"
+                        />
+                        <span className="min-w-0 flex-1 truncate font-mono text-xs text-foreground">
+                          {column.name}
+                        </span>
+                        {column.primary_key && <Badge variant="outline">Primary key</Badge>}
+                        {column.type && <span className="text-xs text-foreground-muted">{column.type}</span>}
+                      </label>
+                    );
+                  })}
+                </div>
+                <div className="mt-1 flex items-center gap-1">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    disabled={busy || selectedColumns.length === safeColumnNames.length}
+                    onClick={() => {
+                      invalidatePreview();
+                      setSelectedColumns(safeColumnNames);
+                    }}
+                  >
+                    Select all
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    disabled={busy || selectedColumns.length === 0}
+                    onClick={() => {
+                      invalidatePreview();
+                      setSelectedColumns([]);
+                    }}
+                  >
+                    Clear
+                  </Button>
+                </div>
+              </div>
+
+              <div>
+                <Label htmlFor="table-publication-limit" className="mb-1.5 block text-xs text-foreground">
+                  Maximum public rows
+                </Label>
+                <Input
+                  id="table-publication-limit"
+                  type="number"
+                  min={1}
+                  max={MAX_TABLE_PUBLICATION_ROWS}
+                  step={1}
+                  inputMode="numeric"
+                  value={rowLimit}
+                  disabled={busy}
+                  onChange={(event) => {
+                    invalidatePreview();
+                    setRowLimit(event.target.value);
+                  }}
+                  aria-invalid={Boolean(rowLimitError) || undefined}
+                  aria-describedby="table-publication-limit-help"
+                />
+                <p
+                  id="table-publication-limit-help"
+                  className={rowLimitError ? "mt-1.5 text-xs text-destructive" : "mt-1.5 text-xs text-foreground-muted"}
+                >
+                  {rowLimitError ||
+                    `Up to ${MAX_TABLE_PUBLICATION_ROWS.toLocaleString()} rows. Default: ${DEFAULT_TABLE_PUBLICATION_ROWS}.`}
+                </p>
+              </div>
+            </div>
+
+            <TablePublicationPreviewPanel
+              table={table}
+              selectedColumnCount={selectedColumns.length}
+              rowLimit={rowLimitError ? null : parsedLimit}
+              ordered={columns.some((column) => column.primary_key)}
+              preview={previewIsCurrent ? preview : null}
+              previewing={previewing}
+            />
+          </div>
+
+          <details className="rounded-[var(--radius-lg)] border border-border bg-surface">
+            <summary className="flex min-h-10 cursor-pointer list-none items-center justify-between gap-3 rounded-[var(--radius-lg)] px-4 py-2 text-sm font-medium text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring">
+              <span>Optional link controls</span>
+              <span className="text-xs font-normal text-foreground-muted">Password · expiry · view limit</span>
+            </summary>
+            <div className="border-t border-border p-4">
+              <PublicationAccessFields
+                value={access}
+                onChange={setAccess}
+                idPrefix="table-publication"
+                disabled={busy}
+              />
+            </div>
+          </details>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={busy}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              loading={previewing}
+              disabled={publishing || Boolean(query.error)}
+              onClick={() => void handlePreview()}
+            >
+              {!previewing && <RefreshCw className="h-4 w-4" aria-hidden />}
+              {previewing ? "Previewing…" : previewIsCurrent ? "Refresh preview" : "Preview query"}
+            </Button>
+            <Button
+              type="submit"
+              variant="accent"
+              loading={publishing}
+              disabled={publishDisabled}
+            >
+              {publishing ? "Publishing…" : mode === "snapshot" ? "Publish snapshot" : "Publish live table"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ModeButton({
+  active,
+  icon: Icon,
+  label,
+  description,
+  onClick,
+}: {
+  active: boolean;
+  icon: typeof Globe2;
+  label: string;
+  description: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onClick}
+      className={`min-h-16 cursor-pointer px-3 py-2 text-left transition-token focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 ${
+        active ? "bg-surface-selected text-surface-selected-foreground" : "bg-surface text-foreground hover:bg-surface-hover"
+      }`}
+    >
+      <span className="flex items-center gap-2 text-sm font-medium">
+        <Icon className="h-4 w-4" aria-hidden />
+        {label}
+      </span>
+      <span className="mt-0.5 block text-xs text-foreground-muted">{description}</span>
+    </button>
+  );
+}
+
+function TablePublicationPreviewPanel({
+  table,
+  selectedColumnCount,
+  rowLimit,
+  ordered,
+  preview,
+  previewing,
+}: {
+  table: string;
+  selectedColumnCount: number;
+  rowLimit: number | null;
+  ordered: boolean;
+  preview: TablePublicationPreview | null;
+  previewing: boolean;
+}) {
+  const rows = preview?.items.slice(0, PREVIEW_ROW_LIMIT) || [];
+  const columns = preview?.columns || [];
+  return (
+    <section
+      aria-labelledby="table-publication-preview-title"
+      aria-busy={previewing}
+      className="flex min-h-80 min-w-0 flex-col overflow-hidden rounded-[var(--radius-lg)] border border-border bg-surface"
+    >
+      <div className="flex min-h-11 items-center gap-3 border-b border-border bg-surface-2 px-3 py-2">
+        <Database className="h-4 w-4 shrink-0 text-link" aria-hidden />
+        <div className="min-w-0 flex-1">
+          <h3 id="table-publication-preview-title" className="text-sm font-semibold text-foreground">
+            Public result preview
+          </h3>
+          <p className="truncate text-xs text-foreground-muted">
+            {table} · {selectedColumnCount} columns · up to {rowLimit?.toLocaleString() || "—"} rows
+          </p>
+        </div>
+        {preview && <Badge variant="success">Verified</Badge>}
+      </div>
+
+      {previewing ? (
+        <div role="status" aria-live="polite" className="flex min-h-64 flex-1 flex-col items-center justify-center gap-3 px-6 text-center">
+          <RefreshCw className="h-6 w-6 animate-spin text-link" aria-hidden />
+          <p className="text-sm font-medium text-foreground">Running the bounded query…</p>
+          <p className="text-xs text-foreground-muted">The server is checking access and result shape.</p>
+        </div>
+      ) : !preview ? (
+        <div className="flex min-h-64 flex-1 flex-col items-center justify-center px-6 py-10 text-center">
+          <Rows3 className="h-8 w-8 text-foreground-muted" aria-hidden />
+          <h4 className="mt-3 text-sm font-semibold text-foreground">Preview required</h4>
+          <p className="mt-1 max-w-sm text-sm text-foreground-muted">
+            Run the generated query before publishing. Changing columns or the row limit requires another preview.
+          </p>
+          {ordered && (
+            <p className="mt-3 inline-flex items-center gap-1.5 text-xs text-foreground-muted">
+              <Columns3 className="h-3.5 w-3.5" aria-hidden />
+              Results are ordered by the table primary key.
+            </p>
+          )}
+        </div>
+      ) : rows.length === 0 ? (
+        <div className="flex min-h-64 flex-1 flex-col items-center justify-center px-6 text-center">
+          <Rows3 className="h-8 w-8 text-foreground-muted" aria-hidden />
+          <h4 className="mt-3 text-sm font-semibold text-foreground">Verified empty result</h4>
+          <p className="mt-1 text-sm text-foreground-muted">
+            The public link is valid, but the query currently returns no rows.
+          </p>
+        </div>
+      ) : (
+        <div role="region" aria-label="Public table preview rows" tabIndex={0} className="min-h-64 flex-1 overflow-auto focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring">
+          <table className="min-w-full border-separate border-spacing-0 text-xs">
+            <thead>
+              <tr>
+                {columns.map((column) => (
+                  <th
+                    key={column}
+                    scope="col"
+                    className="sticky top-0 z-[var(--z-raised)] min-w-32 border-b border-r border-border bg-surface-2 px-3 py-2 text-left font-mono font-medium text-foreground last:border-r-0"
+                  >
+                    {column}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row, rowIndex) => (
+                <tr key={rowIndex} className="hover:bg-surface-hover">
+                  {columns.map((column) => (
+                    <td
+                      key={column}
+                      className="max-w-56 truncate whitespace-nowrap border-b border-r border-border px-3 py-2 text-foreground last:border-r-0"
+                      title={formatPreviewCell(row[column])}
+                    >
+                      {formatPreviewCell(row[column])}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <p className="border-t border-border bg-surface-2 px-3 py-2 text-right text-xs tabular-nums text-foreground-muted">
+            Showing {rows.length} of {preview.items.length.toLocaleString()} returned rows
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function formatPreviewCell(value: unknown): string {
+  if (value === null || value === undefined) return "—";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}

--- a/frontend/src/lib/__tests__/api-publications.test.ts
+++ b/frontend/src/lib/__tests__/api-publications.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createPublication,
+  createPublicationSnapshot,
+  previewTablePublicationQuery,
+} from "@/lib/api";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("publication API", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  it("previews a generated table query through the authenticated SQL endpoint", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        kind: "table_query",
+        columns: ["ticket_id"],
+        items: [{ ticket_id: "t-1" }],
+        total: 1,
+      }),
+    );
+
+    const result = await previewTablePublicationQuery(
+      "team vault",
+      "SELECT ticket_id FROM tickets LIMIT 100",
+    );
+
+    expect(result.total).toBe(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/tables/team%20vault/sql",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ sql: "SELECT ticket_id FROM tickets LIMIT 100" }),
+      }),
+    );
+  });
+
+  it("creates a file publication and snapshots a table publication by slug", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ slug: "file-link" }))
+      .mockResolvedValueOnce(jsonResponse({ slug: "table-link", mode: "snapshot" }));
+
+    await createPublication("demo", {
+      resource_type: "file",
+      uri: "akb://demo/file/11111111-1111-1111-1111-111111111111",
+    });
+    await createPublicationSnapshot("demo", "table/link");
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "/api/v1/publications/demo/create",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/api/v1/publications/demo/table/link/snapshot",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2146,6 +2146,25 @@ export const deletePublication = (vault: string, slug: string) =>
 export const createPublicationSnapshot = (vault: string, slug: string) =>
   api<Publication>(`/publications/${vault}/${slug}/snapshot`, { method: "POST" });
 
+export interface TablePublicationPreview {
+  kind?: "table_query";
+  columns: string[];
+  items: Record<string, unknown>[];
+  total: number;
+}
+
+/** Execute the generated, read-only table publication query as the current user.
+ *
+ * The table publish dialog never accepts raw SQL. It builds a bounded SELECT
+ * from server-provided identifiers, then uses this endpoint as the required
+ * pre-publication preview and permission check.
+ */
+export const previewTablePublicationQuery = (vault: string, sql: string) =>
+  api<TablePublicationPreview>(`/tables/${encodeURIComponent(vault)}/sql`, {
+    method: "POST",
+    body: JSON.stringify({ sql }),
+  });
+
 export const searchUsers = (query?: string) =>
   api<{ users: any[] }>(`/users/search${query ? `?q=${encodeURIComponent(query)}` : ""}`);
 

--- a/frontend/src/lib/publication-options.ts
+++ b/frontend/src/lib/publication-options.ts
@@ -1,0 +1,39 @@
+import type { CreatePublicationRequest } from "@/lib/api";
+
+export interface PublicationAccessOptions {
+  requirePassword: boolean;
+  password: string;
+  expiresIn: string;
+  maxViews: string;
+}
+
+export function emptyPublicationAccessOptions(): PublicationAccessOptions {
+  return {
+    requirePassword: false,
+    password: "",
+    expiresIn: "",
+    maxViews: "",
+  };
+}
+
+export function publicationAccessError(value: PublicationAccessOptions): string | null {
+  if (value.requirePassword && value.password.trim().length < 8) {
+    return "Use at least 8 characters for the publication password.";
+  }
+  const max = value.maxViews.trim();
+  if (max && (!/^\d+$/.test(max) || !Number.isSafeInteger(Number(max)) || Number(max) < 1)) {
+    return "Max views must be a positive whole number.";
+  }
+  return null;
+}
+
+export function publicationAccessPayload(
+  value: PublicationAccessOptions,
+): Pick<CreatePublicationRequest, "password" | "expires_in" | "max_views"> {
+  const max = value.maxViews.trim();
+  return {
+    password: value.requirePassword ? value.password : undefined,
+    expires_in: value.expiresIn || undefined,
+    max_views: max ? Number(max) : undefined,
+  };
+}

--- a/frontend/src/lib/table-publication.ts
+++ b/frontend/src/lib/table-publication.ts
@@ -1,0 +1,58 @@
+export interface PublishableTableColumn {
+  name: string;
+  type?: string;
+  primary_key?: boolean;
+}
+
+export const DEFAULT_TABLE_PUBLICATION_ROWS = 100;
+export const MAX_TABLE_PUBLICATION_ROWS = 10_000;
+
+const TABLE_IDENTIFIER = /^[a-z][a-z0-9_]*$/;
+
+export function isPublishableTableIdentifier(value: string): boolean {
+  return TABLE_IDENTIFIER.test(value);
+}
+
+export function buildTablePublicationQuery({
+  table,
+  columns,
+  selectedColumns,
+  rowLimit,
+}: {
+  table: string;
+  columns: PublishableTableColumn[];
+  selectedColumns: string[];
+  rowLimit: number;
+}): string {
+  if (!isPublishableTableIdentifier(table)) {
+    throw new Error("The table name cannot be published safely.");
+  }
+  if (
+    !Number.isInteger(rowLimit) ||
+    rowLimit < 1 ||
+    rowLimit > MAX_TABLE_PUBLICATION_ROWS
+  ) {
+    throw new Error(
+      `Row limit must be between 1 and ${MAX_TABLE_PUBLICATION_ROWS.toLocaleString()}.`,
+    );
+  }
+
+  const selected = new Set(selectedColumns);
+  const orderedColumns = columns
+    .map((column) => column.name)
+    .filter((name) => selected.has(name));
+  if (orderedColumns.length === 0) {
+    throw new Error("Select at least one column to publish.");
+  }
+  if (orderedColumns.some((name) => !isPublishableTableIdentifier(name))) {
+    throw new Error("One or more columns cannot be published safely.");
+  }
+
+  const primaryKeys = columns
+    .filter(
+      (column) => column.primary_key && isPublishableTableIdentifier(column.name),
+    )
+    .map((column) => column.name);
+  const orderBy = primaryKeys.length ? ` ORDER BY ${primaryKeys.join(", ")}` : "";
+  return `SELECT ${orderedColumns.join(", ")} FROM ${table}${orderBy} LIMIT ${rowLimit}`;
+}

--- a/frontend/src/pages/__tests__/publications-redesign.test.tsx
+++ b/frontend/src/pages/__tests__/publications-redesign.test.tsx
@@ -177,4 +177,30 @@ describe("Publish page redesign", () => {
       );
     });
   });
+
+  it("returns bounded table publications to their source table", async () => {
+    listPublicationsMock.mockResolvedValue({
+      publications: [
+        {
+          ...PUBLICATION,
+          slug: "release-table",
+          share_url: "https://example.test/p/release-table",
+          resource_type: "table_query",
+          resource_uri: null,
+          title: "Release readiness",
+          query_sql: "SELECT service, ready FROM release_status ORDER BY service LIMIT 100",
+          query_vault_names: ["platform-docs"],
+          query_params: {},
+        },
+      ],
+    });
+    renderPage();
+
+    expect(
+      await screen.findByRole("link", { name: "Release readiness" }),
+    ).toHaveAttribute(
+      "href",
+      "/vault/platform-docs/table/release_status",
+    );
+  });
 });

--- a/frontend/src/pages/__tests__/resource-delete-pages.test.tsx
+++ b/frontend/src/pages/__tests__/resource-delete-pages.test.tsx
@@ -8,22 +8,38 @@ import TablePage from "@/pages/table";
 
 vi.mock("@/lib/api", () => ({
   authenticatedFetch: vi.fn(),
+  createPublication: vi.fn(),
+  createPublicationSnapshot: vi.fn(),
+  deletePublication: vi.fn(),
   getVaultInfo: vi.fn(),
+  getDocument: vi.fn(),
+  listPublications: vi.fn(),
+  previewTablePublicationQuery: vi.fn(),
   deleteVaultFile: vi.fn(),
   deleteVaultTable: vi.fn(),
 }));
 
 import {
   authenticatedFetch,
+  createPublication,
+  createPublicationSnapshot,
+  deletePublication,
   deleteVaultFile,
   deleteVaultTable,
   getVaultInfo,
+  listPublications,
+  previewTablePublicationQuery,
 } from "@/lib/api";
 
 const fetchMock = authenticatedFetch as unknown as ReturnType<typeof vi.fn>;
 const vaultInfoMock = getVaultInfo as unknown as ReturnType<typeof vi.fn>;
 const deleteFileMock = deleteVaultFile as unknown as ReturnType<typeof vi.fn>;
 const deleteTableMock = deleteVaultTable as unknown as ReturnType<typeof vi.fn>;
+const createPublicationMock = createPublication as unknown as ReturnType<typeof vi.fn>;
+const snapshotMock = createPublicationSnapshot as unknown as ReturnType<typeof vi.fn>;
+const deletePublicationMock = deletePublication as unknown as ReturnType<typeof vi.fn>;
+const listPublicationsMock = listPublications as unknown as ReturnType<typeof vi.fn>;
+const previewPublicationMock = previewTablePublicationQuery as unknown as ReturnType<typeof vi.fn>;
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -61,6 +77,11 @@ beforeEach(() => {
   deleteTableMock.mockReset();
   deleteFileMock.mockResolvedValue({ deleted: true });
   deleteTableMock.mockResolvedValue({ deleted: true });
+  listPublicationsMock.mockResolvedValue({ publications: [] });
+  createPublicationMock.mockResolvedValue({});
+  snapshotMock.mockResolvedValue({});
+  deletePublicationMock.mockResolvedValue({ deleted: 1 });
+  previewPublicationMock.mockResolvedValue({ columns: [], items: [], total: 0 });
 });
 
 afterEach(() => cleanup());
@@ -90,12 +111,40 @@ describe("resource viewer deletion", () => {
     const { refetchTree } = renderRoute("/vault/v/file/file-1");
 
     await user.click(await screen.findByRole("button", { name: "Actions for diagram.png" }));
+    expect(screen.getByRole("menuitem", { name: "Publish file" })).toBeInTheDocument();
     await user.click(screen.getByRole("menuitem", { name: "Delete file" }));
     await user.click(screen.getByRole("button", { name: "Delete file" }));
 
     await waitFor(() => expect(deleteFileMock).toHaveBeenCalledWith("v", "file-1"));
     expect(refetchTree).toHaveBeenCalledTimes(1);
     expect(screen.getByTestId("pathname")).toHaveTextContent("/vault/v");
+  });
+
+  it("does not expose file publication or deletion to a reader", async () => {
+    vaultInfoMock.mockResolvedValue({ role: "reader" });
+    fetchMock.mockImplementation((url: string) => {
+      if (url.endsWith("/download")) {
+        return Promise.resolve(jsonResponse({
+          name: "diagram.png",
+          download_url: "https://example.test/diagram.png",
+          mime_type: "image/png",
+        }));
+      }
+      return Promise.resolve(jsonResponse({
+        items: [{
+          uri: "akb://v/file/file-1",
+          name: "diagram.png",
+          mime_type: "image/png",
+        }],
+      }));
+    });
+    renderRoute("/vault/v/file/file-1");
+
+    await screen.findByRole("heading", { name: "diagram.png" });
+    await waitFor(() => expect(vaultInfoMock).toHaveBeenCalledWith("v"));
+    expect(
+      screen.queryByRole("button", { name: "Actions for diagram.png" }),
+    ).not.toBeInTheDocument();
   });
 
   it("requires an admin and an exact name before deleting a table", async () => {
@@ -133,19 +182,49 @@ describe("resource viewer deletion", () => {
     expect(screen.getByTestId("pathname")).toHaveTextContent("/vault/v");
   });
 
-  it("does not expose table deletion to a writer", async () => {
+  it("lets a writer publish a table without exposing admin-only deletion", async () => {
     vaultInfoMock.mockResolvedValue({ role: "writer" });
     fetchMock.mockImplementation((url: string, init?: RequestInit) => {
       if (init?.method === "POST" && url.endsWith("/sql")) {
         return Promise.resolve(jsonResponse({ items: [], columns: [], total: 0 }));
       }
       return Promise.resolve(jsonResponse({
-        items: [{ name: "audit_log", row_count: 0, columns: [] }],
+        items: [{
+          name: "audit_log",
+          row_count: 0,
+          columns: [{ name: "event", type: "text" }],
+        }],
+      }));
+    });
+    const user = userEvent.setup();
+    renderRoute("/vault/v/table/audit_log");
+
+    await screen.findByRole("heading", { name: "audit_log" });
+    await user.click(screen.getByRole("button", { name: "Actions for audit_log" }));
+    expect(screen.getByRole("menuitem", { name: "Publish table" })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Delete table" })).not.toBeInTheDocument();
+  });
+
+  it("does not expose table publication or deletion to a reader", async () => {
+    vaultInfoMock.mockResolvedValue({ role: "reader" });
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === "POST" && url.endsWith("/sql")) {
+        return Promise.resolve(jsonResponse({ items: [], columns: [], total: 0 }));
+      }
+      return Promise.resolve(jsonResponse({
+        items: [{
+          name: "audit_log",
+          row_count: 0,
+          columns: [{ name: "event", type: "text" }],
+        }],
       }));
     });
     renderRoute("/vault/v/table/audit_log");
 
     await screen.findByRole("heading", { name: "audit_log" });
-    expect(screen.queryByRole("button", { name: "Actions for audit_log" })).not.toBeInTheDocument();
+    await waitFor(() => expect(vaultInfoMock).toHaveBeenCalledWith("v"));
+    expect(
+      screen.queryByRole("button", { name: "Actions for audit_log" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/file.tsx
+++ b/frontend/src/pages/file.tsx
@@ -27,8 +27,15 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { TooltipText } from "@/components/ui/tooltip-text";
 import { ResourceActionsMenu } from "@/components/resource-actions-menu";
 import { ResourceDeleteDialog } from "@/components/resource-delete-dialog";
+import { PublicationSuccessBanner } from "@/components/publication-success-banner";
+import { PublishOptionsDialog } from "@/components/publish-options-dialog";
 import { useVaultRefresh } from "@/contexts/vault-refresh-context";
-import { authenticatedFetch, deleteVaultFile, getVaultInfo } from "@/lib/api";
+import {
+  authenticatedFetch,
+  deleteVaultFile,
+  getVaultInfo,
+  type Publication,
+} from "@/lib/api";
 import {
   effectiveFileMime,
   filePreviewKind,
@@ -68,6 +75,8 @@ export default function FilePage() {
   const [previewLoading, setPreviewLoading] = useState(true);
   const [canDelete, setCanDelete] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const [publishOpen, setPublishOpen] = useState(false);
+  const [published, setPublished] = useState<Publication | null>(null);
 
   useEffect(() => {
     if (!vault) return;
@@ -204,6 +213,8 @@ export default function FilePage() {
             {canDelete && (
               <ResourceActionsMenu
                 resourceName={displayName}
+                publishLabel={info?.uri ? "Publish file" : undefined}
+                onPublish={info?.uri ? () => setPublishOpen(true) : undefined}
                 deleteLabel="Delete file"
                 onDelete={() => setDeleteOpen(true)}
               />
@@ -211,6 +222,15 @@ export default function FilePage() {
           </>
         }
       />
+
+      {published && (
+        <PublicationSuccessBanner
+          vault={vault!}
+          publication={published}
+          resourceLabel="File"
+          onDismiss={() => setPublished(null)}
+        />
+      )}
 
       <div className="relative min-h-0 flex-1 overflow-hidden">
         <ResourceCanvas>
@@ -313,6 +333,17 @@ export default function FilePage() {
           await deleteVaultFile(vault!, fileId!);
           refetchTree();
           navigate(`/vault/${vault}`);
+        }}
+      />
+      <PublishOptionsDialog
+        open={publishOpen}
+        onOpenChange={setPublishOpen}
+        vault={vault!}
+        resourceType="file"
+        resourceUri={info?.uri}
+        resourceName={displayName}
+        onPublished={(_slug, publication) => {
+          if (publication) setPublished(publication);
         }}
       />
     </ResourceWorkspace>

--- a/frontend/src/pages/publications.tsx
+++ b/frontend/src/pages/publications.tsx
@@ -679,6 +679,15 @@ function PublicationSkeleton() {
 }
 
 function resourceHref(vault: string, publication: Publication): string {
+  if (publication.resource_type === "table_query") {
+    // Table publications created by the bounded UI use one safe source table.
+    // Older/raw SQL publications keep the Vault fallback if a single source
+    // cannot be identified without pretending the query itself is a resource.
+    const tableName = publication.query_sql?.match(/\bFROM\s+([a-z][a-z0-9_]*)\b/i)?.[1];
+    return tableName
+      ? `/vault/${vault}/table/${encodeURIComponent(tableName)}`
+      : `/vault/${vault}`;
+  }
   if (!publication.resource_uri) return `/vault/${vault}`;
   if (publication.resource_type === "document") {
     const docPath = parseDocUri(publication.resource_uri)?.id;

--- a/frontend/src/pages/table.tsx
+++ b/frontend/src/pages/table.tsx
@@ -33,8 +33,15 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { TooltipText } from "@/components/ui/tooltip-text";
 import { ResourceActionsMenu } from "@/components/resource-actions-menu";
 import { ResourceDeleteDialog } from "@/components/resource-delete-dialog";
+import { PublicationSuccessBanner } from "@/components/publication-success-banner";
+import { TablePublishDialog } from "@/components/table-publish-dialog";
 import { useVaultRefresh } from "@/contexts/vault-refresh-context";
-import { authenticatedFetch, deleteVaultTable, getVaultInfo } from "@/lib/api";
+import {
+  authenticatedFetch,
+  deleteVaultTable,
+  getVaultInfo,
+  type Publication,
+} from "@/lib/api";
 import { ROLE_RANK, type Role } from "@/lib/roles";
 import { cn } from "@/lib/utils";
 
@@ -64,8 +71,11 @@ export default function TablePage() {
   const [loading, setLoading] = useState(true);
   const [infoLoading, setInfoLoading] = useState(true);
   const [schemaOpen, setSchemaOpen] = useState(false);
+  const [canPublish, setCanPublish] = useState(false);
   const [canDelete, setCanDelete] = useState(false);
+  const [publishOpen, setPublishOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const [published, setPublished] = useState<Publication | null>(null);
   const schemaToggleRef = useRef<HTMLButtonElement | null>(null);
   const schemaCloseRef = useRef<HTMLButtonElement | null>(null);
   const limit = 50;
@@ -73,20 +83,22 @@ export default function TablePage() {
   useEffect(() => {
     if (!vault) return;
     let cancelled = false;
+    setCanPublish(false);
     setCanDelete(false);
     getVaultInfo(vault)
       .then((data) => {
         const roleRank = ROLE_RANK[data?.role as Role] ?? 0;
+        const writable = !data?.is_archived && !data?.is_external_git;
         if (!cancelled) {
-          setCanDelete(
-            roleRank >= ROLE_RANK.admin &&
-              !data?.is_archived &&
-              !data?.is_external_git,
-          );
+          setCanPublish(roleRank >= ROLE_RANK.writer && writable);
+          setCanDelete(roleRank >= ROLE_RANK.admin && writable);
         }
       })
       .catch(() => {
-        if (!cancelled) setCanDelete(false);
+        if (!cancelled) {
+          setCanPublish(false);
+          setCanDelete(false);
+        }
       });
     return () => {
       cancelled = true;
@@ -223,16 +235,27 @@ export default function TablePage() {
               )}
               <span className="hidden sm:inline">Schema</span>
             </Button>
-            {canDelete && (
+            {(canPublish || canDelete) && (
               <ResourceActionsMenu
                 resourceName={table || "Table"}
-                deleteLabel="Delete table"
-                onDelete={() => setDeleteOpen(true)}
+                publishLabel={canPublish && info?.columns?.length ? "Publish table" : undefined}
+                onPublish={canPublish && info?.columns?.length ? () => setPublishOpen(true) : undefined}
+                deleteLabel={canDelete ? "Delete table" : undefined}
+                onDelete={canDelete ? () => setDeleteOpen(true) : undefined}
               />
             )}
           </>
         }
       />
+
+      {published && (
+        <PublicationSuccessBanner
+          vault={vault!}
+          publication={published}
+          resourceLabel="Table"
+          onDismiss={() => setPublished(null)}
+        />
+      )}
 
       <div className="relative min-h-0 flex-1 overflow-hidden">
         <ResourceCanvas>
@@ -466,6 +489,14 @@ export default function TablePage() {
           refetchTree();
           navigate(`/vault/${vault}`);
         }}
+      />
+      <TablePublishDialog
+        open={publishOpen}
+        onOpenChange={setPublishOpen}
+        vault={vault!}
+        table={table!}
+        columns={info?.columns || []}
+        onPublished={setPublished}
       />
     </ResourceWorkspace>
   );


### PR DESCRIPTION
## Summary

- add file publication from the file viewer with password, expiry, and view-limit controls
- add a bounded table publication builder with schema column selection, server-side preview, and live or snapshot delivery
- preserve writer, admin, and reader permission boundaries and link publication entries back to source resources

## Why

The publication API already supports `file` and `table_query` resources, but the web UI only exposed document publication. Table publication also needed a safe alternative to arbitrary SQL so users can review the exact public result before creating an anonymous link.

## Design and security

- generates a single bounded `SELECT` from validated schema identifiers; the UI never accepts raw SQL
- requires a current server preview after any column or row-limit change
- caps published rows at 10,000 and orders by primary key when available
- hides publish actions for readers, archived vaults, and external Git vaults
- creates distinct file and table links so requested access controls are not silently replaced by an older publication
- revokes the temporary live publication when snapshot creation fails, with an explicit recovery path if cleanup also fails

## User experience

- reuses the document publication access controls for files
- explains anonymous read-only exposure and live versus snapshot behavior before publication
- provides success actions for opening and managing the new link
- routes generated table publications back to their source table when it can be identified safely
- keeps the flows operable at narrow viewport widths and in dark mode

## Validation

- [x] `bash scripts/check.sh`
  - backend Ruff, mypy, and Bandit checks
  - frontend ESLint with 0 errors, TypeScript checks, and 688 unit tests across 99 files
  - SDK build, type, generated-contract, packed-consumer, and 50 unit tests
  - MCP proxy and Inspector contract suites
  - tracked-file secret scan
- [x] `cd frontend && pnpm run design:check`
- [x] `cd frontend && pnpm run build`
- [x] `AKB_URL=http://localhost:8000 bash backend/tests/test_publications_e2e.sh` — 136 passed, 0 failed
- [x] browser smoke tests for file and table flows, preview invalidation, narrow viewport, and dark mode

## Scope

Frontend only. This PR does not change backend APIs or deployment configuration.
