### PR TITLE
feat(sso): declare what the admin SSO routes actually return

### DIFF
--- a/backend/app/api/routes/admin_sso.py
+++ b/backend/app/api/routes/admin_sso.py
@@ -17,6 +17,11 @@ from app.api.routes.admin_auth import (
 )
 from app.config import settings
 from app.exceptions import ForbiddenError
+from app.models.admin_sso import (
+    SsoIdentityMigrationResponse,
+    SsoProviderCatalogResponse,
+    SsoProviderMutationResponse,
+)
 from app.services import audit_log
 from app.sso.keycloak_admin import (
     ProviderControlError,
@@ -298,7 +303,11 @@ def _raise_identity_migration_error(error: IdentityMigrationError) -> None:
     ) from error
 
 
-@router.get("/admin/sso/providers", summary="List managed SSO providers")
+@router.get(
+    "/admin/sso/providers",
+    summary="List managed SSO providers",
+    response_model=SsoProviderCatalogResponse,
+)
 async def list_sso_providers(
     _actor: ProductAdminActor = Depends(get_sso_provider_control_actor),
 ):
@@ -321,6 +330,7 @@ async def list_sso_providers(
 @router.put(
     "/admin/sso/providers/{alias}",
     summary="Configure a disabled SSO provider",
+    response_model=SsoProviderMutationResponse,
 )
 async def configure_sso_provider(
     alias: str,
@@ -408,6 +418,7 @@ async def _toggle_sso_provider(
 
 @router.post(
     "/admin/sso/providers/{alias}/enable",
+    response_model=SsoProviderMutationResponse,
     summary="Enable a configured SSO provider",
 )
 async def enable_sso_provider(
@@ -419,6 +430,7 @@ async def enable_sso_provider(
 
 @router.post(
     "/admin/sso/providers/{alias}/disable",
+    response_model=SsoProviderMutationResponse,
     summary="Disable an SSO provider",
 )
 async def disable_sso_provider(
@@ -487,6 +499,7 @@ async def _verify_and_inspect_identity_migration(
 
 @router.post(
     "/admin/sso/providers/{alias}/identity-migrations/preflight",
+    response_model=SsoIdentityMigrationResponse,
     summary="Verify an exact broker identity migration without writing",
 )
 async def preflight_sso_identity_migration(
@@ -611,6 +624,7 @@ async def _mutate_sso_identity_migration(
 
 @router.post(
     "/admin/sso/providers/{alias}/identity-migrations/apply",
+    response_model=SsoIdentityMigrationResponse,
     summary="Bind an operator-prelinked broker identity to an AKB user",
 )
 async def apply_sso_identity_migration(
@@ -628,6 +642,7 @@ async def apply_sso_identity_migration(
 
 @router.post(
     "/admin/sso/providers/{alias}/identity-migrations/rollback",
+    response_model=SsoIdentityMigrationResponse,
     summary="Remove an AKB broker identity binding before operator cleanup",
 )
 async def rollback_sso_identity_migration(

--- a/backend/app/models/admin_sso.py
+++ b/backend/app/models/admin_sso.py
@@ -1,0 +1,102 @@
+"""Declared response shapes for the managed SSO admin surface.
+
+These routes have always been in this API's OpenAPI document — nothing here is
+newly exposed — but they returned plain dicts, so the document advertised seven
+operations and described none of their payloads. A second consumer in another
+repository then transcribed the envelope by hand, including a list of the
+provider types this installation supports, and four days later this side grew a
+second one. The shape had been written down twice with nothing linking the
+copies (dnotitia/akb#455).
+
+So it is declared here, once, and the framework publishes it.
+
+Every model forbids extra fields. `response_model` FILTERS: a key the model does
+not know is dropped from the response silently, in browsers and in a control
+plane at once, which is exactly why these payloads were left alone until now.
+Forbidding extras converts that silence into a test failure, and
+`test_admin_sso_response_models_unit.py` asserts each model's field set against
+the projection the handlers actually build.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from app.sso.identity_migration import IdentityMigrationState
+from app.sso.models import ProviderState
+
+
+class _AdminSsoModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class SsoProviderCapabilities(_AdminSsoModel):
+    """What a provider of this kind can do, stated rather than inferred.
+
+    A consumer that reads these needs no opinion about what `provider_type`
+    means; one that switches on the type string is approximating them.
+    """
+
+    supports_logout: bool
+    supports_identity_migration: bool
+
+
+class SsoProviderView(_AdminSsoModel):
+    """One provider as an administrator sees it. Never carries a secret."""
+
+    provider_type: str
+    alias: str
+    display_name: str
+    state: ProviderState
+    enabled: bool
+    # Absent until configured: a configuration_error readback carries the alias
+    # and the redirect pair and little else.
+    issuer: str | None = None
+    discovery_url: str | None = None
+    client_id: str | None = None
+    client_secret_configured: bool
+    redirect_uri: str
+    post_logout_redirect_uri: str
+    capabilities: SsoProviderCapabilities
+
+
+class SsoProviderCatalogResponse(_AdminSsoModel):
+    """The catalog. `supported_provider_types` is what THIS installation
+    supports; it is not a statement about what a reader must accept."""
+
+    schema_version: int
+    auth_mode: str
+    control_mode: str
+    supported_provider_types: list[str]
+    providers: list[SsoProviderView]
+
+
+class SsoProviderMutationResponse(_AdminSsoModel):
+    """The readback of exactly one configure, enable or disable."""
+
+    provider: SsoProviderView
+
+
+class SsoIdentityPrelinkView(_AdminSsoModel):
+    """Link evidence with the opaque subjects withheld on purpose: the state
+    proves the exact values in the authenticated request were read back from
+    both authorities, and echoing them would publish them."""
+
+    provider_alias: str
+    provider_state: ProviderState
+    upstream_issuer: str
+    broker_issuer: str
+    broker_username: str
+
+
+class SsoIdentityMigrationView(_AdminSsoModel):
+    user_id: str
+    state: IdentityMigrationState
+    old_issuer: str
+    new_issuer: str
+
+
+class SsoIdentityMigrationResponse(_AdminSsoModel):
+    schema_version: int
+    prelink: SsoIdentityPrelinkView
+    migration: SsoIdentityMigrationView

--- a/backend/tests/test_admin_sso_response_models_unit.py
+++ b/backend/tests/test_admin_sso_response_models_unit.py
@@ -1,0 +1,186 @@
+"""The declared shapes must equal the projections the handlers build.
+
+`response_model` FILTERS. A field the model does not declare is dropped from
+the response silently — in a browser and in the control plane at once — which
+is why these payloads were left untyped until a second consumer appeared
+(#455). Reading the models for plausibility is not enough: this compares each
+one against the dict the code actually produces, key for key, so a model that
+drifts from its projection fails here rather than in somebody's console.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from app.models.admin_sso import (
+    SsoIdentityMigrationResponse,
+    SsoIdentityMigrationView,
+    SsoIdentityPrelinkView,
+    SsoProviderCapabilities,
+    SsoProviderCatalogResponse,
+    SsoProviderMutationResponse,
+    SsoProviderView,
+)
+from app.sso.identity_migration import IdentityMigrationReadback
+from app.sso.models import IdentityPrelinkReadback, ProviderReadback
+
+
+def _provider_readback() -> ProviderReadback:
+    return ProviderReadback(
+        provider_type="keycloak-oidc",
+        alias="platform",
+        display_name="Platform",
+        state="enabled",
+        enabled=True,
+        issuer="https://id.example.com/realms/workforce",
+        discovery_url="https://id.example.com/realms/workforce/.well-known/openid-configuration",
+        client_id="akb-workspace-broker",
+        client_secret_configured=True,
+        redirect_uri="https://auth.example.com/realms/akb/broker/platform/endpoint",
+        post_logout_redirect_uri="https://auth.example.com/realms/akb/broker/platform/endpoint/logout_response",
+        supports_logout=True,
+        supports_identity_migration=True,
+    )
+
+
+def test_the_provider_view_declares_exactly_what_admin_view_projects():
+    projected = _provider_readback().admin_view()
+    assert set(SsoProviderView.model_fields) == set(projected)
+    assert set(SsoProviderCapabilities.model_fields) == set(projected["capabilities"])
+
+
+def test_the_migration_view_declares_exactly_what_admin_view_projects():
+    projected = IdentityMigrationReadback(
+        user_id=uuid.uuid4(),
+        state="linked",
+        old_issuer="https://old.example.com/realms/akb",
+        new_issuer="https://new.example.com/realms/akb",
+    ).admin_view()
+    assert set(SsoIdentityMigrationView.model_fields) == set(projected)
+
+
+def test_the_prelink_view_withholds_the_subjects_and_declares_the_rest():
+    prelink = IdentityPrelinkReadback(
+        provider_alias="platform",
+        provider_state="configured_disabled",
+        upstream_issuer="https://id.example.com/realms/workforce",
+        broker_issuer="https://auth.example.com/realms/akb",
+        broker_subject="broker-subject",
+        upstream_subject="upstream-subject",
+        broker_username="someone",
+    )
+    declared = set(SsoIdentityPrelinkView.model_fields)
+    # Withheld on purpose: echoing an opaque subject publishes it.
+    assert "broker_subject" not in declared
+    assert "upstream_subject" not in declared
+    assert declared == {
+        "provider_alias",
+        "provider_state",
+        "upstream_issuer",
+        "broker_issuer",
+        "broker_username",
+    }
+    for name in declared:
+        assert hasattr(prelink, name), f"{name} is declared but the readback has no such value"
+
+
+def test_a_full_catalog_survives_the_model_unchanged():
+    """The end-to-end property that matters: serialising through the declared
+    model returns the same document the handler built, not a subset of it."""
+    provider = _provider_readback().admin_view()
+    envelope = {
+        "schema_version": 1,
+        "auth_mode": "sso",
+        "control_mode": "direct",
+        "supported_provider_types": ["keycloak-oidc", "oidc"],
+        "providers": [provider],
+    }
+    assert SsoProviderCatalogResponse.model_validate(envelope).model_dump() == envelope
+
+
+def test_a_mutation_readback_survives_the_model_unchanged():
+    envelope = {"provider": _provider_readback().admin_view()}
+    assert SsoProviderMutationResponse.model_validate(envelope).model_dump() == envelope
+
+
+def test_a_migration_response_survives_the_model_unchanged():
+    envelope = {
+        "schema_version": 1,
+        "prelink": {
+            "provider_alias": "platform",
+            "provider_state": "configured_disabled",
+            "upstream_issuer": "https://id.example.com/realms/workforce",
+            "broker_issuer": "https://auth.example.com/realms/akb",
+            "broker_username": "someone",
+        },
+        "migration": {
+            "user_id": str(uuid.uuid4()),
+            "state": "ready_to_link",
+            "old_issuer": "https://old.example.com/realms/akb",
+            "new_issuer": "https://new.example.com/realms/akb",
+        },
+    }
+    assert SsoIdentityMigrationResponse.model_validate(envelope).model_dump() == envelope
+
+
+def test_an_unconfigured_provider_keeps_its_absent_fields_absent():
+    """A configuration_error readback carries no issuer. The model must accept
+    that without inventing a value, and must not drop the keys either."""
+    projected = ProviderReadback(
+        provider_type="keycloak-oidc",
+        alias="broken",
+        display_name="Broken",
+        state="configuration_error",
+        enabled=False,
+        issuer=None,
+        discovery_url=None,
+        client_id=None,
+        client_secret_configured=False,
+        redirect_uri="https://auth.example.com/realms/akb/broker/broken/endpoint",
+        post_logout_redirect_uri="https://auth.example.com/realms/akb/broker/broken/endpoint/logout_response",
+        supports_logout=True,
+        supports_identity_migration=True,
+    ).admin_view()
+    assert SsoProviderView.model_validate(projected).model_dump() == projected
+
+
+def test_a_field_the_model_does_not_know_is_refused_rather_than_dropped():
+    """`extra="forbid"` is the runtime half of this file.
+
+    Without it, a handler that grows a key ships a response missing that key
+    and nobody is told — the silent filtering that made typing these routes
+    risky in the first place. With it, the same mistake is a loud failure at
+    response time, which is the trade this whole change is making.
+    """
+    import pytest
+    from pydantic import ValidationError
+
+    envelope = {
+        "schema_version": 1,
+        "auth_mode": "sso",
+        "control_mode": "direct",
+        "supported_provider_types": ["keycloak-oidc"],
+        "providers": [],
+        "something_a_handler_grew_later": True,
+    }
+    with pytest.raises(ValidationError):
+        SsoProviderCatalogResponse.model_validate(envelope)
+
+
+def test_every_route_on_this_surface_declares_a_response_model():
+    """The next route added here is typed, or this fails.
+
+    Typing six of seven would leave the surface in the state it was already in:
+    the document advertises an operation and describes none of its payload, and
+    the next consumer transcribes the shape by hand.
+    """
+    from fastapi.routing import APIRoute
+
+    from app.api.routes.admin_sso import router
+
+    untyped = [
+        f"{sorted(route.methods)[0]} {route.path}"
+        for route in router.routes
+        if isinstance(route, APIRoute) and route.response_model is None
+    ]
+    assert untyped == [], f"routes on the managed SSO admin surface with no declared response: {untyped}"


### PR DESCRIPTION
Closes #455.

The seven routes in `admin_sso.py` are in this API's OpenAPI document — there is
no `include_in_schema=False` anywhere in that module — and every one of them
returned a plain `dict`. The document advertised the operations and described
none of their payloads.

That was fine while the only reader was a browser written here. A second
consumer now decodes this envelope in another repository, had nothing to
generate or validate against, transcribed the shape by hand including the list
of provider types this installation supports, and broke four days later when
`oidc` was added. Nothing here changed incorrectly. The shape had been written
down twice with nothing linking the copies.

`openapi_contract.py` already states the direction — handlers predate strict SDK
generation, the payloads were left alone deliberately, and routes are typed
incrementally. This module is one of the not-yet-reached ones and the one with a
cross-repository consumer.

## The risk, retired rather than accepted

`response_model` **filters**. A field the model does not declare is dropped
silently, in a browser and in a control plane at once — exactly why these
payloads were left alone. So:

- every model is `extra="forbid"`: a handler that grows a key fails loudly
  instead of shipping a response quietly missing it;
- the tests compare each model's field set against the projection the handlers
  actually build (`admin_view()`, `_prelink_response`), so a model that drifts
  fails here rather than in somebody's console;
- **three envelopes captured from real installations went through the catalog
  model and came back byte-equivalent** — five envelope keys each; one carries
  two providers of different kinds including an enabled non-Keycloak upstream,
  two are empty catalogs.

Mutation proof for the last point: dropping `post_logout_redirect_uri` from the
provider model reddens four unit tests **and** makes all three live envelopes
fail validation. The captured envelopes are not committed — they carry a
customer directory identifier — but the shapes they exercise are.

One assertion is about the next change rather than this one: every route in the
module must declare a response model, so adding an eighth untyped one fails.
Typing six of seven would leave the surface where it already was.

## Alternatives, from #455

A hand-authored JSON Schema with golden fixtures — the `/stats` shape — earns
its keep where a consumer decodes numbers and a silent redefinition would be
charted as if nothing happened. This envelope is structural, and it would give
this repository a third way of stating a shape the framework already derives.

Leaving it untyped and asking consumers to be tolerant is right as far as it
goes, and the consumer has already done it. But a tolerant reader gets no
warning before a `schema_version` bump, and `/api/v1/auth/config` is already at
2 while this document is at 1.

No runtime behaviour changes: same fields, same values, same status codes.

## Verification

```
scripts/check.sh    all checks passed

backend pytest, side by side in one container, same install,
at this branch's exact merge base:

  09a6146 (base)   4 failed, 2503 passed, 676 skipped
  this branch      4 failed, 2512 passed, 676 skipped
```

The difference is exactly the nine added. The four failures are
`tests/test_external_git_capability.py`, pre-existing and environmental — the
slim image's git cannot satisfy the `--config-env` and CURLOPT_RESOLVE probes —
and identical on both sides.

An earlier comparison showed two extra failures here and was **not** evidence: a
generated `backend/config/app.yaml` left by a container run at a different mount
point pointed the local-session key paths at a directory that did not exist.
Removing the generated files on both sides is what made the runs comparable.
