### PR TITLE
fix: retain imported Git lineage anchors during migration

### DIFF
--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -1760,7 +1760,11 @@ class GitService:
             "-M",
             "--name-status",
         ]
-        if since_epoch is not None:
+        # Imported Git documents are created in AKB after their source commit.
+        # In that case a DB-created-at lower bound would hide the very commit
+        # that anchors the imported file's lineage, so retain the complete
+        # path history. Native AKB writes keep the bounded legacy behavior.
+        if since_epoch is not None and current.committed_date >= since_epoch:
             log_args.append(f"--since=@{since_epoch}")
         log_args.extend(["--format=%H%x00%ct", fixed_ref, "--", file_path])
         try:
@@ -1794,16 +1798,24 @@ class GitService:
             status = fields[0]
             if status.startswith("R") and len(fields) >= 3:
                 active["path_at_revision"] = fields[-1]
+                active["action"] = "move"
             elif len(fields) >= 2:
                 active["path_at_revision"] = fields[-1]
+                action = {
+                    "A": "create",
+                    "M": "update",
+                    "D": "delete",
+                }.get(status[:1])
+                if action is not None:
+                    active["action"] = action
         flush()
 
         # Git commit timestamps have one-second precision while the document
         # row's created_at has microseconds. Preserve the standard AKB action
         # so the migration bridge can stop at the newest create commit instead
         # of dropping that commit (or admitting an older same-path lifecycle)
-        # on timestamp comparison alone. Unknown historical commit formats
-        # remain supported through the bridge's timestamp fallback.
+        # on timestamp comparison alone. Plain imported Git commits retain the
+        # action inferred from their exact name-status record above.
         for entry in history:
             try:
                 commit = repo.commit(entry["legacy_git_oid"])

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -133,20 +133,21 @@ def test_manual_fixed_ref_history_infers_plain_git_create_activity(
         content="# Unrelated\n",
         message="Add unrelated document",
     )
+    current = Repo(str(git_service._bare_path(name))).commit(current_oid)
 
     snapshot = git_service.manual_fixed_ref_history(
         name,
         fixed_ref,
         "notes/imported.md",
         current_commit=current_oid,
+        since_epoch=current.committed_date + 1,
     )
 
     assert snapshot["body"] == b"# Imported\n\nPlain Git history.\n"
+    assert snapshot["history"][0]["action"] == "create"
     assert snapshot["activity"] == {
         "legacy_git_oid": current_oid,
-        "committed_at": Repo(str(git_service._bare_path(name)))
-        .commit(current_oid)
-        .committed_datetime,
+        "committed_at": current.committed_datetime,
         "actor": "Fixture Collector",
         "subject": "Import documentation",
         "summary": "",
@@ -182,14 +183,20 @@ def test_manual_fixed_ref_history_infers_plain_git_update_activity(
         author_name="Fixture Collector",
         author_email="collector@example.dev",
     )
+    current = Repo(str(git_service._bare_path(name))).commit(current_oid)
 
     snapshot = git_service.manual_fixed_ref_history(
         name,
         current_oid,
         "notes/imported.md",
         current_commit=current_oid,
+        since_epoch=current.committed_date + 1,
     )
 
+    assert [entry["action"] for entry in snapshot["history"]] == [
+        "update",
+        "create",
+    ]
     assert snapshot["activity"]["action"] == "update"
     assert snapshot["activity"]["actor"] == "Fixture Collector"
     assert snapshot["activity"]["subject"] == "Revise documentation"

--- a/backend/tests/test_native_revision_migration_bridge_pg.py
+++ b/backend/tests/test_native_revision_migration_bridge_pg.py
@@ -448,7 +448,7 @@ async def test_inventory_accepts_plain_git_activity_without_akb_footers(tmp_path
                 """,
                 document_id,
                 namespace_id,
-                current_dt - timedelta(seconds=1),
+                current_dt + timedelta(seconds=1),
                 current_oid,
             )
 


### PR DESCRIPTION
## Summary
- do not apply an AKB created-at lower bound when the imported Git commit predates ingestion
- retain exact Git name-status actions in fixed-ref history
- cover imported create/update histories and migration inventory capture with later AKB creation times

## Validation
- backend unit suite: 2488 passed, 650 skipped, 58 deselected
- GitService suite: 70 passed
- ruff: passed
- mypy: passed (350 source files)
- bandit medium+: passed

This follows the minimal plain-Git compatibility change in #457 and does not alter storage selection or native revision write semantics.