### PR TITLE
fix(revisions): release aborted plan reservations

### DIFF
--- a/backend/app/db/migrations/092_native_revision_plan_supersession.py
+++ b/backend/app/db/migrations/092_native_revision_plan_supersession.py
@@ -1,0 +1,103 @@
+"""Release never-applied migration reservations after an explicit plan abort."""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("akb.migrations")
+
+
+async def migrate(conn) -> None:
+    """Keep aborted plan evidence while allowing a new coverage version to plan."""
+    async with conn.transaction():
+        await conn.execute(
+            """
+            ALTER TABLE native_revision_migration_runs
+                DROP CONSTRAINT IF EXISTS native_revision_migration_runs_status_check;
+            ALTER TABLE native_revision_migration_runs
+                ADD CONSTRAINT native_revision_migration_runs_status_check
+                CHECK (status IN ('planned', 'running', 'complete', 'failed', 'superseded'));
+
+            ALTER TABLE native_revision_migration_items
+                ADD COLUMN IF NOT EXISTS reservation_active BOOLEAN NOT NULL DEFAULT TRUE;
+            ALTER TABLE native_revision_migration_items
+                DROP CONSTRAINT IF EXISTS native_revision_migration_items_reservation_state_check;
+            ALTER TABLE native_revision_migration_items
+                ADD CONSTRAINT native_revision_migration_items_reservation_state_check
+                CHECK (reservation_active OR status = 'pending');
+            ALTER TABLE native_revision_migration_items
+                DROP CONSTRAINT IF EXISTS native_revision_migration_items_resource_head_key;
+            CREATE UNIQUE INDEX IF NOT EXISTS
+                native_revision_migration_items_active_resource_head_key
+                ON native_revision_migration_items(native_resource_id, legacy_head_oid)
+                WHERE reservation_active;
+
+            -- A prior version of abort retained a planned cutover and its
+            -- all-pending inventory forever.  Those rows are durable audit
+            -- evidence, but cannot still reserve a document/head: the linked
+            -- cutover is permanently non-applicable and no native material was
+            -- published.  Do not release any applied, failed, or active run.
+            UPDATE native_revision_migration_items item
+               SET reservation_active = FALSE,
+                   updated_at = NOW()
+             WHERE item.run_id IN (
+                 SELECT DISTINCT run.run_id
+                   FROM native_revision_migration_runs run
+                   JOIN native_revision_cutover_vaults vault
+                     ON vault.migration_run_id = run.run_id
+                   JOIN native_revision_cutover_runs cutover
+                     ON cutover.cutover_id = vault.cutover_id
+                  WHERE run.status = 'planned'
+                    AND cutover.status = 'aborted'
+                    AND cutover.aborted_from_status = 'planned'
+                    AND NOT EXISTS (
+                        SELECT 1
+                          FROM native_revision_migration_items candidate
+                         WHERE candidate.run_id = run.run_id
+                           AND candidate.status <> 'pending'
+                    )
+                    AND NOT EXISTS (
+                        SELECT 1
+                          FROM native_revision_cutover_vaults other_vault
+                          JOIN native_revision_cutover_runs other_cutover
+                            ON other_cutover.cutover_id = other_vault.cutover_id
+                         WHERE other_vault.migration_run_id = run.run_id
+                           AND (
+                               other_cutover.status <> 'aborted'
+                               OR other_cutover.aborted_from_status <> 'planned'
+                           )
+                    )
+             );
+
+            UPDATE native_revision_migration_runs run
+               SET status = 'superseded'
+             WHERE run.status = 'planned'
+               AND EXISTS (
+                   SELECT 1
+                     FROM native_revision_cutover_vaults vault
+                     JOIN native_revision_cutover_runs cutover
+                       ON cutover.cutover_id = vault.cutover_id
+                    WHERE vault.migration_run_id = run.run_id
+                      AND cutover.status = 'aborted'
+                      AND cutover.aborted_from_status = 'planned'
+               )
+               AND NOT EXISTS (
+                   SELECT 1
+                     FROM native_revision_migration_items candidate
+                    WHERE candidate.run_id = run.run_id
+                      AND candidate.status <> 'pending'
+               )
+               AND NOT EXISTS (
+                   SELECT 1
+                     FROM native_revision_cutover_vaults other_vault
+                     JOIN native_revision_cutover_runs other_cutover
+                       ON other_cutover.cutover_id = other_vault.cutover_id
+                    WHERE other_vault.migration_run_id = run.run_id
+                      AND (
+                          other_cutover.status <> 'aborted'
+                          OR other_cutover.aborted_from_status <> 'planned'
+                      )
+               );
+            """
+        )
+    logger.info("Migration 092: aborted Native cutover plans release inactive reservations")

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -314,6 +314,7 @@ async def _apply_pending_migrations(conn, applied: set[str]) -> None:
         "089_native_file_projection_outbox.py",  # durable S3 File mutation reconciliation into Native text projection
         "090_native_revision_vault_purge_fence.py",  # allow an authorized exact-vault lifecycle purge after cutover authority commits
         "091_native_revision_committed_receipt_guard.py",  # freeze a committed cutover's durable authority receipt set
+        "092_native_revision_plan_supersession.py",  # release never-applied aborted-plan reservations for a fresh coverage version
     ):
         if filename in applied:
             continue

--- a/backend/app/repositories/native_revision_cutover_repo.py
+++ b/backend/app/repositories/native_revision_cutover_repo.py
@@ -581,6 +581,11 @@ class NativeRevisionCutoverRepository:
                 )
                 if fence_state != "open":
                     raise CutoverIntegrityError("cutover cannot abort after the Legacy write fence closes")
+                if row["status"] == "planned":
+                    await self._supersede_planned_migration_reservations(
+                        conn,
+                        cutover_id=cutover_id,
+                    )
                 row = await conn.fetchrow(
                     """
                     UPDATE native_revision_cutover_runs
@@ -596,3 +601,58 @@ class NativeRevisionCutoverRepository:
                 )
                 assert row is not None
                 return _run(row)
+
+    @staticmethod
+    async def _supersede_planned_migration_reservations(
+        conn: asyncpg.Connection,
+        *,
+        cutover_id: uuid.UUID,
+    ) -> None:
+        """Release only an aborted cutover's never-applied item reservations."""
+        migration_runs = await conn.fetch(
+            """
+            SELECT migration_run.run_id, migration_run.status
+              FROM native_revision_cutover_vaults cutover_vault
+              JOIN native_revision_migration_runs migration_run
+                ON migration_run.run_id = cutover_vault.migration_run_id
+             WHERE cutover_vault.cutover_id = $1
+             FOR UPDATE OF migration_run
+            """,
+            cutover_id,
+        )
+        if not migration_runs:
+            raise CutoverIntegrityError("planned cutover has no migration runs")
+        if any(run["status"] != "planned" for run in migration_runs):
+            raise CutoverIntegrityError("planned cutover migration run is no longer pending")
+
+        run_ids = [run["run_id"] for run in migration_runs]
+        items = await conn.fetch(
+            """
+            SELECT run_id, status, reservation_active
+              FROM native_revision_migration_items
+             WHERE run_id = ANY($1::uuid[])
+             FOR UPDATE
+            """,
+            run_ids,
+        )
+        if any(item["status"] != "pending" or not item["reservation_active"] for item in items):
+            raise CutoverIntegrityError("planned cutover has non-pending migration inventory")
+
+        await conn.execute(
+            """
+            UPDATE native_revision_migration_items
+               SET reservation_active = FALSE,
+                   updated_at = NOW()
+             WHERE run_id = ANY($1::uuid[])
+            """,
+            run_ids,
+        )
+        await conn.execute(
+            """
+            UPDATE native_revision_migration_runs
+               SET status = 'superseded'
+             WHERE run_id = ANY($1::uuid[])
+               AND status = 'planned'
+            """,
+            run_ids,
+        )

--- a/backend/app/repositories/native_revision_migration_repo.py
+++ b/backend/app/repositories/native_revision_migration_repo.py
@@ -278,6 +278,10 @@ class NativeRevisionMigrationRepository:
                 raise MigrationIntegrityError("migration run disappeared during creation")
             if row["inventory_digest"] != inventory_digest:
                 raise MigrationInventoryDriftError()
+            if row["status"] == "superseded":
+                raise MigrationIntegrityError(
+                    "migration run was superseded; plan with a new coverage version"
+                )
             return _run(row)
 
         if conn is not None:
@@ -296,6 +300,19 @@ class NativeRevisionMigrationRepository:
         """Insert the pre-authority inventory, preserving completed work."""
 
         async def _ensure(acquired: asyncpg.Connection) -> list[MigrationItem]:
+            persisted_run = await acquired.fetchrow(
+                """
+                SELECT status
+                  FROM native_revision_migration_runs
+                 WHERE run_id = $1
+                 FOR UPDATE
+                """,
+                run.run_id,
+            )
+            if persisted_run is None:
+                raise MigrationIntegrityError("migration run disappeared during inventory insertion")
+            if persisted_run["status"] == "superseded":
+                raise MigrationIntegrityError("superseded migration run cannot receive inventory")
             result: list[MigrationItem] = []
             for observed in items:
                 document_id = observed["legacy_document_id"]
@@ -503,6 +520,8 @@ class NativeRevisionMigrationRepository:
                 raise MigrationIntegrityError("migration run disappeared during status update")
             if row["status"] == "complete":
                 return _run(row)
+            if row["status"] == "superseded":
+                raise MigrationIntegrityError("superseded migration run cannot change status")
             await acquired.execute(
                 """
                 UPDATE native_revision_migration_runs

--- a/backend/app/services/native_revision_backfill.py
+++ b/backend/app/services/native_revision_backfill.py
@@ -15,6 +15,7 @@ import asyncpg
 
 from app.exceptions import NotFoundError
 from app.repositories.native_revision_migration_repo import (
+    MigrationIntegrityError,
     MigrationRun,
     NativeRevisionMigrationRepository,
 )
@@ -139,6 +140,8 @@ class NativeRevisionBackfill:
                 failed_items=0,
                 skipped_items=0,
             )
+        if run.status == "superseded":
+            raise MigrationIntegrityError("superseded migration run cannot be backfilled")
         scope = await self.bridge.inventory_scope_for_run(run)
         inventory = scope.inventory
 

--- a/backend/tests/test_access_contributions_postgres.py
+++ b/backend/tests/test_access_contributions_postgres.py
@@ -33,7 +33,7 @@ _MIGRATION_085 = (
     _BACKEND / "app" / "db" / "migrations" / "085_vault_access_contributions.py"
 )
 _MIGRATION_HEAD = (
-    _BACKEND / "app" / "db" / "migrations" / "091_native_revision_committed_receipt_guard.py"
+    _BACKEND / "app" / "db" / "migrations" / "092_native_revision_plan_supersession.py"
 )
 _MIGRATIONS_DIR = _BACKEND / "app" / "db" / "migrations"
 

--- a/backend/tests/test_native_revision_cutover_f2_e2e.py
+++ b/backend/tests/test_native_revision_cutover_f2_e2e.py
@@ -688,8 +688,12 @@ async def test_real_legacy_seed_stops_then_backfills_same_database_and_git(
             ) == 1
 
         # Membership and classifications are bound facts, so retiring the
-        # excluded mirror requires a fresh complete database plan. Reusing the
-        # classification receipt would be a reclassified-state authority bug.
+        # excluded mirror requires permanently closing this never-applied
+        # classification receipt before creating a fresh complete database
+        # plan. Reusing it would be a reclassified-state authority bug.
+        aborted = await cutover.abort(classification.cutover_id)
+        assert aborted.status == "aborted"
+        assert aborted.aborted_from_status == "planned"
         planned = await cutover.plan(
             vaults=[
                 CutoverVaultInput(

--- a/backend/tests/test_native_revision_cutover_pg.py
+++ b/backend/tests/test_native_revision_cutover_pg.py
@@ -19,6 +19,7 @@ import pytest
 from git import Repo
 
 from app.db import postgres
+from app.repositories.native_revision_migration_repo import MigrationIntegrityError
 import app.services.native_revision_cutover as cutover_module
 from app.services.git_service import FixedRefHistoryError, GitService
 from app.services.native_revision_backfill import NativeRevisionBackfill
@@ -98,6 +99,7 @@ async def _fresh_schema(*, cutover_migrations: bool = True):
                     "089_native_file_projection_outbox.py",
                     "090_native_revision_vault_purge_fence.py",
                     "091_native_revision_committed_receipt_guard.py",
+                    "092_native_revision_plan_supersession.py",
                 ]
             )
         for filename in filenames:
@@ -461,6 +463,178 @@ async def test_archived_external_mirror_blocks_authority_without_poisoning_manua
                 == "open"
             )
             assert await conn.fetchval("SELECT count(*) FROM native_revision_existing_authority") == 0
+
+
+async def test_aborting_classification_plan_releases_pending_item_reservations(tmp_path):
+    """A retired external mirror may be replanned only after explicit abort."""
+    async with _fresh_schema() as pool:
+        git = GitService(storage_path=str(tmp_path / "git-reclassification"))
+        manual = await _manual_vault(pool, git, label="reclassification-manual")
+
+        mirror_name = f"cutover-reclassification-mirror-{uuid.uuid4().hex}"
+        git.init_vault(mirror_name)
+        mirror_oid = git.commit_file(
+            mirror_name,
+            "mirrored.md",
+            "persisted external mirror body\n",
+            "[create] mirrored.md\n\nagent: fixture\naction: create\nsummary: mirror",
+        )
+        async with pool.acquire() as conn:
+            mirror_id = await conn.fetchval(
+                """
+                INSERT INTO vaults (name, git_path, status)
+                VALUES ($1, $2, 'active') RETURNING id
+                """,
+                mirror_name,
+                str(git._bare_path(mirror_name)),
+            )
+            await conn.execute(
+                """
+                INSERT INTO vault_external_git (vault_id, remote_url, remote_branch)
+                VALUES ($1, 'https://git.example.invalid/fixture.git', 'main')
+                """,
+                mirror_id,
+            )
+
+        backfill = NativeRevisionBackfill(pool, git=git)
+        cutover = NativeRevisionCutover(
+            pool,
+            backfill=backfill,
+            verifier=_FixtureVerifier(pool),
+        )
+        classification = await cutover.plan(
+            vaults=[
+                manual,
+                CutoverVaultInput(namespace_id=mirror_id, fixed_ref=mirror_oid),
+            ],
+            coverage_version="fixture-reclassification-classification-v1",
+        )
+        assert [item.namespace_id for item in classification.vaults] == [manual.namespace_id]
+        assert [item.namespace_id for item in classification.exclusions] == [mirror_id]
+        classification_run_id = classification.vaults[0].migration_run_id
+        with pytest.raises(
+            asyncpg.UniqueViolationError,
+            match="native_revision_migration_items_active_resource_head_key",
+        ):
+            await cutover.plan(
+                vaults=[
+                    manual,
+                    CutoverVaultInput(namespace_id=mirror_id, fixed_ref=mirror_oid),
+                ],
+                coverage_version="fixture-reclassification-must-abort-v2",
+            )
+
+        async with pool.acquire() as conn:
+            await conn.execute("DELETE FROM vaults WHERE id = $1", mirror_id)
+
+        aborted = await cutover.abort(classification.cutover_id)
+        assert aborted.status == "aborted"
+        assert aborted.aborted_from_status == "planned"
+        async with pool.acquire() as conn:
+            assert (
+                await conn.fetchval(
+                    "SELECT status FROM native_revision_migration_runs WHERE run_id = $1",
+                    classification_run_id,
+                )
+                == "superseded"
+            )
+            assert (
+                await conn.fetchval(
+                    """
+                    SELECT reservation_active
+                      FROM native_revision_migration_items
+                     WHERE run_id = $1
+                    """,
+                    classification_run_id,
+                )
+                is False
+            )
+            assert (
+                await conn.fetchval(
+                    """
+                    SELECT count(*)
+                      FROM native_revision_cutover_exclusions
+                     WHERE cutover_id = $1 AND namespace_id = $2
+                    """,
+                    classification.cutover_id,
+                    mirror_id,
+                )
+                == 1
+            )
+
+        fresh = await cutover.plan(
+            vaults=[manual],
+            coverage_version="fixture-reclassification-authority-v2",
+        )
+        assert fresh.cutover_id != classification.cutover_id
+        assert fresh.vaults[0].migration_run_id != classification_run_id
+        assert (await cutover.apply(fresh.cutover_id)).status == "applied"
+        with pytest.raises(CutoverApplyError, match="aborted"):
+            await cutover.apply(classification.cutover_id)
+        with pytest.raises(MigrationIntegrityError, match="superseded"):
+            await backfill.backfill_run(classification_run_id)
+
+
+async def test_plan_supersession_migration_releases_legacy_aborted_reservations(tmp_path):
+    """Upgrade releases an attempt that was aborted before plan supersession existed."""
+    async with _fresh_schema(cutover_migrations=False) as pool:
+        async with pool.acquire() as conn:
+            for filename in (
+                "088_native_revision_existing_cutover.py",
+                "089_native_file_projection_outbox.py",
+                "090_native_revision_vault_purge_fence.py",
+                "091_native_revision_committed_receipt_guard.py",
+            ):
+                await _load(filename).migrate(conn=conn)
+
+        git = GitService(storage_path=str(tmp_path / "git-legacy-aborted-plan"))
+        manual = await _manual_vault(pool, git, label="legacy-aborted-plan")
+        cutover = NativeRevisionCutover(
+            pool,
+            backfill=NativeRevisionBackfill(pool, git=git),
+            verifier=_FixtureVerifier(pool),
+        )
+        prior = await cutover.plan(
+            vaults=[manual],
+            coverage_version="fixture-legacy-aborted-plan-v1",
+        )
+        prior_run_id = prior.vaults[0].migration_run_id
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                UPDATE native_revision_cutover_runs
+                   SET status = 'aborted',
+                       aborted_from_status = 'planned',
+                       aborted_at = NOW()
+                 WHERE cutover_id = $1
+                """,
+                prior.cutover_id,
+            )
+            await _load("092_native_revision_plan_supersession.py").migrate(conn=conn)
+            assert (
+                await conn.fetchval(
+                    "SELECT status FROM native_revision_migration_runs WHERE run_id = $1",
+                    prior_run_id,
+                )
+                == "superseded"
+            )
+            assert (
+                await conn.fetchval(
+                    """
+                    SELECT reservation_active
+                      FROM native_revision_migration_items
+                     WHERE run_id = $1
+                    """,
+                    prior_run_id,
+                )
+                is False
+            )
+
+        fresh = await cutover.plan(
+            vaults=[manual],
+            coverage_version="fixture-legacy-aborted-plan-v2",
+        )
+        assert fresh.vaults[0].migration_run_id != prior_run_id
 
 
 async def test_deleted_vault_external_git_sidecar_blocks_authority_outside_retained_inventory(tmp_path):
@@ -1240,6 +1414,7 @@ async def test_cutover_migrations_upgrade_once_and_second_runner_start_is_a_noop
             "089_native_file_projection_outbox.py",
             "090_native_revision_vault_purge_fence.py",
             "091_native_revision_committed_receipt_guard.py",
+            "092_native_revision_plan_supersession.py",
         }
         assert cutover_files <= registered
 
@@ -1263,6 +1438,7 @@ async def test_cutover_migrations_upgrade_once_and_second_runner_start_is_a_noop
                 "089_native_file_projection_outbox.py",
                 "090_native_revision_vault_purge_fence.py",
                 "091_native_revision_committed_receipt_guard.py",
+                "092_native_revision_plan_supersession.py",
             ]
             assert await conn.fetchval("SELECT state FROM native_revision_legacy_write_fence") == "open"
             assert await conn.fetchval("SELECT to_regclass('public.native_file_projection_outbox') IS NOT NULL") is True
@@ -1276,7 +1452,7 @@ async def test_cutover_migrations_upgrade_once_and_second_runner_start_is_a_noop
                     "SELECT count(*) FROM schema_migrations WHERE filename = ANY($1::text[])",
                     list(cutover_files),
                 )
-                == 4
+                == 5
             )
 
 


### PR DESCRIPTION
## Summary
- preserve aborted cutover evidence while superseding only never-applied migration reservations
- keep concurrent live plans blocked by a partial unique reservation index
- upgrade legacy aborted plans and refuse replay of superseded runs

## Verification
- real PostgreSQL cutover suite: 16 passed
- disposable Legacy-to-Native F2: 1 passed in 88.27s, zero semantic mismatches
- repository scripts/check.sh: passed
- exact-head Sol(xHigh) review: 0 High / 0 Medium / 0 Low

This is the smallest product fix for the reclassification lifecycle exposed by the merged-head fixture.