### PR TITLE
fix(check): the preflight counted two node projects while the gate ran in three

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,13 +127,16 @@ uv tool install --python 3.14 --force 'ruff==0.15.16'
 uv tool install --python 3.14 --force 'detect-secrets==1.5.0'
 ```
 
-**2. Node deps in both pnpm projects.** `frontend/` and `packages/akb-client/`
-are separate projects with separate lockfiles and separate `node_modules`,
-and the gate runs steps in each. Installing only one is the common mistake:
+**2. Node deps in all three node projects.** `frontend/`,
+`packages/akb-client/` and `packages/akb-mcp-client/` are separate projects
+with separate lockfiles and separate `node_modules`, and the gate runs steps in
+each. They are not all the same package manager. Installing only some of them
+is the common mistake:
 
 ```bash
 (cd frontend && pnpm install --frozen-lockfile)
 (cd packages/akb-client && pnpm install --frozen-lockfile)
+(cd packages/akb-mcp-client && npm ci)
 ```
 
 Then:

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -100,38 +100,73 @@ fi
 
 echo "  mypy + bandit parse Python ${REQUIRED_PYTHON}"
 
-# 2. Node deps must be installed in BOTH pnpm projects.
+# 2. Node deps must be installed in every node project this gate runs in.
 #
-# frontend/ and packages/akb-client/ are separate pnpm projects with separate
-# lockfiles and separate node_modules, and this gate runs steps in each.
-# Installing only one died six steps later, inside the other, as:
+# There are three, they do not share a package manager, and each has its own
+# lockfile and its own node_modules: frontend/ and packages/akb-client/ are
+# pnpm, packages/akb-mcp-client/ is npm. Installing only some of them dies
+# several steps later, inside one of the others, as something that names
+# neither the package nor the missing install:
 #
 #     undefined
 #      ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "vitest" not found
+#     Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@modelcontextprotocol/client'
 #
-# — which names neither the package nor the missing install, and has already
-# been misread once. Worse, the two steps before it can PASS out of a global
-# tsc on PATH, so the run appears to get further than it did and to have
-# typechecked against a compiler nobody pinned. CI installs both explicitly
+# — which has already been misread once. Worse, the steps before it can PASS
+# out of a global tsc on PATH, so the run appears to get further than it did
+# and to have typechecked against a compiler nobody pinned.
+#
+# The list is DERIVED from the committed lockfiles, not restated. It used to be
+# restated — two entries and a hardcoded "2" — and it went stale the moment a
+# third project arrived: the preflight announced "2 of the 2 pnpm projects this
+# gate runs in" while the gate ran in three, so the one it did not know about
+# failed as ERR_MODULE_NOT_FOUND minutes later, which is precisely the failure
+# this preflight exists to prevent. A hand-maintained list reports the wrong
+# number confidently, and a preflight that is confidently wrong is worse than
+# none.
+#
+# A committed lockfile is this repository's own statement that the directory is
+# an installed node project. If one is ever added that this gate does not step
+# into, this will ask for an install it does not strictly need — a cheap wrong,
+# and the opposite of the one it replaces. CI installs each explicitly
 # (.github/workflows/check.yml); nothing else said so, so a fresh clone could
 # not run this script. Say it here and in CONTRIBUTING.md.
+node_install_command() {   # $1 = project directory
+  if [ -f "$1/pnpm-lock.yaml" ]; then
+    printf '(cd %s && pnpm install --frozen-lockfile)' "$1"
+  else
+    printf '(cd %s && npm ci)' "$1"
+  fi
+}
+
+node_projects=()
+while IFS= read -r lockfile; do
+  node_projects+=("$(dirname "${lockfile}")")
+done < <(git ls-files | grep -E '(^|/)(pnpm-lock\.yaml|package-lock\.json)$' | sort)
+
+if [ "${#node_projects[@]}" -eq 0 ]; then
+  echo "  ✗ found no committed node lockfiles — this preflight is measuring the wrong tree" >&2
+  exit 1
+fi
+
 missing_installs=()
-for pnpm_project in frontend packages/akb-client; do
-  [ -d "${pnpm_project}/node_modules" ] || missing_installs+=("${pnpm_project}")
+for node_project in "${node_projects[@]}"; do
+  [ -d "${node_project}/node_modules" ] || missing_installs+=("${node_project}")
 done
 if [ "${#missing_installs[@]}" -ne 0 ]; then
   echo >&2
-  echo "  ✗ node_modules missing in ${#missing_installs[@]} of the 2 pnpm projects this gate runs in:" >&2
-  for pnpm_project in "${missing_installs[@]}"; do
-    echo "      ${pnpm_project}" >&2
+  echo "  ✗ node_modules missing in ${#missing_installs[@]} of the ${#node_projects[@]} node projects this gate runs in:" >&2
+  for node_project in "${missing_installs[@]}"; do
+    echo "      ${node_project}" >&2
   done
   echo >&2
-  echo "    Both are required — they are separate projects with separate lockfiles:" >&2
-  for pnpm_project in "${missing_installs[@]}"; do
-    echo "      (cd ${pnpm_project} && pnpm install --frozen-lockfile)" >&2
+  echo "    All of them are required — separate projects, separate lockfiles," >&2
+  echo "    and not all the same package manager:" >&2
+  for node_project in "${missing_installs[@]}"; do
+    echo "      $(node_install_command "${node_project}")" >&2
   done
   echo >&2
-  echo "    Refusing to run: without them eslint/tsc/vitest either fail without" >&2
+  echo "    Refusing to run: without them eslint/tsc/vitest/node either fail without" >&2
   echo "    naming their package or silently resolve to a global toolchain." >&2
   exit 1
 fi


### PR DESCRIPTION
`scripts/check.sh` refuses to run without node deps and names the projects it
needs — "2 of the 2 pnpm projects this gate runs in". It runs in **three**.

The third, `packages/akb-mcp-client`, is npm rather than pnpm, arrived after the
preflight was written, and was never added to it. So the preflight passed on a
checkout that could not complete the gate, and the run died about six minutes
later inside a step the preflight had said nothing about:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@modelcontextprotocol/client'
  imported from packages/akb-mcp-client/test/protocol.test.mjs
```

That is exactly the failure this preflight exists to prevent, and it is worse
than having no preflight: "2 of the 2" reads as a complete statement of what the
gate needs, so there is nothing to prompt a second look.

## What changed

The list is **derived** from the committed lockfiles instead of restated, and
each project's installer is derived from which lockfile it has — `pnpm install
--frozen-lockfile` for a `pnpm-lock.yaml`, `npm ci` for a `package-lock.json`.

A hand-maintained list reports the wrong number confidently. A derived one
cannot go stale the next time a project is added, which is the only way this
defect could occur.

A committed lockfile is this repository's own statement that the directory is an
installed node project. If one is ever added that the gate does not step into,
this will ask for an install it does not strictly need — the cheap wrong, and
the opposite of the one it replaces. That trade is stated in the comment rather
than left for the next reader to discover.

`CONTRIBUTING.md` carried the same two-project omission, in the very section the
old comment pointed at ("Say it here and in CONTRIBUTING.md"), so both are
fixed.

## Verification, on a fresh worktree

| state | preflight says |
| --- | --- |
| no `node_modules` anywhere | `3 of the 3`, with the right command for each |
| **only `akb-mcp-client` removed** | `1 of the 3`, `(cd packages/akb-mcp-client && npm ci)` |
| all three installed | `scripts/check.sh`: all checks passed |

The middle row is the mutation that matters: before this change that exact state
was green at the preflight and red six minutes later.
