### PR TITLE
test(frontend): fix document diff secret scan fixtures

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -92,7 +92,7 @@
     },
     {
       "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": "/tmp/akb251-corrective-baseline-final.daG6ea"
+      "filename": ".secrets.baseline"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -6468,7 +6468,7 @@
         "filename": "frontend/src/pages/__tests__/document-view-toggle.test.tsx",
         "hashed_secret": "6c688927eafd673c7d9194b46b2b88e096e6c9f7",
         "is_verified": false,
-        "line_number": 85,
+        "line_number": 92,
         "is_secret": false
       }
     ],
@@ -7007,5 +7007,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-02T03:12:19Z"
+  "generated_at": "2026-09-02T08:06:11Z"
 }

--- a/frontend/src/components/__tests__/document-diff-view.test.tsx
+++ b/frontend/src/components/__tests__/document-diff-view.test.tsx
@@ -16,12 +16,14 @@ import {
 } from "@/lib/api";
 
 const getDocumentDiffMock = vi.mocked(getDocumentDiff);
+const TARGET_REVISION = "abcdef123456"; // pragma: allowlist secret — synthetic Git commit
+const BASE_REVISION = "123456abcdef"; // pragma: allowlist secret — synthetic Git commit
 
 function result(overrides: Partial<DocumentDiff> = {}): DocumentDiff {
   return {
     kind: "document_diff",
     file: "notes/guide.md",
-    commit: "abcdef123456", // pragma: allowlist secret — synthetic Git commit
+    commit: TARGET_REVISION,
     type: "modified",
     diff: [
       "--- a/notes/guide.md",
@@ -52,10 +54,10 @@ function renderDiff(props: Partial<React.ComponentProps<typeof DocumentDiffView>
         <DocumentDiffView
           vault="demo"
           docId="notes/guide.md"
-          revision="abcdef123456"
-          baseRevision={"123456abcdef" /* pragma: allowlist secret — synthetic Git commit */}
+          revision={TARGET_REVISION}
+          baseRevision={BASE_REVISION}
           targetEntry={{
-            hash: "abcdef123456",
+            hash: TARGET_REVISION,
             message: "Update guide",
             author: "user-1",
             author_name: "Kim",

--- a/frontend/src/components/__tests__/history-list.test.tsx
+++ b/frontend/src/components/__tests__/history-list.test.tsx
@@ -34,7 +34,7 @@ describe("HistoryList", () => {
     render(<HistoryList entries={entries} onSelect={onSelect} />);
 
     fireEvent.click(screen.getByRole("button", { name: /view version abcdef1/i }));
-    expect(onSelect).toHaveBeenCalledWith("abcdef123456");
+    expect(onSelect).toHaveBeenCalledWith(entries[0].hash);
   });
 
   it("keeps the Changes action visible and passes its trigger for focus restoration", () => {
@@ -43,7 +43,7 @@ describe("HistoryList", () => {
 
     const trigger = screen.getByRole("button", { name: /view changes in version abcdef1/i });
     fireEvent.click(trigger);
-    expect(onCompare).toHaveBeenCalledWith("abcdef123456", trigger);
+    expect(onCompare).toHaveBeenCalledWith(entries[0].hash, trigger);
   });
 
   it("marks a prefix-matched comparison without relying on color alone", () => {

--- a/frontend/src/lib/__tests__/api-document-revisions.test.ts
+++ b/frontend/src/lib/__tests__/api-document-revisions.test.ts
@@ -48,7 +48,7 @@ describe("document revision API", () => {
         vault: "demo",
         total: 1,
         activity: [{
-          hash: "abcdef123456",
+          hash: "abcdef123456", // pragma: allowlist secret — synthetic Git commit
           subject: "Legacy update",
           agent: "legacy-user",
           author_name: "Legacy User",


### PR DESCRIPTION
## Summary

- centralize synthetic Git revision values used by the document Diff component tests
- reuse existing history fixtures in callback assertions instead of repeating high-entropy literals
- mark the remaining legacy-history fixture as an explicit synthetic test value

## Context

The AKB-227 frontend implementation merged in #464, but the post-push static-analysis workflow identified repeated synthetic commit hashes as potential secrets. No credential was present. This follow-up keeps the test semantics unchanged while making the fixtures unambiguous to `detect-secrets`.

## Verification

- focused frontend tests: 14 passed
- TypeScript typecheck
- `git diff --check`
- local detect-secrets scan of the affected fixtures