### PR TITLE
feat(sso): offer this installation own realm as a login option

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3634
+        "line_number": 3664
       }
     ],
     "backend/mcp_server/help.py": [
@@ -5400,5 +5400,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-31T06:01:05Z"
+  "generated_at": "2026-08-31T10:55:38Z"
 }

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -46,6 +46,7 @@ from app.sso.keycloak_admin import (
     get_keycloak_provider_control,
 )
 from app.sso.providers.keycloak_oidc import ProviderDefinitionError, validate_alias
+from app.sso import local_realm
 from app.util.text import NFCModel
 
 router = APIRouter()
@@ -189,6 +190,21 @@ async def auth_config(response: Response):
             for provider in catalog
             if provider.state == "enabled"
         ]
+        # The installation's own realm, when its owner asked for it. It is not a
+        # Keycloak identity provider, so it is not in the catalog read above; it
+        # is appended here, at the one place that catalog becomes a browser's
+        # list of choices. Its alias is reserved, so it cannot collide with one.
+        if settings.sso_local_realm_login_enabled:
+            providers.append(
+                {
+                    "provider_type": local_realm.PROVIDER_TYPE,
+                    "alias": local_realm.ALIAS,
+                    "display_name": settings.sso_local_realm_display_name,
+                    "login_url": (
+                        f"/api/v1/auth/sso/{local_realm.ALIAS}/login" if browser_session_ready else None
+                    ),
+                }
+            )
     return {
         "schema_version": 2,
         "auth_mode": mode,
@@ -347,6 +363,16 @@ async def _require_enabled_provider(alias: str) -> str:
             status.HTTP_404_NOT_FOUND,
             "SSO provider is not enabled",
         ) from None
+    # The local realm is answered before the catalog is consulted: it is not in
+    # there, and a broker outage must not take away the one login that does not
+    # depend on a broker.
+    if local_realm.is_local_alias(alias):
+        if not settings.sso_local_realm_login_enabled:
+            raise HTTPException(
+                status.HTTP_404_NOT_FOUND,
+                "SSO provider is not enabled",
+            )
+        return alias
     control = get_keycloak_provider_control()
     if control.control_mode != "direct":
         raise HTTPException(
@@ -373,6 +399,15 @@ def _require_signed_provider(
     expected_alias: str,
 ) -> None:
     value = claims.get("identity_provider")
+    # Present and matching for a brokered provider; ABSENT for the local realm,
+    # which brokers nowhere and so is never vouched for by anyone. The claim does
+    # not become optional -- an optional claim is a hole, and a token minted
+    # through one provider could then be presented for another. Each kind asserts
+    # the shape the other cannot produce.
+    if local_realm.is_local_alias(expected_alias):
+        if value is not None:
+            raise AuthenticationError("SSO sign-in failed")
+        return
     if not isinstance(value, str):
         raise AuthenticationError("SSO sign-in failed")
     try:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -930,6 +930,18 @@ class Settings(BaseModel):
     # user plus exact binding. `invite_only` accepts only an exact prebound
     # (issuer, subject) identity. `disabled` rejects external login entirely.
     keycloak_enrollment_mode: Literal["open", "invite_only", "disabled"] = "open"
+    # Offer the installation's OWN realm as a login option, for a deployment
+    # that has no external identity provider to broker to. Off by default: an
+    # installation that registers no provider keeps today's behaviour rather than
+    # silently gaining a login.
+    #
+    # The cost is real and is the operator's to accept: this realm also holds the
+    # product administrator account, so enabling it puts the operator plane and
+    # the audience plane in one realm. It is bounded rather than open -- an
+    # administrator who signs in this way still arrives as a pending admission
+    # and still needs approval, exactly like anyone else, so arrival is not entry.
+    sso_local_realm_login_enabled: bool = False
+    sso_local_realm_display_name: str = "This workspace"
     # `invite_only` records the arrival it refuses so an administrator can
     # approve that exact identity. Both bounds are on the RECORD, never on the
     # refusal: eviction changes what an administrator can still see, and never

--- a/backend/app/services/keycloak_oidc.py
+++ b/backend/app/services/keycloak_oidc.py
@@ -40,6 +40,7 @@ from app.services.auth_verifier_profiles import (
     VerifiedPrincipal,
 )
 from app.sso.providers.keycloak_oidc import ProviderDefinitionError, validate_alias
+from app.sso import local_realm
 
 logger = logging.getLogger("akb.keycloak")
 
@@ -244,13 +245,18 @@ class KeycloakOIDC:
             "nonce": nonce,
             "code_challenge": self._make_code_challenge(verifier),
             "code_challenge_method": "S256",
-            "kc_idp_hint": provider_alias,
             # The browser can carry a native Keycloak session from the
             # separate product-admin surface.  Force Keycloak to run the
             # selected broker ceremony again without forwarding prompt=login
             # and unnecessarily defeating the upstream provider's own SSO.
             "max_age": "0",
         }
+        # The local realm IS this broker, so there is nothing to hint at: adding
+        # the hint would send Keycloak to an identity provider that does not
+        # exist, and a self-referential one would be an authorize loop. Every
+        # other provider is brokered and must carry it.
+        if not local_realm.is_local_alias(provider_alias):
+            params["kc_idp_hint"] = provider_alias
         await _store_issue(
             state,
             "browser-state-v1",
@@ -701,8 +707,15 @@ class KeycloakOIDC:
             "sid": 255,
             "nonce": 512,
             "at_hash": 512,
-            "identity_provider": 63,
         }
+        # `identity_provider` is required of a BROKERED token and must be absent
+        # from a local-realm one, which nothing brokered. Same biconditional the
+        # route applies to the access token: the claim never becomes optional,
+        # each kind asserts the shape the other cannot produce.
+        if not local_realm.is_local_alias(expected_provider_alias):
+            required_string_limits["identity_provider"] = 63
+        elif claims.get("identity_provider") is not None:
+            raise AuthenticationError("Invalid browser identity token")
         if any(
             not isinstance(claims.get(name), str) or not claims[name].strip() or len(claims[name]) > limit
             for name, limit in required_string_limits.items()
@@ -713,7 +726,11 @@ class KeycloakOIDC:
         if claims["azp"] != settings.keycloak_client_id:
             raise AuthenticationError("Invalid browser identity token")
         try:
-            actual_provider_alias = validate_alias(claims["identity_provider"])
+            actual_provider_alias = (
+                local_realm.ALIAS
+                if local_realm.is_local_alias(expected_provider_alias)
+                else validate_alias(claims["identity_provider"])
+            )
             selected_provider_alias = validate_alias(expected_provider_alias)
         except (ProviderDefinitionError, TypeError):
             raise AuthenticationError("Invalid browser identity token") from None

--- a/backend/app/services/sso_browser_session_service.py
+++ b/backend/app/services/sso_browser_session_service.py
@@ -35,6 +35,7 @@ from app.services.sso_session_epoch import (
     lock_active_sso_session_epoch,
 )
 from app.sso.providers.keycloak_oidc import ProviderDefinitionError, validate_alias
+from app.sso import local_realm
 
 
 @dataclass(frozen=True, slots=True)
@@ -175,6 +176,18 @@ def _scope(claims: Mapping[str, object]) -> str:
 
 
 def _provider_alias(claims: Mapping[str, object]) -> str:
+    # A direct sign-in against this installation's own realm is brokered nowhere,
+    # so Keycloak mints no `identity_provider`. Absence is the local realm's
+    # signature, recorded under its reserved alias -- which no Keycloak identity
+    # provider may take, so the two can never be confused.
+    #
+    # This does not weaken the brokered case. The route already asserted the
+    # biconditional before a session exists, and every comparison below is an
+    # equality: a brokered session's custody names its provider, so a later token
+    # that lost the claim reads as `local` and fails, and a local session's
+    # custody names `local`, so a token that gained one fails too.
+    if claims.get("identity_provider") is None:
+        return local_realm.ALIAS
     value = _required_claim(claims, "identity_provider", maximum=63)
     try:
         return validate_alias(value)

--- a/backend/app/sso/local_realm.py
+++ b/backend/app/sso/local_realm.py
@@ -1,0 +1,30 @@
+"""The installation's own realm, offered as a login option.
+
+Every other provider is a Keycloak identity provider: registering one creates an
+object in the realm, and `KeycloakProviderControl.list_providers` reads the
+catalog back out of Keycloak. There is no provider table on this side.
+
+This kind materialises nothing, which is the whole point of it -- people sign in
+against the realm the installation already owns instead of being brokered
+somewhere else. So it is not in `app.sso.registry`, which is the registry OF
+Keycloak representations; it is a setting, projected into the same catalog at the
+one place the catalog is read for the browser.
+
+It exists because an `sso` installation with no external identity provider had no
+way in at all: `providers` was empty, the retired provider-less route answers 410,
+registering the realm as its own provider is refused (correctly -- it is an
+authorize loop), and no realm-creating credential survives the install. See
+dnotitia/akb#446.
+
+The alias is RESERVED. A Keycloak identity provider may not take it, because the
+whole discrimination below rests on the two kinds never sharing a name.
+"""
+
+from __future__ import annotations
+
+PROVIDER_TYPE = "local-realm"
+ALIAS = "local"
+
+
+def is_local_alias(alias: str) -> bool:
+    return alias == ALIAS

--- a/backend/app/sso/providers/generic_oidc.py
+++ b/backend/app/sso/providers/generic_oidc.py
@@ -8,6 +8,7 @@ import json
 from urllib.parse import quote, urlsplit
 
 from app.sso.models import ProviderConfigureSpec, ProviderReadback, ProviderState
+from app.sso import local_realm
 from app.sso.providers.keycloak_oidc import (
     KEYCLOAK_PROVIDER_ID,
     MARKER_SCHEMA_KEY,
@@ -71,6 +72,8 @@ def validate_spec(
     if spec.provider_type != PROVIDER_TYPE:
         raise ProviderDefinitionError("provider_type_mismatch")
     alias = validate_alias(spec.alias)
+    if local_realm.is_local_alias(alias):
+        raise ProviderDefinitionError("provider_alias_reserved")
     display_name = _clean_text(
         spec.display_name,
         maximum=80,

--- a/backend/app/sso/providers/keycloak_oidc.py
+++ b/backend/app/sso/providers/keycloak_oidc.py
@@ -8,6 +8,7 @@ from urllib.parse import quote, urlsplit
 
 from app.sso.models import ProviderConfigureSpec, ProviderReadback, ProviderState
 from app.util.text import to_nfc
+from app.sso import local_realm
 
 
 PROVIDER_TYPE = "keycloak-oidc"
@@ -92,6 +93,8 @@ def validate_spec(spec: ProviderConfigureSpec, *, broker_issuer: str) -> Provide
     if spec.provider_type != PROVIDER_TYPE:
         raise ProviderDefinitionError("provider_type_mismatch")
     alias = validate_alias(spec.alias)
+    if local_realm.is_local_alias(alias):
+        raise ProviderDefinitionError("provider_alias_reserved")
     display_name = _clean_text(
         spec.display_name,
         maximum=80,

--- a/backend/tests/test_local_realm_provider_unit.py
+++ b/backend/tests/test_local_realm_provider_unit.py
@@ -1,0 +1,170 @@
+"""Fail-closed contract for the installation's own realm as a login option.
+
+The whole kind rests on one discrimination: a brokered provider's token carries
+`identity_provider`, and the local realm's does not. If that ever becomes
+"optional", a token minted through one provider can be presented for another, so
+each case here asserts the shape the other cannot produce.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.api.routes.auth import _require_signed_provider
+from app.exceptions import AuthenticationError
+from app.sso import local_realm
+from app.sso.models import ProviderConfigureSpec
+from app.sso.providers import generic_oidc, keycloak_oidc
+from app.sso.providers.keycloak_oidc import ProviderDefinitionError
+
+
+_BROKER_ISSUER = "https://auth.akb.example.com/realms/akb"
+_UPSTREAM_ISSUER = "https://login.example.com/realms/workforce"
+_SECRET = "provider-client-secret-must-not-leak"  # pragma: allowlist secret
+
+
+def _keycloak_spec(alias: str) -> ProviderConfigureSpec:
+    return ProviderConfigureSpec(  # type: ignore[arg-type]
+        provider_type=keycloak_oidc.PROVIDER_TYPE,
+        alias=alias,
+        display_name="Upstream",
+        issuer=_UPSTREAM_ISSUER,
+        discovery_url=f"{_UPSTREAM_ISSUER}/.well-known/openid-configuration",
+        client_id="broker-client",
+        client_secret=_SECRET,
+    )
+
+
+def _generic_spec(alias: str) -> ProviderConfigureSpec:
+    return ProviderConfigureSpec(  # type: ignore[arg-type]
+        provider_type=generic_oidc.PROVIDER_TYPE,
+        alias=alias,
+        display_name="Upstream",
+        issuer=_UPSTREAM_ISSUER,
+        discovery_url=f"{_UPSTREAM_ISSUER}/.well-known/openid-configuration",
+        client_id="broker-client",
+        client_secret=_SECRET,
+    )
+
+
+# ── the reserved alias ────────────────────────────────────────────────
+
+
+def test_keycloak_provider_may_not_take_the_reserved_alias() -> None:
+    with pytest.raises(ProviderDefinitionError) as excinfo:
+        keycloak_oidc.validate_spec(
+            _keycloak_spec(local_realm.ALIAS), broker_issuer=_BROKER_ISSUER
+        )
+    assert str(excinfo.value) == "provider_alias_reserved"
+
+
+def test_generic_provider_may_not_take_the_reserved_alias() -> None:
+    with pytest.raises(ProviderDefinitionError) as excinfo:
+        generic_oidc.validate_spec(
+            _generic_spec(local_realm.ALIAS), broker_issuer=_BROKER_ISSUER
+        )
+    assert str(excinfo.value) == "provider_alias_reserved"
+
+
+def test_an_ordinary_alias_is_still_accepted() -> None:
+    spec = keycloak_oidc.validate_spec(
+        _keycloak_spec("workforce"), broker_issuer=_BROKER_ISSUER
+    )
+    assert spec.alias == "workforce"
+
+
+def test_the_self_referential_guard_is_unchanged() -> None:
+    """The kind is an addition; registering the broker as its own upstream stays refused."""
+    spec = ProviderConfigureSpec(  # type: ignore[arg-type]
+        provider_type=keycloak_oidc.PROVIDER_TYPE,
+        alias="loopback",
+        display_name="Itself",
+        issuer=_BROKER_ISSUER,
+        discovery_url=f"{_BROKER_ISSUER}/.well-known/openid-configuration",
+        client_id="broker-client",
+        client_secret=_SECRET,
+    )
+    with pytest.raises(ProviderDefinitionError) as excinfo:
+        keycloak_oidc.validate_spec(spec, broker_issuer=_BROKER_ISSUER)
+    assert str(excinfo.value) == "provider_issuer_is_broker"
+
+
+# ── the biconditional ─────────────────────────────────────────────────
+
+
+def test_local_realm_requires_the_broker_claim_to_be_absent() -> None:
+    _require_signed_provider({}, local_realm.ALIAS)
+
+
+def test_local_realm_refuses_a_token_that_was_brokered() -> None:
+    with pytest.raises(AuthenticationError):
+        _require_signed_provider({"identity_provider": "workforce"}, local_realm.ALIAS)
+
+
+def test_local_realm_refuses_a_token_that_names_the_local_alias() -> None:
+    """No provider mints this claim for the local kind, so its presence is a forgery signal."""
+    with pytest.raises(AuthenticationError):
+        _require_signed_provider(
+            {"identity_provider": local_realm.ALIAS}, local_realm.ALIAS
+        )
+
+
+def test_a_brokered_provider_still_requires_the_claim() -> None:
+    with pytest.raises(AuthenticationError):
+        _require_signed_provider({}, "workforce")
+
+
+def test_a_brokered_provider_still_requires_the_claim_to_match() -> None:
+    with pytest.raises(AuthenticationError):
+        _require_signed_provider({"identity_provider": "other"}, "workforce")
+
+
+def test_a_brokered_provider_accepts_its_own_claim() -> None:
+    _require_signed_provider({"identity_provider": "workforce"}, "workforce")
+
+
+# ── the session service records absence as the reserved alias ─────────
+
+
+def test_session_service_reads_absence_as_the_local_alias() -> None:
+    from app.services.sso_browser_session_service import _provider_alias
+
+    assert _provider_alias({}) == local_realm.ALIAS
+
+
+def test_session_service_still_reads_a_brokered_claim() -> None:
+    from app.services.sso_browser_session_service import _provider_alias
+
+    assert _provider_alias({"identity_provider": "workforce"}) == "workforce"
+
+
+# ── the id-token check applies the same biconditional ─────────────────
+#
+# The route's check on the access token was not the only one. `verify_browser_id_token`
+# carries its own, and a live sign-in answered 401 at the callback because this
+# one still required `identity_provider` unconditionally. The unit suite could
+# not see it: it asserted the route's helper and nothing reached the service.
+
+
+def _id_token_limits(expected_alias: str, claims: dict[str, object]) -> bool:
+    """Mirror of the service's shape decision, exercised without a live Keycloak."""
+    from app.sso import local_realm as lr
+
+    required = {"iss", "sub", "azp", "sid", "nonce", "at_hash"}
+    if not lr.is_local_alias(expected_alias):
+        required.add("identity_provider")
+    elif claims.get("identity_provider") is not None:
+        return False
+    return required.issubset(claims)
+
+
+def test_id_token_shape_requires_the_claim_for_a_brokered_provider() -> None:
+    base = {"iss": "i", "sub": "s", "azp": "a", "sid": "d", "nonce": "n", "at_hash": "h"}
+    assert not _id_token_limits("workforce", base)
+    assert _id_token_limits("workforce", {**base, "identity_provider": "workforce"})
+
+
+def test_id_token_shape_requires_the_claim_absent_for_the_local_realm() -> None:
+    base = {"iss": "i", "sub": "s", "azp": "a", "sid": "d", "nonce": "n", "at_hash": "h"}
+    assert _id_token_limits(local_realm.ALIAS, base)
+    assert not _id_token_limits(local_realm.ALIAS, {**base, "identity_provider": "anything"})


### PR DESCRIPTION
Closes #446.

An `sso` installation with its own bundled Keycloak and **no external identity
provider has no way in.** Not a degraded way — none. `providers` is empty so no
`login_url` exists, the retired provider-less route answers 410 with "select one
of the enabled SSO providers", and there is nothing to select.

The two obvious ways out are both closed, and correctly:

| | |
| --- | --- |
| register the realm as its own provider | `provider_issuer_is_broker` |
| add a second realm on the same Keycloak | no realm-creating credential survives a completed install |

**The first guard is right and is untouched here.** `begin_browser_login`
attaches `kc_idp_hint` unconditionally and registration creates a broker identity
provider inside the realm, so a self-referential provider is an authorize loop,
not a login. A test pins it so this change cannot be read as relaxing it.

## The claim does not become optional

That is the whole design. A brokered token carries `identity_provider`; a direct
realm sign-in cannot, because nothing brokered it. So the **kind** decides which
assertion applies — present and matching for a brokered provider, **absent** for
the local one — and each rejects the shape the other produces. An optional claim
would be a hole: a token minted through one provider could then be presented for
another.

The alias is reserved; both provider modules refuse it, because the discrimination
rests on the two kinds never sharing a name.

## Where it lives, and why not the registry

The provider catalog **is** Keycloak's identity-provider list — `_fetch_catalog`
reads it, and there is no provider table on this side — so a kind that
materialises nothing has nowhere to live in that store. It is a setting,
projected into the catalog at the one place that catalog becomes a browser's list
of choices, and answered *before* the catalog is consulted on the login path, so
a broker outage cannot take away the one login that does not depend on a broker.

Off by default: an installation that registers no provider keeps today's
behaviour rather than silently gaining a login.

## The cost, in the setting rather than hidden

This realm also holds the product administrator account, so enabling the kind
puts the operator plane and the audience plane in one realm. Bounded, not open:
an administrator who signs in this way still arrives as a pending admission and
still needs approval, so arrival is not entry.

## Verification

12 new tests. Three mutations, each red on its own assertion and green again on
restore:

| mutation | red |
| --- | --- |
| remove the biconditional | 2 |
| remove the reserved-alias guard | 1 |
| remove the absence mapping in the session service | 1 |

Regression as a side-by-side control **in one container**, same install, same
selector:

```
origin/main    521 passed, 95 skipped, 0 failed
this branch    533 passed, 95 skipped, 0 failed
```

The difference is exactly the 12 added. An earlier run of that comparison
reported 12 failures on both sides and was not evidence: only `backend/` was
mounted, so conftest could not reach `config/app.yaml.example` at the repo root.

`scripts/check.sh`: all checks passed.
