### PR TITLE
docs(readme): status vocabulary is draft | active | archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ siblings without an extra lookup.
 ---
 title: "Payment API v2 migration plan"
 type: plan              # note | report | decision | spec | plan | session | task | reference
-status: active          # draft | active | archived | superseded
+status: active          # draft | active | archived
 tags: [payments, api]
 domain: engineering
 summary: "REST → gRPC transition plan."


### PR DESCRIPTION
## What

`README.md` §document frontmatter: the `status` comment listed `superseded`; the backend's status vocabulary is `draft | active | archived` and any other value is rejected on put/update. This corrects the example so agents that copy it do not send an invalid status.

## Why now

Agent-facing docs in the family (vault guides, skill packs) cite this README as the reference; an agent following it hits a validation error and, worse, learns to model decision lifecycle as a document status. Lifecycle states such as "superseded" belong in tags (e.g. `decision-state:superseded`), which is what the project vaults do.

## Notes

- `backend/CHANGELOG.md` mentions the old 4-state wording in historical entries; left untouched.
- Docs only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rBaPyE9CHnrStVPaB6ESN
