### PR TITLE
feat(frontend): add document version diff viewer

### DIFF
--- a/docs/design/proposal/2026-09-02-document-version-diff-ui/README.md
+++ b/docs/design/proposal/2026-09-02-document-version-diff-ui/README.md
@@ -1,0 +1,414 @@
+---
+status: implemented
+stage: complete
+issue: AKB-227
+created: 2026-09-02
+updated: 2026-09-02
+---
+
+# Document version diff UI
+
+## Decision
+
+Implement AKB-227, but narrow the launch scope to a **read-only unified diff of
+one document revision against its immediate parent**.
+
+The capability is justified: AKB already preserves immutable document history
+and exposes a reader-authorized diff endpoint, while the current UI makes a
+person open two complete revisions and compare them mentally. The useful loop is
+small and common: History → choose a revision → see what that revision changed →
+return to the same document and History position.
+
+The original issue becomes excessive if “two versions” is interpreted as an
+arbitrary revision picker, or if folding, custom search, split view, rich
+Markdown structural comparison, restore, comments, and merge conflict handling
+all ship together. Those are separate products. Launch should solve change
+inspection without turning the document reader into a code-review system.
+
+## Current-state audit
+
+### What already exists
+
+- `GET /api/v1/diff/{vault}/{doc_id}?commit=...` compares the selected commit
+  with its immediate parent and is available to every Vault reader.
+- `GET /api/v1/history/{vault}/{doc_id}` returns the document Resource's logical
+  lineage newest-first, including revision hash, message, author, resolved
+  author name, and time.
+- `GET /api/v1/documents/{vault}/{doc_id}?version=...` already powers the
+  route-addressable historical Rendered / Raw reader.
+- Document previews launched from Search are route-backed. Query parameters can
+  change without discarding the launching Search state.
+- `@tanstack/react-query` and `@tanstack/react-virtual` are already dependencies,
+  so immutable-result caching and bounded large-list rendering need no new
+  framework.
+
+### Gaps that must be fixed before adding Diff
+
+1. The document History panel currently calls Vault activity with a path filter
+   rather than the document History endpoint. A path-scoped activity feed is
+   not the same as one Resource lineage: path reuse and moves can make it show
+   events that do not belong to the current logical document.
+2. History is held in local effects and untyped `any`; there is no frontend
+   History or Diff API contract.
+3. The generic API error path does not preserve the HTTP status for FastAPI
+   string `detail` bodies. A new compatibility-sensitive helper cannot rely on
+   `instanceof ApiError` to distinguish an old server's 404/405.
+4. The Diff response is a raw unified patch. It contains no explicit base
+   revision or change statistics. The UI can infer the immediate parent from
+   the ordered History list and compute visible additions/deletions, but must
+   label a missing base hash honestly as `Previous revision`.
+5. Native revisions compare the stored Markdown payload, including frontmatter.
+   System-managed metadata such as `updated_at` may therefore appear beside
+   author changes. Launch should show the exact stored patch; a body-only or
+   semantic metadata diff would require a separate backend contract.
+6. A document body may be large enough that an unbounded patch should not be
+   expanded into thousands of DOM rows. Diff must be requested only on demand,
+   parsed after a client size guard, and virtualized above a measured threshold.
+
+## Research synthesis
+
+- GitHub and GitLab distinguish a file's own history from repository-wide
+  history and provide explicit revision comparison. AKB should likewise anchor
+  Diff in the document's logical History, not in the Vault activity feed.
+- Unified view is the right default for AKB. The reader already shares width
+  with persistent Vault navigation and may run inside a Search preview; a split
+  view would halve the useful measure and add a mode without improving the
+  immediate-parent task.
+- A unified patch already omits most unchanged text and organizes changes into
+  hunks. “Collapse unchanged” is therefore inherent at launch. Expanding
+  omitted context requires the complete before/after bodies and is deferred.
+- VS Code exposes a separate accessible unified diff representation with
+  previous/next-difference navigation. AKB should use the same principle:
+  visible hunk navigation and a text-first unified representation, not a purely
+  visual red/green comparison.
+- WCAG 2.2 SC 1.4.1 forbids color as the only distinction. Added and removed
+  lines need literal `+` / `−` markers and programmatic labels in addition to
+  semantic color.
+- `react-diff-view`, Diff2Html, and CodeMirror Merge all cover broader review or
+  editor use cases. Diff2Html generates foreign HTML/CSS, and CodeMirror Merge
+  requires two complete documents and editor infrastructure. Both are too much
+  for this read-only surface. `react-diff-view` is viable but brings its own
+  renderer and styling vocabulary. AKB gets a smaller, more governable result
+  from a zero-dependency unified-diff parser plus its existing virtualizer and
+  design tokens.
+
+References (reviewed 2026-09-02):
+
+- [GitHub: comparing commits](https://docs.github.com/en/pull-requests/how-tos/commit-changes/comparing-commits)
+- [GitHub: viewing and understanding files](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files)
+- [GitLab: compare revisions](https://docs.gitlab.com/user/project/repository/compare_revisions/)
+- [VS Code diff-editor accessibility](https://github.com/microsoft/vscode-docs/blob/main/docs/configure/accessibility/accessibility.md#diff-editor-accessibility)
+- [W3C: Understanding SC 1.4.1, Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color)
+- [`parse-diff`](https://github.com/sergeyt/parse-diff)
+- [`react-diff-view`](https://github.com/otakustay/react-diff-view)
+- [CodeMirror Merge](https://codemirror.net/docs/ref/#merge)
+- [Diff2Html](https://github.com/rtfpessoa/diff2html)
+
+## Product scope
+
+### Launch scope
+
+- History uses the document-lineage endpoint, with an old-server activity
+  fallback only for keeping the existing version list usable.
+- Every eligible History row exposes `View version` and `View changes`.
+- `View changes` opens the main document canvas in Diff mode; it does not open
+  a nested modal or compress the patch into the 24rem document inspector.
+- Diff compares the selected revision with its immediate parent.
+- A compact comparison header shows base → target, author, time, commit message,
+  additions, deletions, and hunk count.
+- Unified raw Markdown patch with old/new line gutters, literal change markers,
+  semantic labels, Copy patch, and previous/next hunk controls.
+- First revision, unchanged, unknown revision, unsupported server, oversized
+  patch, permission loss, network/server failure, and normal loading each have a
+  stable state in the same viewer frame.
+- URL-addressable mode and exact Viewer/Search-preview state restoration.
+
+### Explicit non-goals
+
+- Arbitrary base and target revision selection.
+- Split/side-by-side mode.
+- Rendered Markdown or AST-level semantic diff.
+- Inline comments, approval, restore, revert, merge, or conflict resolution.
+- Syntax highlighting and intra-line word diff.
+- Expanding omitted unchanged source text.
+- Diffing binary files, Vault files, tables, or whole commits.
+
+These can be reconsidered only after usage shows that immediate-parent change
+inspection is insufficient.
+
+## Information architecture
+
+Diff is a peer read mode inside the existing Document workspace, but it is
+entered from History rather than made a permanently visible third tab for every
+document.
+
+```text
+Document workspace header
+  Title · Vault · Collection                         Full page · Edit · …
+
+Historical / comparison status bar
+  Comparing previous revision → a1b2c3d             Back to version
+
+File-context row
+  Author · time · commit message          History · Document panel toggle
+
+Diff viewer frame
+  +12  −4 · 3 changes                Previous change · Next change · Copy
+  ───────────────────────────────────────────────────────────────────────
+  old  new  marker  unified Markdown line
+   18   18           context
+   19    —      −    removed line
+    —   19      +    added line
+```
+
+The document title is not repeated. The primary identity header and outer
+8–12px document gutter stay unchanged. The document inspector remains an
+overlay, so opening Info or History never reduces Diff width.
+
+### History row
+
+Use a two-line, content-sized row rather than the current 22px code-log row:
+
+- line 1: commit message (primary) and relative time;
+- line 2: resolved author and short immutable revision;
+- stable actions: `View version` as the row's main action and a labelled
+  `Changes` button at the trailing edge.
+
+The Changes action is never hover-only. The active revision and active Diff
+revision use text/icon plus `surface-selected`, not color alone.
+
+## URL and state model
+
+- Historical content remains `?commit={revision}`.
+- Diff is `?commit={revision}&view=diff`.
+- Opening Diff pushes one history entry and preserves `location.state` so a
+  Search-launched preview remains a preview.
+- `Back to version` removes only `view=diff`, retaining the selected commit.
+- `Back to latest` removes both `view` and `commit`.
+- Browser Back returns to the exact pre-Diff URL. The document component stays
+  mounted, preserving the open History tab and its scroll offset.
+- On any Diff exit, focus returns to the originating History row's Changes
+  control when it still exists.
+- A directly opened Diff URL is valid. If its History base is not loaded, the
+  comparison label says `Previous revision` rather than fabricating a hash.
+
+`Edit` remains a document mutation in the workspace header and is unavailable
+for historical/Diff mode. Diff must not be represented as an editable state.
+
+## Frontend contract and component boundaries
+
+### Typed API functions
+
+Add narrow helpers in `frontend/src/lib/api.ts`:
+
+```ts
+type DocumentHistoryEntry = {
+  hash: string;
+  message: string;
+  author: string;
+  author_name?: string | null;
+  date: string;
+};
+
+type DocumentDiff = {
+  file: string;
+  commit: string;
+  type: "added" | "deleted" | "modified" | "unknown" | "unchanged";
+  diff: string;
+  error?: string | null;
+};
+```
+
+- `getDocumentHistory(vault, path, limit)` uses `/history`.
+- `getDocumentDiff(vault, path, commit)` uses `/diff`.
+- Both inspect `Response.status` before generic error conversion so 404/405 can
+  be classified as `unsupported` for mixed-version frontend deployments.
+- Do not probe Diff while the reader loads. Fetch only after `view=diff`.
+
+### Query ownership
+
+- History query key: `['document-history', vault, canonicalPath]`.
+- Diff query key: `['document-diff', vault, canonicalPath, revision]`.
+- A Diff result is immutable and may use `staleTime: Infinity`.
+- Failed background History refresh keeps the last successful ledger and adds
+  inline retry feedback; it must not blank the panel.
+
+### Components
+
+- `DocumentHistoryList`: typed lineage list, version/change actions, active
+  state, focus restoration hook.
+- `DocumentDiffView`: lazy-loaded read-only workspace surface.
+- `document-diff.ts`: patch normalization, parsing, row model, statistics, hunk
+  index, and compatibility-state mapping as pure functions.
+
+Use `parse-diff` for unified-patch parsing rather than maintaining a partial Git
+patch grammar. It is zero-dependency and small; pin the reviewed major/minor and
+exercise AKB's headerless added/deleted compatibility fixtures. Render parsed
+text as React text nodes—never `dangerouslySetInnerHTML`.
+
+## Patch compatibility
+
+The existing endpoint has two shapes that the client must normalize:
+
+1. modified revisions generally include unified headers and hunk headers;
+2. added/deleted revisions may be headerless streams of `+` or `−` lines.
+
+For parsing only, synthesize `/dev/null`, file, and one hunk header around the
+headerless first/deleted revision. Preserve the original response for Copy.
+Unknown/error responses never enter the parser.
+
+History should try the canonical `/history` endpoint first. If an old server
+returns 404/405, retain today's path-scoped activity ledger as a compatibility
+fallback and mark `View changes` as server-unavailable after the first rejected
+Diff request. Do not silently call the fallback for authorization or 5xx errors.
+
+## Rendering and performance
+
+- Lazy-load the parser and Diff component; normal Rendered/Raw reading must not
+  pay their bundle or parse cost.
+- Parse in `useMemo` only after a successful immutable query.
+- Keep lines unwrapped by default so a row has fixed height and old/new line
+  columns remain aligned. The viewer owns horizontal scrolling.
+- Use the existing virtualizer above a profiled row threshold; expose
+  `aria-rowcount` / `aria-rowindex` on the virtualized grid.
+- Initial safety guard: do not parse or render a patch over 2 MiB or 20,000
+  patch lines. Show `This change is too large to display safely` with actions to
+  open the previous and selected complete versions. Treat these numbers as
+  measured guardrails, not a permanent public API contract.
+- Hunk navigation targets the parsed row index, so it works with virtualization.
+- Do not implement custom text search at launch. Virtualization makes browser
+  find incomplete, and a correct indexed search UI is disproportionate to the
+  primary task. Previous/next hunk navigation covers change scanning.
+
+The frontend guard prevents DOM lockups but does not bound transfer or backend
+patch construction. If production telemetry shows frequent oversized diffs,
+follow up with an additive server cap/summary contract; do not expand AKB-227
+into a streaming-diff backend rewrite pre-emptively.
+
+## Accessibility
+
+- Diff mode has an `h2` such as `Changes in {short revision}` and a concise
+  description of the comparison.
+- Every visual line exposes old/new line numbers and a text change kind. The
+  visible `+` / `−` marker and an accessible `Added` / `Removed` label duplicate
+  the soft success/destructive tint.
+- Hunk headers are named navigation targets. Previous/next controls announce
+  `Change 2 of 5` in one polite live region.
+- The scrollable patch has a visible label, `tabIndex=0`, preserved focus ring,
+  and no keyboard trap. Arrow/Page keys keep native scrolling behavior.
+- Copy, retry, previous/next, Back, and Changes controls are native buttons with
+  visible labels or tooltips plus `aria-label`.
+- Loading uses one layout-stable `LoadingState`; errors use `Alert`; successful
+  content remains visible during background refresh.
+- Light and dark semantic line fills use AKB tokens. No raw red/green hex and no
+  color-only state.
+
+## State matrix
+
+| State | Viewer behavior | Recovery |
+|---|---|---|
+| loading | keep frame and toolbar geometry; line skeletons | none |
+| modified | render parsed unified hunks | navigate/copy/back |
+| added / first revision | label `First version`; all lines added | open version |
+| unchanged / empty patch | `No content changes in this revision` | open version |
+| unknown + API error | explain unavailable revision without raw server detail | return to History |
+| 404/405 old server | `Changes are not supported by this server yet` | open complete version |
+| 403 | access changed; do not call it unsupported | return to Vault |
+| network / 5xx | keep stable error frame | Retry |
+| over guard | do not parse/mount rows | open previous/current versions |
+
+## Backend evolution (not required for launch)
+
+An additive response may later expose:
+
+```json
+{
+  "base_commit": "... or null",
+  "additions": 12,
+  "deletions": 4,
+  "hunks": 3,
+  "truncated": false
+}
+```
+
+This would make deep-link comparison headers and oversized summaries exact.
+Launch must not depend on these fields, because the frontend is expected to run
+against older backends. Arbitrary `base` / `target` query parameters are not
+part of this proposal.
+
+## Implementation sequence
+
+1. Add typed History/Diff helpers and pure response/patch fixtures.
+2. Move the History inspector from path-scoped activity to Resource History,
+   retaining only the explicit old-server fallback.
+3. Redesign History rows and add the stable Changes action.
+4. Add URL-backed Diff mode and route-state/focus restoration tests.
+5. Add the lazy parser and token-native unified renderer.
+6. Add hunk navigation, Copy, large-patch guard, and complete state matrix.
+7. Run the frontend design gate and E2E against both current and simulated
+   404/405 legacy contracts.
+
+## Test plan
+
+### Unit
+
+- modified, added, deleted, unchanged, malformed, and headerless patches;
+- additions/deletions/hunk counts and old/new line numbers;
+- 404/405 compatibility versus 403/5xx/network failure;
+- size/line guard before parsing;
+- History entry mapping from canonical History and activity fallback.
+
+### Component
+
+- two actions per History row remain keyboard reachable;
+- add/delete is not conveyed by color alone;
+- previous/next hunk navigation scrolls and announces position;
+- Copy uses the original patch;
+- all loading/empty/error states retain one stable frame;
+- virtualized rows expose count and position semantics.
+
+### Route integration
+
+- `?commit=X&view=diff` deep link;
+- Back to version retains `commit=X`;
+- Back to latest clears revision state;
+- browser Back restores Details/History and focused trigger;
+- Search preview remains open across Rendered / Raw / Diff transitions;
+- Edit promotes a Search preview to the full page and never edits Diff state.
+
+### Backend/E2E reuse
+
+Retain the existing reader/forbidden/unauthenticated matrix for History and
+Diff. Add one lineage regression proving a moved/recreated path does not leak a
+different Resource's revisions into the frontend History source.
+
+## Acceptance criteria
+
+- A reader can open Changes for any loaded document History entry and see that
+  revision against its immediate parent.
+- The comparison clearly names target, base or `Previous revision`, author,
+  time, message, additions, deletions, and hunks.
+- Added and removed lines remain distinguishable without color.
+- Loading, first revision, no changes, unsupported old server, permission loss,
+  unknown revision, oversized patch, and retryable failure are distinct.
+- Closing or browser Back restores the original Viewer/Search context, History
+  scroll position, and action focus.
+- Normal document reading does not eagerly download or parse Diff code/data.
+- No raw colors, unsafe HTML, arbitrary revision comparison, restore, or merge
+  behavior enters this task.
+- `npm run design:check && npm run typecheck && npm run lint && npm run test`
+  passes before implementation is proposed for merge.
+
+## Implementation outcome
+
+AKB-227 is implemented in the frontend. Document History now reads the logical
+lineage contract, with an explicit 404/405-only fallback for older servers. A
+labelled `Changes` action opens a route-addressable, lazy-loaded unified Diff
+canvas with line numbers, change markers, hunk navigation, patch copy, bounded
+parsing, and virtualized long output. Returning to the selected version restores
+the History panel and initiating control; Search preview route state is retained.
+
+The implementation includes API compatibility tests, parser/guard tests,
+component state tests, and route-level History/Diff/focus tests. The complete
+frontend design, type, lint, test, and production build gates pass. No backend
+schema or endpoint change is required.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -72,6 +72,7 @@
     "clsx": "^2.1.1",
     "katex": "^0.17.0",
     "lucide-react": "^1.7.0",
+    "parse-diff": "0.12.0",
     "platejs": "~53.0.3",
     "pretendard": "^1.3.9",
     "react": "^19.2.4",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       lucide-react:
         specifier: ^1.7.0
         version: 1.7.0(react@19.2.4)
+      parse-diff:
+        specifier: 0.12.0
+        version: 0.12.0
       platejs:
         specifier: ~53.0.3
         version: 53.0.3(@types/react@19.2.14)(immer@10.2.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(scheduler@0.27.0)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -3175,6 +3178,9 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  parse-diff@0.12.0:
+    resolution: {integrity: sha512-2Xr5mW4Bqd4CqYq2zttfw/RZraK+KcRuJvNkJzbDk3ea67Ap525XeTvBdtDE5tigJMVzIx/DMUzsShAf6+5SCA==}
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
@@ -7156,6 +7162,8 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  parse-diff@0.12.0: {}
 
   parse-entities@4.0.2:
     dependencies:

--- a/frontend/src/components/__tests__/document-diff-view.test.tsx
+++ b/frontend/src/components/__tests__/document-diff-view.test.tsx
@@ -21,7 +21,7 @@ function result(overrides: Partial<DocumentDiff> = {}): DocumentDiff {
   return {
     kind: "document_diff",
     file: "notes/guide.md",
-    commit: "abcdef123456",
+    commit: "abcdef123456", // pragma: allowlist secret — synthetic Git commit
     type: "modified",
     diff: [
       "--- a/notes/guide.md",
@@ -53,7 +53,7 @@ function renderDiff(props: Partial<React.ComponentProps<typeof DocumentDiffView>
           vault="demo"
           docId="notes/guide.md"
           revision="abcdef123456"
-          baseRevision="123456abcdef"
+          baseRevision={"123456abcdef" /* pragma: allowlist secret — synthetic Git commit */}
           targetEntry={{
             hash: "abcdef123456",
             message: "Update guide",

--- a/frontend/src/components/__tests__/document-diff-view.test.tsx
+++ b/frontend/src/components/__tests__/document-diff-view.test.tsx
@@ -1,0 +1,144 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return { ...actual, getDocumentDiff: vi.fn() };
+});
+
+import DocumentDiffView from "@/components/document-diff-view";
+import {
+  DocumentRevisionApiError,
+  getDocumentDiff,
+  type DocumentDiff,
+} from "@/lib/api";
+
+const getDocumentDiffMock = vi.mocked(getDocumentDiff);
+
+function result(overrides: Partial<DocumentDiff> = {}): DocumentDiff {
+  return {
+    kind: "document_diff",
+    file: "notes/guide.md",
+    commit: "abcdef123456",
+    type: "modified",
+    diff: [
+      "--- a/notes/guide.md",
+      "+++ b/notes/guide.md",
+      "@@ -1,2 +1,2 @@",
+      "-Old title",
+      "+New title",
+      " body",
+      "@@ -10,1 +10,1 @@",
+      "-Old ending",
+      "+New ending",
+    ].join("\n"),
+    ...overrides,
+  };
+}
+
+function renderDiff(props: Partial<React.ComponentProps<typeof DocumentDiffView>> = {}) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const callbacks = {
+    onBackToVersion: vi.fn(),
+    onBackToLatest: vi.fn(),
+    onOpenBase: vi.fn(),
+  };
+  return {
+    callbacks,
+    ...render(
+      <QueryClientProvider client={client}>
+        <DocumentDiffView
+          vault="demo"
+          docId="notes/guide.md"
+          revision="abcdef123456"
+          baseRevision="123456abcdef"
+          targetEntry={{
+            hash: "abcdef123456",
+            message: "Update guide",
+            author: "user-1",
+            author_name: "Kim",
+            date: "2026-09-02T00:00:00Z",
+          }}
+          {...callbacks}
+          {...props}
+        />
+      </QueryClientProvider>,
+    ),
+  };
+}
+
+beforeEach(() => {
+  getDocumentDiffMock.mockReset();
+  getDocumentDiffMock.mockResolvedValue(result());
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("DocumentDiffView", () => {
+  it("renders a full-width unified change ledger with non-color labels", async () => {
+    renderDiff();
+
+    expect(await screen.findByRole("table", { name: /unified document changes/i })).toBeInTheDocument();
+    expect(screen.getByRole("row", { name: "Removed line 1: Old title" })).toBeInTheDocument();
+    expect(screen.getByRole("row", { name: "Added line 1: New title" })).toBeInTheDocument();
+    expect(screen.getByLabelText("2 added lines")).toHaveTextContent("+2 added");
+    expect(screen.getByLabelText("2 removed lines")).toHaveTextContent("−2 removed");
+    expect(screen.getByText(/Update guide/)).toHaveTextContent("Update guide · Kim");
+  });
+
+  it("navigates hunks and announces the current change", async () => {
+    const user = userEvent.setup();
+    renderDiff();
+
+    await screen.findByRole("table", { name: /unified document changes/i });
+    const next = screen.getByRole("button", { name: /next change\. change 1 of 2/i });
+    await user.click(next);
+
+    expect(screen.getByText("Change 2 of 2", { selector: ".sr-only" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /next change\. change 2 of 2/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /previous change\. change 2 of 2/i })).toBeEnabled();
+  });
+
+  it("copies the original server patch", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+      writable: true,
+    });
+    const patch = result().diff;
+    renderDiff();
+
+    await screen.findByRole("table", { name: /unified document changes/i });
+    const copy = await screen.findByRole("button", { name: "Copy patch" });
+    copy.click();
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(patch));
+    expect(copy).toHaveAccessibleName("Patch copied");
+  });
+
+  it("distinguishes an old-server 405 from retryable failures", async () => {
+    getDocumentDiffMock.mockRejectedValue(
+      new DocumentRevisionApiError("Method Not Allowed", 405),
+    );
+    const { callbacks } = renderDiff();
+
+    expect(await screen.findByText("Changes are not available on this server")).toBeInTheDocument();
+    await userEvent.setup().click(screen.getByRole("button", { name: "Open version" }));
+    expect(callbacks.onBackToVersion).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+  });
+
+  it("shows a stable no-content state", async () => {
+    getDocumentDiffMock.mockResolvedValue(result({ type: "unchanged", diff: "" }));
+    const { callbacks } = renderDiff();
+
+    expect(await screen.findByText("No content changes in this revision")).toBeInTheDocument();
+    await userEvent.setup().click(screen.getByRole("button", { name: "Open version" }));
+    expect(callbacks.onBackToVersion).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/components/__tests__/history-list.test.tsx
+++ b/frontend/src/components/__tests__/history-list.test.tsx
@@ -5,14 +5,14 @@ import { HistoryList, type HistoryEntry } from "../history-list";
 
 const entries: HistoryEntry[] = [
   {
-    hash: "abcdef123456",
+    hash: "abcdef123456", // pragma: allowlist secret — synthetic Git commit
     author: "user-1",
     author_name: "Kim",
     message: "Initial document",
     date: "2026-05-19T00:00:00Z",
   },
   {
-    hash: "bcdefa234567",
+    hash: "bcdefa234567", // pragma: allowlist secret — synthetic Git commit
     author: "user-2",
     message: "Update architecture",
     date: "2026-05-19T01:00:00Z",

--- a/frontend/src/components/__tests__/history-list.test.tsx
+++ b/frontend/src/components/__tests__/history-list.test.tsx
@@ -1,48 +1,70 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
 import { HistoryList, type HistoryEntry } from "../history-list";
 
 const entries: HistoryEntry[] = [
-  { hash: "hist-a1", agent: "kwoo24", subject: "Initial", timestamp: "2026-05-19T00:00:00Z" },
-  { hash: "hist-b2", agent: "kwoo24", subject: "Update", timestamp: "2026-05-19T01:00:00Z" },
+  {
+    hash: "abcdef123456",
+    author: "user-1",
+    author_name: "Kim",
+    message: "Initial document",
+    date: "2026-05-19T00:00:00Z",
+  },
+  {
+    hash: "bcdefa234567",
+    author: "user-2",
+    message: "Update architecture",
+    date: "2026-05-19T01:00:00Z",
+  },
 ];
 
 describe("HistoryList", () => {
-  it("read-only mode (no onSelect) renders rows as div", () => {
+  it("renders typed document lineage with readable messages and authors", () => {
     render(<HistoryList entries={entries} />);
-    expect(screen.getByText("hist-a1")).toBeTruthy();
-    // no button per row
-    expect(screen.queryByRole("button", { name: /View document at commit/i })).toBeNull();
+
+    expect(screen.getByText("Initial document")).toBeInTheDocument();
+    expect(screen.getByText("Kim")).toBeInTheDocument();
+    expect(screen.getByText("abcdef1")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /view changes/i })).toBeNull();
   });
 
-  it("clickable mode invokes onSelect with the full commit hash", () => {
+  it("opens the complete version from the primary row action", () => {
     const onSelect = vi.fn();
     render(<HistoryList entries={entries} onSelect={onSelect} />);
-    fireEvent.click(screen.getByRole("button", { name: /commit hist-a1/i }));
-    expect(onSelect).toHaveBeenCalledWith("hist-a1");
+
+    fireEvent.click(screen.getByRole("button", { name: /view version abcdef1/i }));
+    expect(onSelect).toHaveBeenCalledWith("abcdef123456");
   });
 
-  it("selectedHash marks matching row with aria-pressed=true", () => {
-    const onSelect = vi.fn();
-    render(<HistoryList entries={entries} onSelect={onSelect} selectedHash="hist-b2" />);
-    const buttons = screen.getAllByRole("button");
-    expect(buttons[0].getAttribute("aria-pressed")).toBe("false");
-    expect(buttons[1].getAttribute("aria-pressed")).toBe("true");
+  it("keeps the Changes action visible and passes its trigger for focus restoration", () => {
+    const onCompare = vi.fn();
+    render(<HistoryList entries={entries} onCompare={onCompare} />);
+
+    const trigger = screen.getByRole("button", { name: /view changes in version abcdef1/i });
+    fireEvent.click(trigger);
+    expect(onCompare).toHaveBeenCalledWith("abcdef123456", trigger);
   });
 
-  it("entry without a hash stays unclickable even in onSelect mode", () => {
-    const onSelect = vi.fn();
-    const withMissing: HistoryEntry[] = [
-      ...entries,
-      { agent: "unknown", subject: "Orphan", timestamp: "2026-05-19T02:00:00Z" },
-    ];
-    render(<HistoryList entries={withMissing} onSelect={onSelect} />);
-    const buttons = screen.getAllByRole("button");
-    expect(buttons.length).toBe(2); // only the two with hashes
+  it("marks a prefix-matched comparison without relying on color alone", () => {
+    render(
+      <HistoryList
+        entries={entries}
+        onCompare={vi.fn()}
+        selectedHash="bcdefa2"
+        diffHash="bcdefa2"
+      />,
+    );
+
+    const changes = screen.getByRole("button", {
+      name: /view changes in version bcdefa2/i,
+    });
+    expect(changes).toHaveAttribute("aria-pressed", "true");
+    expect(changes).toHaveTextContent("Changes");
   });
 
-  it("empty list renders 'No history yet.'", () => {
+  it("renders a clear empty state", () => {
     render(<HistoryList entries={[]} />);
-    expect(screen.getByText(/no history yet/i)).toBeTruthy();
+    expect(screen.getByText(/no versions yet/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/document-diff-view.tsx
+++ b/frontend/src/components/document-diff-view.tsx
@@ -1,0 +1,485 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import {
+  ArrowDown,
+  ArrowLeft,
+  ArrowRight,
+  ArrowUp,
+  Check,
+  CircleSlash2,
+  Copy,
+  FileWarning,
+  GitCompareArrows,
+  History,
+  RotateCcw,
+  ShieldAlert,
+} from "lucide-react";
+
+import {
+  DocumentRevisionApiError,
+  getDocumentDiff,
+  type DocumentHistoryEntry,
+} from "@/lib/api";
+import {
+  DOCUMENT_DIFF_VIRTUALIZE_THRESHOLD,
+  inspectDocumentDiffPatch,
+  parseDocumentDiffPatch,
+  type DocumentDiffLine,
+  type ParsedDocumentDiff,
+} from "@/lib/document-diff";
+import { cn, timeAgo } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { LoadingState } from "@/components/ui/loading-state";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface DocumentDiffViewProps {
+  vault: string;
+  docId: string;
+  revision: string;
+  baseRevision?: string;
+  targetEntry?: DocumentHistoryEntry;
+  onBackToVersion: () => void;
+  onBackToLatest: () => void;
+  onOpenBase?: () => void;
+}
+
+type ParseResult =
+  | { parsed: ParsedDocumentDiff; error: null }
+  | { parsed: null; error: Error };
+
+export default function DocumentDiffView({
+  vault,
+  docId,
+  revision,
+  baseRevision,
+  targetEntry,
+  onBackToVersion,
+  onBackToLatest,
+  onOpenBase,
+}: DocumentDiffViewProps) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [activeHunk, setActiveHunk] = useState(0);
+  const [copied, setCopied] = useState(false);
+
+  const diffQuery = useQuery({
+    queryKey: ["document-diff", vault, docId, revision],
+    queryFn: () => getDocumentDiff(vault, docId, revision),
+    staleTime: Number.POSITIVE_INFINITY,
+    retry: false,
+  });
+
+  const guard = useMemo(
+    () => (diffQuery.data ? inspectDocumentDiffPatch(diffQuery.data.diff) : null),
+    [diffQuery.data],
+  );
+  const parseResult = useMemo<ParseResult | null>(() => {
+    const response = diffQuery.data;
+    if (
+      !response ||
+      guard?.tooLarge ||
+      response.truncated ||
+      response.type === "unknown" ||
+      response.type === "unchanged" ||
+      !response.diff
+    ) {
+      return null;
+    }
+    try {
+      return { parsed: parseDocumentDiffPatch(response), error: null };
+    } catch (error) {
+      return {
+        parsed: null,
+        error: error instanceof Error ? error : new Error("Unable to read this diff."),
+      };
+    }
+  }, [diffQuery.data, guard]);
+  const parsed = parseResult?.parsed ?? null;
+  const rows = parsed?.rows ?? [];
+  const hunks = parsed?.hunks ?? [];
+  const shouldVirtualize = rows.length > DOCUMENT_DIFF_VIRTUALIZE_THRESHOLD;
+
+  const rowVirtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: (index) => (rows[index]?.kind === "hunk" ? 32 : 24),
+    overscan: 16,
+    enabled: shouldVirtualize,
+  });
+
+  useEffect(() => {
+    setActiveHunk(0);
+    setCopied(false);
+  }, [revision]);
+
+  const targetShort = shortRevision(revision);
+  const baseShort = baseRevision ? shortRevision(baseRevision) : "Previous revision";
+  const response = diffQuery.data;
+  const additions = response?.additions ?? parsed?.additions ?? 0;
+  const deletions = response?.deletions ?? parsed?.deletions ?? 0;
+  const hunkCount = response?.hunks ?? hunks.length;
+
+  function goToHunk(nextIndex: number) {
+    if (!hunks.length) return;
+    const bounded = Math.max(0, Math.min(hunks.length - 1, nextIndex));
+    setActiveHunk(bounded);
+    const rowIndex = hunks[bounded].rowIndex;
+    if (shouldVirtualize) {
+      rowVirtualizer.scrollToIndex(rowIndex, { align: "start" });
+    } else {
+      document.getElementById(`document-diff-hunk-${bounded}`)?.scrollIntoView({
+        behavior: "auto",
+        block: "start",
+      });
+    }
+  }
+
+  async function copyPatch() {
+    if (!response?.diff) return;
+    try {
+      await navigator.clipboard?.writeText(response.diff);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2_000);
+    } catch {
+      // Insecure origins may not expose Clipboard. The selectable patch stays available.
+    }
+  }
+
+  const queryError = diffQuery.error;
+  const revisionError =
+    queryError instanceof DocumentRevisionApiError ? queryError : null;
+
+  return (
+    <section
+      aria-labelledby="document-diff-heading"
+      className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-[var(--radius-lg)] border border-border bg-surface shadow-sm"
+    >
+      <header className="flex shrink-0 flex-wrap items-start justify-between gap-3 border-b border-border bg-surface px-4 py-3 sm:px-5">
+        <div className="flex min-w-0 items-start gap-3">
+          <span className="mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-md)] border border-border bg-surface-selected text-surface-selected-foreground">
+            <GitCompareArrows className="h-4 w-4" aria-hidden />
+          </span>
+          <div className="min-w-0">
+            <h2 id="document-diff-heading" className="font-display text-sm font-semibold text-foreground sm:text-base">
+              Changes in <code className="font-mono text-sm">{targetShort}</code>
+            </h2>
+            <p className="mt-0.5 truncate text-xs text-foreground-muted">
+              {targetEntry?.message || "Document revision"}
+              {targetEntry && (
+                <>
+                  <span aria-hidden> · </span>
+                  {targetEntry.author_name || targetEntry.author}
+                  {targetEntry.date && (
+                    <>
+                      <span aria-hidden> · </span>
+                      {timeAgo(targetEntry.date)}
+                    </>
+                  )}
+                </>
+              )}
+            </p>
+          </div>
+        </div>
+        <div
+          aria-label={`Comparing ${response?.type === "added" ? "the first version" : baseShort} with ${targetShort}`}
+          className="flex min-w-0 items-center gap-2 text-xs text-foreground-muted"
+        >
+          <code className="max-w-40 truncate rounded-[var(--radius-sm)] bg-surface-2 px-2 py-1 font-mono text-foreground">
+            {response?.type === "added" ? "First version" : baseShort}
+          </code>
+          <ArrowRight className="h-3.5 w-3.5 shrink-0" aria-hidden />
+          <code className="rounded-[var(--radius-sm)] bg-surface-selected px-2 py-1 font-mono text-surface-selected-foreground">
+            {targetShort}
+          </code>
+        </div>
+      </header>
+
+      <div className="flex min-h-11 shrink-0 flex-wrap items-center gap-2 border-b border-border bg-surface-2 px-3 py-1.5">
+        <div className="mr-auto flex items-center gap-3 text-xs tabular-nums">
+          {diffQuery.isPending ? (
+            <span className="text-foreground-muted">Loading change…</span>
+          ) : parsed ? (
+            <>
+              <span className="inline-flex items-center gap-1 font-medium text-success" aria-label={`${additions} added lines`}>
+                <span aria-hidden>+</span>{additions} added
+              </span>
+              <span className="inline-flex items-center gap-1 font-medium text-destructive" aria-label={`${deletions} removed lines`}>
+                <span aria-hidden>−</span>{deletions} removed
+              </span>
+              <span className="hidden text-foreground-muted sm:inline">
+                {hunkCount} {hunkCount === 1 ? "change" : "changes"}
+              </span>
+            </>
+          ) : (
+            <span className="text-foreground-muted">Revision comparison</span>
+          )}
+        </div>
+
+        <div className="flex items-center gap-1" aria-label="Change navigation">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => goToHunk(activeHunk - 1)}
+            disabled={!hunks.length || activeHunk === 0}
+            aria-label={`Previous change${hunks.length ? `. Change ${activeHunk + 1} of ${hunks.length}` : ""}`}
+          >
+            <ArrowUp className="h-3.5 w-3.5" aria-hidden />
+            <span className="hidden md:inline">Previous</span>
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => goToHunk(activeHunk + 1)}
+            disabled={!hunks.length || activeHunk >= hunks.length - 1}
+            aria-label={`Next change${hunks.length ? `. Change ${activeHunk + 1} of ${hunks.length}` : ""}`}
+          >
+            <ArrowDown className="h-3.5 w-3.5" aria-hidden />
+            <span className="hidden md:inline">Next</span>
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => void copyPatch()}
+            disabled={!response?.diff}
+            aria-label={copied ? "Patch copied" : "Copy patch"}
+          >
+            {copied ? <Check className="h-3.5 w-3.5 text-success" aria-hidden /> : <Copy className="h-3.5 w-3.5" aria-hidden />}
+            <span className="hidden sm:inline">{copied ? "Copied" : "Copy patch"}</span>
+          </Button>
+        </div>
+        <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+          {hunks.length ? `Change ${activeHunk + 1} of ${hunks.length}` : ""}
+        </span>
+      </div>
+
+      {diffQuery.isPending ? (
+        <DiffLoading />
+      ) : revisionError?.status === 404 || revisionError?.status === 405 ? (
+        <DiffState
+          icon={CircleSlash2}
+          title="Changes are not available on this server"
+          description="You can still open the complete revision. Diff support will become available after the backend is updated."
+          primaryLabel="Open version"
+          onPrimary={onBackToVersion}
+        />
+      ) : revisionError?.status === 403 ? (
+        <DiffState
+          icon={ShieldAlert}
+          title="Access to this change was denied"
+          description="Your Vault access may have changed. Return to the latest document or the Vault to continue."
+          primaryLabel="Back to latest"
+          onPrimary={onBackToLatest}
+        />
+      ) : diffQuery.isError ? (
+        <DiffState
+          icon={RotateCcw}
+          title="Couldn't load this change"
+          description="The server or network did not complete the request. Retry without leaving this document."
+          primaryLabel="Retry"
+          onPrimary={() => void diffQuery.refetch()}
+          secondaryLabel="Open version"
+          onSecondary={onBackToVersion}
+        />
+      ) : response?.type === "unknown" || response?.error ? (
+        <DiffState
+          icon={FileWarning}
+          title="This revision cannot be compared"
+          description="The revision may no longer be available or its history cannot be resolved safely."
+          primaryLabel="Return to history"
+          onPrimary={onBackToVersion}
+        />
+      ) : response?.truncated || guard?.tooLarge ? (
+        <DiffState
+          icon={FileWarning}
+          title="This change is too large to display safely"
+          description={guard ? `${formatCount(guard.lineCount)} patch lines · ${formatBytes(guard.byteCount)}. Open either complete version instead.` : "Open either complete version instead."}
+          primaryLabel="Open selected version"
+          onPrimary={onBackToVersion}
+          secondaryLabel={onOpenBase ? "Open previous version" : undefined}
+          onSecondary={onOpenBase}
+        />
+      ) : parseResult?.error ? (
+        <DiffState
+          icon={FileWarning}
+          title="This change uses an unsupported diff format"
+          description="The complete revision is still available to read."
+          primaryLabel="Open version"
+          onPrimary={onBackToVersion}
+        />
+      ) : response?.type === "unchanged" || !response?.diff || !rows.length ? (
+        <DiffState
+          icon={History}
+          title="No content changes in this revision"
+          description="The revision may contain metadata-only changes. Open the complete version to inspect it."
+          primaryLabel="Open version"
+          onPrimary={onBackToVersion}
+        />
+      ) : (
+        <div
+          ref={scrollRef}
+          role="table"
+          aria-label={`Unified document changes for revision ${targetShort}`}
+          aria-rowcount={rows.length + 1}
+          tabIndex={0}
+          className="min-h-0 flex-1 overflow-auto bg-surface font-mono text-xs leading-6 rail-scroll focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+        >
+          <DiffColumnHeaders />
+          {shouldVirtualize ? (
+            <div
+              role="rowgroup"
+              className="relative min-w-[48rem]"
+              style={{ height: rowVirtualizer.getTotalSize() }}
+            >
+              {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                const row = rows[virtualRow.index];
+                return (
+                  <div
+                    key={row.id}
+                    ref={rowVirtualizer.measureElement}
+                    data-index={virtualRow.index}
+                    className="absolute left-0 top-0 w-full"
+                    style={{ transform: `translateY(${virtualRow.start}px)` }}
+                  >
+                    <DiffRow row={row} rowIndex={virtualRow.index} />
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div role="rowgroup" className="min-w-[48rem]">
+              {rows.map((row, index) => (
+                <DiffRow key={row.id} row={row} rowIndex={index} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function DiffColumnHeaders() {
+  return (
+    <div
+      role="row"
+      className="sticky top-0 z-[var(--z-sticky)] grid min-w-[48rem] grid-cols-[3.5rem_3.5rem_2rem_minmax(0,1fr)] border-b border-border bg-surface-2 text-foreground-muted"
+    >
+      <span role="columnheader" className="px-2 text-right">Old</span>
+      <span role="columnheader" className="border-l border-border px-2 text-right">New</span>
+      <span role="columnheader" className="border-l border-border text-center"><span className="sr-only">Change type</span></span>
+      <span role="columnheader" className="border-l border-border px-3 font-sans font-medium">Markdown</span>
+    </div>
+  );
+}
+
+function DiffRow({ row, rowIndex }: { row: DocumentDiffLine; rowIndex: number }) {
+  if (row.kind === "hunk") {
+    return (
+      <div
+        id={`document-diff-hunk-${row.hunkIndex}`}
+        role="row"
+        aria-rowindex={rowIndex + 2}
+        aria-label={`Change ${row.hunkIndex + 1}: ${row.content}`}
+        className="grid min-h-8 grid-cols-[3.5rem_3.5rem_2rem_minmax(0,1fr)] border-b border-info/30 bg-info-soft text-info-soft-foreground"
+      >
+        <span aria-hidden className="col-span-3 border-r border-info/30 px-2 text-right">{row.hunkIndex + 1}</span>
+        <code aria-hidden className="px-3 font-mono font-medium">{row.content}</code>
+      </div>
+    );
+  }
+
+  const marker = row.kind === "added" ? "+" : row.kind === "removed" ? "−" : "";
+  const label =
+    row.kind === "added"
+      ? `Added line ${row.newLine}: ${row.content}`
+      : row.kind === "removed"
+        ? `Removed line ${row.oldLine}: ${row.content}`
+        : `Unchanged line ${row.oldLine}: ${row.content}`;
+  return (
+    <div
+      role="row"
+      aria-rowindex={rowIndex + 2}
+      aria-label={label}
+      className={cn(
+        "grid min-h-6 grid-cols-[3.5rem_3.5rem_2rem_minmax(0,1fr)] border-b border-border/70",
+        row.kind === "added" && "bg-success-soft text-success-soft-foreground",
+        row.kind === "removed" && "bg-destructive-soft text-destructive-soft-foreground",
+      )}
+    >
+      <span aria-hidden className="select-none px-2 text-right tabular-nums text-foreground-muted">{row.oldLine ?? ""}</span>
+      <span aria-hidden className="select-none border-l border-border/70 px-2 text-right tabular-nums text-foreground-muted">{row.newLine ?? ""}</span>
+      <span aria-hidden className="select-none border-l border-border/70 text-center font-semibold">{marker}</span>
+      <code aria-hidden className="whitespace-pre border-l border-border/70 px-3 font-mono text-foreground">{row.content || " "}</code>
+    </div>
+  );
+}
+
+function DiffLoading() {
+  return (
+    <LoadingState label="Loading document changes" className="min-h-0 flex-1 bg-surface p-4">
+      <div className="space-y-2">
+        {Array.from({ length: 12 }, (_, index) => (
+          <Skeleton key={index} className={cn("h-5 rounded-[var(--radius-sm)]", index % 4 === 0 ? "w-4/5" : "w-full")} />
+        ))}
+      </div>
+    </LoadingState>
+  );
+}
+
+function DiffState({
+  icon: Icon,
+  title,
+  description,
+  primaryLabel,
+  onPrimary,
+  secondaryLabel,
+  onSecondary,
+}: {
+  icon: typeof FileWarning;
+  title: string;
+  description: string;
+  primaryLabel: string;
+  onPrimary: () => void;
+  secondaryLabel?: string;
+  onSecondary?: () => void;
+}) {
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center bg-surface px-5 py-10">
+      <div className="w-full max-w-xl text-center">
+        <span className="mx-auto inline-flex h-11 w-11 items-center justify-center rounded-[var(--radius-lg)] border border-border bg-surface-2 text-foreground-muted">
+          <Icon className="h-5 w-5" aria-hidden />
+        </span>
+        <h3 className="mt-4 font-display text-base font-semibold text-foreground">{title}</h3>
+        <p className="mx-auto mt-1.5 max-w-lg text-sm leading-relaxed text-foreground-muted">{description}</p>
+        <div className="mt-5 flex flex-wrap justify-center gap-2">
+          <Button type="button" variant="outline" size="sm" onClick={onPrimary}>
+            <ArrowLeft className="h-3.5 w-3.5" aria-hidden />
+            {primaryLabel}
+          </Button>
+          {secondaryLabel && onSecondary && (
+            <Button type="button" variant="ghost" size="sm" onClick={onSecondary}>
+              {secondaryLabel}
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function shortRevision(revision: string) {
+  return revision.slice(0, 7);
+}
+
+function formatCount(value: number) {
+  return new Intl.NumberFormat().format(value);
+}
+
+function formatBytes(bytes: number) {
+  if (bytes < 1024) return `${bytes} ${bytes === 1 ? "Byte" : "Bytes"}`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/frontend/src/components/history-list.tsx
+++ b/frontend/src/components/history-list.tsx
@@ -1,212 +1,96 @@
-import { useRef } from "react";
-import { useVirtualizer } from "@tanstack/react-virtual";
-import { cn } from "@/lib/utils";
-import { timeAgo } from "@/lib/utils";
+import { GitCompareArrows, GitCommitHorizontal } from "lucide-react";
+
+import type { DocumentHistoryEntry } from "@/lib/api";
+import { sameCommitRef } from "@/lib/commit";
+import { cn, timeAgo } from "@/lib/utils";
 import { TooltipText } from "@/components/ui/tooltip-text";
 
-export interface HistoryEntry {
-  hash?: string;
-  agent?: string;
-  author?: string;
-  subject?: string;
-  timestamp?: string;
-}
+export type HistoryEntry = DocumentHistoryEntry;
 
 interface HistoryListProps {
   entries: HistoryEntry[];
-  /**
-   * Called with the commit hash when a row is clicked. When omitted,
-   * rows stay read-only (legacy behavior).
-   */
+  /** Open the complete document at a revision. */
   onSelect?: (hash: string) => void;
-  /**
-   * Commit hash currently being viewed — that row gets the active style.
-   */
+  /** Compare a revision with its immediate parent. */
+  onCompare?: (hash: string, trigger: HTMLButtonElement) => void;
   selectedHash?: string;
+  diffHash?: string;
 }
 
-const ROW_HEIGHT = 22;
-const VIRTUALIZE_THRESHOLD = 60;
-
-export function HistoryList({ entries, onSelect, selectedHash }: HistoryListProps) {
-  if (entries.length === 0) {
-    return <div className="coord">No history yet.</div>;
-  }
-  if (entries.length < VIRTUALIZE_THRESHOLD) {
-    return (
-      <ol className="font-mono text-[11px] leading-[1.9] space-y-0.5">
-        {entries.map((p, i) => (
-          <Row
-            key={p.hash || i}
-            entry={p}
-            onSelect={onSelect}
-            active={!!selectedHash && p.hash === selectedHash}
-          />
-        ))}
-      </ol>
-    );
-  }
-  return (
-    <VirtualHistoryList
-      entries={entries}
-      onSelect={onSelect}
-      selectedHash={selectedHash}
-    />
-  );
-}
-
-function VirtualHistoryList({
+export function HistoryList({
   entries,
   onSelect,
+  onCompare,
   selectedHash,
-}: {
-  entries: HistoryEntry[];
-  onSelect?: (hash: string) => void;
-  selectedHash?: string;
-}) {
-  const parentRef = useRef<HTMLDivElement | null>(null);
-  const rowVirtualizer = useVirtualizer({
-    count: entries.length,
-    getScrollElement: () => parentRef.current,
-    estimateSize: () => ROW_HEIGHT,
-    overscan: 8,
-  });
-
-  return (
-    <div
-      ref={parentRef}
-      className="font-mono text-[11px] leading-[1.9] overflow-y-auto rail-scroll"
-      style={{ maxHeight: "100%" }}
-    >
-      <ol
-        style={{
-          height: rowVirtualizer.getTotalSize(),
-          position: "relative",
-          width: "100%",
-        }}
-      >
-        {rowVirtualizer.getVirtualItems().map((vRow) => {
-          const p = entries[vRow.index];
-          const isActive = !!selectedHash && p.hash === selectedHash;
-          return (
-            <li
-              key={p.hash || vRow.index}
-              data-index={vRow.index}
-              ref={rowVirtualizer.measureElement}
-              style={{
-                position: "absolute",
-                top: 0,
-                left: 0,
-                width: "100%",
-                transform: `translateY(${vRow.start}px)`,
-              }}
-            >
-              <RowInner entry={p} onSelect={onSelect} active={isActive} />
-            </li>
-          );
-        })}
-      </ol>
-    </div>
-  );
-}
-
-function Row({
-  entry,
-  onSelect,
-  active,
-}: {
-  entry: HistoryEntry;
-  onSelect?: (hash: string) => void;
-  active?: boolean;
-}) {
-  return (
-    <li>
-      <RowInner entry={entry} onSelect={onSelect} active={active} />
-    </li>
-  );
-}
-
-function RowInner({
-  entry,
-  onSelect,
-  active,
-}: {
-  entry: HistoryEntry;
-  onSelect?: (hash: string) => void;
-  active?: boolean;
-}) {
-  const baseLayout = "grid grid-cols-[54px_1fr_auto] gap-2 w-full px-1";
-  // No commit hash → never clickable (e.g. unparseable git log entry).
-  if (!entry.hash || !onSelect) {
-    return (
-      <div
-        className={cn(
-          baseLayout,
-          active && "bg-surface-selected text-surface-selected-foreground",
-        )}
-      >
-        <RowContent entry={entry} active={active} />
-      </div>
-    );
+  diffHash,
+}: HistoryListProps) {
+  if (entries.length === 0) {
+    return <p className="text-sm text-foreground-muted">No versions yet.</p>;
   }
-  return (
-    <button
-      type="button"
-      onClick={() => onSelect(entry.hash!)}
-      aria-pressed={active}
-      aria-label={`View document at commit ${entry.hash.slice(0, 7)}`}
-      title={`Open this version (${entry.hash.slice(0, 7)})`}
-      className={cn(
-        baseLayout,
-        "text-left cursor-pointer transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface",
-        active
-          ? "bg-surface-selected text-surface-selected-foreground"
-          : "hover:bg-surface-hover",
-      )}
-    >
-      <RowContent entry={entry} active={active} />
-    </button>
-  );
-}
 
-function RowContent({
-  entry,
-  active,
-}: {
-  entry: HistoryEntry;
-  active?: boolean;
-}) {
-  // When active, the row container carries text-surface-selected-foreground;
-  // inner spans drop their own color so it cascades (no per-span orange).
   return (
-    <>
-      <span className={active ? undefined : "text-link"}>
-        {(entry.hash || "").slice(0, 7)}
-      </span>
-      <TooltipText
-        tip={`${entry.agent || entry.author || "unknown"}${entry.subject ? ` · ${entry.subject}` : ""}`}
-        className="truncate"
-      >
-        <span className={active ? undefined : "text-foreground-muted"}>
-          {entry.agent || entry.author || "unknown"}
-        </span>
-        {entry.subject && (
-          <>
-            {" "}
-            <span className={active ? undefined : "text-foreground"}>
-              · {entry.subject}
-            </span>
-          </>
-        )}
-      </TooltipText>
-      <span
-        className={cn(
-          "tabular-nums text-right shrink-0",
-          !active && "text-foreground-muted",
-        )}
-      >
-        {timeAgo(entry.timestamp)}
-      </span>
-    </>
+    <ol className="overflow-hidden rounded-[var(--radius-md)] border border-border bg-surface divide-y divide-border">
+      {entries.map((entry) => {
+        const selected = sameCommitRef(entry.hash, selectedHash);
+        const comparing = sameCommitRef(entry.hash, diffHash);
+        const author = entry.author_name || entry.author || "Unknown author";
+        const shortHash = entry.hash.slice(0, 7);
+        return (
+          <li
+            key={entry.hash}
+            className={cn(
+              "grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 px-2 py-2 transition-token",
+              (selected || comparing) && "bg-surface-selected text-surface-selected-foreground",
+            )}
+          >
+            <button
+              type="button"
+              onClick={() => onSelect?.(entry.hash)}
+              disabled={!onSelect}
+              aria-pressed={selected && !comparing}
+              aria-label={`View version ${shortHash}: ${entry.message}`}
+              className="min-w-0 rounded-[var(--radius-sm)] px-1 py-0.5 text-left transition-token hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default disabled:opacity-100"
+            >
+              <TooltipText tip={entry.message} className="block truncate text-sm font-medium text-foreground">
+                {entry.message || "Document update"}
+              </TooltipText>
+              <span className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-foreground-muted">
+                <GitCommitHorizontal className="h-3 w-3 shrink-0" aria-hidden />
+                <code className="shrink-0 font-mono text-link">{shortHash}</code>
+                <span aria-hidden>·</span>
+                <span className="min-w-0 truncate">{author}</span>
+                {entry.date && (
+                  <>
+                    <span aria-hidden>·</span>
+                    <span className="shrink-0 tabular-nums">{timeAgo(entry.date)}</span>
+                  </>
+                )}
+              </span>
+            </button>
+
+            <div className="flex shrink-0 items-center gap-1">
+              {onCompare && (
+                <button
+                  type="button"
+                  data-document-diff-trigger={entry.hash}
+                  onClick={(event) => onCompare(entry.hash, event.currentTarget)}
+                  aria-pressed={comparing}
+                  aria-label={`View changes in version ${shortHash}`}
+                  className={cn(
+                    "inline-flex h-8 items-center gap-1.5 rounded-[var(--radius-md)] border px-2 text-xs font-medium transition-token focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                    comparing
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "border-border bg-surface text-foreground-muted hover:border-border-strong hover:bg-surface-hover hover:text-link",
+                  )}
+                >
+                  <GitCompareArrows className="h-3.5 w-3.5" aria-hidden />
+                  Changes
+                </button>
+              )}
+            </div>
+          </li>
+        );
+      })}
+    </ol>
   );
 }

--- a/frontend/src/lib/__tests__/api-document-revisions.test.ts
+++ b/frontend/src/lib/__tests__/api-document-revisions.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DocumentRevisionApiError,
+  getDocumentDiff,
+  getDocumentHistory,
+  getDocumentHistoryWithFallback,
+} from "@/lib/api";
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+describe("document revision API", () => {
+  it("loads the canonical logical document history", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({
+      kind: "document_history",
+      uri: "akb://demo/coll/notes/doc/guide.md",
+      history: [{
+        hash: "abcdef123456",
+        message: "Update guide",
+        author: "user-1",
+        author_name: "Kim",
+        date: "2026-09-02T00:00:00Z",
+      }],
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await getDocumentHistory("demo", "notes/guide.md", 20);
+
+    expect(result.source).toBe("document");
+    expect(result.history[0].message).toBe("Update guide");
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "/api/v1/history/demo/notes%2Fguide.md?limit=20",
+    );
+  });
+
+  it("falls back to path activity only when an old server returns 404/405", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ detail: "Not Found" }, 404))
+      .mockResolvedValueOnce(jsonResponse({
+        vault: "demo",
+        total: 1,
+        activity: [{
+          hash: "abcdef123456",
+          subject: "Legacy update",
+          agent: "legacy-user",
+          author_name: "Legacy User",
+          timestamp: "2026-09-01T00:00:00Z",
+        }],
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await getDocumentHistoryWithFallback("demo", "notes/guide.md");
+
+    expect(result.source).toBe("activity");
+    expect(result.history[0]).toMatchObject({
+      message: "Legacy update",
+      author: "legacy-user",
+      author_name: "Legacy User",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves 403 instead of mislabelling it as an unsupported server", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({ detail: "Forbidden" }, 403),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      getDocumentHistoryWithFallback("demo", "notes/guide.md"),
+    ).rejects.toMatchObject({
+      name: "DocumentRevisionApiError",
+      status: 403,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps string-detail status codes for Diff compatibility states", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ detail: "Method Not Allowed" }, 405)),
+    );
+
+    try {
+      await getDocumentDiff("demo", "notes/guide.md", "abcdef1");
+      throw new Error("expected getDocumentDiff to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(DocumentRevisionApiError);
+      expect(error).toMatchObject({ status: 405, message: "Method Not Allowed" });
+    }
+  });
+});

--- a/frontend/src/lib/__tests__/api-document-revisions.test.ts
+++ b/frontend/src/lib/__tests__/api-document-revisions.test.ts
@@ -23,7 +23,7 @@ describe("document revision API", () => {
       kind: "document_history",
       uri: "akb://demo/coll/notes/doc/guide.md",
       history: [{
-        hash: "abcdef123456",
+        hash: "abcdef123456", // pragma: allowlist secret — synthetic Git commit
         message: "Update guide",
         author: "user-1",
         author_name: "Kim",

--- a/frontend/src/lib/__tests__/document-diff.test.ts
+++ b/frontend/src/lib/__tests__/document-diff.test.ts
@@ -12,7 +12,7 @@ function response(overrides: Partial<DocumentDiff> = {}): DocumentDiff {
   return {
     kind: "document_diff",
     file: "notes/guide.md",
-    commit: "abcdef123456",
+    commit: "abcdef123456", // pragma: allowlist secret — synthetic Git commit
     type: "modified",
     diff: "",
     ...overrides,

--- a/frontend/src/lib/__tests__/document-diff.test.ts
+++ b/frontend/src/lib/__tests__/document-diff.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import type { DocumentDiff } from "@/lib/api";
+import {
+  DOCUMENT_DIFF_MAX_LINES,
+  inspectDocumentDiffPatch,
+  normalizeDocumentDiffPatch,
+  parseDocumentDiffPatch,
+} from "@/lib/document-diff";
+
+function response(overrides: Partial<DocumentDiff> = {}): DocumentDiff {
+  return {
+    kind: "document_diff",
+    file: "notes/guide.md",
+    commit: "abcdef123456",
+    type: "modified",
+    diff: "",
+    ...overrides,
+  };
+}
+
+describe("document diff parser", () => {
+  it("maps unified changes to aligned old/new line numbers", () => {
+    const parsed = parseDocumentDiffPatch(response({
+      diff: [
+        "--- a/notes/guide.md",
+        "+++ b/notes/guide.md",
+        "@@ -1,2 +1,2 @@",
+        "-Old title",
+        "+New title",
+        " body",
+      ].join("\n"),
+    }));
+
+    expect(parsed).toMatchObject({ additions: 1, deletions: 1 });
+    expect(parsed.hunks).toHaveLength(1);
+    expect(parsed.rows.map((row) => ({
+      kind: row.kind,
+      oldLine: row.oldLine,
+      newLine: row.newLine,
+      content: row.content,
+    }))).toEqual([
+      { kind: "hunk", oldLine: null, newLine: null, content: "@@ -1,2 +1,2 @@" },
+      { kind: "removed", oldLine: 1, newLine: null, content: "Old title" },
+      { kind: "added", oldLine: null, newLine: 1, content: "New title" },
+      { kind: "context", oldLine: 2, newLine: 2, content: "body" },
+    ]);
+  });
+
+  it("normalizes native headerless create revisions without changing display text", () => {
+    const diff = response({
+      type: "added",
+      diff: "+# Guide\n+\n+Body",
+    });
+
+    expect(normalizeDocumentDiffPatch(diff)).toContain("--- /dev/null");
+    const parsed = parseDocumentDiffPatch(diff);
+    expect(parsed.additions).toBe(3);
+    expect(parsed.deletions).toBe(0);
+    expect(parsed.rows.filter((row) => row.kind === "added")).toHaveLength(3);
+    expect(diff.diff).toBe("+# Guide\n+\n+Body");
+  });
+
+  it("normalizes native headerless delete revisions", () => {
+    const parsed = parseDocumentDiffPatch(response({
+      type: "deleted",
+      diff: "-First\n-Second",
+    }));
+
+    expect(parsed.additions).toBe(0);
+    expect(parsed.deletions).toBe(2);
+    expect(parsed.rows.filter((row) => row.kind === "removed")).toHaveLength(2);
+  });
+
+  it("rejects a non-empty unsupported patch instead of rendering misleading rows", () => {
+    expect(() => parseDocumentDiffPatch(response({ diff: "not a unified diff" }))).toThrow(
+      /cannot display/i,
+    );
+  });
+
+  it("guards the parser before an excessive line count is mounted", () => {
+    const patch = Array.from({ length: DOCUMENT_DIFF_MAX_LINES + 1 }, () => "+x").join("\n");
+    const guard = inspectDocumentDiffPatch(patch);
+
+    expect(guard.lineCount).toBe(DOCUMENT_DIFF_MAX_LINES + 1);
+    expect(guard.tooLarge).toBe(true);
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1191,6 +1191,141 @@ export const getDocument = (vault: string, id: string, version?: string) => {
     version ? `${path}?version=${encodeURIComponent(version)}` : path,
   );
 };
+
+export interface DocumentHistoryEntry {
+  hash: string;
+  message: string;
+  author: string;
+  author_name?: string | null;
+  date: string;
+}
+
+export interface DocumentHistoryResult {
+  kind: "document_history";
+  uri?: string;
+  history: DocumentHistoryEntry[];
+  /**
+   * `activity` is an explicit compatibility mode for a frontend deployed in
+   * front of a server that predates the document-lineage endpoint. It keeps
+   * version browsing available, but the UI labels the reduced guarantee.
+   */
+  source: "document" | "activity";
+}
+
+export interface DocumentDiff {
+  kind: "document_diff";
+  file: string;
+  commit: string;
+  type: "added" | "deleted" | "modified" | "unknown" | "unchanged";
+  diff: string;
+  error?: string | null;
+  /** Additive fields understood by newer servers; the current UI does not require them. */
+  base_commit?: string | null;
+  additions?: number;
+  deletions?: number;
+  hunks?: number;
+  truncated?: boolean;
+}
+
+/**
+ * Status-preserving failure for the version-history surfaces.
+ *
+ * The generic API helper historically discarded status when FastAPI returned
+ * a string `detail`. History/Diff need the status to distinguish an old
+ * server's 404/405 from lost access or a retryable server failure.
+ */
+export class DocumentRevisionApiError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "DocumentRevisionApiError";
+    this.status = status;
+  }
+}
+
+async function documentRevisionJson<T>(path: string): Promise<T> {
+  const response = await authenticatedFetch(`${API_BASE}${path}`);
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    const detail = body?.detail;
+    const message =
+      typeof detail === "string"
+        ? detail
+        : typeof detail?.message === "string"
+          ? detail.message
+          : typeof body?.error === "string"
+            ? body.error
+            : `${response.status} ${response.statusText || "Request failed"}`;
+    throw new DocumentRevisionApiError(message, response.status);
+  }
+  return response.json() as Promise<T>;
+}
+
+export async function getDocumentHistory(
+  vault: string,
+  id: string,
+  limit = 20,
+): Promise<DocumentHistoryResult> {
+  const query = new URLSearchParams({ limit: String(limit) });
+  const result = await documentRevisionJson<{
+    kind: "document_history";
+    uri: string;
+    history: DocumentHistoryEntry[];
+  }>(
+    `/history/${encodeURIComponent(vault)}/${encodeURIComponent(id)}?${query}`,
+  );
+  return { ...result, source: "document" };
+}
+
+function activityEntryToDocumentHistory(entry: ActivityEntry): DocumentHistoryEntry | null {
+  if (!entry.hash) return null;
+  return {
+    hash: entry.hash,
+    message: entry.subject || entry.summary || "Document update",
+    author: entry.author || entry.agent || "Unknown author",
+    author_name: entry.author_name ?? null,
+    date: entry.date || entry.timestamp || "",
+  };
+}
+
+export async function getDocumentHistoryWithFallback(
+  vault: string,
+  id: string,
+  limit = 20,
+): Promise<DocumentHistoryResult> {
+  try {
+    return await getDocumentHistory(vault, id, limit);
+  } catch (error) {
+    if (
+      !(error instanceof DocumentRevisionApiError) ||
+      (error.status !== 404 && error.status !== 405)
+    ) {
+      throw error;
+    }
+  }
+
+  const legacy = await getVaultActivity(vault, { collection: id, limit });
+  return {
+    kind: "document_history",
+    history: legacy.activity
+      .map(activityEntryToDocumentHistory)
+      .filter((entry): entry is DocumentHistoryEntry => entry !== null),
+    source: "activity",
+  };
+}
+
+export function getDocumentDiff(
+  vault: string,
+  id: string,
+  commit: string,
+): Promise<DocumentDiff> {
+  const query = new URLSearchParams({ commit });
+  return documentRevisionJson<DocumentDiff>(
+    `/diff/${encodeURIComponent(vault)}/${encodeURIComponent(id)}?${query}`,
+  );
+}
+
 export const updateDocument = (vault: string, id: string, data: any) =>
   api<any>(`/documents/${vault}/${encodeURIComponent(id)}`, { method: "PATCH", body: JSON.stringify(data) });
 

--- a/frontend/src/lib/document-diff.ts
+++ b/frontend/src/lib/document-diff.ts
@@ -1,0 +1,147 @@
+import parseDiff from "parse-diff";
+
+import type { DocumentDiff } from "@/lib/api";
+
+export const DOCUMENT_DIFF_MAX_BYTES = 2 * 1024 * 1024;
+export const DOCUMENT_DIFF_MAX_LINES = 20_000;
+export const DOCUMENT_DIFF_VIRTUALIZE_THRESHOLD = 50;
+
+export type DocumentDiffLineKind = "hunk" | "context" | "added" | "removed";
+
+export interface DocumentDiffLine {
+  id: string;
+  kind: DocumentDiffLineKind;
+  content: string;
+  oldLine: number | null;
+  newLine: number | null;
+  hunkIndex: number;
+}
+export interface DocumentDiffHunk {
+  index: number;
+  header: string;
+  rowIndex: number;
+  oldStart: number;
+  newStart: number;
+}
+
+export interface ParsedDocumentDiff {
+  rows: DocumentDiffLine[];
+  hunks: DocumentDiffHunk[];
+  additions: number;
+  deletions: number;
+}
+
+export interface DocumentDiffGuard {
+  byteCount: number;
+  lineCount: number;
+  tooLarge: boolean;
+}
+
+export function inspectDocumentDiffPatch(patch: string): DocumentDiffGuard {
+  const byteCount = new TextEncoder().encode(patch).byteLength;
+  let lineCount = patch.length === 0 ? 0 : 1;
+  for (let index = 0; index < patch.length; index += 1) {
+    if (patch.charCodeAt(index) === 10) lineCount += 1;
+  }
+  return {
+    byteCount,
+    lineCount,
+    tooLarge:
+      byteCount > DOCUMENT_DIFF_MAX_BYTES ||
+      lineCount > DOCUMENT_DIFF_MAX_LINES,
+  };
+}
+
+/**
+ * Native create/delete revisions intentionally return a compact stream of
+ * `+` or `-` lines without Git headers. `parse-diff` expects a complete
+ * unified patch, so add synthetic headers for parsing only. The untouched
+ * response remains the source for Copy.
+ */
+export function normalizeDocumentDiffPatch(diff: DocumentDiff): string {
+  const patch = diff.diff.replace(/\r\n?/g, "\n");
+  if (!patch || /^@@\s/m.test(patch) || /^---\s/m.test(patch)) return patch;
+
+  const lines = patch.split("\n");
+  const safeFile = diff.file || "document.md";
+  if (diff.type === "added" && lines.every((line) => line.startsWith("+"))) {
+    return [
+      "--- /dev/null",
+      `+++ b/${safeFile}`,
+      `@@ -0,0 +1,${lines.length} @@`,
+      patch,
+    ].join("\n");
+  }
+  if (diff.type === "deleted" && lines.every((line) => line.startsWith("-"))) {
+    return [
+      `--- a/${safeFile}`,
+      "+++ /dev/null",
+      `@@ -1,${lines.length} +0,0 @@`,
+      patch,
+    ].join("\n");
+  }
+  return patch;
+}
+
+export function parseDocumentDiffPatch(diff: DocumentDiff): ParsedDocumentDiff {
+  const normalized = normalizeDocumentDiffPatch(diff);
+  if (!normalized) {
+    return { rows: [], hunks: [], additions: 0, deletions: 0 };
+  }
+
+  const files = parseDiff(normalized);
+  const rows: DocumentDiffLine[] = [];
+  const hunks: DocumentDiffHunk[] = [];
+  let additions = 0;
+  let deletions = 0;
+
+  for (const file of files) {
+    additions += file.additions;
+    deletions += file.deletions;
+    for (const chunk of file.chunks) {
+      const hunkIndex = hunks.length;
+      hunks.push({
+        index: hunkIndex,
+        header: chunk.content,
+        rowIndex: rows.length,
+        oldStart: chunk.oldStart,
+        newStart: chunk.newStart,
+      });
+      rows.push({
+        id: `hunk-${hunkIndex}`,
+        kind: "hunk",
+        content: chunk.content,
+        oldLine: null,
+        newLine: null,
+        hunkIndex,
+      });
+
+      for (const change of chunk.changes) {
+        const kind: DocumentDiffLineKind =
+          change.type === "add"
+            ? "added"
+            : change.type === "del"
+              ? "removed"
+              : "context";
+        const oldLine =
+          change.type === "normal" ? change.ln1 : change.type === "del" ? change.ln : null;
+        const newLine =
+          change.type === "normal" ? change.ln2 : change.type === "add" ? change.ln : null;
+        rows.push({
+          id: `${hunkIndex}-${rows.length}-${kind}`,
+          kind,
+          content: change.content.slice(1),
+          oldLine,
+          newLine,
+          hunkIndex,
+        });
+      }
+    }
+  }
+
+  if (rows.length === 0 && diff.diff.trim()) {
+    throw new Error("The server returned a diff format this client cannot display.");
+  }
+
+  return { rows, hunks, additions, deletions };
+}

--- a/frontend/src/pages/__tests__/document-skill-redirect.test.tsx
+++ b/frontend/src/pages/__tests__/document-skill-redirect.test.tsx
@@ -9,6 +9,7 @@ import { VAULT_SKILL_PATH } from "@/lib/skill";
 vi.mock("@/lib/api", () => ({
   authenticatedFetch: vi.fn(),
   getDocument: vi.fn(),
+  getDocumentHistoryWithFallback: vi.fn(),
   getVaultInfo: vi.fn(),
   getRelations: vi.fn(),
   deleteDocument: vi.fn(),
@@ -19,12 +20,14 @@ vi.mock("@/lib/api", () => ({
 import {
   authenticatedFetch,
   getDocument,
+  getDocumentHistoryWithFallback,
   getRelations,
   getVaultInfo,
 } from "@/lib/api";
 
 const authenticatedFetchMock = authenticatedFetch as unknown as ReturnType<typeof vi.fn>;
 const getDocumentMock = getDocument as unknown as ReturnType<typeof vi.fn>;
+const getDocumentHistoryMock = getDocumentHistoryWithFallback as unknown as ReturnType<typeof vi.fn>;
 const getRelationsMock = getRelations as unknown as ReturnType<typeof vi.fn>;
 const getVaultInfoMock = getVaultInfo as unknown as ReturnType<typeof vi.fn>;
 
@@ -55,10 +58,16 @@ function renderAt(url: string) {
 beforeEach(() => {
   authenticatedFetchMock.mockReset();
   getDocumentMock.mockReset();
+  getDocumentHistoryMock.mockReset();
   getRelationsMock.mockReset();
   getVaultInfoMock.mockReset();
 
   authenticatedFetchMock.mockResolvedValue({ ok: true, json: async () => ({ activity: [] }) });
+  getDocumentHistoryMock.mockResolvedValue({
+    kind: "document_history",
+    source: "document",
+    history: [],
+  });
   getDocumentMock.mockResolvedValue({
     path: VAULT_SKILL_PATH,
     title: "Vault guide",

--- a/frontend/src/pages/__tests__/document-view-toggle.test.tsx
+++ b/frontend/src/pages/__tests__/document-view-toggle.test.tsx
@@ -13,6 +13,8 @@ vi.mock("@/lib/api", async (importOriginal) => {
   return {
     ...actual,
     getDocument: vi.fn(),
+    getDocumentDiff: vi.fn(),
+    getDocumentHistoryWithFallback: vi.fn(),
     getVaultInfo: vi.fn(),
     getRelations: vi.fn(),
     deleteDocument: vi.fn(),
@@ -44,8 +46,11 @@ vi.mock("@/components/markdown-editor", () => ({
 
 import {
   ApiError,
+  DocumentRevisionApiError,
   deleteDocument,
   getDocument,
+  getDocumentDiff,
+  getDocumentHistoryWithFallback,
   getVaultInfo,
   getRelations,
   browseVault,
@@ -55,6 +60,8 @@ import {
 
 const getDocumentMock = getDocument as unknown as ReturnType<typeof vi.fn>;
 const deleteDocumentMock = deleteDocument as unknown as ReturnType<typeof vi.fn>;
+const getDocumentDiffMock = getDocumentDiff as unknown as ReturnType<typeof vi.fn>;
+const getDocumentHistoryMock = getDocumentHistoryWithFallback as unknown as ReturnType<typeof vi.fn>;
 const getVaultInfoMock = getVaultInfo as unknown as ReturnType<typeof vi.fn>;
 const getRelationsMock = getRelations as unknown as ReturnType<typeof vi.fn>;
 const updateDocumentMock = updateDocument as unknown as ReturnType<typeof vi.fn>;
@@ -163,6 +170,8 @@ beforeEach(() => {
   localStorage.clear();
   getDocumentMock.mockReset();
   deleteDocumentMock.mockReset();
+  getDocumentDiffMock.mockReset();
+  getDocumentHistoryMock.mockReset();
   getVaultInfoMock.mockReset();
   getRelationsMock.mockReset();
   updateDocumentMock.mockReset();
@@ -172,6 +181,19 @@ beforeEach(() => {
   getDocumentMock.mockResolvedValue(makeDoc());
   getVaultInfoMock.mockResolvedValue({ role: "reader" });
   getRelationsMock.mockResolvedValue({ relations: [] });
+  getDocumentHistoryMock.mockResolvedValue({
+    kind: "document_history",
+    uri: "akb://v/coll/notes/doc/hello.md",
+    source: "document",
+    history: [],
+  });
+  getDocumentDiffMock.mockResolvedValue({
+    kind: "document_diff",
+    file: "notes/hello.md",
+    commit: "abcdef1234567",
+    type: "modified",
+    diff: "--- a/notes/hello.md\n+++ b/notes/hello.md\n@@ -1,2 +1,2 @@\n-Old title\n+New title\n body",
+  });
   updateDocumentMock.mockResolvedValue({
     current_commit: UPDATED_COMMIT,
     commit_hash: UPDATED_COMMIT,
@@ -194,7 +216,7 @@ beforeEach(() => {
   });
   deleteDocumentMock.mockResolvedValue({ deleted: true });
 
-  // /activity is fetched directly via fetch() — stub it to a no-op.
+  // Keep a safe transport fallback for components that issue direct requests.
   vi.stubGlobal(
     "fetch",
     vi.fn().mockResolvedValue({
@@ -528,6 +550,124 @@ describe("DocumentPage view toggle", () => {
     const relationsTab = await screen.findByRole("tab", { name: /^Relations/ });
     expect(relationsTab).toHaveTextContent(/^Relations1$/);
     expect(relationsTab).not.toHaveTextContent("2");
+  });
+
+  it("loads logical document lineage instead of path-scoped Vault activity", async () => {
+    renderAt("/vault/v/doc/notes%2Fhello.md");
+
+    await screen.findByRole("heading", { level: 1, name: "DocTitle" });
+    await waitFor(() =>
+      expect(getDocumentHistoryMock).toHaveBeenCalledWith(
+        "v",
+        "notes/hello.md",
+        20,
+      ),
+    );
+  });
+
+  it("opens a History revision as a full-canvas Diff and restores History focus", async () => {
+    const user = userEvent.setup();
+    getDocumentHistoryMock.mockResolvedValue({
+      kind: "document_history",
+      uri: "akb://v/coll/notes/doc/hello.md",
+      source: "document",
+      history: [
+        {
+          hash: "abcdef1234567",
+          message: "Update title",
+          author: "user-1",
+          author_name: "Kim",
+          date: "2026-09-02T00:00:00Z",
+        },
+        {
+          hash: "1234567abcdef",
+          message: "Create document",
+          author: "user-1",
+          author_name: "Kim",
+          date: "2026-09-01T00:00:00Z",
+        },
+      ],
+    });
+    renderAt("/vault/v/doc/notes%2Fhello.md");
+
+    await user.click(await screen.findByRole("button", { name: "History" }));
+    const changes = await screen.findByRole("button", {
+      name: "View changes in version abcdef1",
+    });
+    await user.click(changes);
+
+    expect(await screen.findByRole("table", { name: /unified document changes/i })).toBeInTheDocument();
+    expect(screen.getByTestId("location-search")).toHaveTextContent(
+      "commit=abcdef1234567&view=diff",
+    );
+    expect(document.getElementById("document-details-panel")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+    expect(screen.queryByRole("tablist", { name: "Document view" })).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Back to version" }));
+    await screen.findByRole("heading", { level: 2, name: "BodyHeading" });
+    expect(screen.getByTestId("location-search")).toHaveTextContent(
+      "commit=abcdef1234567",
+    );
+    expect(screen.getByTestId("location-search")).not.toHaveTextContent("view=diff");
+    expect(document.getElementById("document-details-panel")).toHaveAttribute(
+      "aria-hidden",
+      "false",
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "View changes in version abcdef1" }),
+      ).toHaveFocus(),
+    );
+  });
+
+  it("keeps Search preview route state while entering Diff", async () => {
+    const user = userEvent.setup();
+    getDocumentHistoryMock.mockResolvedValue({
+      kind: "document_history",
+      source: "document",
+      history: [{
+        hash: "abcdef1234567",
+        message: "Update title",
+        author: "user-1",
+        date: "2026-09-02T00:00:00Z",
+      }],
+    });
+    renderPreviewAt("/vault/v/doc/notes%2Fhello.md");
+
+    await user.click(await screen.findByRole("button", { name: "History" }));
+    await user.click(await screen.findByRole("button", {
+      name: "View changes in version abcdef1",
+    }));
+
+    expect(await screen.findByRole("table", { name: /unified document changes/i })).toBeInTheDocument();
+    expect(screen.getByTestId("location-state")).toHaveTextContent(
+      '"documentPreview":true',
+    );
+    expect(screen.getByTestId("location-search")).toHaveTextContent("view=diff");
+  });
+
+  it("keeps the Diff frame available for an unsupported direct revision URL", async () => {
+    getDocumentDiffMock.mockRejectedValue(
+      new DocumentRevisionApiError("Not found", 404),
+    );
+
+    renderAt(
+      "/vault/v/doc/notes%2Fhello.md?commit=missing-revision&view=diff",
+    );
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "Changes are not available on this server",
+      }),
+    ).toBeInTheDocument();
+    expect(getDocumentMock).toHaveBeenCalledWith(
+      "v",
+      "notes/hello.md",
+      undefined,
+    );
   });
 
   it("?view=raw renders the raw markdown inside <pre>", async () => {

--- a/frontend/src/pages/__tests__/document-view-toggle.test.tsx
+++ b/frontend/src/pages/__tests__/document-view-toggle.test.tsx
@@ -580,7 +580,7 @@ describe("DocumentPage view toggle", () => {
           date: "2026-09-02T00:00:00Z",
         },
         {
-          hash: "1234567abcdef",
+          hash: "1234567abcdef", // pragma: allowlist secret — synthetic Git commit
           message: "Create document",
           author: "user-1",
           author_name: "Kim",

--- a/frontend/src/pages/document.tsx
+++ b/frontend/src/pages/document.tsx
@@ -18,6 +18,7 @@ import {
   ExternalLink,
   FileText,
   FolderTree,
+  GitCompareArrows,
   GitCommitHorizontal,
   History,
   Info,
@@ -32,13 +33,14 @@ import {
   Share2,
 } from "lucide-react";
 import {
-  authenticatedFetch,
   ApiError,
   browseVault,
   deleteDocument,
   getDocument,
+  getDocumentHistoryWithFallback,
   getRelations,
   getVaultInfo,
+  type DocumentHistoryEntry,
   type RelationRow,
   unpublishDoc,
   updateDocument,
@@ -85,8 +87,10 @@ import {
 // Plate is heavy (~hundreds of KB gzipped); lazy-load so the read-only path
 // (Rendered / Raw) stays cheap.
 const MarkdownEditor = lazy(() => import("@/components/markdown-editor"));
+const DocumentDiffView = lazy(() => import("@/components/document-diff-view"));
 
-type DocView = "rendered" | "raw" | "edit";
+type DocView = "rendered" | "raw" | "edit" | "diff";
+const EMPTY_DOCUMENT_HISTORY: DocumentHistoryEntry[] = [];
 
 type BrowsedDocumentTitle = {
   type: "document";
@@ -122,11 +126,21 @@ export default function DocumentPage({
   const commitHash = searchParams.get("commit") || undefined;
   const rawView = searchParams.get("view");
   const view: DocView =
-    rawView === "raw" ? "raw" : rawView === "edit" ? "edit" : "rendered";
+    rawView === "raw"
+      ? "raw"
+      : rawView === "edit"
+        ? "edit"
+        : rawView === "diff" && commitHash
+          ? "diff"
+          : "rendered";
+  const isDiffMode = view === "diff";
+  // Diff owns revision validation and its compatibility/error states. Keep the
+  // surrounding document identity on HEAD so a stale or mistyped revision can
+  // still render the comparison frame instead of replacing the whole page with
+  // the generic document error state.
+  const documentVersion = isDiffMode ? undefined : commitHash;
   const [relations, setRelations] = useState<RelationRow[]>([]);
   const [relationsError, setRelationsError] = useState(false);
-  const [provenance, setProvenance] = useState<any[]>([]);
-  const [historyError, setHistoryError] = useState(false);
   const [pendingView, setPendingView] = useState<DocView | null>(null);
   const [pendingExistingPath, setPendingExistingPath] = useState<string | null>(null);
   const [docOverride, setDocOverride] = useState<any>(null);
@@ -149,6 +163,8 @@ export default function DocumentPage({
   const cancelEditButtonRef = useRef<HTMLButtonElement | null>(null);
   const editTitleRef = useRef<HTMLInputElement | null>(null);
   const titleConflictRef = useRef<HTMLDivElement | null>(null);
+  const diffOriginHashRef = useRef<string | null>(null);
+  const wasDiffModeRef = useRef(false);
   const restoreEditFocusRef = useRef(false);
   // Plate manages its own state; we remount via `editorKey` when hydrating
   // a fresh server value rather than treating `value` as controlled.
@@ -296,13 +312,21 @@ export default function DocumentPage({
   }, [view]);
 
   const docQuery = useQuery({
-    queryKey: ["document", name, docId, commitHash],
-    queryFn: () => getDocument(name!, docId, commitHash),
+    queryKey: ["document", name, docId, documentVersion],
+    queryFn: () => getDocument(name!, docId, documentVersion),
     enabled: !!name && !!docId,
     retry: false,
   });
 
   const doc = docOverride ?? docQuery.data ?? null;
+  const historyQuery = useQuery({
+    queryKey: ["document-history", name, doc?.path],
+    queryFn: () => getDocumentHistoryWithFallback(name!, doc!.path, 20),
+    enabled: Boolean(name && doc?.path),
+    staleTime: 30_000,
+    retry: false,
+  });
+  const provenance = historyQuery.data?.history ?? EMPTY_DOCUMENT_HISTORY;
   const currentUserId = currentUser?.user_id;
   const editTitleCandidatesQuery = useQuery({
     queryKey: ["document-edit-title-candidates", name],
@@ -367,10 +391,14 @@ export default function DocumentPage({
   const headQuery = useQuery({
     queryKey: ["document", name, docId, undefined],
     queryFn: () => getDocument(name!, docId),
-    enabled: !!name && !!docId && !!commitHash,
+    enabled: !!name && !!docId && !!commitHash && !isDiffMode,
     retry: false,
   });
-  const headCommit = commitHash ? headQuery.data?.current_commit : doc?.current_commit;
+  const headCommit = commitHash
+    ? isDiffMode
+      ? doc?.current_commit
+      : headQuery.data?.current_commit
+    : doc?.current_commit;
   // Genuinely historical only when the pin points at a commit OTHER than HEAD.
   // sameCommitRef does a prefix-tolerant compare (the commit log links 12-char
   // short hashes; current_commit is the full SHA) and returns false while HEAD
@@ -378,7 +406,43 @@ export default function DocumentPage({
   const isHistorical = !!commitHash && !sameCommitRef(commitHash, headCommit);
   const canEdit =
     !isHistorical &&
+    !isDiffMode &&
     (vaultRole === "writer" || vaultRole === "admin" || vaultRole === "owner");
+
+  const selectedHistoryIndex = useMemo(
+    () =>
+      commitHash
+        ? provenance.findIndex((entry) => sameCommitRef(entry.hash, commitHash))
+        : -1,
+    [commitHash, provenance],
+  );
+  const selectedHistoryEntry: DocumentHistoryEntry | undefined =
+    selectedHistoryIndex >= 0 ? provenance[selectedHistoryIndex] : undefined;
+  const baseHistoryEntry: DocumentHistoryEntry | undefined =
+    selectedHistoryIndex >= 0 ? provenance[selectedHistoryIndex + 1] : undefined;
+
+  useEffect(() => {
+    if (isDiffMode) {
+      wasDiffModeRef.current = true;
+      return;
+    }
+    if (!wasDiffModeRef.current || !diffOriginHashRef.current) return;
+    wasDiffModeRef.current = false;
+    const originHash = diffOriginHashRef.current;
+    setDetailsTab("history");
+    setDetailsOpen(true);
+    const firstFrame = window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => {
+        const triggers = document.querySelectorAll<HTMLButtonElement>(
+          "[data-document-diff-trigger]",
+        );
+        Array.from(triggers).find(
+          (trigger) => trigger.dataset.documentDiffTrigger === originHash,
+        )?.focus();
+      });
+    });
+    return () => window.cancelAnimationFrame(firstFrame);
+  }, [isDiffMode]);
   // Parse headings once for the outline-tab count (the outline + renderer each
   // re-scan internally; this removes the third pass that ran on every render).
   const headingSlugs = useMemo(() => parseHeadings(doc?.content || ""), [doc?.content]);
@@ -396,10 +460,8 @@ export default function DocumentPage({
   useEffect(() => {
     const d = docQuery.data;
     setDocOverride(null);
-    setProvenance([]);
     setRelations([]);
     setRelationsError(false);
-    setHistoryError(false);
     setBodyError("");
     setTitleTouched(false);
     setServerTitleConflict(null);
@@ -429,9 +491,6 @@ export default function DocumentPage({
       getRelations(name!, d.path)
         .then((r) => setRelations(r.relations || []))
         .catch(() => setRelationsError(true));
-    }
-    if (d.path) {
-      loadHistory(name!, d.path);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [docQuery.data]);
@@ -605,25 +664,6 @@ export default function DocumentPage({
     setView("rendered");
   }
 
-  // History = `git log -- <doc.path>` scoped to this document.
-  async function loadHistory(vault: string, docPath: string) {
-    try {
-      const r = await authenticatedFetch(
-        `/api/v1/activity/${encodeURIComponent(vault)}?collection=${encodeURIComponent(docPath)}&limit=20`,
-      );
-      if (!r.ok) {
-        setProvenance([]);
-        setHistoryError(true);
-        return;
-      }
-      const d = await r.json();
-      setProvenance(d.activity || []);
-    } catch {
-      setProvenance([]);
-      setHistoryError(true);
-    }
-  }
-
   // The vault guide is system-managed: its only editing surface is the guide
   // section in vault settings, so the plain full-page viewer bounces there.
   // Search preview is exempt so every document result keeps the same modal
@@ -687,7 +727,7 @@ export default function DocumentPage({
     }
   }
 
-  const commitShort = headCommit?.slice(0, 7);
+  const commitShort = (commitHash || headCommit)?.slice(0, 7);
   const inEditMode = view === "edit";
   const fileName = doc.path?.split("/").pop() || doc.title || "Document";
   const collectionPath = doc.path?.includes("/")
@@ -705,13 +745,32 @@ export default function DocumentPage({
     vaultRole,
     vaultKind,
     vaultReadOnly,
-    isHistorical,
+    isHistorical: isHistorical || isDiffMode,
   });
   const canDelete =
     canWrite &&
     !vaultReadOnly &&
     !isHistorical &&
+    !isDiffMode &&
     doc.path !== VAULT_SKILL_PATH;
+
+  const openVersion = (hash?: string, options: { replace?: boolean } = {}) => {
+    const params = new URLSearchParams(searchParams);
+    params.delete("view");
+    if (hash) params.set("commit", hash);
+    else params.delete("commit");
+    updateRouteParams(params, { replace: options.replace ?? false });
+  };
+
+  const openDiff = (hash: string, trigger: HTMLButtonElement) => {
+    diffOriginHashRef.current = hash;
+    trigger.blur();
+    setDetailsOpen(false);
+    const params = new URLSearchParams(searchParams);
+    params.set("commit", hash);
+    params.set("view", "diff");
+    updateRouteParams(params, { replace: false });
+  };
 
   const closeDetails = () => {
     setDetailsOpen(false);
@@ -742,7 +801,9 @@ export default function DocumentPage({
                 <h1 id="doc-title" className="truncate font-display text-base font-semibold text-foreground sm:text-lg">
                   {doc.title}
                 </h1>
-                {isHistorical ? (
+                {isDiffMode ? (
+                  <Badge variant="info-outline">Comparing</Badge>
+                ) : isHistorical ? (
                   <Badge variant="warning">Historical</Badge>
                 ) : (
                   <Badge variant={doc.status === "archived" ? "archived" : doc.status === "draft" ? "draft" : "active"}>
@@ -837,7 +898,30 @@ export default function DocumentPage({
           </div>
         </header>
 
-        {isHistorical && (
+        {isDiffMode ? (
+          <div
+            role="status"
+            aria-live="polite"
+            className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-info/30 bg-info-soft px-4 py-2 text-sm text-info-soft-foreground sm:px-6"
+          >
+            <div className="flex min-w-0 items-center gap-2">
+              <GitCompareArrows className="h-4 w-4 shrink-0" aria-hidden />
+              <span>
+                Comparing {baseHistoryEntry ? <code className="font-mono font-medium">{baseHistoryEntry.hash.slice(0, 7)}</code> : "the previous revision"}
+                <span aria-hidden> → </span>
+                <code className="font-mono font-medium">{commitHash?.slice(0, 7)}</code>
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button type="button" variant="outline" size="sm" onClick={() => openVersion(commitHash, { replace: true })}>
+                Back to version
+              </Button>
+              <Button type="button" variant="ghost" size="sm" onClick={() => openVersion(undefined, { replace: true })}>
+                Back to latest
+              </Button>
+            </div>
+          </div>
+        ) : isHistorical ? (
           <div
             role="status"
             aria-live="polite"
@@ -853,16 +937,12 @@ export default function DocumentPage({
               type="button"
               variant="outline"
               size="sm"
-              onClick={() => {
-                const p = new URLSearchParams(searchParams);
-                p.delete("commit");
-                updateRouteParams(p, { replace: false });
-              }}
+              onClick={() => openVersion()}
             >
               Back to latest
             </Button>
           </div>
-        )}
+        ) : null}
 
         {publishError && (
           <div className="shrink-0 border-b border-border bg-surface px-4 py-3 sm:px-6">
@@ -873,7 +953,10 @@ export default function DocumentPage({
         <div className="relative min-h-0 flex-1 overflow-hidden">
           <main
             id="document-reading-canvas"
-            className="h-full overflow-y-auto bg-background"
+            className={cn(
+              "h-full bg-background",
+              isDiffMode ? "overflow-hidden" : "overflow-y-auto",
+            )}
           >
             <article
               ref={setArticleEl}
@@ -882,10 +965,12 @@ export default function DocumentPage({
                 "w-full",
                 inEditMode
                   ? "px-3 py-4 sm:px-4 sm:py-5 lg:px-5 xl:px-6 2xl:px-8"
-                  : "p-2 sm:p-3",
+                  : isDiffMode
+                    ? "flex h-full min-h-0 flex-col p-2 sm:p-3"
+                    : "p-2 sm:p-3",
               )}
             >
-              <div className="mb-3 flex min-h-11 min-w-0 items-center gap-3 rounded-[var(--radius-lg)] border border-border bg-surface px-3 shadow-xs">
+              <div className="mb-3 flex min-h-11 shrink-0 min-w-0 items-center gap-3 rounded-[var(--radius-lg)] border border-border bg-surface px-3 shadow-xs">
                 <div className="flex min-w-0 items-center gap-2 text-xs text-foreground-muted">
                   <FolderTree className="h-3.5 w-3.5 shrink-0 text-link" aria-hidden />
                   <span className="truncate font-medium text-foreground">{collectionPath}</span>
@@ -1052,12 +1137,25 @@ export default function DocumentPage({
                     {bodyError && <Alert variant="destructive" className="mt-4">{bodyError}</Alert>}
                   </div>
                 </section>
+              ) : isDiffMode && commitHash ? (
+                <Suspense fallback={<DocumentDiffModuleLoading />}>
+                  <DocumentDiffView
+                    vault={name!}
+                    docId={doc.path || docId}
+                    revision={commitHash}
+                    baseRevision={baseHistoryEntry?.hash}
+                    targetEntry={selectedHistoryEntry}
+                    onBackToVersion={() => openVersion(commitHash, { replace: true })}
+                    onBackToLatest={() => openVersion(undefined, { replace: true })}
+                    onOpenBase={baseHistoryEntry ? () => openVersion(baseHistoryEntry.hash, { replace: true }) : undefined}
+                  />
+                </Suspense>
               ) : (
                 <DocumentView
                   vault={name!}
                   docId={docId}
                   version={commitHash}
-                  view={view}
+                  view={view === "raw" ? "raw" : "rendered"}
                   onViewChange={(next) => setView(next)}
                   appearance="file"
                 />
@@ -1274,21 +1372,37 @@ export default function DocumentPage({
                 <TabsContent value="history" className="min-h-0 flex-1 overflow-y-auto px-4 pb-4 pt-3 rail-scroll">
                   <div className="mb-3 border-b border-border pb-3">
                     <h3 className="text-sm font-semibold text-foreground">Version history</h3>
-                    <p className="mt-0.5 text-xs text-foreground-muted">Select a commit to inspect that version.</p>
+                    <p className="mt-0.5 text-xs text-foreground-muted">Open a version or inspect what changed from its parent.</p>
                   </div>
-                  {historyError ? (
-                    <Alert variant="destructive">Failed to load history.</Alert>
+                  {historyQuery.isPending ? (
+                    <LoadingState label="Loading version history" className="space-y-2">
+                      <Skeleton className="h-16 w-full rounded-[var(--radius-md)]" />
+                      <Skeleton className="h-16 w-full rounded-[var(--radius-md)]" />
+                      <Skeleton className="h-16 w-full rounded-[var(--radius-md)]" />
+                    </LoadingState>
+                  ) : historyQuery.isError ? (
+                    <Alert variant="destructive" title="Couldn't load version history">
+                      <div className="mt-2">
+                        <Button type="button" variant="outline" size="sm" onClick={() => void historyQuery.refetch()}>
+                          Try again
+                        </Button>
+                      </div>
+                    </Alert>
                   ) : (
-                    <HistoryList
-                      entries={provenance as any}
-                      selectedHash={commitHash}
-                      onSelect={(hash) => {
-                        const p = new URLSearchParams(searchParams);
-                        if (commitHash === hash) p.delete("commit");
-                        else p.set("commit", hash);
-                        updateRouteParams(p, { replace: false });
-                      }}
-                    />
+                    <div className="space-y-3">
+                      {historyQuery.data?.source === "activity" && (
+                        <Alert variant="info" title="Limited history from an older server">
+                          Version browsing remains available. Exact document lineage and change comparison require a newer backend.
+                        </Alert>
+                      )}
+                      <HistoryList
+                        entries={provenance}
+                        selectedHash={commitHash}
+                        diffHash={isDiffMode ? commitHash : undefined}
+                        onSelect={(hash) => openVersion(hash)}
+                        onCompare={openDiff}
+                      />
+                    </div>
                   )}
                 </TabsContent>
               </Tabs>
@@ -1496,6 +1610,34 @@ function documentMoveDisabledReason({
     isHistorical,
   });
   return reason?.replace("renaming", "moving") ?? null;
+}
+
+function DocumentDiffModuleLoading() {
+  return (
+    <LoadingState
+      label="Opening document changes"
+      className="min-h-0 flex-1 overflow-hidden rounded-[var(--radius-lg)] border border-border bg-surface shadow-sm"
+    >
+      <div className="flex h-full min-h-[28rem] flex-col">
+        <div className="flex min-h-16 items-center gap-3 border-b border-border px-4">
+          <Skeleton className="h-8 w-8 rounded-[var(--radius-md)]" />
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-4 w-40 rounded-[var(--radius-sm)]" />
+            <Skeleton className="h-3 w-64 rounded-[var(--radius-sm)]" />
+          </div>
+        </div>
+        <div className="flex min-h-11 items-center gap-2 border-b border-border bg-surface-2 px-3">
+          <Skeleton className="h-3 w-24 rounded-[var(--radius-sm)]" />
+          <Skeleton className="h-3 w-24 rounded-[var(--radius-sm)]" />
+        </div>
+        <div className="flex-1 space-y-2 p-4">
+          {Array.from({ length: 10 }, (_, index) => (
+            <Skeleton key={index} className="h-5 w-full rounded-[var(--radius-sm)]" />
+          ))}
+        </div>
+      </div>
+    </LoadingState>
+  );
 }
 
 function DocumentPageLoading({ presentation }: { presentation: "page" | "preview" }) {

--- a/frontend/src/stories/components-status-content.stories.tsx
+++ b/frontend/src/stories/components-status-content.stories.tsx
@@ -28,20 +28,21 @@ type Story = StoryObj<typeof meta>;
 const history: HistoryEntry[] = [
   {
     hash: "story-a",
-    agent: "codex",
-    subject: "Add Storybook scenarios",
-    timestamp: new Date(Date.now() - 8 * 60_000).toISOString(),
+    author: "codex",
+    message: "Add Storybook scenarios",
+    date: new Date(Date.now() - 8 * 60_000).toISOString(),
   },
   {
     hash: "story-b",
     author: "jylkim",
-    subject: "Tune vault settings copy",
-    timestamp: new Date(Date.now() - 4 * 60 * 60_000).toISOString(),
+    message: "Tune vault settings copy",
+    date: new Date(Date.now() - 4 * 60 * 60_000).toISOString(),
   },
   {
-    agent: "importer",
-    subject: "Legacy entry without hash",
-    timestamp: new Date(Date.now() - 2 * 24 * 60 * 60_000).toISOString(),
+    hash: "story-c",
+    author: "importer",
+    message: "Import legacy document",
+    date: new Date(Date.now() - 2 * 24 * 60 * 60_000).toISOString(),
   },
 ];
 


### PR DESCRIPTION
## Summary

- replace path-scoped activity in the document inspector with logical document lineage, retaining a 404/405-only compatibility fallback for older servers
- add a URL-addressable, lazy-loaded unified diff canvas for each history revision
- provide old/new line numbers, explicit change markers, hunk navigation, patch copy, large-patch guards, virtualization, and accessible recovery states
- preserve document/search-preview routing and restore History focus when leaving a comparison

## Motivation

AKB already stores immutable document revisions and exposes reader-authorized history and diff endpoints, but the frontend required users to open complete versions and compare them manually. This change closes that gap without adding arbitrary two-revision selection, restore, comments, or merge behavior.

## Compatibility

The frontend continues to work with older backends. A missing History endpoint falls back to the existing path-filtered activity feed only for HTTP 404/405, while unsupported Diff responses keep the selected revision readable. Permission and server failures remain distinct.

## Verification

- frontend design check
- TypeScript typecheck
- ESLint (no errors)
- 104 frontend test files / 720 tests
- frontend production build
- History/Diff REST E2E: 48 checks

## Documentation

See `docs/design/proposal/2026-09-02-document-version-diff-ui/README.md` for the scope, accessibility rationale, state matrix, and deferred non-goals.