### PR TITLE
fix: support plain Git activity during revision migration

### DIFF
--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -1832,8 +1832,9 @@ class GitService:
     def _manual_fixed_ref_activity(self, repo: Repo, commit, file_path: str) -> dict:
         """Freeze the legacy public activity projection for one file commit."""
         metadata = self._legacy_commit_metadata(commit)
-        action = metadata["action"]
-        if action not in {"create", "update", "move", "delete"}:
+        declared_action = metadata["action"]
+        supported_actions = {"create", "update", "move", "delete"}
+        if declared_action and declared_action not in supported_actions:
             raise FixedRefHistoryError(
                 "fixed-ref current commit has no supported public activity action"
             )
@@ -1881,11 +1882,17 @@ class GitService:
                             "path_to": file_path,
                         }
                     )
-        if len(changes) != 1 or changes[0]["change"] != action:
+        if len(changes) != 1:
             raise FixedRefHistoryError(
                 "fixed-ref current commit activity does not match the file action"
             )
         selected_change = changes[0]
+        inferred_action = selected_change["change"]
+        action = declared_action or inferred_action
+        if action != inferred_action:
+            raise FixedRefHistoryError(
+                "fixed-ref current commit activity does not match the file action"
+            )
         return {
             "legacy_git_oid": commit.hexsha,
             "committed_at": datetime.fromtimestamp(

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -19,7 +19,7 @@ import pytest
 from git import Repo
 
 from app.services.external_git_service import ExternalGitService
-from app.services.git_service import GitService
+from app.services.git_service import FixedRefHistoryError, GitService
 from tests.extgit_http import build_runner
 
 
@@ -111,6 +111,124 @@ def test_commit_file_creates_initial_commit(git_service: GitService) -> None:
     assert len(sha) == 40
     assert git_service.read_file(name, "first.md") == "first\n"
     assert _vault_commit_count(git_service, name) == 1
+
+
+def test_manual_fixed_ref_history_infers_plain_git_create_activity(
+    git_service: GitService,
+) -> None:
+    """An imported Git commit need not carry AKB's private activity footer."""
+    name = f"plain_import_{uuid.uuid4().hex[:8]}"
+    git_service.init_vault(name)
+    current_oid = git_service.commit_file(
+        vault_name=name,
+        file_path="notes/imported.md",
+        content="# Imported\n\nPlain Git history.\n",
+        message="Import documentation",
+        author_name="Fixture Collector",
+        author_email="collector@example.dev",
+    )
+    fixed_ref = git_service.commit_file(
+        vault_name=name,
+        file_path="notes/unrelated.md",
+        content="# Unrelated\n",
+        message="Add unrelated document",
+    )
+
+    snapshot = git_service.manual_fixed_ref_history(
+        name,
+        fixed_ref,
+        "notes/imported.md",
+        current_commit=current_oid,
+    )
+
+    assert snapshot["body"] == b"# Imported\n\nPlain Git history.\n"
+    assert snapshot["activity"] == {
+        "legacy_git_oid": current_oid,
+        "committed_at": Repo(str(git_service._bare_path(name)))
+        .commit(current_oid)
+        .committed_datetime,
+        "actor": "Fixture Collector",
+        "subject": "Import documentation",
+        "summary": "",
+        "action": "create",
+        "path_from": None,
+        "path_to": "notes/imported.md",
+        "changed_paths": [
+            {
+                "change": "create",
+                "path_from": None,
+                "path_to": "notes/imported.md",
+            }
+        ],
+    }
+
+
+def test_manual_fixed_ref_history_infers_plain_git_update_activity(
+    git_service: GitService,
+) -> None:
+    name = f"plain_update_{uuid.uuid4().hex[:8]}"
+    git_service.init_vault(name)
+    git_service.commit_file(
+        vault_name=name,
+        file_path="notes/imported.md",
+        content="# Imported\n",
+        message="Import documentation",
+    )
+    current_oid = git_service.commit_file(
+        vault_name=name,
+        file_path="notes/imported.md",
+        content="# Imported\n\nRevised.\n",
+        message="Revise documentation",
+        author_name="Fixture Collector",
+        author_email="collector@example.dev",
+    )
+
+    snapshot = git_service.manual_fixed_ref_history(
+        name,
+        current_oid,
+        "notes/imported.md",
+        current_commit=current_oid,
+    )
+
+    assert snapshot["activity"]["action"] == "update"
+    assert snapshot["activity"]["actor"] == "Fixture Collector"
+    assert snapshot["activity"]["subject"] == "Revise documentation"
+    assert snapshot["activity"]["changed_paths"] == [
+        {
+            "change": "update",
+            "path_from": None,
+            "path_to": "notes/imported.md",
+        }
+    ]
+
+
+def test_manual_fixed_ref_history_rejects_declared_activity_that_conflicts_with_git(
+    git_service: GitService,
+) -> None:
+    name = f"invalid_activity_{uuid.uuid4().hex[:8]}"
+    git_service.init_vault(name)
+    current_oid = git_service.commit_file(
+        vault_name=name,
+        file_path="notes/imported.md",
+        content="# Imported\n",
+        message=(
+            "Import documentation\n\n"
+            "agent: fixture-collector\n"
+            "action: update\n"
+            "summary: claims an update for a newly added file"
+        ),
+    )
+
+    with pytest.raises(
+        FixedRefHistoryError,
+        match="activity does not match the file action",
+    ):
+        git_service.manual_fixed_ref_history(
+            name,
+            current_oid,
+            "notes/imported.md",
+            current_commit=current_oid,
+        )
 
 
 def test_read_file_closes_repo_while_caller_still_references_it(

--- a/backend/tests/test_native_revision_migration_bridge_pg.py
+++ b/backend/tests/test_native_revision_migration_bridge_pg.py
@@ -405,6 +405,68 @@ async def test_inventory_is_fixed_ref_bounded_and_includes_archived_manual_vault
             ) == 0
 
 
+async def test_inventory_accepts_plain_git_activity_without_akb_footers(tmp_path):
+    async with _fresh_schema(tmp_path) as pool:
+        git = GitService(storage_path=str(tmp_path / "plain-import-git"))
+        vault_name = f"plain-import-{uuid.uuid4().hex}"
+        git.init_vault(vault_name)
+        current_oid = git.commit_file(
+            vault_name,
+            "notes/imported.md",
+            "# Imported\n\nPlain Git history.\n",
+            "Import documentation",
+            author_name="Fixture Collector",
+            author_email="collector@example.dev",
+        )
+        current_dt = Repo(str(git._bare_path(vault_name))).commit(
+            current_oid
+        ).committed_datetime
+        fixed_ref = git.commit_file(
+            vault_name,
+            "notes/unrelated.md",
+            "# Unrelated\n",
+            "Add unrelated document",
+        )
+
+        async with pool.acquire() as conn:
+            namespace_id = await conn.fetchval(
+                """
+                INSERT INTO vaults (name, git_path, status)
+                VALUES ($1, $2, 'active')
+                RETURNING id
+                """,
+                vault_name,
+                str(git._bare_path(vault_name)),
+            )
+            document_id = uuid.uuid4()
+            await conn.execute(
+                """
+                INSERT INTO documents
+                    (id, vault_id, path, title, created_at, updated_at,
+                     current_commit, source)
+                VALUES ($1, $2, 'notes/imported.md', 'Imported', $3, $3, $4, 'manual')
+                """,
+                document_id,
+                namespace_id,
+                current_dt - timedelta(seconds=1),
+                current_oid,
+            )
+
+        scope = await LegacyRevisionBridge(pool, git=git).capture_inventory_scope(
+            namespace_id=namespace_id,
+            fixed_ref=fixed_ref,
+            coverage_version="plain-import-v1",
+        )
+
+        assert len(scope.inventory.documents) == 1
+        document = scope.inventory.documents[0]
+        assert document.resource_id == document_id
+        assert document.activity.action == "create"
+        assert document.activity.actor == "Fixture Collector"
+        assert document.activity.subject == "Import documentation"
+        assert document.activity.summary == ""
+
+
 async def test_inventory_rejects_duplicate_completed_ordinal_zero_anchor(tmp_path):
     async with _fresh_schema(tmp_path) as pool:
         fixture = await _make_fixture(pool, tmp_path)


### PR DESCRIPTION
## Summary
- infer missing legacy activity actions from the exact Git diff for imported commits
- preserve fail-closed validation when an explicit action conflicts with Git
- cover plain Git create/update and migration inventory capture

## Validation
- backend unit suite: 2488 passed, 650 skipped, 58 deselected
- ruff: passed
- mypy: passed (350 source files)
- bandit medium+: passed

The change does not alter external Git ingestion, storage selection, or native revision data semantics.