### PR TITLE
docs(sso): say what the local-realm kind actually costs, and where to turn it on

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -935,11 +935,14 @@ class Settings(BaseModel):
     # installation that registers no provider keeps today's behaviour rather than
     # silently gaining a login.
     #
-    # The cost is real and is the operator's to accept: this realm also holds the
-    # product administrator account, so enabling it puts the operator plane and
-    # the audience plane in one realm. It is bounded rather than open -- an
-    # administrator who signs in this way still arrives as a pending admission
-    # and still needs approval, exactly like anyone else, so arrival is not entry.
+    # This does not put two planes into one realm. A realm-local native identity
+    # is already what this realm is for: the product administrator is one, and
+    # this realm is the only human issuer the installation accepts. What the
+    # setting decides is whether ordinary people also hold an account here rather
+    # than at an upstream -- an installation-owner's choice, which is why it is a
+    # setting and not a default. Bounded either way: whoever signs in this way
+    # arrives as a pending admission and still needs approval, exactly like
+    # anyone else, so arrival is not entry.
     sso_local_realm_login_enabled: bool = False
     sso_local_realm_display_name: str = "This workspace"
     # `invite_only` records the arrival it refuses so an administrator can

--- a/config/app.yaml.example
+++ b/config/app.yaml.example
@@ -243,6 +243,21 @@ app_credential_overlap_seconds: 300
 #                                         # Exact subject bindings need no email claim.
 #                                         # Set false ONLY for a trusted realm with
 #                                         # controlled emails.
+# sso_local_realm_login_enabled: false    # offer THIS installation's own realm as a
+#                                         # login option, for a deployment with no
+#                                         # external identity provider to broker to.
+#                                         # Off by default: an installation that
+#                                         # registers no provider keeps the behaviour
+#                                         # it has rather than gaining a login. The
+#                                         # kind appears as provider_type
+#                                         # `local-realm` under the reserved alias
+#                                         # `local`, carries no broker hint, and
+#                                         # requires the identity_provider claim to be
+#                                         # ABSENT where a brokered provider requires
+#                                         # it present and matching. Registering this
+#                                         # realm as its own upstream provider stays
+#                                         # refused; that would be an authorize loop.
+# sso_local_realm_display_name: "This workspace"  # label shown for that choice
 # keycloak_link_by_email is a deprecated migration marker; omit it. Setting it
 # to true fails canonical startup. Exact pre-binding is the only account-link path.
 # Ordinary AKB browser login uses authorization code + PKCE/nonce and a fixed

--- a/deploy/k8s/standalone-sso/README.md
+++ b/deploy/k8s/standalone-sso/README.md
@@ -33,10 +33,15 @@ encrypts the Keycloak refresh/ID token set and never persists an access token.
 The bootstrap maps the `identity_provider` user-session note into both ordinary
 token profiles so AKB can bind each callback and refresh to the exact enabled
 broker alias rather than trusting `kc_idp_hint`.
-It becomes ready only after the browser-session encryption key is supplied and
-an upstream provider is enabled. `/admin` uses the dedicated confidential
-client and requires a fresh native Keycloak password ceremony; a brokered
-upstream identity is not accepted as the recovery administrator.
+That custody becomes ready once its own configuration is complete — the
+browser-session encryption key is the last piece an operator supplies — and
+readiness is a property of that profile alone, never of the provider list.
+Readiness is not a way in, though: a person still needs somewhere to sign in,
+which is either an enabled upstream provider or this installation's own realm
+(see [Sign in without an upstream provider](#sign-in-without-an-upstream-provider)).
+`/admin` uses the dedicated confidential client and requires a fresh native
+Keycloak password ceremony; a brokered upstream identity is not accepted as the
+recovery administrator.
 
 The browser-facing AKB origin and Keycloak-to-AKB back-channel are separate
 deployment concerns. `keycloak_backchannel_logout_uri` is registered on the
@@ -154,6 +159,40 @@ Apply only after all durable and first-install one-time Secrets exist. Wait for 
 pod's `bootstrap-standalone-sso` init container and main container to complete,
 then inspect the init log. Its JSON report contains only IDs, key metadata, and
 the exact role names; it never contains credential values.
+
+## Sign in without an upstream provider
+
+A bundled-Keycloak install has a realm of its own, and an installation that has
+no external identity provider to broker to can use it as the place people
+authenticate:
+
+```yaml
+sso_local_realm_login_enabled: true
+sso_local_realm_display_name: "This workspace"
+```
+
+`/api/v1/auth/config` then offers one provider of type `local-realm` under the
+reserved alias `local`, whose `login_url` is `/api/v1/auth/sso/local/login`; that
+route redirects to this realm's own authorize endpoint with no broker hint
+attached. Off by default, so an installation that
+registers no provider keeps the behaviour it has rather than silently gaining a
+login.
+
+The two kinds are not interchangeable and neither accepts the other's shape. A
+brokered sign-in carries the `identity_provider` claim and it must be present
+and equal to the selected alias; a direct realm sign-in cannot carry it, because
+nothing brokered it, and it must be absent. The claim never becomes optional:
+that would let a token minted through one provider be presented for another.
+
+Registering this realm as its own upstream provider is a different thing and
+stays refused (`provider_issuer_is_broker`) -- it would be an authorize loop,
+not a login.
+
+This realm already holds a realm-local native identity: the product
+administrator is one. So enabling this does not introduce a plane that was
+absent; it decides that ordinary people also hold an account here rather than at
+an upstream. Whoever arrives this way is a pending admission and still needs an
+administrator's approval, exactly like anyone arriving through a broker.
 
 ## Upgrade an existing receipt
 

--- a/deploy/k8s/standalone-sso/backend-config-patch.yaml
+++ b/deploy/k8s/standalone-sso/backend-config-patch.yaml
@@ -36,6 +36,11 @@ data:
     keycloak_require_verified_email: true
     api_oauth_audience: https://akb.example.com/api
     keycloak_verify_ssl: true
+    # With no external identity provider to broker to, uncomment these to let
+    # people sign in with an account in this installation's own realm. See
+    # "Sign in without an upstream provider" in README.md.
+    # sso_local_realm_login_enabled: true
+    # sso_local_realm_display_name: "This workspace"
 
     vector_store_driver: pgvector
     vector_store_dsn: ""


### PR DESCRIPTION
Two corrections and one gap, all about `sso_local_realm_login_enabled`. No
behaviour changes: comments, documentation, and two commented-out keys.

## The cost note was overstated

The comment on the setting said that enabling it "puts the operator plane and
the audience plane in one realm". That reads as though the setting introduces a
mixing that was absent, and it does not.

A realm-local native identity is already what this realm is for: the product
administrator is one, and in `sso` mode this realm is the only human issuer the
installation accepts. What the setting actually decides is narrower — whether
ordinary people also hold an account here rather than at an upstream.

That is still an installation-owner's choice, which is why it stays a setting
and stays off. It is just not the trade the comment described, and a wrong
reason for a right default is the kind of sentence the next person makes a
decision on.

## The standalone bundle's README said an upstream was required

> It becomes ready only after the browser-session encryption key is supplied and
> an upstream provider is enabled.

That was already inaccurate before this kind existed. `sso_browser_session_ready()`
looks at the auth mode, the client, the epoch and the encryption key — never at
the provider list. Readiness and having a way in are two different questions,
and that sentence merged them, so a reader concluded an upstream IdP was
mandatory. Both halves are now stated separately.

## The setting was documented nowhere an installer would look

It was absent from `config/app.yaml.example`, which documents every other
Keycloak key, and absent from the standalone overlay's ConfigMap, which is a
plain file the installer edits. So the one deployment shape that needs it — a
bundled Keycloak with nothing to broker to, exactly the state #446 describes —
had no path to it that did not involve reading the source.

Added to both, plus a README section that states the discrimination explicitly:
`identity_provider` present and matching for a brokered provider, **absent** for
this one, neither accepting the other's shape. It also records that
`provider_issuer_is_broker` is untouched, so this cannot be read as relaxing it.

## Verification

```
scripts/check.sh                    all checks passed
backend pytest (python:3.14-slim)   2476 passed, 650 skipped, 4 failed
```

The 4 failures are in `tests/test_external_git_capability.py` and are
pre-existing and environmental. Negative control: the same container against a
pristine `origin/main` worktree fails the same 4 (`4 failed, 14 passed`). They
are the git `--config-env` and CURLOPT_RESOLVE probes, which the slim image's
git cannot satisfy.
