### PR TITLE
fix: allow isolated E2E dependency ports

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -176,7 +176,7 @@
         "filename": "backend/scripts/ci/README.md",
         "hashed_secret": "f017223a0417e247cdef8c5c3e5681c6d5439219",
         "is_verified": false,
-        "line_number": 100
+        "line_number": 106
       }
     ],
     "backend/scripts/ci/dependency-compose.yaml": [
@@ -208,21 +208,21 @@
         "filename": "backend/scripts/ci/e2e_runtime.py",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 796
+        "line_number": 807
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/scripts/ci/e2e_runtime.py",
         "hashed_secret": "7bd173a7d5330a38f4e220b20348085e38bf232b",
         "is_verified": false,
-        "line_number": 1132
+        "line_number": 1156
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/scripts/ci/e2e_runtime.py",
         "hashed_secret": "ea67b3a75dccf0e8c1d6058e060151a3c5ed90a8",
         "is_verified": false,
-        "line_number": 1134
+        "line_number": 1158
       }
     ],
     "backend/tests/bench/sparse_shape_bench.py": [
@@ -5400,5 +5400,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-31T10:55:38Z"
+  "generated_at": "2026-09-01T09:44:53Z"
 }

--- a/backend/scripts/ci/README.md
+++ b/backend/scripts/ci/README.md
@@ -57,8 +57,8 @@ The topology is deliberately small:
 
 | Component | Process owner | Endpoint / image | Responsibility |
 | --- | --- | --- | --- |
-| PostgreSQL + pgvector | dependency Compose | `pgvector/pgvector:pg16`, `127.0.0.1:15432` | AKB database and vector index |
-| MinIO | dependency Compose | pinned `minio/minio:RELEASE.2025-09-07T16-13-09Z`, `127.0.0.1:9000` | S3-compatible file storage |
+| PostgreSQL + pgvector | dependency Compose | `pgvector/pgvector:pg16`, `127.0.0.1:15432` by default | AKB database and vector index |
+| MinIO | dependency Compose | pinned `minio/minio:RELEASE.2025-09-07T16-13-09Z`, `127.0.0.1:9000` by default | S3-compatible file storage |
 | embedding stub | Ubuntu host process | `127.0.0.1:8888` | deterministic `/v1/embeddings` responses |
 | backend | Ubuntu host process | `127.0.0.1:8000` | AKB application under test |
 | fixture control | supervisor-owned in-process app | `127.0.0.1:8889` | health, discovery, and empty reset |
@@ -69,6 +69,12 @@ Only PostgreSQL and MinIO are managed by
 is the normal development stack and is the default path for contributors;
 the dependency Compose file is an internal implementation detail of this
 runtime and should not be started directly.
+
+Callers that share a host with another development stack may select free
+`RuntimeConfig.postgres_port` and `RuntimeConfig.minio_port` values. The
+supervisor passes those exact values to Compose, generated AKB configuration,
+readiness probes, and fixture database/S3 clients; the defaults above remain
+unchanged for the canonical local and CI paths.
 
 The supervisor has two modes:
 

--- a/backend/scripts/ci/dependency-compose.yaml
+++ b/backend/scripts/ci/dependency-compose.yaml
@@ -6,7 +6,7 @@ services:
       POSTGRES_PASSWORD: akb
       POSTGRES_DB: akb
     ports:
-      - "15432:5432"
+      - "${AKB_E2E_POSTGRES_PORT:-15432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -22,7 +22,7 @@ services:
       MINIO_ROOT_USER: akb-ci
       MINIO_ROOT_PASSWORD: akb-ci-secret
     ports:
-      - "9000:9000"
+      - "${AKB_E2E_MINIO_PORT:-9000}:9000"
     volumes:
       - minio_data:/data
     healthcheck:

--- a/backend/scripts/ci/e2e_runtime.py
+++ b/backend/scripts/ci/e2e_runtime.py
@@ -64,6 +64,8 @@ DEFAULT_PASSWORD_ENV = "AKB_E2E_PASSWORD"
 DEFAULT_APP_PORT = 8000
 DEFAULT_EMBED_PORT = 8888
 DEFAULT_FIXTURE_PORT = 8889
+DEFAULT_POSTGRES_PORT = 15432
+DEFAULT_MINIO_PORT = 9000
 DEFAULT_COMPOSE_PROJECT = "akb-e2e"
 DEFAULT_TIMEOUT_SECONDS = 180.0
 DEFAULT_PROFILE = "tool-only"
@@ -195,6 +197,8 @@ class RuntimeConfig:
     embed_port: int = DEFAULT_EMBED_PORT
     fixture_host: str = "127.0.0.1"
     fixture_port: int = DEFAULT_FIXTURE_PORT
+    postgres_port: int = DEFAULT_POSTGRES_PORT
+    minio_port: int = DEFAULT_MINIO_PORT
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS
     credentials: CredentialNames = dataclasses.field(default_factory=CredentialNames)
     scenario: Scenario = SCENARIO
@@ -216,6 +220,10 @@ class RuntimeConfig:
     @property
     def fixture_origin(self) -> str:
         return f"http://{self.fixture_host}:{self.fixture_port}"
+
+    @property
+    def minio_origin(self) -> str:
+        return f"http://127.0.0.1:{self.minio_port}"
 
     @property
     def state_dir(self) -> Path:
@@ -793,7 +801,11 @@ class E2ERuntime:
                 ):
                     return False
                 connection = await asyncpg.connect(
-                    host="127.0.0.1", port=15432, user="akb", password="akb", database="akb"
+                    host="127.0.0.1",
+                    port=self.config.postgres_port,
+                    user="akb",
+                    password="akb",
+                    database="akb",
                 )
                 try:
                     current = await connection.fetchval(
@@ -838,7 +850,11 @@ class E2ERuntime:
             if not isinstance(vault_id, str):
                 return False
             connection = await asyncpg.connect(
-                host="127.0.0.1", port=15432, user="akb", password="akb", database="akb"
+                host="127.0.0.1",
+                port=self.config.postgres_port,
+                user="akb",
+                password="akb",
+                database="akb",
             )
             try:
                 vault_name = await connection.fetchval("SELECT name FROM vaults WHERE id=$1", uuid.UUID(vault_id))
@@ -872,7 +888,11 @@ class E2ERuntime:
                 ):
                     return False
                 connection = await asyncpg.connect(
-                    host="127.0.0.1", port=15432, user="akb", password="akb", database="akb"
+                    host="127.0.0.1",
+                    port=self.config.postgres_port,
+                    user="akb",
+                    password="akb",
+                    database="akb",
                 )
                 try:
                     await connection.execute(
@@ -900,7 +920,11 @@ class E2ERuntime:
             if not isinstance(vault_id, str):
                 return False
             connection = await asyncpg.connect(
-                host="127.0.0.1", port=15432, user="akb", password="akb", database="akb"
+                host="127.0.0.1",
+                port=self.config.postgres_port,
+                user="akb",
+                password="akb",
+                database="akb",
             )
             try:
                 vault_name = await connection.fetchval(
@@ -1095,7 +1119,7 @@ class E2ERuntime:
             "local_session_private_key_path": str(local_key_dir / "private.pem"),
             "local_session_jwks_path": str(local_key_dir / "jwks.json"),
             "db_host": "127.0.0.1",
-            "db_port": 15432,
+            "db_port": self.config.postgres_port,
             "db_name": "akb",
             "db_user": "akb",
             "public_base_url": self.config.app_origin,
@@ -1107,8 +1131,8 @@ class E2ERuntime:
             "llm_base_url": "",
             "llm_model": "",
             "rerank_enabled": False,
-            "s3_endpoint_url": "http://127.0.0.1:9000",
-            "s3_public_url": "http://127.0.0.1:9000",
+            "s3_endpoint_url": self.config.minio_origin,
+            "s3_public_url": self.config.minio_origin,
             "s3_bucket": "akb-files",
         }
         if self.oidc_fixture is not None:
@@ -1147,6 +1171,8 @@ class E2ERuntime:
         env["PYTHONUNBUFFERED"] = "1"
         env["PYTHONFAULTHANDLER"] = "1"
         env["AKB_URL"] = self.config.app_origin
+        env["AKB_E2E_POSTGRES_PORT"] = str(self.config.postgres_port)
+        env["AKB_E2E_MINIO_PORT"] = str(self.config.minio_port)
         if not env.get("AKB_PG_EXEC"):
             env["AKB_PG_EXEC"] = shlex.join(
                 [
@@ -1317,10 +1343,10 @@ class E2ERuntime:
 
     async def _start_dependencies(self) -> None:
         await self._compose("up", "--detach", "--wait")
-        await self._wait_tcp("PostgreSQL", "127.0.0.1", 15432)
+        await self._wait_tcp("PostgreSQL", "127.0.0.1", self.config.postgres_port)
         await self._wait_http(
             "MinIO",
-            "http://127.0.0.1:9000/minio/health/live",
+            f"{self.config.minio_origin}/minio/health/live",
             lambda status, _body: status == 200,
         )
         await asyncio.to_thread(self._ensure_minio_bucket)
@@ -1332,7 +1358,7 @@ class E2ERuntime:
 
             client = boto3.client(
                 "s3",
-                endpoint_url="http://127.0.0.1:9000",
+                endpoint_url=self.config.minio_origin,
                 aws_access_key_id="akb-ci",
                 aws_secret_access_key="akb-ci-secret",
             )
@@ -2922,7 +2948,7 @@ class E2ERuntime:
             system_admin_id = uuid.uuid4()
             connection = await asyncpg.connect(
                 host="127.0.0.1",
-                port=15432,
+                port=self.config.postgres_port,
                 user="akb",
                 password="akb",
                 database="akb",

--- a/backend/tests/test_e2e_runtime_unit.py
+++ b/backend/tests/test_e2e_runtime_unit.py
@@ -303,9 +303,34 @@ def test_suite_sql_uses_compose_psql_by_default_and_preserves_override(tmp_path,
     monkeypatch.delenv("AKB_PG_EXEC", raising=False)
     child_env = runtime._child_environment()
     assert child_env["AKB_PG_EXEC"].endswith("exec -T postgres")
+    assert child_env["AKB_E2E_POSTGRES_PORT"] == "15432"
+    assert child_env["AKB_E2E_MINIO_PORT"] == "9000"
 
     monkeypatch.setenv("AKB_PG_EXEC", "custom-pg-command")
     assert runtime._child_environment()["AKB_PG_EXEC"] == "custom-pg-command"
+
+
+def test_runtime_uses_selected_dependency_ports_consistently(tmp_path):
+    runtime = E2ERuntime(
+        dataclasses.replace(
+            make_config(tmp_path),
+            postgres_port=25432,
+            minio_port=29000,
+        )
+    )
+    prepare_private_runtime_root(runtime.config.runtime_root)
+
+    runtime._write_config()
+
+    child_env = runtime._child_environment()
+    app_config = yaml.safe_load(
+        (runtime.config.config_dir / "app.yaml").read_text(encoding="utf-8")
+    )
+    assert child_env["AKB_E2E_POSTGRES_PORT"] == "25432"
+    assert child_env["AKB_E2E_MINIO_PORT"] == "29000"
+    assert app_config["db_port"] == 25432
+    assert app_config["s3_endpoint_url"] == "http://127.0.0.1:29000"
+    assert app_config["s3_public_url"] == "http://127.0.0.1:29000"
 
 
 def test_runtime_root_is_private_and_separate(tmp_path):
@@ -986,8 +1011,12 @@ def test_compose_and_hosted_workflow_preserve_the_live_topology():
     assert compose["services"]["minio"]["image"] == (
         "minio/minio:RELEASE.2025-09-07T16-13-09Z"
     )
-    assert compose["services"]["postgres"]["ports"] == ["15432:5432"]
-    assert compose["services"]["minio"]["ports"] == ["9000:9000"]
+    assert compose["services"]["postgres"]["ports"] == [
+        "${AKB_E2E_POSTGRES_PORT:-15432}:5432"
+    ]
+    assert compose["services"]["minio"]["ports"] == [
+        "${AKB_E2E_MINIO_PORT:-9000}:9000"
+    ]
 
     workflow = WORKFLOW.read_text()
     assert "backend/scripts/ci/e2e_runtime.py gate" in workflow


### PR DESCRIPTION
## Summary
- preserve the canonical PostgreSQL 15432 and MinIO 9000 defaults
- let RuntimeConfig select alternate dependency ports for shared hosts
- bind Compose, generated AKB config, readiness, DB and S3 clients to the same selected values

## Validation
- backend unit suite: 2488 passed, 650 skipped, 59 deselected
- focused E2E runtime unit tests: 34 passed
- Ruff, MyPy and Bandit standard backend checks passed
- Docker Compose render verified alternate 25432/29000 publication
- exact-head code review: 0 High, 0 Medium