### PR TITLE
feat(revisions): retire external Git mirrors offline

### DIFF
--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -76,7 +76,9 @@ STANDALONE_SSO_BOOTSTRAP_USAGE = (
 
 MIGRATE_REVISION_BACKEND_USAGE = (
     "Usage: python -m app.cli migrate-revision-backend "
-    "{plan --coverage-version VERSION|apply|verify|commit|abort --cutover-id UUID}"
+    "{plan --coverage-version VERSION|apply|verify|commit|abort --cutover-id UUID|"
+    "retire-external-git --vault-id UUID --manifest-file PATH --idempotency-key UUID "
+    "--requested-by ID --confirm-planned-downtime RETIRE-EXTERNAL-GIT:UUID}"
 )
 
 
@@ -650,7 +652,67 @@ def _native_revision_cutover_parser() -> argparse.ArgumentParser:
     for phase in ("apply", "verify", "commit", "abort"):
         command = phases.add_parser(phase, add_help=False)
         command.add_argument("--cutover-id", required=True)
+    retire = phases.add_parser("retire-external-git", add_help=False)
+    retire.add_argument("--vault-id", required=True)
+    retire.add_argument("--manifest-file", required=True)
+    retire.add_argument("--idempotency-key", required=True)
+    retire.add_argument("--requested-by", required=True)
+    retire.add_argument("--confirm-planned-downtime", required=True)
     return parser
+
+
+def _require_external_git_retirement_confirmation(vault_id: str, confirmation: str) -> uuid.UUID:
+    """Require the operator's exact, vault-bound planned-downtime acknowledgement."""
+    try:
+        parsed_vault_id = uuid.UUID(vault_id)
+    except (TypeError, ValueError):
+        raise ValueError("external Git retirement vault id is invalid") from None
+    expected = f"RETIRE-EXTERNAL-GIT:{parsed_vault_id}"
+    if confirmation != expected:
+        raise ValueError("external Git retirement requires the exact planned-downtime confirmation")
+    return parsed_vault_id
+
+
+async def _execute_external_git_retirement(
+    *,
+    vault_id: str,
+    manifest_file: str,
+    idempotency_key: str,
+    requested_by: str,
+    planned_downtime_confirmation: str,
+) -> dict[str, object]:
+    """Run the offline, one-vault external-Git retirement command."""
+    from app.db.postgres import close_pool, get_pool, init_db
+    from app.services.external_git_retirement import (
+        ExternalGitRetirement,
+        ExternalGitRetirementError,
+        load_adoption_manifest,
+    )
+
+    try:
+        parsed_vault_id = _require_external_git_retirement_confirmation(
+            vault_id,
+            planned_downtime_confirmation,
+        )
+        try:
+            parsed_idempotency_key = uuid.UUID(idempotency_key)
+        except (TypeError, ValueError):
+            raise ValueError("external Git retirement idempotency key is invalid") from None
+        manifest = load_adoption_manifest(Path(manifest_file))
+        if manifest.vault_id != parsed_vault_id:
+            raise ExternalGitRetirementError("external Git retirement vault id does not match the manifest")
+        await init_db()
+        pool = await get_pool()
+        result = await ExternalGitRetirement(pool).retire(
+            manifest=manifest,
+            idempotency_key=parsed_idempotency_key,
+            requested_by=requested_by,
+        )
+        if not is_dataclass(result):
+            raise RuntimeError("external Git retirement returned an invalid operator receipt")
+        return json.loads(json.dumps(asdict(result), default=str))
+    finally:
+        await close_pool()
 
 
 async def _execute_native_revision_cutover(
@@ -728,13 +790,31 @@ async def _migrate_revision_backend(args: list[str]) -> int:
         return 2
 
     try:
-        report = await _execute_native_revision_cutover(
-            parsed.phase,
-            coverage_version=getattr(parsed, "coverage_version", None),
-            cutover_id=getattr(parsed, "cutover_id", None),
-        )
+        if parsed.phase == "retire-external-git":
+            _require_external_git_retirement_confirmation(
+                parsed.vault_id,
+                parsed.confirm_planned_downtime,
+            )
+            report = await _execute_external_git_retirement(
+                vault_id=parsed.vault_id,
+                manifest_file=parsed.manifest_file,
+                idempotency_key=parsed.idempotency_key,
+                requested_by=parsed.requested_by,
+                planned_downtime_confirmation=parsed.confirm_planned_downtime,
+            )
+        else:
+            report = await _execute_native_revision_cutover(
+                parsed.phase,
+                coverage_version=getattr(parsed, "coverage_version", None),
+                cutover_id=getattr(parsed, "cutover_id", None),
+            )
     except (ValueError, RuntimeError) as exc:
-        print(f"revision_backend_cutover_failed: {exc}", file=sys.stderr)
+        prefix = (
+            "revision_backend_retirement_failed"
+            if parsed.phase == "retire-external-git"
+            else "revision_backend_cutover_failed"
+        )
+        print(f"{prefix}: {exc}", file=sys.stderr)
         return 1
     print(json.dumps(report, sort_keys=True))
     return 0

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -685,7 +685,6 @@ async def _execute_external_git_retirement(
     from app.db.postgres import close_pool, get_pool, init_db
     from app.services.external_git_retirement import (
         ExternalGitRetirement,
-        ExternalGitRetirementError,
         load_adoption_manifest,
     )
 
@@ -699,12 +698,11 @@ async def _execute_external_git_retirement(
         except (TypeError, ValueError):
             raise ValueError("external Git retirement idempotency key is invalid") from None
         manifest = load_adoption_manifest(Path(manifest_file))
-        if manifest.vault_id != parsed_vault_id:
-            raise ExternalGitRetirementError("external Git retirement vault id does not match the manifest")
         await init_db()
         pool = await get_pool()
         result = await ExternalGitRetirement(pool).retire(
             manifest=manifest,
+            expected_vault_id=parsed_vault_id,
             idempotency_key=parsed_idempotency_key,
             requested_by=requested_by,
         )

--- a/backend/app/db/migrations/093_external_git_retirement.py
+++ b/backend/app/db/migrations/093_external_git_retirement.py
@@ -1,0 +1,102 @@
+"""Durable, credential-free receipts for offline external-Git retirement."""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("akb.migrations")
+
+
+async def migrate(conn) -> None:
+    """Add the one-way retirement intent/receipt ledger.
+
+    ``vault_id`` intentionally has no foreign key: this is audit evidence for
+    a completed handoff and must not vanish if a later, separately-authorized
+    whole-vault lifecycle purge removes the live vault rows.  The table never
+    stores the manifest payload, document content, or external Git token.
+    """
+    async with conn.transaction():
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS external_git_retirements (
+                retirement_id UUID NOT NULL UNIQUE DEFAULT uuid_generate_v4(),
+                vault_id UUID PRIMARY KEY,
+                vault_name TEXT NOT NULL,
+                manifest_digest TEXT NOT NULL,
+                document_count INTEGER NOT NULL,
+                remote_url TEXT NOT NULL,
+                remote_branch TEXT NOT NULL,
+                last_synced_sha TEXT NOT NULL,
+                idempotency_key UUID NOT NULL UNIQUE,
+                requested_by TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'quarantined',
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                retired_at TIMESTAMPTZ,
+                CONSTRAINT external_git_retirements_vault_name_check
+                    CHECK (btrim(vault_name) <> ''),
+                CONSTRAINT external_git_retirements_manifest_digest_check
+                    CHECK (manifest_digest ~ '^[0-9a-f]{64}$'),
+                CONSTRAINT external_git_retirements_document_count_check
+                    CHECK (document_count >= 0),
+                CONSTRAINT external_git_retirements_remote_url_check
+                    CHECK (btrim(remote_url) <> ''),
+                CONSTRAINT external_git_retirements_remote_branch_check
+                    CHECK (btrim(remote_branch) <> ''),
+                CONSTRAINT external_git_retirements_last_synced_sha_check
+                    CHECK (last_synced_sha ~ '^[0-9a-f]{40}$'),
+                CONSTRAINT external_git_retirements_requested_by_check
+                    CHECK (btrim(requested_by) <> ''),
+                CONSTRAINT external_git_retirements_status_check
+                    CHECK (status IN ('quarantined', 'retired')),
+                CONSTRAINT external_git_retirements_status_shape_check
+                    CHECK (
+                        (status = 'quarantined' AND retired_at IS NULL)
+                        OR (status = 'retired' AND retired_at IS NOT NULL)
+                    )
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_external_git_retirements_status
+                ON external_git_retirements(status, created_at);
+
+            CREATE OR REPLACE FUNCTION guard_external_git_retirement_receipt()
+            RETURNS TRIGGER LANGUAGE plpgsql AS $guard$
+            BEGIN
+                IF TG_OP = 'DELETE' THEN
+                    RAISE EXCEPTION 'external Git retirement receipt cannot be deleted'
+                        USING ERRCODE = '55000';
+                END IF;
+                IF NEW.retirement_id IS DISTINCT FROM OLD.retirement_id
+                   OR NEW.vault_id IS DISTINCT FROM OLD.vault_id
+                   OR NEW.vault_name IS DISTINCT FROM OLD.vault_name
+                   OR NEW.manifest_digest IS DISTINCT FROM OLD.manifest_digest
+                   OR NEW.document_count IS DISTINCT FROM OLD.document_count
+                   OR NEW.remote_url IS DISTINCT FROM OLD.remote_url
+                   OR NEW.remote_branch IS DISTINCT FROM OLD.remote_branch
+                   OR NEW.last_synced_sha IS DISTINCT FROM OLD.last_synced_sha
+                   OR NEW.idempotency_key IS DISTINCT FROM OLD.idempotency_key
+                   OR NEW.requested_by IS DISTINCT FROM OLD.requested_by
+                   OR NEW.created_at IS DISTINCT FROM OLD.created_at
+                THEN
+                    RAISE EXCEPTION 'external Git retirement receipt identity is immutable'
+                        USING ERRCODE = '55000';
+                END IF;
+                IF OLD.status = 'quarantined'
+                   AND NEW.status = 'retired'
+                   AND OLD.retired_at IS NULL
+                   AND NEW.retired_at IS NOT NULL
+                THEN
+                    RETURN NEW;
+                END IF;
+                RAISE EXCEPTION 'external Git retirement receipt transition is invalid'
+                    USING ERRCODE = '55000';
+            END;
+            $guard$;
+
+            DROP TRIGGER IF EXISTS guard_external_git_retirement_receipt
+                ON external_git_retirements;
+            CREATE TRIGGER guard_external_git_retirement_receipt
+                BEFORE UPDATE OR DELETE ON external_git_retirements
+                FOR EACH ROW EXECUTE FUNCTION guard_external_git_retirement_receipt();
+            """
+        )
+    logger.info("Migration 093: external-Git retirement receipt ledger ready")

--- a/backend/app/db/migrations/094_native_revision_completed_reservation_transfer.py
+++ b/backend/app/db/migrations/094_native_revision_completed_reservation_transfer.py
@@ -1,0 +1,22 @@
+"""Permit an aborted completed cutover to transfer its active reservation."""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("akb.migrations")
+
+
+async def migrate(conn) -> None:
+    """Keep completed audit rows while a replacement run adopts their work."""
+    async with conn.transaction():
+        await conn.execute(
+            """
+            ALTER TABLE native_revision_migration_items
+                DROP CONSTRAINT IF EXISTS native_revision_migration_items_reservation_state_check;
+            ALTER TABLE native_revision_migration_items
+                ADD CONSTRAINT native_revision_migration_items_reservation_state_check
+                CHECK (reservation_active OR status IN ('pending', 'complete'));
+            """
+        )
+    logger.info("Migration 094: completed aborted cutovers may transfer reservations")

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -316,6 +316,7 @@ async def _apply_pending_migrations(conn, applied: set[str]) -> None:
         "091_native_revision_committed_receipt_guard.py",  # freeze a committed cutover's durable authority receipt set
         "092_native_revision_plan_supersession.py",  # release never-applied aborted-plan reservations for a fresh coverage version
         "093_external_git_retirement.py",  # durable offline retirement receipt for a Collector-adopted external Git mirror
+        "094_native_revision_completed_reservation_transfer.py",  # let a fresh coverage run adopt completed work from an aborted pre-authority cutover
     ):
         if filename in applied:
             continue

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -315,6 +315,7 @@ async def _apply_pending_migrations(conn, applied: set[str]) -> None:
         "090_native_revision_vault_purge_fence.py",  # allow an authorized exact-vault lifecycle purge after cutover authority commits
         "091_native_revision_committed_receipt_guard.py",  # freeze a committed cutover's durable authority receipt set
         "092_native_revision_plan_supersession.py",  # release never-applied aborted-plan reservations for a fresh coverage version
+        "093_external_git_retirement.py",  # durable offline retirement receipt for a Collector-adopted external Git mirror
     ):
         if filename in applied:
             continue

--- a/backend/app/repositories/native_revision_migration_repo.py
+++ b/backend/app/repositories/native_revision_migration_repo.py
@@ -290,6 +290,140 @@ class NativeRevisionMigrationRepository:
             async with acquired.transaction():
                 return await _get_or_create(acquired)
 
+    @staticmethod
+    async def _adopt_aborted_completed_reservation(
+        conn: asyncpg.Connection,
+        *,
+        run: MigrationRun,
+        legacy_document_id: uuid.UUID,
+        captured_path: str,
+        legacy_head_oid: str,
+        body_digest: str,
+        byte_size: int,
+    ) -> bool:
+        """Move one completed reservation from an aborted cutover to ``run``.
+
+        The old completed run and its immutable Legacy mappings remain audit and
+        selector authority.  Only its partial-index reservation is released,
+        then the replacement run records the exact already-published native
+        head as complete.  This is intentionally narrower than a generic
+        duplicate-resource escape hatch: the source must be fully complete and
+        linked only to an aborted, pre-authority applied/verified cutover.
+        """
+        source = await conn.fetchrow(
+            """
+            SELECT item.run_id, item.namespace_id, item.legacy_document_id,
+                   item.native_resource_id, item.captured_path,
+                   item.legacy_head_oid, item.native_head_revision_id,
+                   item.body_digest, item.byte_size, item.status,
+                   source_run.status AS run_status
+              FROM native_revision_migration_items item
+              JOIN native_revision_migration_runs source_run
+                ON source_run.run_id = item.run_id
+               AND source_run.namespace_id = item.namespace_id
+             WHERE item.native_resource_id = $1
+               AND item.legacy_head_oid = $2
+               AND item.reservation_active
+             FOR UPDATE OF item, source_run
+            """,
+            legacy_document_id,
+            legacy_head_oid,
+        )
+        if source is None:
+            return False
+        expected_source = (
+            run.namespace_id,
+            legacy_document_id,
+            legacy_document_id,
+            captured_path,
+            legacy_head_oid,
+            body_digest,
+            byte_size,
+        )
+        observed_source = (
+            source["namespace_id"],
+            source["legacy_document_id"],
+            source["native_resource_id"],
+            source["captured_path"],
+            source["legacy_head_oid"],
+            source["body_digest"],
+            source["byte_size"],
+        )
+        native_head_revision_id = source["native_head_revision_id"]
+        if (
+            source["run_status"] != "complete"
+            or source["status"] != "complete"
+            or observed_source != expected_source
+            or not isinstance(native_head_revision_id, str)
+            or _OID_RE.fullmatch(native_head_revision_id) is None
+        ):
+            return False
+        if not await conn.fetchval(
+            """
+            SELECT NOT EXISTS (
+                SELECT 1
+                  FROM native_revision_migration_items
+                 WHERE run_id = $1 AND status <> 'complete'
+            )
+            """,
+            source["run_id"],
+        ):
+            return False
+        cutover_context = await conn.fetchrow(
+            """
+            SELECT COUNT(*) AS cutover_count,
+                   bool_and(
+                       cutover.status = 'aborted'
+                       AND cutover.aborted_from_status IN ('applied', 'verified')
+                   ) AS all_aborted_completed
+              FROM native_revision_cutover_vaults cutover_vault
+              JOIN native_revision_cutover_runs cutover
+                ON cutover.cutover_id = cutover_vault.cutover_id
+             WHERE cutover_vault.migration_run_id = $1
+            """,
+            source["run_id"],
+        )
+        if (
+            cutover_context is None
+            or cutover_context["cutover_count"] != 1
+            or cutover_context["all_aborted_completed"] is not True
+        ):
+            return False
+
+        released = await conn.execute(
+            """
+            UPDATE native_revision_migration_items
+               SET reservation_active = FALSE,
+                   updated_at = NOW()
+             WHERE run_id = $1
+               AND legacy_document_id = $2
+               AND reservation_active
+            """,
+            source["run_id"],
+            source["legacy_document_id"],
+        )
+        if released != "UPDATE 1":
+            raise MigrationIntegrityError("completed migration reservation changed during transfer")
+        await conn.execute(
+            """
+            INSERT INTO native_revision_migration_items
+                (run_id, namespace_id, legacy_document_id, native_resource_id,
+                 captured_path, legacy_head_oid, native_head_revision_id,
+                 body_digest, byte_size, status)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'complete')
+            """,
+            run.run_id,
+            run.namespace_id,
+            legacy_document_id,
+            legacy_document_id,
+            captured_path,
+            legacy_head_oid,
+            native_head_revision_id,
+            body_digest,
+            byte_size,
+        )
+        return True
+
     async def ensure_pending_items(
         self,
         run: MigrationRun,
@@ -340,16 +474,38 @@ class NativeRevisionMigrationRepository:
                     document_id,
                 )
                 if row is None:
-                    await acquired.execute(
-                        """
-                        INSERT INTO native_revision_migration_items
-                            (run_id, namespace_id, legacy_document_id,
-                             native_resource_id, captured_path, legacy_head_oid,
-                             body_digest, byte_size, status)
-                        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'pending')
-                        """,
-                        *expected,
-                    )
+                    try:
+                        # Isolate the uniqueness failure in a savepoint so a
+                        # completed reservation may be transferred without
+                        # aborting the caller's larger frozen-inventory txn.
+                        async with acquired.transaction():
+                            await acquired.execute(
+                                """
+                                INSERT INTO native_revision_migration_items
+                                    (run_id, namespace_id, legacy_document_id,
+                                     native_resource_id, captured_path, legacy_head_oid,
+                                     body_digest, byte_size, status)
+                                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'pending')
+                                """,
+                                *expected,
+                            )
+                    except asyncpg.UniqueViolationError as exc:
+                        if (
+                            exc.constraint_name
+                            != "native_revision_migration_items_active_resource_head_key"
+                        ):
+                            raise
+                        adopted = await self._adopt_aborted_completed_reservation(
+                            acquired,
+                            run=run,
+                            legacy_document_id=document_id,
+                            captured_path=observed["captured_path"],
+                            legacy_head_oid=observed["legacy_head_oid"],
+                            body_digest=observed["body_digest"],
+                            byte_size=observed["byte_size"],
+                        )
+                        if not adopted:
+                            raise
                 else:
                     observed_identity = (
                         row["run_id"],
@@ -416,6 +572,75 @@ class NativeRevisionMigrationRepository:
             async with self.pool.acquire() as acquired:
                 rows = await acquired.fetch(sql, run_id)
         return [_item(row) for row in rows]
+
+    async def is_completed_reservation_transfer(
+        self,
+        *,
+        owner_run_id: uuid.UUID,
+        replacement_run_id: uuid.UUID,
+        legacy_document_id: uuid.UUID,
+        native_head_revision_id: str,
+    ) -> bool:
+        """Prove that a completed item only transferred its active reservation.
+
+        Immutable Legacy mappings stay owned by ``owner_run_id``.  The
+        replacement may reference the already-published Native head only when
+        the source cutover was explicitly aborted after apply/verify and every
+        frozen item fact is byte-for-byte identical.
+        """
+        _require_oid(native_head_revision_id, "native_head_revision_id")
+        async with self.pool.acquire() as conn:
+            return bool(
+                await conn.fetchval(
+                    """
+                    SELECT EXISTS (
+                        SELECT 1
+                          FROM native_revision_migration_items source
+                          JOIN native_revision_migration_items replacement
+                            ON replacement.run_id = $2
+                           AND replacement.legacy_document_id = source.legacy_document_id
+                          JOIN native_revision_migration_runs source_run
+                            ON source_run.run_id = source.run_id
+                           AND source_run.namespace_id = source.namespace_id
+                          JOIN native_revision_migration_runs replacement_run
+                            ON replacement_run.run_id = replacement.run_id
+                           AND replacement_run.namespace_id = replacement.namespace_id
+                         WHERE source.run_id = $1
+                           AND source.legacy_document_id = $3
+                           AND source.status = 'complete'
+                           AND replacement.status = 'complete'
+                           AND NOT source.reservation_active
+                           AND replacement.reservation_active
+                           AND source_run.status = 'complete'
+                           AND replacement_run.status = 'complete'
+                           AND source.namespace_id = replacement.namespace_id
+                           AND source.legacy_document_id = replacement.legacy_document_id
+                           AND source.native_resource_id = replacement.native_resource_id
+                           AND source.captured_path = replacement.captured_path
+                           AND source.legacy_head_oid = replacement.legacy_head_oid
+                           AND source.native_head_revision_id = replacement.native_head_revision_id
+                           AND source.native_head_revision_id = $4
+                           AND source.body_digest = replacement.body_digest
+                           AND source.byte_size = replacement.byte_size
+                           AND (
+                               SELECT COUNT(*) = 1
+                                      AND bool_and(
+                                          cutover.status = 'aborted'
+                                          AND cutover.aborted_from_status IN ('applied', 'verified')
+                                      )
+                                 FROM native_revision_cutover_vaults cutover_vault
+                                 JOIN native_revision_cutover_runs cutover
+                                   ON cutover.cutover_id = cutover_vault.cutover_id
+                                WHERE cutover_vault.migration_run_id = source.run_id
+                           )
+                    )
+                    """,
+                    owner_run_id,
+                    replacement_run_id,
+                    legacy_document_id,
+                    native_head_revision_id,
+                )
+            )
 
     async def get_item(
         self,

--- a/backend/app/services/external_git_retirement.py
+++ b/backend/app/services/external_git_retirement.py
@@ -12,11 +12,10 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
-import math
 import re
 import uuid
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Mapping
 
 import asyncpg
@@ -29,24 +28,36 @@ from app.services.uri_service import doc_uri
 from app.util.text import to_nfc
 
 
-_MANIFEST_SCHEMA_VERSION = 1
+_COLLECTOR_MANIFEST_SCHEMA = "akb-collector.git-adoption-manifest"
+_COLLECTOR_MANIFEST_VERSION = 1
+_COLLECTOR_MANIFEST_PURPOSE = "legacy-external-git-retirement"
 _OID_RE = re.compile(r"^[0-9a-f]{40}$")
 _DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
 _MANIFEST_KEYS = frozenset(
     {
-        "schema_version",
-        "vault_id",
-        "vault_name",
-        "remote_url",
-        "remote_branch",
-        "last_synced_sha",
+        "schema",
+        "version",
+        "purpose",
+        "binding",
+        "source",
         "documents",
     }
 )
-_DOCUMENT_KEYS = frozenset({"uri", "path", "content_hash", "managed_metadata"})
-_MANAGED_METADATA_KEYS = frozenset(
-    {"title", "type", "status", "tags", "domain", "summary", "metadata"}
+_BINDING_KEYS = frozenset({"name", "source_scope", "target_vault", "target_collection"})
+_SOURCE_KEYS = frozenset({"remote_url", "branch", "snapshot_commit", "path_prefix"})
+_DOCUMENT_KEYS = frozenset(
+    {
+        "origin_key",
+        "path",
+        "resource_uri",
+        "source_version",
+        "blob_sha",
+        "akb_content_sha256",
+        "akb_current_version",
+        "managed_metadata",
+    }
 )
+_MANAGED_METADATA_KEYS = frozenset({"managed", "title", "type", "tags", "summary", "domain"})
 _MAX_MANIFEST_BYTES = 8 * 1024 * 1024
 
 
@@ -67,16 +78,24 @@ class ExternalGitRetirementConflict(ExternalGitRetirementError):
 class AdoptionDocument:
     """One active external-Git document's credential-free adoption facts."""
 
-    uri: str
+    origin_key: str
     path: str
-    content_hash: str
+    resource_uri: str
+    source_version: str
+    blob_sha: str
+    akb_content_sha256: str
+    akb_current_version: str
     managed_metadata: dict[str, Any]
 
     def fact(self) -> dict[str, Any]:
         return {
-            "uri": self.uri,
+            "origin_key": self.origin_key,
             "path": self.path,
-            "content_hash": self.content_hash,
+            "resource_uri": self.resource_uri,
+            "source_version": self.source_version,
+            "blob_sha": self.blob_sha,
+            "akb_content_sha256": self.akb_content_sha256,
+            "akb_current_version": self.akb_current_version,
             "managed_metadata": self.managed_metadata,
         }
 
@@ -85,11 +104,14 @@ class AdoptionDocument:
 class AdoptionManifest:
     """Canonical, body-free manifest accepted by the retirement command."""
 
-    vault_id: uuid.UUID
-    vault_name: str
+    binding_name: str
+    source_scope: str
+    target_vault: str
+    target_collection: str
     remote_url: str
     remote_branch: str
-    last_synced_sha: str
+    snapshot_commit: str
+    path_prefix: str | None
     documents: tuple[AdoptionDocument, ...]
     digest: str
 
@@ -97,14 +119,33 @@ class AdoptionManifest:
     def document_count(self) -> int:
         return len(self.documents)
 
+    @property
+    def vault_name(self) -> str:
+        """The existing receipt column names the Collector target Vault."""
+        return self.target_vault
+
+    @property
+    def last_synced_sha(self) -> str:
+        """The source snapshot is the mirror's only accepted fixed ref."""
+        return self.snapshot_commit
+
     def fact(self) -> dict[str, Any]:
         return {
-            "schema_version": _MANIFEST_SCHEMA_VERSION,
-            "vault_id": str(self.vault_id),
-            "vault_name": self.vault_name,
-            "remote_url": self.remote_url,
-            "remote_branch": self.remote_branch,
-            "last_synced_sha": self.last_synced_sha,
+            "schema": _COLLECTOR_MANIFEST_SCHEMA,
+            "version": _COLLECTOR_MANIFEST_VERSION,
+            "purpose": _COLLECTOR_MANIFEST_PURPOSE,
+            "binding": {
+                "name": self.binding_name,
+                "source_scope": self.source_scope,
+                "target_vault": self.target_vault,
+                "target_collection": self.target_collection,
+            },
+            "source": {
+                "remote_url": self.remote_url,
+                "branch": self.remote_branch,
+                "snapshot_commit": self.snapshot_commit,
+                "path_prefix": self.path_prefix,
+            },
             "documents": [document.fact() for document in self.documents],
         }
 
@@ -118,35 +159,32 @@ def _require_exact_keys(value: Mapping[str, Any], expected: frozenset[str]) -> N
         raise _manifest_shape_error()
 
 
-def _text(value: object, *, allow_none: bool = False) -> str | None:
-    if value is None and allow_none:
-        return None
+def _canonical_text(value: object, *, allow_empty: bool = False) -> str:
     if not isinstance(value, str):
         raise _manifest_shape_error()
-    return to_nfc(value)
+    if value != value.strip() or (not allow_empty and not value):
+        raise _manifest_shape_error()
+    return value
 
 
-def _json_value(value: object) -> Any:
-    """Return NFC-normalized JSON data without accepting Python-only values."""
-    if value is None or isinstance(value, (str, bool, int)):
-        return to_nfc(value) if isinstance(value, str) else value
-    if isinstance(value, float):
-        if not math.isfinite(value):
-            raise _manifest_shape_error()
-        return value
-    if isinstance(value, list):
-        return [_json_value(item) for item in value]
-    if isinstance(value, Mapping):
-        normalized: dict[str, Any] = {}
-        for raw_key, raw_value in value.items():
-            if not isinstance(raw_key, str):
-                raise _manifest_shape_error()
-            key = to_nfc(raw_key)
-            if key in normalized:
-                raise _manifest_shape_error()
-            normalized[key] = _json_value(raw_value)
-        return normalized
-    raise _manifest_shape_error()
+def _canonical_path(value: object) -> str:
+    path = _canonical_text(value)
+    pure = PurePosixPath(path)
+    if (
+        pure.is_absolute()
+        or path.endswith("/")
+        or any(component in {"", ".", ".."} for component in path.split("/"))
+    ):
+        raise ExternalGitRetirementError("external Git adoption manifest document path is invalid")
+    return path
+
+
+def _collector_path_prefix(value: object) -> str:
+    """Keep Collector's canonical selection fact without giving it AKB meaning."""
+    prefix = _canonical_text(value)
+    if prefix != prefix.strip("/"):
+        raise _manifest_shape_error()
+    return prefix
 
 
 def _managed_metadata(value: object) -> dict[str, Any]:
@@ -154,32 +192,26 @@ def _managed_metadata(value: object) -> dict[str, Any]:
         raise _manifest_shape_error()
     _require_exact_keys(value, _MANAGED_METADATA_KEYS)
 
-    title = _text(value["title"])
-    doc_type = _text(value["type"], allow_none=True)
-    status = _text(value["status"])
-    domain = _text(value["domain"], allow_none=True)
-    summary = _text(value["summary"], allow_none=True)
+    managed = value["managed"]
+    title = _canonical_text(value["title"], allow_empty=True)
+    doc_type = _canonical_text(value["type"])
+    domain = _canonical_text(value["domain"], allow_empty=True)
+    summary = _canonical_text(value["summary"], allow_empty=True)
     tags = value["tags"]
-    metadata = value["metadata"]
-    if status != "active" or not isinstance(tags, list) or not isinstance(metadata, Mapping):
+    if type(managed) is not bool or not isinstance(tags, list):
         raise _manifest_shape_error()
     normalized_tags: list[str] = []
     for tag in tags:
-        normalized_tag = _text(tag)
-        assert normalized_tag is not None
-        normalized_tags.append(normalized_tag)
-    normalized_metadata = _json_value(metadata)
-    if not isinstance(normalized_metadata, dict):
-        raise _manifest_shape_error()
-    assert title is not None and status is not None
+        normalized_tags.append(_canonical_text(tag))
+    if not managed and (doc_type != "reference" or normalized_tags or summary or domain):
+        raise ExternalGitRetirementError("external Git adoption manifest unmanaged metadata is invalid")
     return {
+        "managed": managed,
         "title": title,
         "type": doc_type,
-        "status": status,
         "tags": normalized_tags,
         "domain": domain,
         "summary": summary,
-        "metadata": normalized_metadata,
     }
 
 
@@ -195,7 +227,7 @@ def _canonical_digest(value: Mapping[str, Any]) -> str:
 
 
 def parse_adoption_manifest(value: object) -> AdoptionManifest:
-    """Parse one strict credential-free Collector adoption manifest.
+    """Parse the exact strict credential-free Collector v1 manifest.
 
     Unknown keys are refused rather than ignored.  That makes a future
     credential/body field a hard compatibility break instead of something that
@@ -204,25 +236,30 @@ def parse_adoption_manifest(value: object) -> AdoptionManifest:
     if not isinstance(value, Mapping):
         raise _manifest_shape_error()
     _require_exact_keys(value, _MANIFEST_KEYS)
-    if isinstance(value["schema_version"], bool) or value["schema_version"] != _MANIFEST_SCHEMA_VERSION:
-        raise _manifest_shape_error()
-    try:
-        vault_id = uuid.UUID(_text(value["vault_id"]) or "")
-    except (TypeError, ValueError, AttributeError):
-        raise _manifest_shape_error() from None
-    vault_name = _text(value["vault_name"])
-    remote_url = _text(value["remote_url"])
-    remote_branch = _text(value["remote_branch"])
-    last_synced_sha = _text(value["last_synced_sha"])
-    documents = value["documents"]
     if (
-        not vault_name
-        or not remote_url
-        or not remote_branch
-        or not last_synced_sha
-        or not isinstance(documents, list)
-        or _OID_RE.fullmatch(last_synced_sha) is None
+        value["schema"] != _COLLECTOR_MANIFEST_SCHEMA
+        or isinstance(value["version"], bool)
+        or value["version"] != _COLLECTOR_MANIFEST_VERSION
+        or value["purpose"] != _COLLECTOR_MANIFEST_PURPOSE
+        or not isinstance(value["binding"], Mapping)
+        or not isinstance(value["source"], Mapping)
     ):
+        raise _manifest_shape_error()
+    binding = value["binding"]
+    source = value["source"]
+    _require_exact_keys(binding, _BINDING_KEYS)
+    _require_exact_keys(source, _SOURCE_KEYS)
+    binding_name = _canonical_text(binding["name"])
+    source_scope = _canonical_text(binding["source_scope"])
+    target_vault = _canonical_text(binding["target_vault"])
+    target_collection = _canonical_text(binding["target_collection"])
+    remote_url = _canonical_text(source["remote_url"])
+    remote_branch = _canonical_text(source["branch"])
+    snapshot_commit = _canonical_text(source["snapshot_commit"])
+    raw_path_prefix = source["path_prefix"]
+    path_prefix = None if raw_path_prefix is None else _collector_path_prefix(raw_path_prefix)
+    documents = value["documents"]
+    if not isinstance(documents, list) or _OID_RE.fullmatch(snapshot_commit) is None:
         raise _manifest_shape_error()
     try:
         remote = validate(
@@ -239,51 +276,70 @@ def parse_adoption_manifest(value: object) -> AdoptionManifest:
 
     parsed_documents: list[AdoptionDocument] = []
     paths: set[str] = set()
-    uris: set[str] = set()
+    resource_uris: set[str] = set()
+    origin_keys: set[str] = set()
     for document in documents:
         if not isinstance(document, Mapping):
             raise _manifest_shape_error()
         _require_exact_keys(document, _DOCUMENT_KEYS)
-        uri = _text(document["uri"])
-        path = _text(document["path"])
-        content_hash = _text(document["content_hash"])
+        origin_key = _canonical_text(document["origin_key"])
+        path = _canonical_path(document["path"])
+        resource_uri = _canonical_text(document["resource_uri"])
+        source_version = _canonical_text(document["source_version"])
+        blob_sha = _canonical_text(document["blob_sha"])
+        akb_content_sha256 = _canonical_text(document["akb_content_sha256"])
+        akb_current_version = _canonical_text(document["akb_current_version"])
         if (
-            not uri
-            or not path
-            or not content_hash
-            or _DIGEST_RE.fullmatch(content_hash) is None
-            or uri != doc_uri(vault_name, path)
+            _OID_RE.fullmatch(source_version) is None
+            or _OID_RE.fullmatch(blob_sha) is None
+            or _DIGEST_RE.fullmatch(akb_content_sha256) is None
+            or _OID_RE.fullmatch(akb_current_version) is None
         ):
+            raise _manifest_shape_error()
+        if source_version != blob_sha or origin_key != f"git://{source_scope}/{path}":
+            raise ExternalGitRetirementError("external Git adoption manifest source identity is invalid")
+        if resource_uri != doc_uri(target_vault, path):
             raise ExternalGitRetirementError("external Git adoption manifest document URI is invalid")
-        if path in paths or uri in uris:
+        if path in paths or resource_uri in resource_uris or origin_key in origin_keys:
             raise ExternalGitRetirementError("external Git adoption manifest contains duplicate documents")
         paths.add(path)
-        uris.add(uri)
+        resource_uris.add(resource_uri)
+        origin_keys.add(origin_key)
         parsed_documents.append(
             AdoptionDocument(
-                uri=uri,
+                origin_key=origin_key,
                 path=path,
-                content_hash=content_hash,
+                resource_uri=resource_uri,
+                source_version=source_version,
+                blob_sha=blob_sha,
+                akb_content_sha256=akb_content_sha256,
+                akb_current_version=akb_current_version,
                 managed_metadata=_managed_metadata(document["managed_metadata"]),
             )
         )
 
-    ordered = tuple(sorted(parsed_documents, key=lambda document: document.path))
+    ordered = tuple(sorted(parsed_documents, key=lambda document: (document.path, document.origin_key)))
     preliminary = AdoptionManifest(
-        vault_id=vault_id,
-        vault_name=vault_name,
+        binding_name=binding_name,
+        source_scope=source_scope,
+        target_vault=target_vault,
+        target_collection=target_collection,
         remote_url=remote.canonical_url,
         remote_branch=remote.branch,
-        last_synced_sha=last_synced_sha,
+        snapshot_commit=snapshot_commit,
+        path_prefix=path_prefix,
         documents=ordered,
         digest="",
     )
     return AdoptionManifest(
-        vault_id=preliminary.vault_id,
-        vault_name=preliminary.vault_name,
+        binding_name=preliminary.binding_name,
+        source_scope=preliminary.source_scope,
+        target_vault=preliminary.target_vault,
+        target_collection=preliminary.target_collection,
         remote_url=preliminary.remote_url,
         remote_branch=preliminary.remote_branch,
-        last_synced_sha=preliminary.last_synced_sha,
+        snapshot_commit=preliminary.snapshot_commit,
+        path_prefix=preliminary.path_prefix,
         documents=preliminary.documents,
         digest=_canonical_digest(preliminary.fact()),
     )
@@ -373,19 +429,27 @@ def _requested_by(value: object) -> str:
     return normalized
 
 
-def _strict_db_metadata(value: object) -> dict[str, Any]:
-    """Decode the JSONB driver value without silently replacing corruption."""
-    decoded = value
-    if isinstance(decoded, str):
-        try:
-            decoded = json.loads(decoded)
-        except json.JSONDecodeError:
-            raise ExternalGitRetirementError("external Git managed metadata is invalid") from None
-    if not isinstance(decoded, Mapping):
-        raise ExternalGitRetirementError("external Git managed metadata is invalid")
-    normalized = _json_value(decoded)
-    if not isinstance(normalized, dict):
-        raise ExternalGitRetirementError("external Git managed metadata is invalid")
+def _normalized_live_metadata_text(value: object, *, default: str) -> str:
+    """Use the same blank/default rules as Collector's public AKB proof."""
+    if value is None:
+        return default
+    if not isinstance(value, str):
+        raise ExternalGitRetirementError("external Git retirement document facts are invalid")
+    return value.strip() or default
+
+
+def _normalized_live_metadata_tags(value: object) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, (list, tuple)):
+        raise ExternalGitRetirementError("external Git retirement document facts are invalid")
+    normalized: list[str] = []
+    for tag in value:
+        if not isinstance(tag, str):
+            raise ExternalGitRetirementError("external Git retirement document facts are invalid")
+        trimmed = tag.strip()
+        if trimmed:
+            normalized.append(trimmed)
     return normalized
 
 
@@ -413,11 +477,12 @@ class ExternalGitRetirement:
         receipt: ExternalGitRetirementReceipt,
         manifest: AdoptionManifest,
         *,
+        expected_vault_id: uuid.UUID,
         idempotency_key: uuid.UUID,
         requested_by: str,
     ) -> bool:
         return (
-            receipt.vault_id == manifest.vault_id
+            receipt.vault_id == expected_vault_id
             and receipt.vault_name == manifest.vault_name
             and receipt.manifest_digest == manifest.digest
             and receipt.document_count == manifest.document_count
@@ -434,24 +499,31 @@ class ExternalGitRetirement:
         receipt: ExternalGitRetirementReceipt,
         manifest: AdoptionManifest,
         *,
+        expected_vault_id: uuid.UUID,
         idempotency_key: uuid.UUID,
         requested_by: str,
     ) -> None:
         if not cls._same_binding(
             receipt,
             manifest,
+            expected_vault_id=expected_vault_id,
             idempotency_key=idempotency_key,
             requested_by=requested_by,
         ):
             raise ExternalGitRetirementConflict("external Git retirement replay conflicts with its durable receipt")
 
     @staticmethod
-    async def _locked_vault(conn: asyncpg.Connection, manifest: AdoptionManifest) -> asyncpg.Record:
+    async def _locked_vault(
+        conn: asyncpg.Connection,
+        manifest: AdoptionManifest,
+        *,
+        expected_vault_id: uuid.UUID,
+    ) -> asyncpg.Record:
         row = await conn.fetchrow(
-            "SELECT id, name, status FROM vaults WHERE id = $1 FOR UPDATE",
-            manifest.vault_id,
+            "SELECT id, name, status FROM vaults WHERE name = $1 FOR UPDATE",
+            manifest.target_vault,
         )
-        if row is None or row["name"] != manifest.vault_name:
+        if row is None or row["id"] != expected_vault_id:
             raise ExternalGitRetirementError("external Git retirement vault binding is stale")
         if row["status"] == "deleted":
             raise ExternalGitRetirementError("external Git retirement cannot reclassify a deleted vault")
@@ -508,79 +580,89 @@ class ExternalGitRetirement:
             raise ExternalGitRetirementError("external Git retirement sidecar binding is stale")
 
     @staticmethod
-    def _live_document(vault_name: str, row: Mapping[str, Any]) -> AdoptionDocument:
-        path = row["path"]
-        content_hash = row["content_hash"]
-        tags = row["tags"]
+    def _require_live_document_matches(
+        manifest: AdoptionManifest,
+        document: AdoptionDocument,
+        row: Mapping[str, Any],
+    ) -> None:
+        """Prove every Collector fact against the active AKB mirror row."""
         if (
             row["source"] != "external_git"
-            or row["external_path"] != path
-            or not isinstance(row["external_blob"], str)
-            or _OID_RE.fullmatch(row["external_blob"]) is None
-            or not isinstance(path, str)
-            or not isinstance(content_hash, str)
-            or _DIGEST_RE.fullmatch(content_hash) is None
+            or row["status"] != "active"
+            or row["external_path"] != document.path
+            or row["external_blob"] != document.blob_sha
+            or row["content_hash"] != document.akb_content_sha256
             or row["hash_algorithm"] != "sha256"
-            or not isinstance(tags, (list, tuple))
+            or row["current_commit"] != document.akb_current_version
+            or document.source_version != document.blob_sha
+            or document.origin_key != f"git://{manifest.source_scope}/{document.path}"
+            or document.resource_uri != doc_uri(manifest.target_vault, document.path)
         ):
-            raise ExternalGitRetirementError("external Git retirement document facts are invalid")
+            raise ExternalGitRetirementError("external Git retirement manifest does not match live documents")
+        if not document.managed_metadata["managed"]:
+            return
+        expected_metadata = {
+            "title": document.managed_metadata["title"],
+            "type": document.managed_metadata["type"],
+            "tags": document.managed_metadata["tags"],
+            "summary": document.managed_metadata["summary"],
+            "domain": document.managed_metadata["domain"],
+        }
         try:
-            managed_metadata = _managed_metadata(
-                {
-                    "title": row["title"],
-                    "type": row["doc_type"],
-                    "status": row["status"],
-                    "tags": list(tags),
-                    "domain": row["domain"],
-                    "summary": row["summary"],
-                    "metadata": _strict_db_metadata(row["metadata"]),
-                }
-            )
+            live_metadata = {
+                "title": _normalized_live_metadata_text(row["title"], default=""),
+                "type": _normalized_live_metadata_text(row["doc_type"], default="reference"),
+                "tags": _normalized_live_metadata_tags(row["tags"]),
+                "summary": _normalized_live_metadata_text(row["summary"], default=""),
+                "domain": _normalized_live_metadata_text(row["domain"], default=""),
+            }
         except ExternalGitRetirementError:
-            raise
-        except Exception as exc:  # noqa: BLE001 - never expose persisted document values
-            raise ExternalGitRetirementError("external Git retirement document facts are invalid") from exc
-        normalized_path = to_nfc(path)
-        normalized_hash = to_nfc(content_hash)
-        return AdoptionDocument(
-            uri=doc_uri(vault_name, normalized_path),
-            path=normalized_path,
-            content_hash=normalized_hash,
-            managed_metadata=managed_metadata,
-        )
+            raise ExternalGitRetirementError(
+                "external Git retirement manifest does not match live documents"
+            ) from None
+        if live_metadata != expected_metadata:
+            raise ExternalGitRetirementError("external Git retirement manifest does not match live documents")
 
     async def _validate_live_documents(
         self,
         conn: asyncpg.Connection,
         manifest: AdoptionManifest,
+        *,
+        vault_id: uuid.UUID,
     ) -> None:
         rows = await conn.fetch(
             """
             SELECT id, path, title, doc_type, status, tags, domain, summary,
-                   metadata, source, external_path, external_blob, content_hash,
-                   hash_algorithm
+                   source, external_path, external_blob, content_hash,
+                   hash_algorithm, current_commit
               FROM documents
              WHERE vault_id = $1 AND source = 'external_git'
              ORDER BY path
              FOR UPDATE
             """,
-            manifest.vault_id,
+            vault_id,
         )
-        live = tuple(
-            sorted(
-                (self._live_document(manifest.vault_name, row) for row in rows),
-                key=lambda document: document.path,
-            )
-        )
-        if len(live) != manifest.document_count or [item.fact() for item in live] != [
-            item.fact() for item in manifest.documents
-        ]:
+        if len(rows) != manifest.document_count:
+            raise ExternalGitRetirementError("external Git retirement manifest does not match live documents")
+        expected_by_path = {document.path: document for document in manifest.documents}
+        seen_paths: set[str] = set()
+        for row in rows:
+            path = row["path"]
+            if not isinstance(path, str) or path in seen_paths:
+                raise ExternalGitRetirementError("external Git retirement manifest does not match live documents")
+            document = expected_by_path.get(path)
+            if document is None:
+                raise ExternalGitRetirementError("external Git retirement manifest does not match live documents")
+            seen_paths.add(path)
+            self._require_live_document_matches(manifest, document, row)
+        if len(seen_paths) != manifest.document_count:
             raise ExternalGitRetirementError("external Git retirement manifest does not match live documents")
 
     async def _load_or_quarantine(
         self,
         manifest: AdoptionManifest,
         *,
+        expected_vault_id: uuid.UUID,
         idempotency_key: uuid.UUID,
         requested_by: str,
     ) -> ExternalGitRetirementReceipt:
@@ -588,30 +670,40 @@ class ExternalGitRetirement:
             async with conn.transaction():
                 record = await conn.fetchrow(
                     "SELECT * FROM external_git_retirements WHERE vault_id = $1 FOR UPDATE",
-                    manifest.vault_id,
+                    expected_vault_id,
                 )
                 if record is not None:
                     receipt = _receipt(record)
                     self._require_same_binding(
                         receipt,
                         manifest,
+                        expected_vault_id=expected_vault_id,
                         idempotency_key=idempotency_key,
                         requested_by=requested_by,
                     )
                     if receipt.status == "retired":
                         return receipt
-                    await self._locked_vault(conn, manifest)
+                    vault = await self._locked_vault(
+                        conn,
+                        manifest,
+                        expected_vault_id=expected_vault_id,
+                    )
                     await self._require_open_authority(conn)
-                    sidecar = await self._locked_sidecar(conn, manifest.vault_id)
+                    sidecar = await self._locked_sidecar(conn, vault["id"])
                     if (
                         sidecar["sync_state"] != "quarantined"
                         or sidecar["sync_state_reason"] != _RETIREMENT_PENDING_REASON
                     ):
                         raise ExternalGitRetirementError("external Git retirement quarantine intent is stale")
                     self._validate_sidecar(sidecar, manifest)
-                    await self._validate_live_documents(conn, manifest)
+                    await self._validate_live_documents(conn, manifest, vault_id=vault["id"])
                     return receipt
 
+                vault = await self._locked_vault(
+                    conn,
+                    manifest,
+                    expected_vault_id=expected_vault_id,
+                )
                 key_record = await conn.fetchrow(
                     "SELECT * FROM external_git_retirements WHERE idempotency_key = $1 FOR UPDATE",
                     idempotency_key,
@@ -620,13 +712,12 @@ class ExternalGitRetirement:
                     raise ExternalGitRetirementConflict(
                         "external Git retirement idempotency key is already bound to another receipt"
                     )
-                await self._locked_vault(conn, manifest)
                 await self._require_open_authority(conn)
-                sidecar = await self._locked_sidecar(conn, manifest.vault_id)
+                sidecar = await self._locked_sidecar(conn, vault["id"])
                 if sidecar["sync_state"] not in {"active", "pending_preflight"}:
                     raise ExternalGitRetirementError("external Git retirement sidecar is not claimable for retirement")
                 self._validate_sidecar(sidecar, manifest)
-                await self._validate_live_documents(conn, manifest)
+                await self._validate_live_documents(conn, manifest, vault_id=vault["id"])
 
                 try:
                     record = await conn.fetchrow(
@@ -638,7 +729,7 @@ class ExternalGitRetirement:
                         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
                         RETURNING *
                         """,
-                        manifest.vault_id,
+                        vault["id"],
                         manifest.vault_name,
                         manifest.digest,
                         manifest.document_count,
@@ -664,7 +755,7 @@ class ExternalGitRetirement:
                      WHERE vault_id = $1
                        AND sync_state IN ('active', 'pending_preflight')
                     """,
-                    manifest.vault_id,
+                    vault["id"],
                     _RETIREMENT_PENDING_REASON,
                     _RETIREMENT_PENDING_ERROR,
                 )
@@ -676,6 +767,7 @@ class ExternalGitRetirement:
         self,
         manifest: AdoptionManifest,
         *,
+        expected_vault_id: uuid.UUID,
         idempotency_key: uuid.UUID,
         requested_by: str,
     ) -> ExternalGitRetirementReceipt:
@@ -683,7 +775,7 @@ class ExternalGitRetirement:
             async with conn.transaction():
                 record = await conn.fetchrow(
                     "SELECT * FROM external_git_retirements WHERE vault_id = $1 FOR UPDATE",
-                    manifest.vault_id,
+                    expected_vault_id,
                 )
                 if record is None:
                     raise ExternalGitRetirementError("external Git retirement intent disappeared")
@@ -691,21 +783,26 @@ class ExternalGitRetirement:
                 self._require_same_binding(
                     receipt,
                     manifest,
+                    expected_vault_id=expected_vault_id,
                     idempotency_key=idempotency_key,
                     requested_by=requested_by,
                 )
                 if receipt.status == "retired":
                     return receipt
-                await self._locked_vault(conn, manifest)
+                vault = await self._locked_vault(
+                    conn,
+                    manifest,
+                    expected_vault_id=expected_vault_id,
+                )
                 await self._require_open_authority(conn)
-                sidecar = await self._locked_sidecar(conn, manifest.vault_id)
+                sidecar = await self._locked_sidecar(conn, vault["id"])
                 if (
                     sidecar["sync_state"] != "quarantined"
                     or sidecar["sync_state_reason"] != _RETIREMENT_PENDING_REASON
                 ):
                     raise ExternalGitRetirementError("external Git retirement quarantine intent is stale")
                 self._validate_sidecar(sidecar, manifest)
-                await self._validate_live_documents(conn, manifest)
+                await self._validate_live_documents(conn, manifest, vault_id=vault["id"])
 
                 reclassified = await conn.execute(
                     """
@@ -719,13 +816,13 @@ class ExternalGitRetirement:
                            llm_next_attempt_at = NULL
                      WHERE vault_id = $1 AND source = 'external_git'
                     """,
-                    manifest.vault_id,
+                    vault["id"],
                 )
                 if _command_count(reclassified) != manifest.document_count:
                     raise ExternalGitRetirementError("external Git retirement document reclassification drifted")
                 deleted = await conn.execute(
                     "DELETE FROM vault_external_git WHERE vault_id = $1",
-                    manifest.vault_id,
+                    vault["id"],
                 )
                 if not _command_updated_one(deleted):
                     raise ExternalGitRetirementError("external Git retirement sidecar delete was superseded")
@@ -736,7 +833,7 @@ class ExternalGitRetirement:
                      WHERE vault_id = $1 AND status = 'quarantined'
                     RETURNING *
                     """,
-                    manifest.vault_id,
+                    vault["id"],
                 )
                 if row is None:
                     raise ExternalGitRetirementError("external Git retirement receipt transition was superseded")
@@ -746,6 +843,7 @@ class ExternalGitRetirement:
         self,
         manifest: AdoptionManifest,
         *,
+        expected_vault_id: uuid.UUID,
         idempotency_key: uuid.UUID,
         requested_by: str,
     ) -> None:
@@ -754,7 +852,7 @@ class ExternalGitRetirement:
             async with conn.transaction():
                 record = await conn.fetchrow(
                     "SELECT * FROM external_git_retirements WHERE vault_id = $1 FOR UPDATE",
-                    manifest.vault_id,
+                    expected_vault_id,
                 )
                 if record is None:
                     raise ExternalGitRetirementError("external Git retirement receipt disappeared")
@@ -762,6 +860,7 @@ class ExternalGitRetirement:
                 self._require_same_binding(
                     receipt,
                     manifest,
+                    expected_vault_id=expected_vault_id,
                     idempotency_key=idempotency_key,
                     requested_by=requested_by,
                 )
@@ -769,7 +868,7 @@ class ExternalGitRetirement:
                     raise ExternalGitRetirementError("external Git retirement is not complete")
                 vault = await conn.fetchrow(
                     "SELECT id, name FROM vaults WHERE id = $1 FOR UPDATE",
-                    manifest.vault_id,
+                    expected_vault_id,
                 )
                 if vault is None:
                     return
@@ -777,12 +876,12 @@ class ExternalGitRetirement:
                     raise ExternalGitRetirementError("external Git retirement vault binding is stale")
                 if await conn.fetchval(
                     "SELECT 1 FROM vault_external_git WHERE vault_id = $1",
-                    manifest.vault_id,
+                    expected_vault_id,
                 ):
                     raise ExternalGitRetirementError("external Git retirement sidecar unexpectedly remains")
                 if await conn.fetchval(
                     "SELECT 1 FROM documents WHERE vault_id = $1 AND source = 'external_git'",
-                    manifest.vault_id,
+                    expected_vault_id,
                 ):
                     raise ExternalGitRetirementError("external Git retirement document reclassification is incomplete")
                 vault_name = vault["name"]
@@ -800,23 +899,34 @@ class ExternalGitRetirement:
         self,
         *,
         manifest: AdoptionManifest,
+        expected_vault_id: uuid.UUID,
         idempotency_key: uuid.UUID,
         requested_by: str,
     ) -> ExternalGitRetirementReceipt:
         """Retire one pre-adopted external-Git sidecar with exact replay only."""
         if not isinstance(manifest, AdoptionManifest):
             raise ExternalGitRetirementError("external Git retirement manifest is invalid")
+        if not isinstance(expected_vault_id, uuid.UUID):
+            raise ExternalGitRetirementError("external Git retirement vault id is invalid")
         if not isinstance(idempotency_key, uuid.UUID):
             raise ExternalGitRetirementError("external Git retirement idempotency key is invalid")
+        try:
+            canonical_manifest = parse_adoption_manifest(manifest.fact())
+        except ExternalGitRetirementError:
+            raise ExternalGitRetirementError("external Git retirement manifest is invalid") from None
+        if canonical_manifest != manifest:
+            raise ExternalGitRetirementError("external Git retirement manifest is invalid")
         requested_by = _requested_by(requested_by)
         receipt = await self._load_or_quarantine(
             manifest,
+            expected_vault_id=expected_vault_id,
             idempotency_key=idempotency_key,
             requested_by=requested_by,
         )
         if receipt.status == "retired":
             await self._finish_completed_marker(
                 manifest,
+                expected_vault_id=expected_vault_id,
                 idempotency_key=idempotency_key,
                 requested_by=requested_by,
             )
@@ -831,11 +941,13 @@ class ExternalGitRetirement:
             raise ExternalGitRetirementError("external Git retirement marker quarantine failed") from exc
         receipt = await self._finalize(
             manifest,
+            expected_vault_id=expected_vault_id,
             idempotency_key=idempotency_key,
             requested_by=requested_by,
         )
         await self._finish_completed_marker(
             manifest,
+            expected_vault_id=expected_vault_id,
             idempotency_key=idempotency_key,
             requested_by=requested_by,
         )

--- a/backend/app/services/external_git_retirement.py
+++ b/backend/app/services/external_git_retirement.py
@@ -1,0 +1,842 @@
+"""Offline, operator-only retirement of an external-Git mirror.
+
+The Collector creates the adoption manifest while AKB is still the read-only
+mirror authority.  This module owns the deliberately narrow handoff from that
+state to a retained manual vault.  The manifest parser is strict by design:
+it accepts only the credential-free facts needed to bind the handoff and never
+accepts document bodies or authentication material.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import math
+import re
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+import asyncpg
+
+from app.config import settings
+from app.exceptions import MirrorMarkerError
+from app.services.external_git_validation import ExternalGitPolicyError, validate
+from app.services.git_service import GitService
+from app.services.uri_service import doc_uri
+from app.util.text import to_nfc
+
+
+_MANIFEST_SCHEMA_VERSION = 1
+_OID_RE = re.compile(r"^[0-9a-f]{40}$")
+_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+_MANIFEST_KEYS = frozenset(
+    {
+        "schema_version",
+        "vault_id",
+        "vault_name",
+        "remote_url",
+        "remote_branch",
+        "last_synced_sha",
+        "documents",
+    }
+)
+_DOCUMENT_KEYS = frozenset({"uri", "path", "content_hash", "managed_metadata"})
+_MANAGED_METADATA_KEYS = frozenset(
+    {"title", "type", "status", "tags", "domain", "summary", "metadata"}
+)
+_MAX_MANIFEST_BYTES = 8 * 1024 * 1024
+
+
+class ExternalGitRetirementError(RuntimeError):
+    """A safe, operator-actionable external-Git retirement refusal.
+
+    Manifest content can contain customer metadata.  Every message in this
+    class is deliberately value-free so a CLI caller can print it without
+    accidentally emitting a document body, token, or unvalidated remote.
+    """
+
+
+class ExternalGitRetirementConflict(ExternalGitRetirementError):
+    """A retry did not exactly match a durable retirement record."""
+
+
+@dataclass(frozen=True, slots=True)
+class AdoptionDocument:
+    """One active external-Git document's credential-free adoption facts."""
+
+    uri: str
+    path: str
+    content_hash: str
+    managed_metadata: dict[str, Any]
+
+    def fact(self) -> dict[str, Any]:
+        return {
+            "uri": self.uri,
+            "path": self.path,
+            "content_hash": self.content_hash,
+            "managed_metadata": self.managed_metadata,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AdoptionManifest:
+    """Canonical, body-free manifest accepted by the retirement command."""
+
+    vault_id: uuid.UUID
+    vault_name: str
+    remote_url: str
+    remote_branch: str
+    last_synced_sha: str
+    documents: tuple[AdoptionDocument, ...]
+    digest: str
+
+    @property
+    def document_count(self) -> int:
+        return len(self.documents)
+
+    def fact(self) -> dict[str, Any]:
+        return {
+            "schema_version": _MANIFEST_SCHEMA_VERSION,
+            "vault_id": str(self.vault_id),
+            "vault_name": self.vault_name,
+            "remote_url": self.remote_url,
+            "remote_branch": self.remote_branch,
+            "last_synced_sha": self.last_synced_sha,
+            "documents": [document.fact() for document in self.documents],
+        }
+
+
+def _manifest_shape_error() -> ExternalGitRetirementError:
+    return ExternalGitRetirementError("external Git adoption manifest shape is invalid")
+
+
+def _require_exact_keys(value: Mapping[str, Any], expected: frozenset[str]) -> None:
+    if set(value) != expected:
+        raise _manifest_shape_error()
+
+
+def _text(value: object, *, allow_none: bool = False) -> str | None:
+    if value is None and allow_none:
+        return None
+    if not isinstance(value, str):
+        raise _manifest_shape_error()
+    return to_nfc(value)
+
+
+def _json_value(value: object) -> Any:
+    """Return NFC-normalized JSON data without accepting Python-only values."""
+    if value is None or isinstance(value, (str, bool, int)):
+        return to_nfc(value) if isinstance(value, str) else value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise _manifest_shape_error()
+        return value
+    if isinstance(value, list):
+        return [_json_value(item) for item in value]
+    if isinstance(value, Mapping):
+        normalized: dict[str, Any] = {}
+        for raw_key, raw_value in value.items():
+            if not isinstance(raw_key, str):
+                raise _manifest_shape_error()
+            key = to_nfc(raw_key)
+            if key in normalized:
+                raise _manifest_shape_error()
+            normalized[key] = _json_value(raw_value)
+        return normalized
+    raise _manifest_shape_error()
+
+
+def _managed_metadata(value: object) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise _manifest_shape_error()
+    _require_exact_keys(value, _MANAGED_METADATA_KEYS)
+
+    title = _text(value["title"])
+    doc_type = _text(value["type"], allow_none=True)
+    status = _text(value["status"])
+    domain = _text(value["domain"], allow_none=True)
+    summary = _text(value["summary"], allow_none=True)
+    tags = value["tags"]
+    metadata = value["metadata"]
+    if status != "active" or not isinstance(tags, list) or not isinstance(metadata, Mapping):
+        raise _manifest_shape_error()
+    normalized_tags: list[str] = []
+    for tag in tags:
+        normalized_tag = _text(tag)
+        assert normalized_tag is not None
+        normalized_tags.append(normalized_tag)
+    normalized_metadata = _json_value(metadata)
+    if not isinstance(normalized_metadata, dict):
+        raise _manifest_shape_error()
+    assert title is not None and status is not None
+    return {
+        "title": title,
+        "type": doc_type,
+        "status": status,
+        "tags": normalized_tags,
+        "domain": domain,
+        "summary": summary,
+        "metadata": normalized_metadata,
+    }
+
+
+def _canonical_digest(value: Mapping[str, Any]) -> str:
+    payload = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def parse_adoption_manifest(value: object) -> AdoptionManifest:
+    """Parse one strict credential-free Collector adoption manifest.
+
+    Unknown keys are refused rather than ignored.  That makes a future
+    credential/body field a hard compatibility break instead of something that
+    could be silently accepted, logged, or persisted by an older AKB image.
+    """
+    if not isinstance(value, Mapping):
+        raise _manifest_shape_error()
+    _require_exact_keys(value, _MANIFEST_KEYS)
+    if isinstance(value["schema_version"], bool) or value["schema_version"] != _MANIFEST_SCHEMA_VERSION:
+        raise _manifest_shape_error()
+    try:
+        vault_id = uuid.UUID(_text(value["vault_id"]) or "")
+    except (TypeError, ValueError, AttributeError):
+        raise _manifest_shape_error() from None
+    vault_name = _text(value["vault_name"])
+    remote_url = _text(value["remote_url"])
+    remote_branch = _text(value["remote_branch"])
+    last_synced_sha = _text(value["last_synced_sha"])
+    documents = value["documents"]
+    if (
+        not vault_name
+        or not remote_url
+        or not remote_branch
+        or not last_synced_sha
+        or not isinstance(documents, list)
+        or _OID_RE.fullmatch(last_synced_sha) is None
+    ):
+        raise _manifest_shape_error()
+    try:
+        remote = validate(
+            {
+                "remote_url": remote_url,
+                "remote_branch": remote_branch,
+                "auth_token": None,
+            },
+            settings=settings,
+            resolve=False,
+        )
+    except ExternalGitPolicyError as exc:
+        raise ExternalGitRetirementError("external Git adoption manifest remote is invalid") from exc
+
+    parsed_documents: list[AdoptionDocument] = []
+    paths: set[str] = set()
+    uris: set[str] = set()
+    for document in documents:
+        if not isinstance(document, Mapping):
+            raise _manifest_shape_error()
+        _require_exact_keys(document, _DOCUMENT_KEYS)
+        uri = _text(document["uri"])
+        path = _text(document["path"])
+        content_hash = _text(document["content_hash"])
+        if (
+            not uri
+            or not path
+            or not content_hash
+            or _DIGEST_RE.fullmatch(content_hash) is None
+            or uri != doc_uri(vault_name, path)
+        ):
+            raise ExternalGitRetirementError("external Git adoption manifest document URI is invalid")
+        if path in paths or uri in uris:
+            raise ExternalGitRetirementError("external Git adoption manifest contains duplicate documents")
+        paths.add(path)
+        uris.add(uri)
+        parsed_documents.append(
+            AdoptionDocument(
+                uri=uri,
+                path=path,
+                content_hash=content_hash,
+                managed_metadata=_managed_metadata(document["managed_metadata"]),
+            )
+        )
+
+    ordered = tuple(sorted(parsed_documents, key=lambda document: document.path))
+    preliminary = AdoptionManifest(
+        vault_id=vault_id,
+        vault_name=vault_name,
+        remote_url=remote.canonical_url,
+        remote_branch=remote.branch,
+        last_synced_sha=last_synced_sha,
+        documents=ordered,
+        digest="",
+    )
+    return AdoptionManifest(
+        vault_id=preliminary.vault_id,
+        vault_name=preliminary.vault_name,
+        remote_url=preliminary.remote_url,
+        remote_branch=preliminary.remote_branch,
+        last_synced_sha=preliminary.last_synced_sha,
+        documents=preliminary.documents,
+        digest=_canonical_digest(preliminary.fact()),
+    )
+
+
+def load_adoption_manifest(path: str | Path) -> AdoptionManifest:
+    """Load a bounded JSON manifest without reflecting its raw contents.
+
+    A malformed input is reported only as a shape/read failure.  In particular,
+    neither a JSON decoder message nor a file body is allowed into the
+    operator-facing exception path.
+    """
+    try:
+        raw = Path(path).read_bytes()
+    except (OSError, TypeError, ValueError):
+        raise ExternalGitRetirementError("external Git adoption manifest cannot be read") from None
+    if len(raw) > _MAX_MANIFEST_BYTES:
+        raise ExternalGitRetirementError("external Git adoption manifest exceeds the operator size limit")
+    try:
+        value = json.loads(raw.decode("utf-8", errors="strict"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        raise ExternalGitRetirementError("external Git adoption manifest is not valid JSON") from None
+    return parse_adoption_manifest(value)
+
+
+_RETIREMENT_PENDING_REASON = "external_git_retirement_pending"
+_RETIREMENT_PENDING_ERROR = "[quarantine] external_git_retirement_pending"
+
+
+@dataclass(frozen=True, slots=True)
+class ExternalGitRetirementReceipt:
+    """The durable, credential-free operator receipt."""
+
+    retirement_id: uuid.UUID
+    vault_id: uuid.UUID
+    vault_name: str
+    manifest_digest: str
+    document_count: int
+    remote_url: str
+    remote_branch: str
+    last_synced_sha: str
+    idempotency_key: uuid.UUID
+    requested_by: str
+    status: str
+    created_at: Any
+    retired_at: Any
+
+
+def _receipt(row: Mapping[str, Any]) -> ExternalGitRetirementReceipt:
+    return ExternalGitRetirementReceipt(
+        retirement_id=row["retirement_id"],
+        vault_id=row["vault_id"],
+        vault_name=row["vault_name"],
+        manifest_digest=row["manifest_digest"],
+        document_count=int(row["document_count"]),
+        remote_url=row["remote_url"],
+        remote_branch=row["remote_branch"],
+        last_synced_sha=row["last_synced_sha"],
+        idempotency_key=row["idempotency_key"],
+        requested_by=row["requested_by"],
+        status=row["status"],
+        created_at=row["created_at"],
+        retired_at=row["retired_at"],
+    )
+
+
+def _command_updated_one(status: str | None) -> bool:
+    try:
+        return int(status.split()[-1]) == 1  # type: ignore[union-attr]
+    except (AttributeError, IndexError, ValueError):
+        return False
+
+
+def _command_count(status: str | None) -> int | None:
+    try:
+        return int(status.split()[-1])  # type: ignore[union-attr]
+    except (AttributeError, IndexError, ValueError):
+        return None
+
+
+def _requested_by(value: object) -> str:
+    if not isinstance(value, str):
+        raise ExternalGitRetirementError("external Git retirement operator identity is invalid")
+    normalized = to_nfc(value)
+    if not normalized.strip() or len(normalized) > 255:
+        raise ExternalGitRetirementError("external Git retirement operator identity is invalid")
+    return normalized
+
+
+def _strict_db_metadata(value: object) -> dict[str, Any]:
+    """Decode the JSONB driver value without silently replacing corruption."""
+    decoded = value
+    if isinstance(decoded, str):
+        try:
+            decoded = json.loads(decoded)
+        except json.JSONDecodeError:
+            raise ExternalGitRetirementError("external Git managed metadata is invalid") from None
+    if not isinstance(decoded, Mapping):
+        raise ExternalGitRetirementError("external Git managed metadata is invalid")
+    normalized = _json_value(decoded)
+    if not isinstance(normalized, dict):
+        raise ExternalGitRetirementError("external Git managed metadata is invalid")
+    return normalized
+
+
+class ExternalGitRetirement:
+    """One narrow, offline transition from an AKB mirror to a manual vault.
+
+    PostgreSQL and the filesystem cannot share a transaction.  The protocol is
+    therefore deliberately three-phase and only moves forward:
+
+    1. lock and validate live rows, then persist a quarantine intent and move
+       the sidecar out of every poller claim state;
+    2. replace the normal mirror marker with a fail-closed tombstone under the
+       per-vault Git lock;
+    3. re-lock/revalidate rows, reclassify documents, delete just the sidecar,
+       and commit the immutable receipt.  A final tombstone cleanup is safe to
+       replay after that commit.
+    """
+
+    def __init__(self, pool: asyncpg.Pool, *, git: GitService | None = None):
+        self.pool = pool
+        self.git = git or GitService()
+
+    @staticmethod
+    def _same_binding(
+        receipt: ExternalGitRetirementReceipt,
+        manifest: AdoptionManifest,
+        *,
+        idempotency_key: uuid.UUID,
+        requested_by: str,
+    ) -> bool:
+        return (
+            receipt.vault_id == manifest.vault_id
+            and receipt.vault_name == manifest.vault_name
+            and receipt.manifest_digest == manifest.digest
+            and receipt.document_count == manifest.document_count
+            and receipt.remote_url == manifest.remote_url
+            and receipt.remote_branch == manifest.remote_branch
+            and receipt.last_synced_sha == manifest.last_synced_sha
+            and receipt.idempotency_key == idempotency_key
+            and receipt.requested_by == requested_by
+        )
+
+    @classmethod
+    def _require_same_binding(
+        cls,
+        receipt: ExternalGitRetirementReceipt,
+        manifest: AdoptionManifest,
+        *,
+        idempotency_key: uuid.UUID,
+        requested_by: str,
+    ) -> None:
+        if not cls._same_binding(
+            receipt,
+            manifest,
+            idempotency_key=idempotency_key,
+            requested_by=requested_by,
+        ):
+            raise ExternalGitRetirementConflict("external Git retirement replay conflicts with its durable receipt")
+
+    @staticmethod
+    async def _locked_vault(conn: asyncpg.Connection, manifest: AdoptionManifest) -> asyncpg.Record:
+        row = await conn.fetchrow(
+            "SELECT id, name, status FROM vaults WHERE id = $1 FOR UPDATE",
+            manifest.vault_id,
+        )
+        if row is None or row["name"] != manifest.vault_name:
+            raise ExternalGitRetirementError("external Git retirement vault binding is stale")
+        if row["status"] == "deleted":
+            raise ExternalGitRetirementError("external Git retirement cannot reclassify a deleted vault")
+        return row
+
+    @staticmethod
+    async def _require_open_authority(conn: asyncpg.Connection) -> None:
+        committed = await conn.fetchval(
+            """
+            SELECT 1
+              FROM native_revision_existing_authority
+             WHERE marker_id = TRUE AND status = 'committed'
+            """
+        )
+        if committed:
+            raise ExternalGitRetirementError("external Git retirement is unavailable after Native authority commit")
+
+    @staticmethod
+    async def _locked_sidecar(conn: asyncpg.Connection, vault_id: uuid.UUID) -> asyncpg.Record:
+        row = await conn.fetchrow(
+            """
+            SELECT vault_id, remote_url, remote_branch, last_synced_sha,
+                   sync_state, sync_state_reason
+              FROM vault_external_git
+             WHERE vault_id = $1
+             FOR UPDATE
+            """,
+            vault_id,
+        )
+        if row is None:
+            raise ExternalGitRetirementError("external Git retirement sidecar is missing")
+        return row
+
+    @staticmethod
+    def _validate_sidecar(row: Mapping[str, Any], manifest: AdoptionManifest) -> None:
+        try:
+            remote = validate(
+                {
+                    "remote_url": row["remote_url"],
+                    "remote_branch": row["remote_branch"],
+                    "auth_token": None,
+                },
+                settings=settings,
+                resolve=False,
+            )
+        except ExternalGitPolicyError as exc:
+            raise ExternalGitRetirementError("external Git retirement sidecar remote is invalid") from exc
+        if (
+            remote.canonical_url != manifest.remote_url
+            or remote.branch != manifest.remote_branch
+            or row["last_synced_sha"] != manifest.last_synced_sha
+            or _OID_RE.fullmatch(str(row["last_synced_sha"] or "")) is None
+        ):
+            raise ExternalGitRetirementError("external Git retirement sidecar binding is stale")
+
+    @staticmethod
+    def _live_document(vault_name: str, row: Mapping[str, Any]) -> AdoptionDocument:
+        path = row["path"]
+        content_hash = row["content_hash"]
+        tags = row["tags"]
+        if (
+            row["source"] != "external_git"
+            or row["external_path"] != path
+            or not isinstance(row["external_blob"], str)
+            or _OID_RE.fullmatch(row["external_blob"]) is None
+            or not isinstance(path, str)
+            or not isinstance(content_hash, str)
+            or _DIGEST_RE.fullmatch(content_hash) is None
+            or row["hash_algorithm"] != "sha256"
+            or not isinstance(tags, (list, tuple))
+        ):
+            raise ExternalGitRetirementError("external Git retirement document facts are invalid")
+        try:
+            managed_metadata = _managed_metadata(
+                {
+                    "title": row["title"],
+                    "type": row["doc_type"],
+                    "status": row["status"],
+                    "tags": list(tags),
+                    "domain": row["domain"],
+                    "summary": row["summary"],
+                    "metadata": _strict_db_metadata(row["metadata"]),
+                }
+            )
+        except ExternalGitRetirementError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - never expose persisted document values
+            raise ExternalGitRetirementError("external Git retirement document facts are invalid") from exc
+        normalized_path = to_nfc(path)
+        normalized_hash = to_nfc(content_hash)
+        return AdoptionDocument(
+            uri=doc_uri(vault_name, normalized_path),
+            path=normalized_path,
+            content_hash=normalized_hash,
+            managed_metadata=managed_metadata,
+        )
+
+    async def _validate_live_documents(
+        self,
+        conn: asyncpg.Connection,
+        manifest: AdoptionManifest,
+    ) -> None:
+        rows = await conn.fetch(
+            """
+            SELECT id, path, title, doc_type, status, tags, domain, summary,
+                   metadata, source, external_path, external_blob, content_hash,
+                   hash_algorithm
+              FROM documents
+             WHERE vault_id = $1 AND source = 'external_git'
+             ORDER BY path
+             FOR UPDATE
+            """,
+            manifest.vault_id,
+        )
+        live = tuple(
+            sorted(
+                (self._live_document(manifest.vault_name, row) for row in rows),
+                key=lambda document: document.path,
+            )
+        )
+        if len(live) != manifest.document_count or [item.fact() for item in live] != [
+            item.fact() for item in manifest.documents
+        ]:
+            raise ExternalGitRetirementError("external Git retirement manifest does not match live documents")
+
+    async def _load_or_quarantine(
+        self,
+        manifest: AdoptionManifest,
+        *,
+        idempotency_key: uuid.UUID,
+        requested_by: str,
+    ) -> ExternalGitRetirementReceipt:
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                record = await conn.fetchrow(
+                    "SELECT * FROM external_git_retirements WHERE vault_id = $1 FOR UPDATE",
+                    manifest.vault_id,
+                )
+                if record is not None:
+                    receipt = _receipt(record)
+                    self._require_same_binding(
+                        receipt,
+                        manifest,
+                        idempotency_key=idempotency_key,
+                        requested_by=requested_by,
+                    )
+                    if receipt.status == "retired":
+                        return receipt
+                    await self._locked_vault(conn, manifest)
+                    await self._require_open_authority(conn)
+                    sidecar = await self._locked_sidecar(conn, manifest.vault_id)
+                    if (
+                        sidecar["sync_state"] != "quarantined"
+                        or sidecar["sync_state_reason"] != _RETIREMENT_PENDING_REASON
+                    ):
+                        raise ExternalGitRetirementError("external Git retirement quarantine intent is stale")
+                    self._validate_sidecar(sidecar, manifest)
+                    await self._validate_live_documents(conn, manifest)
+                    return receipt
+
+                key_record = await conn.fetchrow(
+                    "SELECT * FROM external_git_retirements WHERE idempotency_key = $1 FOR UPDATE",
+                    idempotency_key,
+                )
+                if key_record is not None:
+                    raise ExternalGitRetirementConflict(
+                        "external Git retirement idempotency key is already bound to another receipt"
+                    )
+                await self._locked_vault(conn, manifest)
+                await self._require_open_authority(conn)
+                sidecar = await self._locked_sidecar(conn, manifest.vault_id)
+                if sidecar["sync_state"] not in {"active", "pending_preflight"}:
+                    raise ExternalGitRetirementError("external Git retirement sidecar is not claimable for retirement")
+                self._validate_sidecar(sidecar, manifest)
+                await self._validate_live_documents(conn, manifest)
+
+                try:
+                    record = await conn.fetchrow(
+                        """
+                        INSERT INTO external_git_retirements (
+                            vault_id, vault_name, manifest_digest, document_count,
+                            remote_url, remote_branch, last_synced_sha,
+                            idempotency_key, requested_by
+                        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                        RETURNING *
+                        """,
+                        manifest.vault_id,
+                        manifest.vault_name,
+                        manifest.digest,
+                        manifest.document_count,
+                        manifest.remote_url,
+                        manifest.remote_branch,
+                        manifest.last_synced_sha,
+                        idempotency_key,
+                        requested_by,
+                    )
+                except asyncpg.UniqueViolationError as exc:
+                    raise ExternalGitRetirementConflict(
+                        "external Git retirement conflicts with an existing receipt"
+                    ) from exc
+                status = await conn.execute(
+                    """
+                    UPDATE vault_external_git
+                       SET sync_state = 'quarantined',
+                           sync_state_reason = $2,
+                           sync_state_at = NOW(),
+                           poll_next_at = 'infinity',
+                           last_error = $3,
+                           updated_at = NOW()
+                     WHERE vault_id = $1
+                       AND sync_state IN ('active', 'pending_preflight')
+                    """,
+                    manifest.vault_id,
+                    _RETIREMENT_PENDING_REASON,
+                    _RETIREMENT_PENDING_ERROR,
+                )
+                if not _command_updated_one(status) or record is None:
+                    raise ExternalGitRetirementError("external Git retirement quarantine transition was superseded")
+                return _receipt(record)
+
+    async def _finalize(
+        self,
+        manifest: AdoptionManifest,
+        *,
+        idempotency_key: uuid.UUID,
+        requested_by: str,
+    ) -> ExternalGitRetirementReceipt:
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                record = await conn.fetchrow(
+                    "SELECT * FROM external_git_retirements WHERE vault_id = $1 FOR UPDATE",
+                    manifest.vault_id,
+                )
+                if record is None:
+                    raise ExternalGitRetirementError("external Git retirement intent disappeared")
+                receipt = _receipt(record)
+                self._require_same_binding(
+                    receipt,
+                    manifest,
+                    idempotency_key=idempotency_key,
+                    requested_by=requested_by,
+                )
+                if receipt.status == "retired":
+                    return receipt
+                await self._locked_vault(conn, manifest)
+                await self._require_open_authority(conn)
+                sidecar = await self._locked_sidecar(conn, manifest.vault_id)
+                if (
+                    sidecar["sync_state"] != "quarantined"
+                    or sidecar["sync_state_reason"] != _RETIREMENT_PENDING_REASON
+                ):
+                    raise ExternalGitRetirementError("external Git retirement quarantine intent is stale")
+                self._validate_sidecar(sidecar, manifest)
+                await self._validate_live_documents(conn, manifest)
+
+                reclassified = await conn.execute(
+                    """
+                    UPDATE documents
+                       SET source = 'manual',
+                           external_path = NULL,
+                           external_blob = NULL,
+                           llm_metadata_at = NULL,
+                           llm_retry_count = 0,
+                           llm_last_error = NULL,
+                           llm_next_attempt_at = NULL
+                     WHERE vault_id = $1 AND source = 'external_git'
+                    """,
+                    manifest.vault_id,
+                )
+                if _command_count(reclassified) != manifest.document_count:
+                    raise ExternalGitRetirementError("external Git retirement document reclassification drifted")
+                deleted = await conn.execute(
+                    "DELETE FROM vault_external_git WHERE vault_id = $1",
+                    manifest.vault_id,
+                )
+                if not _command_updated_one(deleted):
+                    raise ExternalGitRetirementError("external Git retirement sidecar delete was superseded")
+                row = await conn.fetchrow(
+                    """
+                    UPDATE external_git_retirements
+                       SET status = 'retired', retired_at = NOW()
+                     WHERE vault_id = $1 AND status = 'quarantined'
+                    RETURNING *
+                    """,
+                    manifest.vault_id,
+                )
+                if row is None:
+                    raise ExternalGitRetirementError("external Git retirement receipt transition was superseded")
+                return _receipt(row)
+
+    async def _finish_completed_marker(
+        self,
+        manifest: AdoptionManifest,
+        *,
+        idempotency_key: uuid.UUID,
+        requested_by: str,
+    ) -> None:
+        vault_name: str | None = None
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                record = await conn.fetchrow(
+                    "SELECT * FROM external_git_retirements WHERE vault_id = $1 FOR UPDATE",
+                    manifest.vault_id,
+                )
+                if record is None:
+                    raise ExternalGitRetirementError("external Git retirement receipt disappeared")
+                receipt = _receipt(record)
+                self._require_same_binding(
+                    receipt,
+                    manifest,
+                    idempotency_key=idempotency_key,
+                    requested_by=requested_by,
+                )
+                if receipt.status != "retired":
+                    raise ExternalGitRetirementError("external Git retirement is not complete")
+                vault = await conn.fetchrow(
+                    "SELECT id, name FROM vaults WHERE id = $1 FOR UPDATE",
+                    manifest.vault_id,
+                )
+                if vault is None:
+                    return
+                if vault["name"] != manifest.vault_name:
+                    raise ExternalGitRetirementError("external Git retirement vault binding is stale")
+                if await conn.fetchval(
+                    "SELECT 1 FROM vault_external_git WHERE vault_id = $1",
+                    manifest.vault_id,
+                ):
+                    raise ExternalGitRetirementError("external Git retirement sidecar unexpectedly remains")
+                if await conn.fetchval(
+                    "SELECT 1 FROM documents WHERE vault_id = $1 AND source = 'external_git'",
+                    manifest.vault_id,
+                ):
+                    raise ExternalGitRetirementError("external Git retirement document reclassification is incomplete")
+                vault_name = vault["name"]
+        if vault_name is not None:
+            try:
+                await asyncio.to_thread(
+                    self.git.finalize_external_mirror_retirement,
+                    vault_name,
+                    expected_ref=manifest.last_synced_sha,
+                )
+            except MirrorMarkerError as exc:
+                raise ExternalGitRetirementError("external Git retirement marker finalization failed") from exc
+
+    async def retire(
+        self,
+        *,
+        manifest: AdoptionManifest,
+        idempotency_key: uuid.UUID,
+        requested_by: str,
+    ) -> ExternalGitRetirementReceipt:
+        """Retire one pre-adopted external-Git sidecar with exact replay only."""
+        if not isinstance(manifest, AdoptionManifest):
+            raise ExternalGitRetirementError("external Git retirement manifest is invalid")
+        if not isinstance(idempotency_key, uuid.UUID):
+            raise ExternalGitRetirementError("external Git retirement idempotency key is invalid")
+        requested_by = _requested_by(requested_by)
+        receipt = await self._load_or_quarantine(
+            manifest,
+            idempotency_key=idempotency_key,
+            requested_by=requested_by,
+        )
+        if receipt.status == "retired":
+            await self._finish_completed_marker(
+                manifest,
+                idempotency_key=idempotency_key,
+                requested_by=requested_by,
+            )
+            return receipt
+        try:
+            await asyncio.to_thread(
+                self.git.quarantine_external_mirror_marker,
+                manifest.vault_name,
+                expected_ref=manifest.last_synced_sha,
+            )
+        except MirrorMarkerError as exc:
+            raise ExternalGitRetirementError("external Git retirement marker quarantine failed") from exc
+        receipt = await self._finalize(
+            manifest,
+            idempotency_key=idempotency_key,
+            requested_by=requested_by,
+        )
+        await self._finish_completed_marker(
+            manifest,
+            idempotency_key=idempotency_key,
+            requested_by=requested_by,
+        )
+        return receipt

--- a/backend/app/services/external_git_service.py
+++ b/backend/app/services/external_git_service.py
@@ -166,6 +166,15 @@ class ExternalGitService:
             logger.info("Bootstrap clone: vault=%s host=%s", vault_name, host)
             sha = self.git.clone_mirror(vault_name, remote_url, branch, auth_token)
             return ("cloned", sha)
+        # A normal marker is written only by a fresh clone or the
+        # DB-authoritative startup backfill. Do NOT recreate it from this stale
+        # poller snapshot: after a completed retirement the retained bare is a
+        # manual vault and an old reconcile must neither clean it up nor make it
+        # eligible for a later fetch publication.
+        if not self.git._is_mirror(vault_name) and last_synced_sha is not None:
+            raise MirrorMarkerError(
+                "external-git mirror marker is missing; refusing to sync"
+            )
         # Findings are value-less enum-style codes → safe to log.
         findings = self.git.inspect_mirror_structure(vault_name, remote_url, branch)
         if last_synced_sha is None or findings or not self.git.is_healthy_repo(vault_name):
@@ -197,26 +206,6 @@ class ExternalGitService:
                     "re-clone in a loop (systemic git/inspector incompatibility)"
                 )
             return ("cloned", sha)
-        # Self-heal belt: this bare is a trusted, existing mirror we
-        # are about to keep (unchanged or fetched — not re-cloned). ensure_local_bare
-        # is only ever called for a DB-registered mirror, so if it predates the
-        # marker (created before the marker existed, or missed by the startup
-        # backfill) stamp it now — otherwise _is_mirror stays False and this
-        # mirror's reads keep falling through to GitPython. The unchanged fast
-        # path below would otherwise perpetuate the marker-less state forever.
-        # Idempotent + cheap (a fast lstat when already marked); the
-        # clone/re-clone paths above get their marker from clone_mirror instead.
-        self.git.mark_as_mirror(vault_name)
-        # Fail-CLOSED: confirm the marker now reads back as a
-        # genuine mirror before we KEEP (and serve reads from) this bare. An
-        # abnormal marker entry already made mark_as_mirror raise; this also
-        # refuses the pathological "mark returned but _is_mirror is still False"
-        # case rather than letting the mirror's reads fall open to GitPython.
-        if not self.git._is_mirror(vault_name):
-            raise MirrorMarkerError(
-                f"external-git mirror {vault_name!r} could not establish its "
-                "on-disk marker; refusing to serve"
-            )
         # Treat the mirror as unchanged ONLY when the ls-remote hint, the
         # recorded cursor, AND the LOCAL materialized ref all agree. If the local
         # ref is missing or differs (e.g. a prior partial reconcile advanced the

--- a/backend/app/services/external_git_service.py
+++ b/backend/app/services/external_git_service.py
@@ -126,6 +126,8 @@ class ExternalGitService:
         remote_url: str,
         branch: str,
         auth_token: str | None,
+        *,
+        allow_unmarked_never_synced: bool = False,
     ) -> tuple[str, str]:
         """Make the local bare repo present and trustworthy before reconcile
         reads blobs from it. Returns `(action, materialized_sha)` where action
@@ -193,7 +195,7 @@ class ExternalGitService:
                 remote_url,
                 branch,
                 auth_token,
-                allow_unmarked_never_synced=last_synced_sha is None,
+                allow_unmarked_never_synced=allow_unmarked_never_synced,
             )
             # Loop-breaker: a FRESH, sterilely re-cloned bare must be
             # structurally clean. If it STILL trips the structure inspector, the
@@ -225,6 +227,64 @@ class ExternalGitService:
             return ("unchanged", local_sha)
         sha = self.git.fetch_remote(vault_name, remote_url, branch, auth_token)
         return ("fetched", sha)
+
+    async def _ensure_local_bare_for_reconcile(
+        self,
+        pool,
+        *,
+        vault_id: uuid.UUID,
+        vault_name: str,
+        cfg: dict,
+        new_sha: str,
+    ) -> tuple[str, str]:
+        """Run the one exceptional unmarked re-clone under live DB authority.
+
+        An unmarked existing directory is eligible for self-healing only before
+        the mirror's first successful sync. Hold ``FOR SHARE`` on the exact
+        active sidecar while the staged re-clone publishes, so retirement
+        (which needs ``FOR UPDATE`` on that row) either waits for publication or
+        completes first and makes this stale worker refuse. Normal marked paths
+        keep the existing filesystem-only fast path.
+        """
+        values = (
+            vault_name,
+            cfg["last_synced_sha"],
+            new_sha,
+            cfg["remote_url"],
+            cfg["remote_branch"],
+            cfg["auth_token"],
+        )
+        if cfg["last_synced_sha"] is not None or not self.git.vault_exists(vault_name):
+            return await asyncio.to_thread(self.ensure_local_bare, *values)
+
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                active = await conn.fetchval(
+                    """
+                    SELECT 1
+                      FROM vault_external_git
+                     WHERE vault_id = $1
+                       AND sync_state = 'active'
+                       AND last_synced_sha IS NULL
+                       AND remote_url = $2
+                       AND remote_branch = $3
+                       AND auth_token IS NOT DISTINCT FROM $4
+                     FOR SHARE
+                    """,
+                    vault_id,
+                    cfg["remote_url"],
+                    cfg["remote_branch"],
+                    cfg["auth_token"],
+                )
+                if not active:
+                    raise MirrorMarkerError(
+                        "external-git first-sync publication is no longer active"
+                    )
+                return await asyncio.to_thread(
+                    self.ensure_local_bare,
+                    *values,
+                    allow_unmarked_never_synced=True,
+                )
 
     # ── Reconcile (called by poller) ─────────────────────────
 
@@ -264,14 +324,12 @@ class ExternalGitService:
         # authoritative materialized SHA (local ref), which we use from here on
         # so a force-push between ls-remote and fetch can't desync the tree
         # from the cursor. 'unchanged' short-circuits the rest.
-        action, materialized_sha = await asyncio.to_thread(
-            self.ensure_local_bare,
-            vault_name,
-            cfg["last_synced_sha"],
-            new_sha,
-            cfg["remote_url"],
-            cfg["remote_branch"],
-            cfg["auth_token"],
+        action, materialized_sha = await self._ensure_local_bare_for_reconcile(
+            pool,
+            vault_id=vault_id,
+            vault_name=vault_name,
+            cfg=cfg,
+            new_sha=new_sha,
         )
         if action == "unchanged":
             marked = await ext_repo.mark_success(

--- a/backend/app/services/external_git_service.py
+++ b/backend/app/services/external_git_service.py
@@ -88,6 +88,28 @@ class ExternalGitCompatError(AKBError):
         super().__init__(message, status_code=502, code="external_git_compat")
 
 
+async def _active_sidecar_for_document_mutation(conn, vault_id: uuid.UUID) -> bool:
+    """Take an in-transaction active-sidecar snapshot before a mirror write.
+
+    ``lock_vault_for_child_write`` must be held first.  Retirement takes that
+    parent row ``FOR UPDATE`` before it quarantines the sidecar, so a document
+    mutation ordered before quarantine can finish and is revalidated by
+    retirement; one ordered after cannot pass this gate or change a now-manual
+    document back into an external-Git row.
+    """
+    return bool(
+        await conn.fetchval(
+            """
+            SELECT 1
+              FROM vault_external_git
+             WHERE vault_id = $1 AND sync_state = 'active'
+             FOR KEY SHARE
+            """,
+            vault_id,
+        )
+    )
+
+
 class ExternalGitService:
     """Encapsulates clone/fetch/reconcile for read-only mirror vaults."""
 
@@ -314,6 +336,8 @@ class ExternalGitService:
                             vault_id=vault_id, vault_name=vault_name, path=path,
                             expected_blob=existing["external_blob"],
                         )
+                        if outcome == "superseded":
+                            return {"status": "superseded", "sha": materialized_sha}
                         if outcome == "conflict":
                             # A concurrent reconcile moved this path's blob after
                             # our snapshot; the tombstone CAS did not match. Treat
@@ -341,11 +365,13 @@ class ExternalGitService:
                         )
                     skipped += 1
                     continue
-                await self._reindex_file(
+                reindex_outcome = await self._reindex_file(
                     vault_id=vault_id, vault_name=vault_name,
                     path=path, blob_sha=blob_sha, remote_url=cfg["remote_url"],
                     tip_sha=materialized_sha,
                 )
+                if reindex_outcome == "superseded":
+                    return {"status": "superseded", "sha": materialized_sha}
                 if existing:
                     updated += 1
                 else:
@@ -363,6 +389,8 @@ class ExternalGitService:
                     vault_id=vault_id, vault_name=vault_name, path=path,
                     expected_blob=local[path]["external_blob"],
                 )
+                if outcome == "superseded":
+                    return {"status": "superseded", "sha": materialized_sha}
                 if outcome == "conflict":
                     # A concurrent reconcile re-indexed this path to a newer blob
                     # after our snapshot, so it is NOT actually gone from truth.
@@ -432,7 +460,7 @@ class ExternalGitService:
         blob_sha: str,
         remote_url: str,
         tip_sha: str,
-    ) -> None:
+    ) -> str | None:
         raw = await asyncio.to_thread(self.git.cat_blob, vault_name, blob_sha)
         try:
             content = raw.decode("utf-8")
@@ -512,6 +540,8 @@ class ExternalGitService:
                         "Vault was deleted during external Git synchronization",
                         status_code=409,
                     )
+                if not await _active_sidecar_for_document_mutation(conn, vault_id):
+                    return "superseded"
                 previous_asset_state = await doc_repo.find_asset_sync_state_for_update(
                     vault_id, path, conn=conn,
                 )
@@ -592,6 +622,7 @@ class ExternalGitService:
                         "hash_algorithm": HASH_ALGORITHM,
                     },
                 )
+        return None
 
     async def _delete_external_path(
         self,
@@ -615,6 +646,9 @@ class ExternalGitService:
           cursor over content this reconcile never reconciled. Otherwise the next
           poll's ``unchanged`` fast-path (cursor == upstream SHA) would perpetuate
           the stale prior content forever.
+        * ``"superseded"`` — the sidecar is no longer active inside this
+          transaction, so retirement/reconfiguration won before any document,
+          chunk, collection, or event mutation began.
 
         The row is re-read and LOCKED (``FOR UPDATE``) INSIDE the transaction,
         never before it. Two reconciles that overlap (a claim lease that expired
@@ -635,6 +669,8 @@ class ExternalGitService:
             async with conn.transaction():
                 if not await lock_vault_for_child_write(conn, vault_id):
                     return "already_absent"
+                if not await _active_sidecar_for_document_mutation(conn, vault_id):
+                    return "superseded"
                 row = await conn.fetchrow(
                     """
                     SELECT id, collection_id, created_by, external_blob

--- a/backend/app/services/external_git_service.py
+++ b/backend/app/services/external_git_service.py
@@ -188,8 +188,13 @@ class ExternalGitService:
                 "Untrusted bare repo for mirror %s (%s); re-cloning from %s",
                 vault_name, reason, host,
             )
-            self.git.cleanup_vault_dirs(vault_name)
-            sha = self.git.clone_mirror(vault_name, remote_url, branch, auth_token)
+            sha = self.git.reclone_active_mirror(
+                vault_name,
+                remote_url,
+                branch,
+                auth_token,
+                allow_unmarked_never_synced=last_synced_sha is None,
+            )
             # Loop-breaker: a FRESH, sterilely re-cloned bare must be
             # structurally clean. If it STILL trips the structure inspector, the
             # findings are systemic — a git-version / inspector incompatibility

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -453,6 +453,18 @@ class GitService:
             raise MirrorMarkerError("external-git mirror retirement is incomplete")
         return _marker_state(bare / _MIRROR_MARKER) == "valid"
 
+    def _require_normal_write_allowed(self, vault_name: str) -> None:
+        """Fail closed only for an in-progress mirror retirement.
+
+        The usual mirror read-only policy remains owned by the service layer;
+        this guard deliberately does not reinterpret a normal mirror marker.
+        It closes the committed-receipt-to-tombstone-cleanup window for every
+        ordinary Git mutation, under the same vault lock used by retirement.
+        """
+        bare = self._bare_path(vault_name)
+        if _marker_state(bare / _RETIRING_MIRROR_MARKER) == "valid":
+            raise MirrorMarkerError("external-git mirror retirement is incomplete")
+
     def _use_mirror_reader(self, vault_name: str) -> bool:
         """Decide how a READ on ``vault_name`` must be served, fail-CLOSED.
 
@@ -2073,6 +2085,7 @@ class GitService:
         attach the worktree to — happens once at vault creation).
         """
         with self._vault_write_lock(vault_name):
+            self._require_normal_write_allowed(vault_name)
             wt = self._ensure_worktree(vault_name)
             if wt is None:
                 return self._commit_via_clone(vault_name, file_path, content, message, author_name, author_email)
@@ -2107,6 +2120,7 @@ class GitService:
     ) -> str:
         """Delete a file and commit. Returns the commit hash."""
         with self._vault_write_lock(vault_name):
+            self._require_normal_write_allowed(vault_name)
             wt = self._ensure_worktree(vault_name)
             if wt is None:
                 raise FileNotFoundError(f"File not found in vault: {file_path}")
@@ -2146,6 +2160,7 @@ class GitService:
         if old_path == new_path:
             raise ValueError("move_file: old_path and new_path are identical")
         with self._vault_write_lock(vault_name):
+            self._require_normal_write_allowed(vault_name)
             wt = self._ensure_worktree(vault_name)
             if wt is None:
                 raise FileNotFoundError(f"File not found in vault: {old_path}")
@@ -2217,6 +2232,7 @@ class GitService:
         Returns the new commit's hex SHA, or `None` when no commit was made.
         """
         with self._vault_write_lock(vault_name):
+            self._require_normal_write_allowed(vault_name)
             wt = self._ensure_worktree(vault_name)
             if wt is None:
                 # Empty bare repo or missing vault — nothing to delete.

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -1089,6 +1089,70 @@ class GitService:
         logger.info("Mirror cloned: vault=%s branch=%s", vault_name, branch)
         return sha
 
+    def reclone_active_mirror(
+        self,
+        vault_name: str,
+        remote_url: str,
+        branch: str,
+        auth_token: str | None = None,
+        timeout: int | None = None,
+        *,
+        allow_unmarked_never_synced: bool = False,
+    ) -> str:
+        """Sterilely replace an untrusted *active* external mirror.
+
+        Network clone work is staged away from the published bare repository.
+        At the short publication boundary, the vault lock is acquired and both
+        retirement markers are re-read before the old repository is touched.
+        A poller whose health decision predates a completed retirement therefore
+        discards its staged clone instead of deleting or re-marking the retained
+        manual repository.
+        """
+        self._require_safe_vault_name(vault_name)
+        tmp = self.storage_path / f".extgit-clone-{vault_name}-{uuid.uuid4().hex}"
+        backup = self.storage_path / f".extgit-replaced-{vault_name}-{uuid.uuid4().hex}"
+        try:
+            sha = self._ext_runner.clone_bare(
+                remote_url, branch, auth_token, tmp, timeout=timeout
+            )
+            (tmp / _MIRROR_MARKER).write_text(
+                "akb external-git mirror\n", encoding="utf-8"
+            )
+            self._contained(tmp)
+            self._contained(backup)
+            with self._vault_write_lock(vault_name):
+                bare = self._retirement_bare(vault_name)
+                if allow_unmarked_never_synced:
+                    # A pre-first-sync stale directory predates publication and
+                    # legitimately has no marker. A retirement tombstone still
+                    # always wins. Abnormal marker shapes fail in _marker_state.
+                    if _marker_state(bare / _RETIRING_MIRROR_MARKER) == "valid":
+                        raise MirrorMarkerError(
+                            "external-git mirror retirement is incomplete"
+                        )
+                    _marker_state(bare / _MIRROR_MARKER)
+                else:
+                    self._require_active_external_mirror_publication(bare)
+
+                # Keep the retained repository recoverable if publication
+                # itself faults. Both renames are same-filesystem and occur
+                # while every Git mutation/retirement publication is excluded.
+                os.rename(bare, backup)
+                try:
+                    os.rename(tmp, bare)
+                except BaseException:
+                    os.rename(backup, bare)
+                    raise
+                self._rmtree_quiet(backup)
+        except BaseException:
+            self._rmtree_quiet(tmp)
+            # Never delete ``backup`` here. If publication failed and even the
+            # rollback rename faulted, it is the only retained copy of the
+            # operator's repository and must remain available for recovery.
+            raise
+        logger.info("Mirror re-cloned: vault=%s branch=%s", vault_name, branch)
+        return sha
+
     def fetch_remote(
         self,
         vault_name: str,

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -465,6 +465,21 @@ class GitService:
         if _marker_state(bare / _RETIRING_MIRROR_MARKER) == "valid":
             raise MirrorMarkerError("external-git mirror retirement is incomplete")
 
+    @staticmethod
+    def _require_active_external_mirror_publication(bare: Path) -> None:
+        """Prove a staged external fetch may still publish into ``bare``.
+
+        A fetch receives objects and a namespaced temporary ref outside the
+        vault lock. Its branch-ref promotion is the persistent publication
+        boundary, so re-read both markers while the lock is held: a retirement
+        tombstone blocks the handoff window and an absent normal marker means a
+        completed retirement returned this bare to manual ownership.
+        """
+        if _marker_state(bare / _RETIRING_MIRROR_MARKER) == "valid":
+            raise MirrorMarkerError("external-git mirror retirement is incomplete")
+        if _marker_state(bare / _MIRROR_MARKER) != "valid":
+            raise MirrorMarkerError("external-git mirror is no longer active")
+
     def _use_mirror_reader(self, vault_name: str) -> bool:
         """Decide how a READ on ``vault_name`` must be served, fail-CLOSED.
 
@@ -1034,6 +1049,11 @@ class GitService:
         if bare_path.exists():
             raise FileExistsError(f"Vault already exists: {vault_name}")
         with self._vault_write_lock(vault_name):
+            # The initial existence check is only a fast failure. Re-check at
+            # the publication lock boundary so a staged clone never lands over
+            # a vault retained or created while this caller waited for the lock.
+            if bare_path.exists():
+                raise FileExistsError(f"Vault already exists: {vault_name}")
             # Age-qualified sweep INSIDE the lock: only reap leftover
             # temp clone dirs older than the clone timeout, so a concurrent
             # same-vault clone's ACTIVE temp is never deleted. Same-vault clones
@@ -1056,6 +1076,8 @@ class GitService:
                 # outside storage. ``bare_path`` doesn't exist yet — ``_contained``
                 # resolves its existing parents lexically, which is what we want.
                 self._contained(bare_path)
+                if bare_path.exists():
+                    raise FileExistsError(f"Vault already exists: {vault_name}")
                 # Atomic within storage_path (same filesystem). bare_path was
                 # asserted absent above / removed by a sterile re-clone caller.
                 os.rename(tmp, bare_path)
@@ -1105,6 +1127,12 @@ class GitService:
 
         # Brief critical section: promote tmp ref → branch ref, read the sha.
         with self._vault_write_lock(vault_name):
+            # Network I/O above deliberately runs without this lock. Re-resolve
+            # the live bare and its mirror/retirement authority immediately
+            # before promotion, so a stale poller cannot overwrite the HEAD of
+            # a retained manual vault after retirement finishes.
+            bare_path = self._retirement_bare(vault_name)
+            self._require_active_external_mirror_publication(bare_path)
             self._ext_runner.update_ref(bare_path, f"refs/heads/{vbranch}", tmp_ref)
             self._ext_runner.delete_ref_quiet(bare_path, tmp_ref)
             return self._ext_runner.rev_parse(bare_path, f"refs/heads/{vbranch}")

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -94,6 +94,15 @@ def _managed_repo(repo: Repo) -> Iterator[Repo]:
 # default-deny inspector.
 _MIRROR_MARKER = "akb-external-mirror"
 
+# An operator retirement moves the normal mirror marker through this
+# fail-closed tombstone before the sidecar is deleted.  A process crash cannot
+# then turn an external mirror into an ordinary GitPython-readable vault in the
+# gap between the filesystem and PostgreSQL phases: every read refuses while
+# this marker exists.  It is deliberately a sibling of ``_MIRROR_MARKER`` so
+# the transition stays under the same per-vault lock and storage containment
+# checks.
+_RETIRING_MIRROR_MARKER = "akb-external-mirror-retiring"
+
 # Slack over ``external_git_blob_max_bytes`` for the runner's STREAMING output
 # cap. The per-blob size pre-check already refuses an
 # over-cap blob, so a passed blob's streamed read is at most ``cap`` bytes; this
@@ -439,7 +448,10 @@ class GitService:
         promisor/rewrite config cannot re-open lazy-fetch on a plain public
         READ; returning ``False`` on an ambiguous entry would re-open exactly
         that (fail-open), hence the raise."""
-        return _marker_state(self._bare_path(vault_name) / _MIRROR_MARKER) == "valid"
+        bare = self._bare_path(vault_name)
+        if _marker_state(bare / _RETIRING_MIRROR_MARKER) == "valid":
+            raise MirrorMarkerError("external-git mirror retirement is incomplete")
+        return _marker_state(bare / _MIRROR_MARKER) == "valid"
 
     def _use_mirror_reader(self, vault_name: str) -> bool:
         """Decide how a READ on ``vault_name`` must be served, fail-CLOSED.
@@ -516,6 +528,13 @@ class GitService:
             # resolve-under-root catches a parent-dir symlink that would redirect
             # the marker write out of storage on a restored/tampered layout.
             self._contained(bare)
+            if _marker_state(bare / _RETIRING_MIRROR_MARKER) == "valid":
+                # A retirement tombstone means the operator has intentionally
+                # quiesced this mirror but has not yet committed its durable
+                # sidecar handoff. Re-stamping the normal marker would conceal
+                # that interrupted state; fail closed until the same operator
+                # command resumes it.
+                raise MirrorMarkerError("external-git mirror retirement is incomplete")
             marker = bare / _MIRROR_MARKER
             if _marker_state(marker) == "valid":
                 return False  # already a valid marker — idempotent no-op
@@ -543,6 +562,131 @@ class GitService:
                 os.close(fd)
             logger.info("Backfilled external-git mirror marker for vault %s", vault_name)
             return True
+
+    def _retirement_bare(self, vault_name: str) -> Path:
+        """Return a real, contained bare repo for an offline retirement step."""
+        bare = self._bare_path(vault_name)
+        try:
+            bare_st = os.lstat(bare)
+        except FileNotFoundError as exc:
+            raise MirrorMarkerError("external-git mirror bare repository is missing") from exc
+        except OSError as exc:
+            raise MirrorMarkerError("external-git mirror bare repository is unreadable") from exc
+        if stat.S_ISLNK(bare_st.st_mode) or not stat.S_ISDIR(bare_st.st_mode):
+            raise MirrorMarkerError("external-git mirror bare repository is not a real directory")
+        self._contained(bare)
+        return bare
+
+    def _verify_retirement_ref(self, bare: Path, expected_ref: str) -> None:
+        """Check the locally materialized mirror tip without any network I/O."""
+        if re.fullmatch(r"[0-9a-f]{40}", expected_ref) is None:
+            raise MirrorMarkerError("external-git mirror retirement fixed ref is invalid")
+        try:
+            observed = self._ext_runner.rev_parse(bare, "HEAD")
+        except Exception as exc:  # noqa: BLE001 - surface only a safe operator error
+            raise MirrorMarkerError("external-git mirror retirement fixed ref could not be read") from exc
+        if observed != expected_ref:
+            raise MirrorMarkerError("external-git mirror retirement fixed ref did not match")
+
+    @staticmethod
+    def _write_retirement_marker(marker: Path) -> None:
+        """Create the tombstone no-clobber before unlinking the old marker."""
+        try:
+            fd = os.open(
+                marker,
+                os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_NOFOLLOW,
+                0o644,
+            )
+        except FileExistsError:
+            # The caller re-classifies the entry below; never overwrite a
+            # concurrent/foreign marker.
+            return
+        try:
+            os.write(fd, b"akb external-git mirror retirement in progress\n")
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+
+    @staticmethod
+    def _fsync_retirement_directory(bare: Path) -> None:
+        """Durably publish a marker create or unlink in the bare directory."""
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_CLOEXEC", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        try:
+            fd = os.open(bare, flags)
+        except OSError as exc:
+            raise MirrorMarkerError("external-git mirror retirement directory cannot be synced") from exc
+        try:
+            os.fsync(fd)
+        except OSError as exc:
+            raise MirrorMarkerError("external-git mirror retirement directory cannot be synced") from exc
+        finally:
+            os.close(fd)
+
+    def quarantine_external_mirror_marker(self, vault_name: str, *, expected_ref: str) -> None:
+        """Replace a mirror marker with a fail-closed retirement tombstone.
+
+        This is the filesystem half of the external-Git retirement protocol.
+        It is intentionally recoverable: a crash after the tombstone is created
+        but before the old marker is unlinked leaves *both* regular files, which
+        is still fail-closed and is completed on the next exact replay.  A crash
+        after unlink leaves only the tombstone, also fail-closed.  The caller
+        must persist the sidecar quarantine intent before invoking this method.
+        """
+        with self._vault_write_lock(vault_name):
+            bare = self._retirement_bare(vault_name)
+            marker = bare / _MIRROR_MARKER
+            tombstone = bare / _RETIRING_MIRROR_MARKER
+            marker_state = _marker_state(marker)
+            tombstone_state = _marker_state(tombstone)
+            if marker_state == "absent" and tombstone_state == "absent":
+                raise MirrorMarkerError("external-git mirror retirement marker is missing")
+            self._verify_retirement_ref(bare, expected_ref)
+            if tombstone_state == "absent":
+                if marker_state != "valid":
+                    raise MirrorMarkerError("external-git mirror retirement marker is invalid")
+                self._write_retirement_marker(tombstone)
+                tombstone_state = _marker_state(tombstone)
+                if tombstone_state != "valid":
+                    raise MirrorMarkerError("external-git mirror retirement tombstone was not created")
+                self._fsync_retirement_directory(bare)
+            if marker_state == "valid":
+                try:
+                    os.unlink(marker)
+                except OSError as exc:
+                    raise MirrorMarkerError("external-git mirror marker could not be removed") from exc
+                self._fsync_retirement_directory(bare)
+            if _marker_state(marker) != "absent" or _marker_state(tombstone) != "valid":
+                raise MirrorMarkerError("external-git mirror retirement marker readback failed")
+
+    def finalize_external_mirror_retirement(self, vault_name: str, *, expected_ref: str) -> None:
+        """Remove a completed retirement tombstone after the DB receipt commits.
+
+        An interrupted final cleanup leaves the tombstone in place and therefore
+        rejects every read.  Exact replay performs this small, idempotent final
+        step; no caller is allowed to turn a still-quarantined mirror writable.
+        """
+        with self._vault_write_lock(vault_name):
+            bare = self._retirement_bare(vault_name)
+            marker = bare / _MIRROR_MARKER
+            tombstone = bare / _RETIRING_MIRROR_MARKER
+            marker_state = _marker_state(marker)
+            tombstone_state = _marker_state(tombstone)
+            if marker_state != "absent":
+                raise MirrorMarkerError("external-git mirror retirement marker is still present")
+            if tombstone_state == "valid":
+                # The fixed ref is load-bearing only while the tombstone still
+                # blocks the handoff. Once both markers are absent the vault is
+                # a normal writable vault and an exact receipt replay must not
+                # reject an ordinary post-retirement commit.
+                self._verify_retirement_ref(bare, expected_ref)
+                try:
+                    os.unlink(tombstone)
+                except OSError as exc:
+                    raise MirrorMarkerError("external-git mirror retirement tombstone could not be removed") from exc
+                self._fsync_retirement_directory(bare)
+            if _marker_state(marker) != "absent" or _marker_state(tombstone) != "absent":
+                raise MirrorMarkerError("external-git mirror retirement final readback failed")
 
     @staticmethod
     def _git_author_env(author_name: str, author_email: str) -> dict[str, str]:

--- a/backend/app/services/native_revision_shadow.py
+++ b/backend/app/services/native_revision_shadow.py
@@ -94,6 +94,15 @@ class MigrationReadRepository(Protocol):
 
     async def list_items(self, run_id: uuid.UUID) -> list[MigrationItem]: ...
 
+    async def is_completed_reservation_transfer(
+        self,
+        *,
+        owner_run_id: uuid.UUID,
+        replacement_run_id: uuid.UUID,
+        legacy_document_id: uuid.UUID,
+        native_head_revision_id: str,
+    ) -> bool: ...
+
     async def exact_mapping(
         self,
         *,
@@ -1352,7 +1361,16 @@ class NativeRevisionShadowComparator:
                 if current_item is None or self._value(current_item, "native_head_revision_id") != native_id:
                     raise ShadowComparisonError("current-run mapping has no matching completed migration item")
             elif current_item is not None:
-                raise ShadowComparisonError("current-run item attempts to re-home an immutable mapping")
+                if (
+                    self._value(current_item, "native_head_revision_id") != native_id
+                    or not await self.repository.is_completed_reservation_transfer(
+                        owner_run_id=owner_run_uuid,
+                        replacement_run_id=comparison_run_id,
+                        legacy_document_id=document.resource_id,
+                        native_head_revision_id=native_id,
+                    )
+                ):
+                    raise ShadowComparisonError("current-run item attempts to re-home an immutable mapping")
             ordered_private = [private_mappings[entry.legacy_git_oid] for entry in document.lineage]
             native_parent_bindings: list[dict[str, Any]] = []
             prior_native: dict[str, Any] | None = None

--- a/backend/tests/test_access_contributions_postgres.py
+++ b/backend/tests/test_access_contributions_postgres.py
@@ -33,7 +33,7 @@ _MIGRATION_085 = (
     _BACKEND / "app" / "db" / "migrations" / "085_vault_access_contributions.py"
 )
 _MIGRATION_HEAD = (
-    _BACKEND / "app" / "db" / "migrations" / "092_native_revision_plan_supersession.py"
+    _BACKEND / "app" / "db" / "migrations" / "093_external_git_retirement.py"
 )
 _MIGRATIONS_DIR = _BACKEND / "app" / "db" / "migrations"
 

--- a/backend/tests/test_access_contributions_postgres.py
+++ b/backend/tests/test_access_contributions_postgres.py
@@ -33,7 +33,7 @@ _MIGRATION_085 = (
     _BACKEND / "app" / "db" / "migrations" / "085_vault_access_contributions.py"
 )
 _MIGRATION_HEAD = (
-    _BACKEND / "app" / "db" / "migrations" / "093_external_git_retirement.py"
+    _BACKEND / "app" / "db" / "migrations" / "094_native_revision_completed_reservation_transfer.py"
 )
 _MIGRATIONS_DIR = _BACKEND / "app" / "db" / "migrations"
 

--- a/backend/tests/test_cli_native_revision_cutover_unit.py
+++ b/backend/tests/test_cli_native_revision_cutover_unit.py
@@ -122,3 +122,49 @@ def test_native_revision_cutover_cli_routes_abort(monkeypatch) -> None:
 def test_native_revision_cutover_cli_rejects_incomplete_arguments(capsys) -> None:
     assert cli.main(["migrate-revision-backend", "apply"]) == 2
     assert "migrate-revision-backend" in capsys.readouterr().err
+
+
+def test_external_git_retirement_cli_routes_only_with_the_exact_downtime_confirmation(monkeypatch, capsys) -> None:
+    calls: list[dict[str, str]] = []
+    vault_id = "00000000-0000-0000-0000-000000000093"
+
+    async def fake_retire(**kwargs):
+        calls.append(kwargs)
+        return {"status": "retired", "vault_id": vault_id}
+
+    monkeypatch.setattr(cli, "_execute_external_git_retirement", fake_retire, raising=False)
+    args = [
+        "migrate-revision-backend",
+        "retire-external-git",
+        "--vault-id",
+        vault_id,
+        "--manifest-file",
+        "/safe/operator/manifest.json",
+        "--idempotency-key",
+        "00000000-0000-0000-0000-000000000094",
+        "--requested-by",
+        "collector-adoption-operator",
+        "--confirm-planned-downtime",
+        f"RETIRE-EXTERNAL-GIT:{vault_id}",
+    ]
+
+    assert cli.main(args) == 0
+    assert calls == [
+        {
+            "vault_id": vault_id,
+            "manifest_file": "/safe/operator/manifest.json",
+            "idempotency_key": "00000000-0000-0000-0000-000000000094",
+            "requested_by": "collector-adoption-operator",
+            "planned_downtime_confirmation": f"RETIRE-EXTERNAL-GIT:{vault_id}",
+        }
+    ]
+    assert json.loads(capsys.readouterr().out)["status"] == "retired"
+
+    calls.clear()
+    bad_args = [
+        *args[:-1],
+        "RETIRE-EXTERNAL-GIT:wrong-vault",
+    ]
+    assert cli.main(bad_args) == 1
+    assert calls == []
+    assert "planned-downtime confirmation" in capsys.readouterr().err

--- a/backend/tests/test_cli_native_revision_cutover_unit.py
+++ b/backend/tests/test_cli_native_revision_cutover_unit.py
@@ -10,6 +10,7 @@ from app.db import postgres
 import app.services.git_service as git_service
 import app.services.native_revision_backfill as backfill_module
 import app.services.native_revision_cutover as cutover_module
+import app.services.external_git_retirement as retirement_module
 
 
 def test_native_revision_cutover_cli_routes_plan(monkeypatch, capsys) -> None:
@@ -168,3 +169,56 @@ def test_external_git_retirement_cli_routes_only_with_the_exact_downtime_confirm
     assert cli.main(bad_args) == 1
     assert calls == []
     assert "planned-downtime confirmation" in capsys.readouterr().err
+
+
+def test_external_git_retirement_cli_binds_the_operator_vault_id_to_the_service(monkeypatch) -> None:
+    vault_id = uuid.UUID("00000000-0000-0000-0000-000000000093")
+    manifest = object()
+    calls: list[dict[str, object]] = []
+
+    @dataclass
+    class _Receipt:
+        status: str
+
+    class _Retirement:
+        def __init__(self, pool) -> None:
+            assert pool == "pool"
+
+        async def retire(self, **kwargs):
+            calls.append(kwargs)
+            return _Receipt(status="retired")
+
+    async def _init_db() -> None:
+        return None
+
+    async def _get_pool():
+        return "pool"
+
+    async def _close_pool() -> None:
+        return None
+
+    monkeypatch.setattr(postgres, "init_db", _init_db)
+    monkeypatch.setattr(postgres, "get_pool", _get_pool)
+    monkeypatch.setattr(postgres, "close_pool", _close_pool)
+    monkeypatch.setattr(retirement_module, "load_adoption_manifest", lambda _path: manifest)
+    monkeypatch.setattr(retirement_module, "ExternalGitRetirement", _Retirement)
+
+    report = asyncio.run(
+        cli._execute_external_git_retirement(
+            vault_id=str(vault_id),
+            manifest_file="/safe/operator/manifest.json",
+            idempotency_key="00000000-0000-0000-0000-000000000094",
+            requested_by="collector-adoption-operator",
+            planned_downtime_confirmation=f"RETIRE-EXTERNAL-GIT:{vault_id}",
+        )
+    )
+
+    assert report == {"status": "retired"}
+    assert calls == [
+        {
+            "manifest": manifest,
+            "expected_vault_id": vault_id,
+            "idempotency_key": uuid.UUID("00000000-0000-0000-0000-000000000094"),
+            "requested_by": "collector-adoption-operator",
+        }
+    ]

--- a/backend/tests/test_external_git_asset_lock_order_unit.py
+++ b/backend/tests/test_external_git_asset_lock_order_unit.py
@@ -34,10 +34,14 @@ class _Connection:
         return _AsyncContext()
 
     async def fetchval(self, sql, *args):
-        assert "FROM vaults" in sql and "FOR KEY SHARE" in sql
         assert args == (self.vault_id,)
-        self.order.append("vault")
-        return self.vault_id
+        if "FROM vaults" in sql:
+            assert "FOR KEY SHARE" in sql
+            self.order.append("vault")
+            return self.vault_id
+        assert "FROM vault_external_git" in sql and "sync_state = 'active'" in sql
+        self.order.append("sidecar")
+        return 1
 
 
 class _Pool:
@@ -102,4 +106,4 @@ async def test_external_git_write_locks_vault_before_document(monkeypatch):
         tip_sha="a" * 40,
     )
 
-    assert order[:2] == ["vault", "document"]
+    assert order[:3] == ["vault", "sidecar", "document"]

--- a/backend/tests/test_external_git_delete_race_unit.py
+++ b/backend/tests/test_external_git_delete_race_unit.py
@@ -36,6 +36,7 @@ class _FakeState:
         # it ran on THIS connection inside the transaction — see _FakeConn.fetch.
         self.publication_deletes: list[tuple] = []
         self.lock_order: list[str] = []
+        self.sidecar_active = True
 
 
 class _FakeConn:
@@ -75,6 +76,10 @@ class _FakeConn:
             assert self._in_tx[0], "vault lifecycle lock ran OUTSIDE the transaction"
             self.state.lock_order.append("vault")
             return args[0]
+        if "FROM vault_external_git" in s and "sync_state = 'active'" in s:
+            assert self._in_tx[0], "sidecar fence ran OUTSIDE the transaction"
+            self.state.lock_order.append("sidecar")
+            return 1 if self.state.sidecar_active else None
         if s.startswith("DELETE FROM documents") and "RETURNING" in s:
             assert self._in_tx[0]
             row_id = args[0]
@@ -202,7 +207,7 @@ async def test_delete_external_path_normal_single_delete(monkeypatch):
     assert state.relation_deletes == [("v", "a.md")]
     assert state.decrements == [row["collection_id"]]
     assert state.events == ["document.delete"]
-    assert state.lock_order[:2] == ["vault", "document"]
+    assert state.lock_order[:3] == ["vault", "sidecar", "document"]
     assert state.select_sqls and all("FOR UPDATE" in s for s in state.select_sqls)
     # The publication cascade is app-level since migration 022 dropped
     # `publications.document_id`: without it the mirrored path's slug outlives
@@ -271,6 +276,30 @@ async def test_missing_row_is_a_noop(monkeypatch):
     assert state.decrements == []
     assert state.events == []
     assert state.publication_deletes == []
+
+
+@pytest.mark.asyncio
+async def test_quarantined_sidecar_refuses_direct_external_delete(monkeypatch):
+    """A stale poller cannot delete a row after retirement quarantines its sidecar."""
+    row = _row()
+    state = _wire(monkeypatch, row)
+    state.sidecar_active = False
+
+    outcome = await _svc()._delete_external_path(
+        vault_id=uuid.uuid4(),
+        vault_name="v",
+        path="a.md",
+        expected_blob=row["external_blob"],
+    )
+
+    assert outcome == "superseded"
+    assert state.row is not None
+    assert state.chunk_deletes == []
+    assert state.relation_deletes == []
+    assert state.decrements == []
+    assert state.events == []
+    assert state.publication_deletes == []
+    assert state.lock_order == ["vault", "sidecar"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_external_git_oversized_unit.py
+++ b/backend/tests/test_external_git_oversized_unit.py
@@ -52,6 +52,9 @@ def _make_service(monkeypatch, *, tree, sizes, local, mark_ok=True):
             return local
 
     class _Git:
+        def vault_exists(self, name):
+            return False
+
         def ls_remote_head(self, url, branch, token):
             return "hint_sha"
 

--- a/backend/tests/test_external_git_poller_unit.py
+++ b/backend/tests/test_external_git_poller_unit.py
@@ -850,6 +850,9 @@ async def test_reconcile_mark_success_branches(monkeypatch, action, mark_ok,
             return {}
 
     class _Git:
+        def vault_exists(self, name):
+            return False
+
         def ls_remote_head(self, url, branch, token):
             return "hint_sha"
 

--- a/backend/tests/test_external_git_retirement_git_unit.py
+++ b/backend/tests/test_external_git_retirement_git_unit.py
@@ -22,6 +22,18 @@ def test_external_mirror_marker_retires_through_a_fail_closed_tombstone(tmp_path
     assert (bare / "akb-external-mirror-retiring").is_file()
     with pytest.raises(MirrorMarkerError, match="retirement is incomplete"):
         git.current_commit(vault)
+    for mutation in (
+        lambda: git.commit_file(vault, "new.md", "# New\n", "post-quarantine write"),
+        lambda: git.delete_file(vault, "overview.md", "post-quarantine delete"),
+        lambda: git.move_file(vault, "overview.md", "renamed.md", "post-quarantine move"),
+        lambda: git.delete_paths_bulk(
+            vault_name=vault,
+            file_paths=["overview.md"],
+            message="post-quarantine bulk delete",
+        ),
+    ):
+        with pytest.raises(MirrorMarkerError, match="retirement is incomplete"):
+            mutation()
 
     # Both phases are recovery-safe when a process restarts after either side
     # of the non-transactional filesystem transition.
@@ -32,6 +44,7 @@ def test_external_mirror_marker_retires_through_a_fail_closed_tombstone(tmp_path
     assert not (bare / "akb-external-mirror").exists()
     assert not (bare / "akb-external-mirror-retiring").exists()
     assert git.current_commit(vault) == fixed_ref
+    assert git.commit_file(vault, "new.md", "# New\n", "post-retirement write") != fixed_ref
 
 
 def test_external_mirror_marker_refuses_a_ref_drift_before_removal(tmp_path) -> None:

--- a/backend/tests/test_external_git_retirement_git_unit.py
+++ b/backend/tests/test_external_git_retirement_git_unit.py
@@ -1,0 +1,48 @@
+"""Crash-safe mirror-marker retirement checks."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.exceptions import MirrorMarkerError
+from app.services.git_service import GitService
+
+
+def test_external_mirror_marker_retires_through_a_fail_closed_tombstone(tmp_path) -> None:
+    git = GitService(storage_path=str(tmp_path / "git"))
+    vault = "retirement-marker"
+    git.init_vault(vault)
+    fixed_ref = git.commit_file(vault, "overview.md", "# Overview\n", "seed")
+    assert git.mark_as_mirror(vault) is True
+
+    git.quarantine_external_mirror_marker(vault, expected_ref=fixed_ref)
+
+    bare = git._bare_path(vault)
+    assert not (bare / "akb-external-mirror").exists()
+    assert (bare / "akb-external-mirror-retiring").is_file()
+    with pytest.raises(MirrorMarkerError, match="retirement is incomplete"):
+        git.current_commit(vault)
+
+    # Both phases are recovery-safe when a process restarts after either side
+    # of the non-transactional filesystem transition.
+    git.quarantine_external_mirror_marker(vault, expected_ref=fixed_ref)
+    git.finalize_external_mirror_retirement(vault, expected_ref=fixed_ref)
+    git.finalize_external_mirror_retirement(vault, expected_ref=fixed_ref)
+
+    assert not (bare / "akb-external-mirror").exists()
+    assert not (bare / "akb-external-mirror-retiring").exists()
+    assert git.current_commit(vault) == fixed_ref
+
+
+def test_external_mirror_marker_refuses_a_ref_drift_before_removal(tmp_path) -> None:
+    git = GitService(storage_path=str(tmp_path / "git"))
+    vault = "retirement-ref-drift"
+    git.init_vault(vault)
+    fixed_ref = git.commit_file(vault, "overview.md", "# Overview\n", "seed")
+    assert git.mark_as_mirror(vault) is True
+
+    with pytest.raises(MirrorMarkerError, match="fixed ref did not match"):
+        git.quarantine_external_mirror_marker(vault, expected_ref="a" * 40)
+
+    assert (git._bare_path(vault) / "akb-external-mirror").is_file()
+    assert git.current_commit(vault) == fixed_ref

--- a/backend/tests/test_external_git_retirement_unit.py
+++ b/backend/tests/test_external_git_retirement_unit.py
@@ -1,0 +1,92 @@
+"""Pure contract tests for offline external-Git retirement manifests."""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from app.services.external_git_retirement import (
+    ExternalGitRetirementError,
+    parse_adoption_manifest,
+)
+
+
+_VAULT_ID = "11111111-1111-1111-1111-111111111111"
+_REF = "a" * 40
+
+
+def _manifest() -> dict:
+    return {
+        "schema_version": 1,
+        "vault_id": _VAULT_ID,
+        "vault_name": "collector-adoption",
+        "remote_url": "https://git.example.invalid/acme/knowledge.git",
+        "remote_branch": "main",
+        "last_synced_sha": _REF,
+        "documents": [
+            {
+                "uri": "akb://collector-adoption/doc/overview.md",
+                "path": "overview.md",
+                "content_hash": "b" * 64,
+                "managed_metadata": {
+                    "title": "Overview",
+                    "type": "note",
+                    "status": "active",
+                    "tags": ["collector"],
+                    "domain": "operations",
+                    "summary": "Adopted source",
+                    "metadata": {"external_path": "overview.md", "topic": "adoption"},
+                },
+            },
+            {
+                "uri": "akb://collector-adoption/coll/specs/doc/contract.md",
+                "path": "specs/contract.md",
+                "content_hash": "c" * 64,
+                "managed_metadata": {
+                    "title": "Contract",
+                    "type": "spec",
+                    "status": "active",
+                    "tags": [],
+                    "domain": "",
+                    "summary": "",
+                    "metadata": {"external_path": "specs/contract.md"},
+                },
+            },
+        ],
+    }
+
+
+def test_adoption_manifest_is_body_free_and_order_independent() -> None:
+    manifest = _manifest()
+    reordered = copy.deepcopy(manifest)
+    reordered["documents"].reverse()
+
+    parsed = parse_adoption_manifest(manifest)
+    assert parsed.digest == parse_adoption_manifest(reordered).digest
+    assert [document.path for document in parsed.documents] == [
+        "overview.md",
+        "specs/contract.md",
+    ]
+
+    with_body = copy.deepcopy(manifest)
+    with_body["documents"][0]["body"] = "never persist document bodies"
+    with pytest.raises(ExternalGitRetirementError, match="manifest shape"):
+        parse_adoption_manifest(with_body)
+
+    with_token = copy.deepcopy(manifest)
+    with_token["auth_token"] = "must-never-enter-akb"
+    with pytest.raises(ExternalGitRetirementError, match="manifest shape"):
+        parse_adoption_manifest(with_token)
+
+
+def test_adoption_manifest_rejects_duplicate_or_mismatched_uri_entries() -> None:
+    duplicate = _manifest()
+    duplicate["documents"].append(copy.deepcopy(duplicate["documents"][0]))
+    with pytest.raises(ExternalGitRetirementError, match="duplicate"):
+        parse_adoption_manifest(duplicate)
+
+    mismatched_uri = _manifest()
+    mismatched_uri["documents"][0]["uri"] = "akb://collector-adoption/doc/other.md"
+    with pytest.raises(ExternalGitRetirementError, match="URI"):
+        parse_adoption_manifest(mismatched_uri)

--- a/backend/tests/test_external_git_retirement_unit.py
+++ b/backend/tests/test_external_git_retirement_unit.py
@@ -1,4 +1,4 @@
-"""Pure contract tests for offline external-Git retirement manifests."""
+"""Exact frozen Collector v1 contract tests for external-Git retirement."""
 
 from __future__ import annotations
 
@@ -12,62 +12,86 @@ from app.services.external_git_retirement import (
 )
 
 
-_VAULT_ID = "11111111-1111-1111-1111-111111111111"
 _REF = "a" * 40
 
 
 def _manifest() -> dict:
+    """The exact JSON shape emitted by the frozen Collector v1 contract."""
     return {
-        "schema_version": 1,
-        "vault_id": _VAULT_ID,
-        "vault_name": "collector-adoption",
-        "remote_url": "https://git.example.invalid/acme/knowledge.git",
-        "remote_branch": "main",
-        "last_synced_sha": _REF,
+        "schema": "akb-collector.git-adoption-manifest",
+        "version": 1,
+        "purpose": "legacy-external-git-retirement",
+        "binding": {
+            "name": "git-fixture",
+            "source_scope": "fixture/repository",
+            "target_vault": "collector-adoption",
+            "target_collection": "collector-control",
+        },
+        "source": {
+            "remote_url": "https://git.example.invalid/acme/knowledge.git",
+            "branch": "main",
+            "snapshot_commit": _REF,
+            "path_prefix": None,
+        },
         "documents": [
             {
-                "uri": "akb://collector-adoption/doc/overview.md",
+                "origin_key": "git://fixture/repository/overview.md",
                 "path": "overview.md",
-                "content_hash": "b" * 64,
+                "resource_uri": "akb://collector-adoption/doc/overview.md",
+                "source_version": "b" * 40,
+                "blob_sha": "b" * 40,
+                "akb_content_sha256": "c" * 64,
+                "akb_current_version": "d" * 40,
                 "managed_metadata": {
+                    "managed": True,
                     "title": "Overview",
                     "type": "note",
-                    "status": "active",
                     "tags": ["collector"],
-                    "domain": "operations",
                     "summary": "Adopted source",
-                    "metadata": {"external_path": "overview.md", "topic": "adoption"},
+                    "domain": "operations",
                 },
             },
             {
-                "uri": "akb://collector-adoption/coll/specs/doc/contract.md",
-                "path": "specs/contract.md",
-                "content_hash": "c" * 64,
+                "origin_key": "git://fixture/repository/specs/contract.txt",
+                "path": "specs/contract.txt",
+                "resource_uri": "akb://collector-adoption/coll/specs/doc/contract.txt",
+                "source_version": "e" * 40,
+                "blob_sha": "e" * 40,
+                "akb_content_sha256": "f" * 64,
+                "akb_current_version": _REF,
                 "managed_metadata": {
-                    "title": "Contract",
-                    "type": "spec",
-                    "status": "active",
+                    "managed": False,
+                    "title": "contract",
+                    "type": "reference",
                     "tags": [],
-                    "domain": "",
                     "summary": "",
-                    "metadata": {"external_path": "specs/contract.md"},
+                    "domain": "",
                 },
             },
         ],
     }
 
 
-def test_adoption_manifest_is_body_free_and_order_independent() -> None:
+def test_collector_v1_manifest_is_strict_body_free_and_order_independent() -> None:
     manifest = _manifest()
     reordered = copy.deepcopy(manifest)
     reordered["documents"].reverse()
 
     parsed = parse_adoption_manifest(manifest)
     assert parsed.digest == parse_adoption_manifest(reordered).digest
+    assert parsed.target_vault == "collector-adoption"
+    assert parsed.target_collection == "collector-control"
+    assert parsed.source_scope == "fixture/repository"
+    assert parsed.path_prefix is None
     assert [document.path for document in parsed.documents] == [
         "overview.md",
-        "specs/contract.md",
+        "specs/contract.txt",
     ]
+    filtered = copy.deepcopy(manifest)
+    filtered["source"]["path_prefix"] = "specs"
+    filtered_parsed = parse_adoption_manifest(filtered)
+    assert filtered_parsed.path_prefix == "specs"
+    assert filtered_parsed.digest != parsed.digest
 
     with_body = copy.deepcopy(manifest)
     with_body["documents"][0]["body"] = "never persist document bodies"
@@ -79,14 +103,50 @@ def test_adoption_manifest_is_body_free_and_order_independent() -> None:
     with pytest.raises(ExternalGitRetirementError, match="manifest shape"):
         parse_adoption_manifest(with_token)
 
+    without_prefix = copy.deepcopy(manifest)
+    del without_prefix["source"]["path_prefix"]
+    with pytest.raises(ExternalGitRetirementError, match="manifest shape"):
+        parse_adoption_manifest(without_prefix)
 
-def test_adoption_manifest_rejects_duplicate_or_mismatched_uri_entries() -> None:
+
+def test_collector_v1_path_prefix_is_only_a_canonical_receipt_fact() -> None:
+    manifest = _manifest()
+    # Collector canonicalizes this field by trimming only leading/trailing
+    # slashes.  It is a binding fact, never an AKB live-inventory selector.
+    manifest["source"]["path_prefix"] = "docs//generated"
+    parsed = parse_adoption_manifest(manifest)
+    assert parsed.path_prefix == "docs//generated"
+
+    noncanonical = _manifest()
+    noncanonical["source"]["path_prefix"] = "/docs/"
+    with pytest.raises(ExternalGitRetirementError, match="manifest shape"):
+        parse_adoption_manifest(noncanonical)
+
+
+def test_collector_v1_manifest_rejects_ambiguous_or_noncanonical_proofs() -> None:
     duplicate = _manifest()
     duplicate["documents"].append(copy.deepcopy(duplicate["documents"][0]))
     with pytest.raises(ExternalGitRetirementError, match="duplicate"):
         parse_adoption_manifest(duplicate)
 
     mismatched_uri = _manifest()
-    mismatched_uri["documents"][0]["uri"] = "akb://collector-adoption/doc/other.md"
+    mismatched_uri["documents"][0]["resource_uri"] = "akb://collector-adoption/doc/other.md"
     with pytest.raises(ExternalGitRetirementError, match="URI"):
         parse_adoption_manifest(mismatched_uri)
+
+    mismatched_source_identity = _manifest()
+    mismatched_source_identity["documents"][0]["source_version"] = "f" * 40
+    with pytest.raises(ExternalGitRetirementError, match="source identity"):
+        parse_adoption_manifest(mismatched_source_identity)
+
+    unsafe_path = _manifest()
+    unsafe_path["documents"][0]["path"] = "../overview.md"
+    unsafe_path["documents"][0]["resource_uri"] = "akb://collector-adoption/coll/../doc/overview.md"
+    unsafe_path["documents"][0]["origin_key"] = "git://fixture/repository/../overview.md"
+    with pytest.raises(ExternalGitRetirementError, match="path"):
+        parse_adoption_manifest(unsafe_path)
+
+    nondefault_unmanaged = _manifest()
+    nondefault_unmanaged["documents"][1]["managed_metadata"]["type"] = "note"
+    with pytest.raises(ExternalGitRetirementError, match="unmanaged metadata"):
+        parse_adoption_manifest(nondefault_unmanaged)

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -467,6 +467,68 @@ def test_ensure_local_bare_fetches_when_upstream_advances(git_http, tmp_path):
     assert "doc.md" in tree and "extra.md" in tree
 
 
+def test_fetch_remote_refuses_stale_poller_promotion_after_retirement(
+    git_http, tmp_path, monkeypatch,
+):
+    """A fetch staged before retirement must never advance the retained HEAD.
+
+    ``fetch_to_ref`` is the poller's network/staging boundary.  Pause at that
+    seam, finish the offline marker retirement, then resume the stale poller:
+    only its temporary ref may exist; the manual vault's published ``HEAD``
+    must remain the frozen ref.
+    """
+    from app.exceptions import MirrorMarkerError
+
+    git = _mirror_git(git_http, tmp_path)
+    url, head1 = git_http.add_repo("retired-fetch", {"doc.md": "one\n"})
+    vault_name = f"retired-fetch-{uuid.uuid4().hex[:8]}"
+    git.clone_mirror(vault_name, url, "main", None)
+    head2 = git_http.publish_change("retired-fetch", "doc.md", "two\n")
+    assert head2 != head1
+
+    original_fetch = git._ext_runner.fetch_to_ref
+
+    def fetch_then_finish_retirement(*args, **kwargs):
+        original_fetch(*args, **kwargs)
+        git.quarantine_external_mirror_marker(vault_name, expected_ref=head1)
+        git.finalize_external_mirror_retirement(vault_name, expected_ref=head1)
+
+    monkeypatch.setattr(git._ext_runner, "fetch_to_ref", fetch_then_finish_retirement)
+
+    with pytest.raises(MirrorMarkerError, match="external-git mirror is no longer active"):
+        git.fetch_remote(vault_name, url, "main", None)
+
+    bare = _mirror_bare(tmp_path, vault_name)
+    assert git.current_commit(vault_name) == head1
+    assert not (bare / "akb-external-mirror").exists()
+    assert not (bare / "akb-external-mirror-retiring").exists()
+
+
+def test_stale_sync_cannot_rearm_a_completed_retired_mirror(git_http, tmp_path):
+    """A later stale reconcile cannot recreate the mirror marker after handoff."""
+    from app.exceptions import MirrorMarkerError
+
+    git = _mirror_git(git_http, tmp_path)
+    service = ExternalGitService(git=git)
+    url, head1 = git_http.add_repo("retired-rearm", {"doc.md": "one\n"})
+    vault_name = f"retired-rearm-{uuid.uuid4().hex[:8]}"
+    assert service.ensure_local_bare(vault_name, None, head1, url, "main", None) == (
+        "cloned",
+        head1,
+    )
+    git.quarantine_external_mirror_marker(vault_name, expected_ref=head1)
+    git.finalize_external_mirror_retirement(vault_name, expected_ref=head1)
+    head2 = git_http.publish_change("retired-rearm", "doc.md", "two\n")
+
+    with pytest.raises(MirrorMarkerError, match="external-git mirror marker is missing"):
+        service.ensure_local_bare(vault_name, head1, head2, url, "main", None)
+
+    bare = _mirror_bare(tmp_path, vault_name)
+    assert git.current_commit(vault_name) == head1
+    assert not (bare / "akb-external-mirror").exists()
+    assert not (bare / "akb-external-mirror-retiring").exists()
+
+
 def test_is_healthy_repo(git_http, tmp_path):
     """Structural soundness probe: absent → False, healthy clone → True,
     objects dropped → False."""
@@ -694,8 +756,9 @@ def test_ensure_local_bare_reclones_after_structure_finding(git_http, tmp_path):
 # `clone_mirror` only writes the marker on a fresh clone, so a mirror created
 # before the marker existed has none — `_is_mirror` is False and its reads
 # fall through to GitPython (fail-open). The DB (`vault_external_git`) is the
-# authoritative mirror list; the startup backfill re-stamps the on-disk marker,
-# and `ensure_local_bare` self-heals any miss. Tests use `git init --bare` via
+# authoritative mirror list; the startup backfill re-stamps the on-disk marker.
+# `ensure_local_bare` deliberately refuses a missing marker rather than letting
+# a stale poller re-arm a retired manual vault. Tests use `git init --bare` via
 # the local in-process git fixture (no real network); the fixture host pins
 # GIT_TERMINAL_PROMPT=0 in the runner's sealed env, and we also set it for the
 # fixture's own non-runner git calls as a belt.
@@ -886,7 +949,12 @@ def test_backfill_mirror_markers_unconditional_and_fail_fast(git_http, tmp_path,
     assert "failv" in str(boot_err.value)
 
 
-def test_ensure_local_bare_self_heals_missing_marker(git_http, tmp_path, monkeypatch):
+def test_ensure_local_bare_requires_authoritative_backfill_for_a_missing_marker(
+    git_http, tmp_path, monkeypatch,
+):
+    from app.exceptions import MirrorMarkerError
+    from app.services.external_git_service import _stamp_mirror_markers
+
     monkeypatch.setenv("GIT_TERMINAL_PROMPT", "0")
     git = _mirror_git(git_http, tmp_path)
     svc = ExternalGitService(git=git)
@@ -898,9 +966,13 @@ def test_ensure_local_bare_self_heals_missing_marker(git_http, tmp_path, monkeyp
     (_mirror_bare(tmp_path, "healv") / "akb-external-mirror").unlink()
     assert git._is_mirror("healv") is False
 
-    # A normal reconcile pass on an UNCHANGED mirror must re-stamp the marker
-    # (self-heal belt) — the unchanged fast path would otherwise perpetuate the
-    # marker-less, fail-open state forever.
+    # A stale reconcile may not recreate a missing marker itself: completed
+    # retirement intentionally leaves the retained manual vault marker-less.
+    with pytest.raises(MirrorMarkerError, match="marker is missing"):
+        svc.ensure_local_bare("healv", head, head, url, "main", None)
+
+    # The DB-authoritative startup sweep is the sole marker-restoration path.
+    assert _stamp_mirror_markers(git, ["healv"]) == (1, [])
     action, sha2 = svc.ensure_local_bare("healv", head, head, url, "main", None)
     assert action == "unchanged" and sha2 == head
     assert git._is_mirror("healv") is True

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -422,13 +422,88 @@ def test_ensure_local_bare_reclones_untrusted_stale_dir(git_http, tmp_path):
     (stale / "garbage").write_text("not a git repo")
     assert git.vault_exists(name)  # path present → old code would SKIP clone
 
-    action, sha = svc.ensure_local_bare(name, None, head, url, "main", None)
+    action, sha = svc.ensure_local_bare(
+        name,
+        None,
+        head,
+        url,
+        "main",
+        None,
+        allow_unmarked_never_synced=True,
+    )
 
     assert action == "cloned"
     assert sha == head
     # Stale garbage gone, replaced by a valid clone at the upstream head.
     assert not (git._bare_path(name) / "garbage").exists()
     assert "doc.md" in git.ls_tree(name, sha)
+
+
+def test_never_synced_reclone_holds_exact_active_sidecar_authority(
+    git_service, monkeypatch,
+):
+    """The exceptional unmarked cleanup runs while retirement is DB-blocked."""
+    import asyncio
+
+    state = {"transaction_open": False, "ensure_calls": 0}
+
+    class _Transaction:
+        async def __aenter__(self):
+            state["transaction_open"] = True
+
+        async def __aexit__(self, *_args):
+            state["transaction_open"] = False
+
+    class _Connection:
+        def transaction(self):
+            return _Transaction()
+
+        async def fetchval(self, query, *args):
+            assert "FOR SHARE" in query
+            assert args[0] == vault_id
+            return 1
+
+    class _Acquire:
+        async def __aenter__(self):
+            return _Connection()
+
+        async def __aexit__(self, *_args):
+            return None
+
+    class _Pool:
+        def acquire(self):
+            return _Acquire()
+
+    vault_id = uuid.uuid4()
+    vault_name = f"never-synced-{uuid.uuid4().hex[:8]}"
+    git_service._bare_path(vault_name).mkdir()
+    service = ExternalGitService(git=git_service)
+
+    def _ensure(*args, **kwargs):
+        assert state["transaction_open"] is True
+        assert kwargs == {"allow_unmarked_never_synced": True}
+        state["ensure_calls"] += 1
+        return ("cloned", "a" * 40)
+
+    monkeypatch.setattr(service, "ensure_local_bare", _ensure)
+    cfg = {
+        "last_synced_sha": None,
+        "remote_url": "https://example.invalid/repo.git",
+        "remote_branch": "main",
+        "auth_token": None,
+    }
+    result = asyncio.run(
+        service._ensure_local_bare_for_reconcile(
+            _Pool(),
+            vault_id=vault_id,
+            vault_name=vault_name,
+            cfg=cfg,
+            new_sha="a" * 40,
+        )
+    )
+
+    assert result == ("cloned", "a" * 40)
+    assert state == {"transaction_open": False, "ensure_calls": 1}
 
 
 def test_ensure_local_bare_unchanged_when_synced_and_sha_matches(git_http, tmp_path):
@@ -572,6 +647,35 @@ def test_stale_reclone_cannot_replace_a_completed_retired_mirror(
     assert git.current_commit(vault_name) == head1
     assert git.read_file(vault_name, "doc.md") == "one\n"
     assert [item.hexsha for item in Repo(str(bare)).iter_commits()] == [head1]
+    assert not (bare / "akb-external-mirror").exists()
+    assert not (bare / "akb-external-mirror-retiring").exists()
+
+
+def test_stale_first_sync_snapshot_cannot_replace_a_completed_retired_mirror(
+    git_http, tmp_path, monkeypatch,
+):
+    """A stale ``last_synced_sha=None`` snapshot is not publication authority."""
+    from app.exceptions import MirrorMarkerError
+
+    git = _mirror_git(git_http, tmp_path)
+    service = ExternalGitService(git=git)
+    url, head = git_http.add_repo("retired-first-sync", {"doc.md": "one\n"})
+    vault_name = f"retired-first-sync-{uuid.uuid4().hex[:8]}"
+    service.ensure_local_bare(vault_name, None, head, url, "main", None)
+    git.quarantine_external_mirror_marker(vault_name, expected_ref=head)
+    git.finalize_external_mirror_retirement(vault_name, expected_ref=head)
+    monkeypatch.setattr(
+        git,
+        "inspect_mirror_structure",
+        lambda *args, **kwargs: ["disallowed-config"],
+    )
+
+    with pytest.raises(MirrorMarkerError, match="external-git mirror is no longer active"):
+        service.ensure_local_bare(vault_name, None, head, url, "main", None)
+
+    bare = _mirror_bare(tmp_path, vault_name)
+    assert git.current_commit(vault_name) == head
+    assert git.read_file(vault_name, "doc.md") == "one\n"
     assert not (bare / "akb-external-mirror").exists()
     assert not (bare / "akb-external-mirror-retiring").exists()
 

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -529,6 +529,53 @@ def test_stale_sync_cannot_rearm_a_completed_retired_mirror(git_http, tmp_path):
     assert not (bare / "akb-external-mirror-retiring").exists()
 
 
+def test_stale_reclone_cannot_replace_a_completed_retired_mirror(
+    git_http, tmp_path, monkeypatch,
+):
+    """A health decision made before retirement has no destructive authority.
+
+    Pause at the re-clone publication seam, complete offline retirement, then
+    resume the stale poller. Its staged clone must be discarded: the retained
+    repository, frozen HEAD/history, and marker-free manual-vault shape survive.
+    """
+    from app.exceptions import MirrorMarkerError
+
+    git = _mirror_git(git_http, tmp_path)
+    service = ExternalGitService(git=git)
+    url, head1 = git_http.add_repo("retired-reclone", {"doc.md": "one\n"})
+    vault_name = f"retired-reclone-{uuid.uuid4().hex[:8]}"
+    assert service.ensure_local_bare(vault_name, None, head1, url, "main", None) == (
+        "cloned",
+        head1,
+    )
+    head2 = git_http.publish_change("retired-reclone", "doc.md", "two\n")
+    assert head2 != head1
+
+    real_reclone = git.reclone_active_mirror
+
+    def _retire_then_resume(*args, **kwargs):
+        git.quarantine_external_mirror_marker(vault_name, expected_ref=head1)
+        git.finalize_external_mirror_retirement(vault_name, expected_ref=head1)
+        return real_reclone(*args, **kwargs)
+
+    monkeypatch.setattr(git, "reclone_active_mirror", _retire_then_resume)
+    monkeypatch.setattr(
+        git,
+        "inspect_mirror_structure",
+        lambda *args, **kwargs: ["disallowed-config"],
+    )
+
+    with pytest.raises(MirrorMarkerError, match="external-git mirror is no longer active"):
+        service.ensure_local_bare(vault_name, head1, head2, url, "main", None)
+
+    bare = _mirror_bare(tmp_path, vault_name)
+    assert git.current_commit(vault_name) == head1
+    assert git.read_file(vault_name, "doc.md") == "one\n"
+    assert [item.hexsha for item in Repo(str(bare)).iter_commits()] == [head1]
+    assert not (bare / "akb-external-mirror").exists()
+    assert not (bare / "akb-external-mirror-retiring").exists()
+
+
 def test_is_healthy_repo(git_http, tmp_path):
     """Structural soundness probe: absent → False, healthy clone → True,
     objects dropped → False."""
@@ -1131,13 +1178,13 @@ def test_ensure_local_bare_breaks_reclone_loop_on_systemic_findings(git_http, tm
     # EVERY structure inspection — including on our own fresh sterile re-clone —
     # reports a finding.
     clones: list[str] = []
-    real_clone = git.clone_mirror
+    real_clone = git.reclone_active_mirror
 
     def _counting_clone(name, *a, **k):
         clones.append(name)
         return real_clone(name, *a, **k)
 
-    monkeypatch.setattr(git, "clone_mirror", _counting_clone)
+    monkeypatch.setattr(git, "reclone_active_mirror", _counting_clone)
     monkeypatch.setattr(
         git, "inspect_mirror_structure", lambda *a, **k: ["disallowed config entry"]
     )

--- a/backend/tests/test_native_revision_cutover_pg.py
+++ b/backend/tests/test_native_revision_cutover_pg.py
@@ -117,6 +117,7 @@ async def _fresh_schema(*, cutover_migrations: bool = True):
                     "091_native_revision_committed_receipt_guard.py",
                     "092_native_revision_plan_supersession.py",
                     "093_external_git_retirement.py",
+                    "094_native_revision_completed_reservation_transfer.py",
                 ]
             )
         for filename in filenames:
@@ -1084,6 +1085,66 @@ async def test_plan_supersession_migration_releases_legacy_aborted_reservations(
         assert fresh.vaults[0].migration_run_id != prior_run_id
 
 
+async def test_completed_reservation_transfer_migration_upgrades_aborted_applied_cutover(tmp_path):
+    """Migration 094 releases only an eligible completed reservation on demand."""
+    async with _fresh_schema(cutover_migrations=False) as pool:
+        async with pool.acquire() as conn:
+            for filename in (
+                "088_native_revision_existing_cutover.py",
+                "089_native_file_projection_outbox.py",
+                "090_native_revision_vault_purge_fence.py",
+                "091_native_revision_committed_receipt_guard.py",
+                "092_native_revision_plan_supersession.py",
+                "093_external_git_retirement.py",
+            ):
+                await _load(filename).migrate(conn=conn)
+
+        git = GitService(storage_path=str(tmp_path / "git-legacy-aborted-complete"))
+        vault = await _manual_vault(pool, git, label="legacy-aborted-complete")
+        cutover = NativeRevisionCutover(
+            pool,
+            backfill=NativeRevisionBackfill(pool, git=git),
+            verifier=_FixtureVerifier(pool),
+        )
+        prior = await cutover.plan(
+            vaults=[vault],
+            coverage_version="fixture-legacy-aborted-complete-v1",
+        )
+        prior_run_id = prior.vaults[0].migration_run_id
+        assert (await cutover.apply(prior.cutover_id)).status == "applied"
+        assert (await cutover.abort(prior.cutover_id)).aborted_from_status == "applied"
+
+        # Before 094, its deliberate transfer attempt is still blocked by the
+        # older check constraint, and the failed fresh plan rolls back intact.
+        with pytest.raises(
+            asyncpg.CheckViolationError,
+            match="native_revision_migration_items_reservation_state_check",
+        ):
+            await cutover.plan(
+                vaults=[vault],
+                coverage_version="fixture-legacy-aborted-complete-v2",
+            )
+
+        async with pool.acquire() as conn:
+            await _load("094_native_revision_completed_reservation_transfer.py").migrate(conn=conn)
+
+        fresh = await cutover.plan(
+            vaults=[vault],
+            coverage_version="fixture-legacy-aborted-complete-v2",
+        )
+        assert fresh.vaults[0].migration_run_id != prior_run_id
+        assert (await cutover.apply(fresh.cutover_id)).status == "applied"
+
+        async with pool.acquire() as conn:
+            assert (
+                await conn.fetchval(
+                    "SELECT reservation_active FROM native_revision_migration_items WHERE run_id = $1",
+                    prior_run_id,
+                )
+                is False
+            )
+
+
 async def test_deleted_vault_external_git_sidecar_blocks_authority_outside_retained_inventory(tmp_path):
     """A deleted vault is not migratable, but its sidecar still blocks authority."""
     async with _fresh_schema() as pool:
@@ -1862,6 +1923,8 @@ async def test_cutover_migrations_upgrade_once_and_second_runner_start_is_a_noop
             "090_native_revision_vault_purge_fence.py",
             "091_native_revision_committed_receipt_guard.py",
             "092_native_revision_plan_supersession.py",
+            "093_external_git_retirement.py",
+            "094_native_revision_completed_reservation_transfer.py",
         }
         assert cutover_files <= registered
 
@@ -1886,6 +1949,8 @@ async def test_cutover_migrations_upgrade_once_and_second_runner_start_is_a_noop
                 "090_native_revision_vault_purge_fence.py",
                 "091_native_revision_committed_receipt_guard.py",
                 "092_native_revision_plan_supersession.py",
+                "093_external_git_retirement.py",
+                "094_native_revision_completed_reservation_transfer.py",
             ]
             assert await conn.fetchval("SELECT state FROM native_revision_legacy_write_fence") == "open"
             assert await conn.fetchval("SELECT to_regclass('public.native_file_projection_outbox') IS NOT NULL") is True
@@ -1899,7 +1964,7 @@ async def test_cutover_migrations_upgrade_once_and_second_runner_start_is_a_noop
                     "SELECT count(*) FROM schema_migrations WHERE filename = ANY($1::text[])",
                     list(cutover_files),
                 )
-                == 5
+                == 7
             )
 
 
@@ -1984,6 +2049,141 @@ async def test_abort_preserves_additive_evidence_and_keeps_legacy_writes_open(tm
                 "UPDATE documents SET title = 'Legacy remains writable' WHERE vault_id = $1",
                 vault.namespace_id,
             )
+
+
+@pytest.mark.parametrize(
+    ("verify_before_abort", "expected_abort_status"),
+    [(False, "applied"), (True, "verified")],
+    ids=["applied", "verified"],
+)
+async def test_aborted_completed_cutover_transfers_reservations_without_duplicate_history(
+    tmp_path,
+    verify_before_abort,
+    expected_abort_status,
+):
+    """A later coverage plan adopts completed work from an aborted cutover.
+
+    The original native Resource/revisions and immutable Legacy mappings stay
+    owned by the completed run.  Only the active `(resource, legacy head)`
+    reservation moves to the replacement run, so the fresh cutover can apply
+    without a duplicate history or a second link to the old run.
+    """
+    async with _fresh_schema() as pool:
+        git = GitService(storage_path=str(tmp_path / "git-aborted-completed-transfer"))
+        vault = await _manual_vault(
+            pool,
+            git,
+            label=f"aborted-completed-transfer-{expected_abort_status}",
+        )
+        cutover = NativeRevisionCutover(
+            pool,
+            backfill=NativeRevisionBackfill(pool, git=git),
+            verifier=NativeRevisionCutoverVerifier(pool, git=git),
+        )
+
+        prior = await cutover.plan(
+            vaults=[vault],
+            coverage_version=f"fixture-aborted-completed-{expected_abort_status}-v1",
+        )
+        prior_run_id = prior.vaults[0].migration_run_id
+        assert (await cutover.apply(prior.cutover_id)).status == "applied"
+        if verify_before_abort:
+            assert (await cutover.verify(prior.cutover_id)).status == "verified"
+
+        async with pool.acquire() as conn:
+            native_resource_count = await conn.fetchval("SELECT count(*) FROM native_resources")
+            native_revision_count = await conn.fetchval("SELECT count(*) FROM native_revisions")
+            mappings_before = [
+                (row["resource_id"], row["legacy_git_oid"], row["run_id"])
+                for row in await conn.fetch(
+                    """
+                    SELECT resource_id, legacy_git_oid, run_id
+                      FROM legacy_revision_mappings
+                     ORDER BY resource_id, legacy_git_oid
+                    """
+                )
+            ]
+            assert mappings_before
+
+        aborted = await cutover.abort(prior.cutover_id)
+        assert aborted.status == "aborted"
+        assert aborted.aborted_from_status == expected_abort_status
+
+        fresh = await cutover.plan(
+            vaults=[vault],
+            coverage_version=f"fixture-aborted-completed-{expected_abort_status}-v2",
+        )
+        fresh_run_id = fresh.vaults[0].migration_run_id
+        assert fresh.cutover_id != prior.cutover_id
+        assert fresh_run_id != prior_run_id
+        assert (await cutover.apply(fresh.cutover_id)).status == "applied"
+        assert (await cutover.verify(fresh.cutover_id)).status == "verified"
+
+        # The transfer is single-owner, not a uniqueness bypass: while the
+        # replacement cutover remains applicable, another coverage attempt for
+        # the same `(Resource, Legacy head)` still collides at PostgreSQL.
+        with pytest.raises(
+            asyncpg.UniqueViolationError,
+            match="native_revision_migration_items_active_resource_head_key",
+        ):
+            await cutover.plan(
+                vaults=[vault],
+                coverage_version=f"fixture-aborted-completed-{expected_abort_status}-v3",
+            )
+
+        async with pool.acquire() as conn:
+            assert await conn.fetchval("SELECT count(*) FROM native_resources") == native_resource_count
+            assert await conn.fetchval("SELECT count(*) FROM native_revisions") == native_revision_count
+            mappings_after = [
+                (row["resource_id"], row["legacy_git_oid"], row["run_id"])
+                for row in await conn.fetch(
+                    """
+                    SELECT resource_id, legacy_git_oid, run_id
+                      FROM legacy_revision_mappings
+                     ORDER BY resource_id, legacy_git_oid
+                    """
+                )
+            ]
+            assert mappings_after == mappings_before
+            assert {row[2] for row in mappings_after} == {prior_run_id}
+
+            prior_item = await conn.fetchrow(
+                """
+                SELECT status, reservation_active, native_head_revision_id
+                  FROM native_revision_migration_items
+                 WHERE run_id = $1
+                """,
+                prior_run_id,
+            )
+            fresh_item = await conn.fetchrow(
+                """
+                SELECT status, reservation_active, native_head_revision_id
+                  FROM native_revision_migration_items
+                 WHERE run_id = $1
+                """,
+                fresh_run_id,
+            )
+            assert prior_item is not None and fresh_item is not None
+            assert prior_item["status"] == fresh_item["status"] == "complete"
+            assert prior_item["reservation_active"] is False
+            assert fresh_item["reservation_active"] is True
+            assert prior_item["native_head_revision_id"] == fresh_item["native_head_revision_id"]
+
+            links = {
+                (row["cutover_id"], row["migration_run_id"])
+                for row in await conn.fetch(
+                    """
+                    SELECT cutover_id, migration_run_id
+                      FROM native_revision_cutover_vaults
+                     WHERE namespace_id = $1
+                    """,
+                    vault.namespace_id,
+                )
+            }
+            assert links == {
+                (prior.cutover_id, prior_run_id),
+                (fresh.cutover_id, fresh_run_id),
+            }
 
 
 async def test_product_shadow_verifier_checks_real_git_and_native_reads(tmp_path):

--- a/backend/tests/test_native_revision_cutover_pg.py
+++ b/backend/tests/test_native_revision_cutover_pg.py
@@ -25,6 +25,7 @@ from app.models.document import DocumentUpdateRequest
 from app.repositories.native_revision_migration_repo import MigrationIntegrityError
 from app.services import access_service
 from app.services.document_service import DocumentService
+from app.services.external_git_service import ExternalGitService
 from app.services.external_git_retirement import (
     ExternalGitRetirement,
     ExternalGitRetirementConflict,
@@ -600,7 +601,7 @@ async def test_external_git_retirement_reclassifies_a_collector_adoption_and_req
             git = GitService(storage_path=str(tmp_path / "git-external-retirement"))
             vault_name = f"collector-adoption-{uuid.uuid4().hex}"
             root_body = "# Overview\n\nMirrored source.\n"
-            nested_body = "# Contract\n\nMirrored contract.\n"
+            nested_body = "Contract body."
             root_markdown = (
                 "---\n"
                 "title: Overview\n"
@@ -614,23 +615,17 @@ async def test_external_git_retirement_reclassifies_a_collector_adoption_and_req
                 "---\n"
                 f"{root_body}"
             )
-            nested_markdown = (
-                "---\n"
-                "title: Contract\n"
-                "type: spec\n"
-                "status: active\n"
-                "tags: []\n"
-                "domain: ''\n"
-                "summary: ''\n"
-                "external_path: specs/contract.md\n"
-                "---\n"
-                f"{nested_body}"
-            )
             git.init_vault(vault_name)
             root_ref = git.commit_file(vault_name, "overview.md", root_markdown, "seed overview")
-            fixed_ref = git.commit_file(vault_name, "specs/contract.md", nested_markdown, "seed contract")
+            fixed_ref = git.commit_file(vault_name, "specs/contract.txt", nested_body, "seed contract")
             assert root_ref != fixed_ref
             assert git.mark_as_mirror(vault_name) is True
+            bare_repo = Repo(str(git._bare_path(vault_name)))
+            try:
+                root_blob = bare_repo.git.rev_parse(f"{fixed_ref}:overview.md").strip()
+                nested_blob = bare_repo.git.rev_parse(f"{fixed_ref}:specs/contract.txt").strip()
+            finally:
+                bare_repo.close()
 
             owner_id = uuid.uuid4()
             collaborator_id = uuid.uuid4()
@@ -680,9 +675,9 @@ async def test_external_git_retirement_reclassifies_a_collector_adoption_and_req
                         ($1, $3, 'overview.md', 'Overview', 'note', 'active', 'Adopted source', 'operations',
                          'external_git:git.example.invalid', $4, $5, 'sha256', $4, ARRAY['collector'], $6::jsonb,
                          'external_git', 'overview.md', $7),
-                        ($2, $3, 'specs/contract.md', 'Contract', 'spec', 'active', '', '',
+                        ($2, $3, 'specs/contract.txt', 'contract', NULL, 'active', '', '',
                          'external_git:git.example.invalid', $8, $9, 'sha256', $8, ARRAY[]::text[], $10::jsonb,
-                         'external_git', 'specs/contract.md', $11)
+                         'external_git', 'specs/contract.txt', $11)
                     """,
                     uuid.uuid4(),
                     uuid.uuid4(),
@@ -690,11 +685,11 @@ async def test_external_git_retirement_reclassifies_a_collector_adoption_and_req
                     root_ref,
                     hashlib.sha256(root_body.encode()).hexdigest(),
                     json.dumps({"external_path": "overview.md", "topic": "adoption"}),
-                    "b" * 40,
+                    root_blob,
                     fixed_ref,
                     hashlib.sha256(nested_body.encode()).hexdigest(),
-                    json.dumps({"external_path": "specs/contract.md"}),
-                    "c" * 40,
+                    json.dumps({"external_path": "specs/contract.txt"}),
+                    nested_blob,
                 )
                 await conn.execute(
                     """
@@ -734,39 +729,54 @@ async def test_external_git_retirement_reclassifies_a_collector_adoption_and_req
 
             manifest = parse_adoption_manifest(
                 {
-                    "schema_version": 1,
-                    "vault_id": str(vault_id),
-                    "vault_name": vault_name,
-                    "remote_url": "https://git.example.invalid/acme/knowledge.git",
-                    "remote_branch": "main",
-                    "last_synced_sha": fixed_ref,
+                    "schema": "akb-collector.git-adoption-manifest",
+                    "version": 1,
+                    "purpose": "legacy-external-git-retirement",
+                    "binding": {
+                        "name": "git-fixture",
+                        "source_scope": "fixture/repository",
+                        "target_vault": vault_name,
+                        "target_collection": "collector-control",
+                    },
+                    "source": {
+                        "remote_url": "https://git.example.invalid/acme/knowledge.git",
+                        "branch": "main",
+                        "snapshot_commit": fixed_ref,
+                        "path_prefix": None,
+                    },
                     "documents": [
                         {
-                            "uri": doc_uri(vault_name, "specs/contract.md"),
-                            "path": "specs/contract.md",
-                            "content_hash": hashlib.sha256(nested_body.encode()).hexdigest(),
+                            "origin_key": "git://fixture/repository/specs/contract.txt",
+                            "path": "specs/contract.txt",
+                            "resource_uri": doc_uri(vault_name, "specs/contract.txt"),
+                            "source_version": nested_blob,
+                            "blob_sha": nested_blob,
+                            "akb_content_sha256": hashlib.sha256(nested_body.encode()).hexdigest(),
+                            "akb_current_version": fixed_ref,
                             "managed_metadata": {
-                                "title": "Contract",
-                                "type": "spec",
-                                "status": "active",
+                                "managed": False,
+                                "title": "contract",
+                                "type": "reference",
                                 "tags": [],
                                 "domain": "",
                                 "summary": "",
-                                "metadata": {"external_path": "specs/contract.md"},
                             },
                         },
                         {
-                            "uri": doc_uri(vault_name, "overview.md"),
+                            "origin_key": "git://fixture/repository/overview.md",
                             "path": "overview.md",
-                            "content_hash": hashlib.sha256(root_body.encode()).hexdigest(),
+                            "resource_uri": doc_uri(vault_name, "overview.md"),
+                            "source_version": root_blob,
+                            "blob_sha": root_blob,
+                            "akb_content_sha256": hashlib.sha256(root_body.encode()).hexdigest(),
+                            "akb_current_version": root_ref,
                             "managed_metadata": {
+                                "managed": True,
                                 "title": "Overview",
                                 "type": "note",
-                                "status": "active",
                                 "tags": ["collector"],
                                 "domain": "operations",
                                 "summary": "Adopted source",
-                                "metadata": {"external_path": "overview.md", "topic": "adoption"},
                             },
                         },
                     ],
@@ -777,26 +787,41 @@ async def test_external_git_retirement_reclassifies_a_collector_adoption_and_req
             # well-formed manifest has stale, missing, or extra live facts.
             # Duplicate entries are rejected by the strict parser unit contract.
             stale_manifest = manifest.fact()
-            stale_manifest["documents"][0]["content_hash"] = "d" * 64
+            stale_manifest["documents"][0]["akb_content_sha256"] = "d" * 64
             missing_manifest = manifest.fact()
-            missing_manifest["documents"] = missing_manifest["documents"][:-1]
+            missing_manifest["source"]["path_prefix"] = "specs"
+            missing_manifest["documents"] = [
+                document
+                for document in missing_manifest["documents"]
+                if document["path"].startswith("specs/")
+            ]
             extra_manifest = manifest.fact()
             extra_manifest["documents"].append(
                 {
-                    "uri": doc_uri(vault_name, "untracked.md"),
+                    "origin_key": "git://fixture/repository/untracked.md",
                     "path": "untracked.md",
-                    "content_hash": "e" * 64,
+                    "resource_uri": doc_uri(vault_name, "untracked.md"),
+                    "source_version": "e" * 40,
+                    "blob_sha": "e" * 40,
+                    "akb_content_sha256": "f" * 64,
+                    "akb_current_version": fixed_ref,
                     "managed_metadata": {
+                        "managed": True,
                         "title": "Untracked",
                         "type": "note",
-                        "status": "active",
                         "tags": [],
                         "domain": "",
                         "summary": "",
-                        "metadata": {"external_path": "untracked.md"},
                     },
                 }
             )
+            with pytest.raises(ExternalGitRetirementError, match="vault binding is stale"):
+                await retirement.retire(
+                    manifest=manifest,
+                    expected_vault_id=uuid.uuid4(),
+                    idempotency_key=uuid.UUID("00000000-0000-0000-0000-000000000089"),
+                    requested_by="collector-adoption-operator",
+                )
             for invalid_manifest, invalid_key in (
                 (stale_manifest, uuid.UUID("00000000-0000-0000-0000-000000000090")),
                 (missing_manifest, uuid.UUID("00000000-0000-0000-0000-000000000091")),
@@ -805,6 +830,7 @@ async def test_external_git_retirement_reclassifies_a_collector_adoption_and_req
                 with pytest.raises(ExternalGitRetirementError, match="does not match live documents"):
                     await retirement.retire(
                         manifest=parse_adoption_manifest(invalid_manifest),
+                        expected_vault_id=vault_id,
                         idempotency_key=invalid_key,
                         requested_by="collector-adoption-operator",
                     )
@@ -814,8 +840,54 @@ async def test_external_git_retirement_reclassifies_a_collector_adoption_and_req
                 ) == "active"
                 assert await conn.fetchval("SELECT count(*) FROM external_git_retirements") == 0
             idempotency_key = uuid.UUID("00000000-0000-0000-0000-000000000093")
+            quarantined = await retirement._load_or_quarantine(
+                manifest,
+                expected_vault_id=vault_id,
+                idempotency_key=idempotency_key,
+                requested_by="collector-adoption-operator",
+            )
+            assert quarantined.status == "quarantined"
+
+            class _LatePollerGit:
+                def cat_blob(self, _vault_name: str, _blob_sha: str) -> bytes:
+                    return root_markdown.encode()
+
+                def last_commit_for_path(self, _vault_name: str, _path: str, _tip_sha: str) -> str:
+                    return root_ref
+
+            late_poller = ExternalGitService(git=_LatePollerGit())
+            # Real PostgreSQL regression: once the retirement transaction has
+            # quarantined the sidecar, an in-flight poller can no longer upsert
+            # or delete external rows before final reclassification.
+            assert (
+                await late_poller._reindex_file(
+                    vault_id=vault_id,
+                    vault_name=vault_name,
+                    path="overview.md",
+                    blob_sha=root_blob,
+                    remote_url="https://git.example.invalid/acme/knowledge.git",
+                    tip_sha=fixed_ref,
+                )
+            ) == "superseded"
+            assert (
+                await late_poller._delete_external_path(
+                    vault_id=vault_id,
+                    vault_name=vault_name,
+                    path="overview.md",
+                    expected_blob=root_blob,
+                )
+            ) == "superseded"
+            async with pool.acquire() as conn:
+                assert await conn.fetchval(
+                    "SELECT sync_state FROM vault_external_git WHERE vault_id = $1", vault_id
+                ) == "quarantined"
+                assert await conn.fetchval(
+                    "SELECT source FROM documents WHERE vault_id = $1 AND path = 'overview.md'", vault_id
+                ) == "external_git"
+
             receipt = await retirement.retire(
                 manifest=manifest,
+                expected_vault_id=vault_id,
                 idempotency_key=idempotency_key,
                 requested_by="collector-adoption-operator",
             )
@@ -840,7 +912,7 @@ async def test_external_git_retirement_reclassifies_a_collector_adoption_and_req
                 )
                 assert [(row["path"], row["source"], row["external_path"], row["external_blob"]) for row in retained] == [
                     ("overview.md", "manual", None, None),
-                    ("specs/contract.md", "manual", None, None),
+                    ("specs/contract.txt", "manual", None, None),
                 ]
                 assert json.loads(retained[0]["metadata"]) == {
                     "external_path": "overview.md",
@@ -874,6 +946,19 @@ async def test_external_git_retirement_reclassifies_a_collector_adoption_and_req
                         vault_id,
                     )
 
+            # A stale poller that resumes after the committed receipt also
+            # cannot turn the retained manual document back into a mirror row.
+            assert (
+                await late_poller._reindex_file(
+                    vault_id=vault_id,
+                    vault_name=vault_name,
+                    path="overview.md",
+                    blob_sha=root_blob,
+                    remote_url="https://git.example.invalid/acme/knowledge.git",
+                    tip_sha=fixed_ref,
+                )
+            ) == "superseded"
+
             # This is the same normal writer gate and document path a Collector
             # adoption uses after AKB has removed its read-only sidecar.
             access_service.reset_authorized_vault()
@@ -893,8 +978,8 @@ async def test_external_git_retirement_reclassifies_a_collector_adoption_and_req
             # has a native public-activity commit at its fixed ref.
             await DocumentService(git=git).update(
                 vault_name,
-                "specs/contract.md",
-                DocumentUpdateRequest(content="# Contract\n\nCollector-owned update.\n"),
+                "specs/contract.txt",
+                DocumentUpdateRequest(content="Collector-owned update."),
                 agent_id="collector-adoption",
             )
 
@@ -921,6 +1006,7 @@ async def test_external_git_retirement_reclassifies_a_collector_adoption_and_req
             assert (
                 await retirement.retire(
                     manifest=manifest,
+                    expected_vault_id=vault_id,
                     idempotency_key=idempotency_key,
                     requested_by="collector-adoption-operator",
                 )
@@ -928,6 +1014,7 @@ async def test_external_git_retirement_reclassifies_a_collector_adoption_and_req
             with pytest.raises(ExternalGitRetirementConflict, match="replay conflicts"):
                 await retirement.retire(
                     manifest=manifest,
+                    expected_vault_id=vault_id,
                     idempotency_key=idempotency_key,
                     requested_by="different-operator",
                 )

--- a/backend/tests/test_native_revision_cutover_pg.py
+++ b/backend/tests/test_native_revision_cutover_pg.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import importlib.util
+import json
 import os
 import re
 import threading
@@ -19,7 +20,17 @@ import pytest
 from git import Repo
 
 from app.db import postgres
+from app.exceptions import ForbiddenError
+from app.models.document import DocumentUpdateRequest
 from app.repositories.native_revision_migration_repo import MigrationIntegrityError
+from app.services import access_service
+from app.services.document_service import DocumentService
+from app.services.external_git_retirement import (
+    ExternalGitRetirement,
+    ExternalGitRetirementConflict,
+    ExternalGitRetirementError,
+    parse_adoption_manifest,
+)
 import app.services.native_revision_cutover as cutover_module
 from app.services.git_service import FixedRefHistoryError, GitService
 from app.services.native_revision_backfill import NativeRevisionBackfill
@@ -36,6 +47,7 @@ from app.services.native_revision_cutover import (
     NativeRevisionCutoverVerifier,
 )
 from app.services.native_revision_backend import NativeRevisionBackend
+from app.services.uri_service import doc_uri, split_uri
 
 
 pytestmark = pytest.mark.asyncio
@@ -87,7 +99,10 @@ async def _fresh_schema(*, cutover_migrations: bool = True):
         await conn.execute(_INIT_SQL)
         filenames = [
             "010_external_git_mirror.py",
+            "015_events_outbox.py",
+            "044_vault_write_policy.py",
             "048_native_revision_core.py",
+            "049_external_git_quarantine.py",
             "053_native_revision_m1_pg_body.py",
             "060_native_revision_migration_bridge.py",
             "061_native_revision_authority.py",
@@ -100,6 +115,7 @@ async def _fresh_schema(*, cutover_migrations: bool = True):
                     "090_native_revision_vault_purge_fence.py",
                     "091_native_revision_committed_receipt_guard.py",
                     "092_native_revision_plan_supersession.py",
+                    "093_external_git_retirement.py",
                 ]
             )
         for filename in filenames:
@@ -573,6 +589,350 @@ async def test_aborting_classification_plan_releases_pending_item_reservations(t
             await cutover.apply(classification.cutover_id)
         with pytest.raises(MigrationIntegrityError, match="superseded"):
             await backfill.backfill_run(classification_run_id)
+
+
+async def test_external_git_retirement_reclassifies_a_collector_adoption_and_requires_a_fresh_plan(tmp_path):
+    """The one-way retirement keeps the vault/data/Git while removing only its sidecar."""
+    async with _fresh_schema() as pool:
+        previous_pool = postgres._pool
+        postgres._pool = pool
+        try:
+            git = GitService(storage_path=str(tmp_path / "git-external-retirement"))
+            vault_name = f"collector-adoption-{uuid.uuid4().hex}"
+            root_body = "# Overview\n\nMirrored source.\n"
+            nested_body = "# Contract\n\nMirrored contract.\n"
+            root_markdown = (
+                "---\n"
+                "title: Overview\n"
+                "type: note\n"
+                "status: active\n"
+                "tags:\n- collector\n"
+                "domain: operations\n"
+                "summary: Adopted source\n"
+                "external_path: overview.md\n"
+                "topic: adoption\n"
+                "---\n"
+                f"{root_body}"
+            )
+            nested_markdown = (
+                "---\n"
+                "title: Contract\n"
+                "type: spec\n"
+                "status: active\n"
+                "tags: []\n"
+                "domain: ''\n"
+                "summary: ''\n"
+                "external_path: specs/contract.md\n"
+                "---\n"
+                f"{nested_body}"
+            )
+            git.init_vault(vault_name)
+            root_ref = git.commit_file(vault_name, "overview.md", root_markdown, "seed overview")
+            fixed_ref = git.commit_file(vault_name, "specs/contract.md", nested_markdown, "seed contract")
+            assert root_ref != fixed_ref
+            assert git.mark_as_mirror(vault_name) is True
+
+            owner_id = uuid.uuid4()
+            collaborator_id = uuid.uuid4()
+            async with pool.acquire() as conn:
+                await conn.execute(
+                    "INSERT INTO users (id, username, email, password_hash) VALUES ($1, $2, $3, 'x')",
+                    owner_id,
+                    "collector-owner",
+                    "collector-owner@example.test",
+                )
+                await conn.execute(
+                    "INSERT INTO users (id, username, email, password_hash) VALUES ($1, $2, $3, 'x')",
+                    collaborator_id,
+                    "collector-collaborator",
+                    "collector-collaborator@example.test",
+                )
+                vault_id = await conn.fetchval(
+                    """
+                    INSERT INTO vaults (name, git_path, owner_id, status)
+                    VALUES ($1, $2, $3, 'active')
+                    RETURNING id
+                    """,
+                    vault_name,
+                    str(git._bare_path(vault_name)),
+                    owner_id,
+                )
+                await conn.execute(
+                    """
+                    INSERT INTO collections (vault_id, path, name, doc_count)
+                    VALUES ($1, 'specs', 'specs', 1)
+                    """,
+                    vault_id,
+                )
+                await conn.execute(
+                    "INSERT INTO vault_access (vault_id, user_id, role, granted_by) VALUES ($1, $2, 'writer', $3)",
+                    vault_id,
+                    collaborator_id,
+                    owner_id,
+                )
+                await conn.execute(
+                    """
+                    INSERT INTO documents (
+                        id, vault_id, path, title, doc_type, status, summary, domain,
+                        created_by, current_commit, content_hash, hash_algorithm,
+                        content_hash_commit, tags, metadata, source, external_path, external_blob
+                    ) VALUES
+                        ($1, $3, 'overview.md', 'Overview', 'note', 'active', 'Adopted source', 'operations',
+                         'external_git:git.example.invalid', $4, $5, 'sha256', $4, ARRAY['collector'], $6::jsonb,
+                         'external_git', 'overview.md', $7),
+                        ($2, $3, 'specs/contract.md', 'Contract', 'spec', 'active', '', '',
+                         'external_git:git.example.invalid', $8, $9, 'sha256', $8, ARRAY[]::text[], $10::jsonb,
+                         'external_git', 'specs/contract.md', $11)
+                    """,
+                    uuid.uuid4(),
+                    uuid.uuid4(),
+                    vault_id,
+                    root_ref,
+                    hashlib.sha256(root_body.encode()).hexdigest(),
+                    json.dumps({"external_path": "overview.md", "topic": "adoption"}),
+                    "b" * 40,
+                    fixed_ref,
+                    hashlib.sha256(nested_body.encode()).hexdigest(),
+                    json.dumps({"external_path": "specs/contract.md"}),
+                    "c" * 40,
+                )
+                await conn.execute(
+                    """
+                    INSERT INTO vault_external_git (
+                        vault_id, remote_url, remote_branch, auth_token, poll_interval_secs,
+                        last_synced_sha, sync_state, poll_next_at
+                    ) VALUES ($1, 'https://git.example.invalid/acme/knowledge.git', 'main',
+                              'test-token-must-never-escape', 300, $2, 'active', NOW())
+                    """,
+                    vault_id,
+                    fixed_ref,
+                )
+            await _confirmed_file(
+                pool,
+                namespace_id=vault_id,
+                label="retained.txt",
+                data=b"retained file\n",
+                mime_type="text/plain",
+            )
+
+            manual = await _manual_vault(pool, git, label="retirement-existing-plan")
+            cutover = NativeRevisionCutover(
+                pool,
+                backfill=NativeRevisionBackfill(pool, git=git),
+                verifier=_FixtureVerifier(pool),
+                file_reader=lambda _s3_key: b"retained file\n",
+            )
+            existing_plan = await cutover.plan(
+                vaults=[manual, CutoverVaultInput(namespace_id=vault_id, fixed_ref=fixed_ref)],
+                coverage_version="fixture-external-retirement-preexisting-v1",
+            )
+            assert [item.namespace_id for item in existing_plan.vaults] == [manual.namespace_id]
+            assert [item.namespace_id for item in existing_plan.exclusions] == [vault_id]
+
+            with pytest.raises(ForbiddenError, match="read-only external git mirror"):
+                await access_service.check_vault_access(str(owner_id), vault_name, required_role="writer")
+
+            manifest = parse_adoption_manifest(
+                {
+                    "schema_version": 1,
+                    "vault_id": str(vault_id),
+                    "vault_name": vault_name,
+                    "remote_url": "https://git.example.invalid/acme/knowledge.git",
+                    "remote_branch": "main",
+                    "last_synced_sha": fixed_ref,
+                    "documents": [
+                        {
+                            "uri": doc_uri(vault_name, "specs/contract.md"),
+                            "path": "specs/contract.md",
+                            "content_hash": hashlib.sha256(nested_body.encode()).hexdigest(),
+                            "managed_metadata": {
+                                "title": "Contract",
+                                "type": "spec",
+                                "status": "active",
+                                "tags": [],
+                                "domain": "",
+                                "summary": "",
+                                "metadata": {"external_path": "specs/contract.md"},
+                            },
+                        },
+                        {
+                            "uri": doc_uri(vault_name, "overview.md"),
+                            "path": "overview.md",
+                            "content_hash": hashlib.sha256(root_body.encode()).hexdigest(),
+                            "managed_metadata": {
+                                "title": "Overview",
+                                "type": "note",
+                                "status": "active",
+                                "tags": ["collector"],
+                                "domain": "operations",
+                                "summary": "Adopted source",
+                                "metadata": {"external_path": "overview.md", "topic": "adoption"},
+                            },
+                        },
+                    ],
+                }
+            )
+            retirement = ExternalGitRetirement(pool, git=git)
+            # The retirement receipt is not even quarantined when an otherwise
+            # well-formed manifest has stale, missing, or extra live facts.
+            # Duplicate entries are rejected by the strict parser unit contract.
+            stale_manifest = manifest.fact()
+            stale_manifest["documents"][0]["content_hash"] = "d" * 64
+            missing_manifest = manifest.fact()
+            missing_manifest["documents"] = missing_manifest["documents"][:-1]
+            extra_manifest = manifest.fact()
+            extra_manifest["documents"].append(
+                {
+                    "uri": doc_uri(vault_name, "untracked.md"),
+                    "path": "untracked.md",
+                    "content_hash": "e" * 64,
+                    "managed_metadata": {
+                        "title": "Untracked",
+                        "type": "note",
+                        "status": "active",
+                        "tags": [],
+                        "domain": "",
+                        "summary": "",
+                        "metadata": {"external_path": "untracked.md"},
+                    },
+                }
+            )
+            for invalid_manifest, invalid_key in (
+                (stale_manifest, uuid.UUID("00000000-0000-0000-0000-000000000090")),
+                (missing_manifest, uuid.UUID("00000000-0000-0000-0000-000000000091")),
+                (extra_manifest, uuid.UUID("00000000-0000-0000-0000-000000000092")),
+            ):
+                with pytest.raises(ExternalGitRetirementError, match="does not match live documents"):
+                    await retirement.retire(
+                        manifest=parse_adoption_manifest(invalid_manifest),
+                        idempotency_key=invalid_key,
+                        requested_by="collector-adoption-operator",
+                    )
+            async with pool.acquire() as conn:
+                assert await conn.fetchval(
+                    "SELECT sync_state FROM vault_external_git WHERE vault_id = $1", vault_id
+                ) == "active"
+                assert await conn.fetchval("SELECT count(*) FROM external_git_retirements") == 0
+            idempotency_key = uuid.UUID("00000000-0000-0000-0000-000000000093")
+            receipt = await retirement.retire(
+                manifest=manifest,
+                idempotency_key=idempotency_key,
+                requested_by="collector-adoption-operator",
+            )
+            assert receipt.status == "retired"
+            assert receipt.manifest_digest == manifest.digest
+            assert receipt.document_count == 2
+            assert git.current_commit(vault_name) == fixed_ref
+            assert not (git._bare_path(vault_name) / "akb-external-mirror").exists()
+            assert not (git._bare_path(vault_name) / "akb-external-mirror-retiring").exists()
+
+            async with pool.acquire() as conn:
+                assert await conn.fetchval("SELECT count(*) FROM vault_external_git WHERE vault_id = $1", vault_id) == 0
+                retained = await conn.fetch(
+                    """
+                    SELECT path, source, external_path, external_blob, title, doc_type,
+                           status, tags, domain, summary, metadata
+                      FROM documents
+                     WHERE vault_id = $1
+                     ORDER BY path
+                    """,
+                    vault_id,
+                )
+                assert [(row["path"], row["source"], row["external_path"], row["external_blob"]) for row in retained] == [
+                    ("overview.md", "manual", None, None),
+                    ("specs/contract.md", "manual", None, None),
+                ]
+                assert json.loads(retained[0]["metadata"]) == {
+                    "external_path": "overview.md",
+                    "topic": "adoption",
+                }
+                assert await conn.fetchval("SELECT count(*) FROM collections WHERE vault_id = $1", vault_id) == 1
+                assert await conn.fetchval("SELECT count(*) FROM vault_files WHERE vault_id = $1", vault_id) == 1
+                assert await conn.fetchval("SELECT count(*) FROM vault_access WHERE vault_id = $1", vault_id) == 1
+                receipt_row = await conn.fetchrow(
+                    """
+                    SELECT manifest_digest, document_count, remote_url, remote_branch,
+                           last_synced_sha, idempotency_key, requested_by, status
+                      FROM external_git_retirements
+                     WHERE vault_id = $1
+                    """,
+                    vault_id,
+                )
+                assert dict(receipt_row) == {
+                    "manifest_digest": manifest.digest,
+                    "document_count": 2,
+                    "remote_url": manifest.remote_url,
+                    "remote_branch": manifest.remote_branch,
+                    "last_synced_sha": fixed_ref,
+                    "idempotency_key": idempotency_key,
+                    "requested_by": "collector-adoption-operator",
+                    "status": "retired",
+                }
+                with pytest.raises(asyncpg.ObjectNotInPrerequisiteStateError, match="retirement receipt"):
+                    await conn.execute(
+                        "UPDATE external_git_retirements SET remote_url = 'https://example.invalid/changed.git' WHERE vault_id = $1",
+                        vault_id,
+                    )
+
+            # This is the same normal writer gate and document path a Collector
+            # adoption uses after AKB has removed its read-only sidecar.
+            access_service.reset_authorized_vault()
+            grant = await access_service.check_vault_access(str(owner_id), vault_name, required_role="writer")
+            assert grant["vault_id"] == vault_id
+            adopted_uri = doc_uri(vault_name, "overview.md")
+            adopted_vault, adopted_path = split_uri(adopted_uri, expected_type="doc")
+            updated = await DocumentService(git=git).update(
+                adopted_vault,
+                adopted_path,
+                DocumentUpdateRequest(content="# Overview\n\nCollector-owned update.\n"),
+                agent_id="collector-adoption",
+            )
+            assert updated.uri == adopted_uri
+            # A subsequent Collector adoption pass touches each retained
+            # document through the ordinary writer so the fresh Native plan
+            # has a native public-activity commit at its fixed ref.
+            await DocumentService(git=git).update(
+                vault_name,
+                "specs/contract.md",
+                DocumentUpdateRequest(content="# Contract\n\nCollector-owned update.\n"),
+                agent_id="collector-adoption",
+            )
+
+            # The previous plan remains a durable exclusion receipt; it cannot
+            # retroactively acquire the retired vault. A fresh plan after an
+            # explicit abort is the only path that includes it.
+            preserved = await cutover.repository.list_exclusions(existing_plan.cutover_id)
+            assert [item.namespace_id for item in preserved] == [vault_id]
+            assert (await cutover.abort(existing_plan.cutover_id)).status == "aborted"
+            retired_ref = git.current_commit(vault_name)
+            assert retired_ref is not None
+            fresh = await cutover.plan(
+                vaults=[
+                    manual,
+                    CutoverVaultInput(namespace_id=vault_id, fixed_ref=retired_ref),
+                ],
+                coverage_version="fixture-external-retirement-fresh-v2",
+            )
+            assert {item.namespace_id for item in fresh.vaults} == {manual.namespace_id, vault_id}
+            assert fresh.exclusions == ()
+
+            # An exact replay does not reintroduce the sidecar and remains
+            # successful after the ordinary Collector update advanced Git.
+            assert (
+                await retirement.retire(
+                    manifest=manifest,
+                    idempotency_key=idempotency_key,
+                    requested_by="collector-adoption-operator",
+                )
+            ) == receipt
+            with pytest.raises(ExternalGitRetirementConflict, match="replay conflicts"):
+                await retirement.retire(
+                    manifest=manifest,
+                    idempotency_key=idempotency_key,
+                    requested_by="different-operator",
+                )
+        finally:
+            postgres._pool = previous_pool
 
 
 async def test_plan_supersession_migration_releases_legacy_aborted_reservations(tmp_path):

--- a/backend/tests/test_native_revision_migration_bridge_pg.py
+++ b/backend/tests/test_native_revision_migration_bridge_pg.py
@@ -14,7 +14,6 @@ import asyncpg
 import pytest
 from git import Repo
 
-from app.exceptions import NotFoundError
 from app.repositories.native_revision_migration_repo import (
     MigrationInventoryDriftError,
     NativeRevisionMigrationRepository,
@@ -286,7 +285,7 @@ async def _make_compact_failpoint_fixtures(pool, tmp_path: Path) -> tuple[
     return git, fixtures
 
 
-async def test_inventory_is_fixed_ref_bounded_and_manual_only(tmp_path):
+async def test_inventory_is_fixed_ref_bounded_and_includes_archived_manual_vaults(tmp_path):
     async with _fresh_schema(tmp_path) as pool:
         fixture = await _make_fixture(pool, tmp_path)
         bridge = LegacyRevisionBridge(
@@ -371,12 +370,15 @@ async def test_inventory_is_fixed_ref_bounded_and_manual_only(tmp_path):
                 "UPDATE vaults SET status = 'archived' WHERE id = $1",
                 fixture["namespace_id"],
             )
-        with pytest.raises(NotFoundError):
-            await bridge.capture_inventory(
-                namespace_id=fixture["namespace_id"],
-                fixed_ref=fixture["unrelated_tip"],
-                coverage_version="c9-v5",
-            )
+        archived_inventory = await bridge.capture_inventory(
+            namespace_id=fixture["namespace_id"],
+            fixed_ref=fixture["unrelated_tip"],
+            coverage_version="c9-v5",
+        )
+        assert {item.resource_id for item in archived_inventory.documents} == {
+            fixture["document_one"],
+            fixture["document_two"],
+        }
 
         async with pool.acquire() as conn:
             await conn.execute(

--- a/docs/operations/native-revision-existing-database-cutover.md
+++ b/docs/operations/native-revision-existing-database-cutover.md
@@ -12,11 +12,19 @@ It does not perform an online dual write or a reverse migration.
    can be restored into a disposable environment.
 3. For each persisted external-Git source, have Git Collector write a **read-only
    v1 adoption manifest while the source is still an AKB `external_git` mirror**.
-   The manifest is credential-free and body-free: it binds the exact Vault,
-   canonical remote/branch, last-synced fixed SHA, and every active mirrored
-   Document's public URI, path, content hash, and normalized managed metadata.
+   AKB accepts only Collector's exact
+   `akb-collector.git-adoption-manifest` v1 shape: the fixed purpose,
+   `binding.{name,source_scope,target_vault,target_collection}`, and
+   `source.{remote_url,branch,snapshot_commit,path_prefix}`. `path_prefix` is
+   required: it is `null` for an unfiltered source or the Collector's canonical
+   filtered prefix. Each document proves `origin_key`, path, resource URI,
+   source version/blob SHA, AKB content SHA-256/current version, and the
+   `managed_metadata` fields. The manifest is credential-free and body-free.
    Store it as an operator artifact; do not put a token or document body in it.
-   AKB verifies the whole live inventory before it accepts the handoff.
+   AKB resolves `target_vault` to the exact `--vault-id`, preserves the binding
+   fields as Collector proof context, and verifies **every** live active
+   external-Git Document—not only documents under `path_prefix`—before it
+   accepts the handoff.
 4. Record the future Native deployment identity fields in `app.yaml`:
    `document_revision_tenant_id`, `document_revision_namespace`,
    `document_revision_database_id`, and the immutable image digest.
@@ -36,7 +44,10 @@ python -m app.cli migrate-revision-backend retire-external-git \
   --confirm-planned-downtime RETIRE-EXTERNAL-GIT:VAULT_UUID
 ```
 
-This command quarantines the old poller before changing the marker, retains the
+This command quarantines the old poller before changing the marker, and its
+in-transaction sidecar fence prevents an already-running poller from mutating
+Documents after quarantine. The retirement tombstone also blocks ordinary Git
+writes until the durable receipt and marker cleanup complete. It retains the
 Vault, Documents, collections, Files, Git repository, and ACLs, then removes
 only the external-Git sidecar. Its receipt contains only the manifest digest,
 count, remote/branch/fixed ref, idempotency key, and audit identity. An exact

--- a/docs/operations/native-revision-existing-database-cutover.md
+++ b/docs/operations/native-revision-existing-database-cutover.md
@@ -10,16 +10,45 @@ It does not perform an online dual write or a reverse migration.
    the cutover command are installed without changing authority.
 2. Take a coherent PostgreSQL and Git-storage recovery point and verify that it
    can be restored into a disposable environment.
-3. Move persisted external-Git sources to Git Collector. The cutover refuses to
-   commit while an `external_git` sidecar remains.
+3. For each persisted external-Git source, have Git Collector write a **read-only
+   v1 adoption manifest while the source is still an AKB `external_git` mirror**.
+   The manifest is credential-free and body-free: it binds the exact Vault,
+   canonical remote/branch, last-synced fixed SHA, and every active mirrored
+   Document's public URI, path, content hash, and normalized managed metadata.
+   Store it as an operator artifact; do not put a token or document body in it.
+   AKB verifies the whole live inventory before it accepts the handoff.
 4. Record the future Native deployment identity fields in `app.yaml`:
    `document_revision_tenant_id`, `document_revision_namespace`,
    `document_revision_database_id`, and the immutable image digest.
 
 ## Downtime sequence
 
-Stop the API and every AKB/collector worker that can write the database, Git
-storage, or File catalogue. Then run, from the same image and configuration:
+Stop the API and every AKB external-Git/collector worker that can write the
+database, Git storage, or File catalogue. For each manifest created above, run
+the one-way sidecar retirement from the same image and configuration:
+
+```console
+python -m app.cli migrate-revision-backend retire-external-git \
+  --vault-id VAULT_UUID \
+  --manifest-file /secure/operator/collector-adoption.json \
+  --idempotency-key RETIREMENT_UUID \
+  --requested-by OPERATOR_ID \
+  --confirm-planned-downtime RETIRE-EXTERNAL-GIT:VAULT_UUID
+```
+
+This command quarantines the old poller before changing the marker, retains the
+Vault, Documents, collections, Files, Git repository, and ACLs, then removes
+only the external-Git sidecar. Its receipt contains only the manifest digest,
+count, remote/branch/fixed ref, idempotency key, and audit identity. An exact
+replay is safe; changing any of those facts is a conflict. A refusal leaves the
+mirror fail-closed for investigation.
+
+After retirement, let Git Collector perform its ordinary authorized full
+adoption/sync against the retained manual Vault, refreshing every retained
+Document, then stop writers again. Do not reuse a pre-retirement cutover plan:
+it keeps the former mirror as an immutable exclusion. Abort that uncommitted
+plan and make a fresh plan only after the Collector adoption/sync has
+completed. Then run:
 
 ```console
 python -m app.cli migrate-revision-backend plan \


### PR DESCRIPTION
## Summary

- add the operator-only offline external-Git retirement command and immutable retirement ledger
- consume the Collector adoption manifest, reclassify mirrored documents as manual, remove the sidecar, and make the retained repository writable without changing its frozen ref
- transfer completed cutover reservations to a fresh plan without rewriting immutable prior ownership
- fence stale fetch, re-clone, document mutation, and first-sync publication races across retirement

## Validation

- GitService: 67 passed
- external-Git focused suites: 401 passed, 6 skipped
- real PostgreSQL cutover + migration bridge: 36 passed
- full scripts/check.sh: passed
- Sol(xHigh) exact-head review: 0 High / 0 Medium / 0 Low