### PR TITLE
feat(frontend): add server-driven table workspace

### DIFF
--- a/frontend/DESIGN_SYSTEM.md
+++ b/frontend/DESIGN_SYSTEM.md
@@ -574,15 +574,20 @@ commits` control and `Full commit log` route. Below `xl`, the work area stacks
   wrapping chips, and column-header buttons expose single-column sort with
   `aria-sort`. Page, 25/50/100 row size, sort, and repeated filters round-trip
   through the route query string so refresh, Back, and shared links restore the
-  same view. The footer reports the exact visible range and total and provides
-  first/previous/direct-page/next/last navigation. Server pagination—not a
+  same view. Multi-value filters use comma-delimited input; when a declared enum
+  choice itself contains a comma, the UI keeps exact `is` matching available and
+  omits the ambiguous multi-value condition. The footer reports the exact
+  visible range and total and provides first/previous/direct-page/next/last
+  navigation. Server pagination—not a
   client-side slice or an all-row fetch—is the large-table boundary; prior rows
   stay visible and `aria-busy` during a transition. Every order adds the system
   UUID as a deterministic tie-breaker.
   Interactive edits and deletes add the row's loaded `updated_at` to their UUID
   predicate. A zero-row mutation is a concurrency conflict, never a silent
   success: Edit preserves the draft and offers Reload current values or an
-  explicit Overwrite anyway; Delete refreshes the row and requires a second
+  explicit Overwrite anyway. Overwrite revalidates and serializes the current
+  visible draft rather than replaying the payload that first encountered the
+  conflict. Delete refreshes the row and requires a second
   reviewed confirmation. Rows without legacy audit metadata retain exact-ID
   mutation behavior without claiming conflict protection.
   DDL remains a separately governed concern rather than sharing the frequent

--- a/frontend/DESIGN_SYSTEM.md
+++ b/frontend/DESIGN_SYSTEM.md
@@ -569,6 +569,22 @@ commits` control and `Full commit log` route. Below `xl`, the work area stacks
   inline validation, nullable state, and server-managed identity/audit fields
   omitted. Delete uses `ConfirmDialog`, keeps failures inline, and successful
   mutations refresh both the grid and explorer counts with polite status text.
+  The records frame begins with one connected server-query bar: Filters opens a
+  schema-aware condition dialog, active conditions remain visible as removable
+  wrapping chips, and column-header buttons expose single-column sort with
+  `aria-sort`. Page, 25/50/100 row size, sort, and repeated filters round-trip
+  through the route query string so refresh, Back, and shared links restore the
+  same view. The footer reports the exact visible range and total and provides
+  first/previous/direct-page/next/last navigation. Server pagination—not a
+  client-side slice or an all-row fetch—is the large-table boundary; prior rows
+  stay visible and `aria-busy` during a transition. Every order adds the system
+  UUID as a deterministic tie-breaker.
+  Interactive edits and deletes add the row's loaded `updated_at` to their UUID
+  predicate. A zero-row mutation is a concurrency conflict, never a silent
+  success: Edit preserves the draft and offers Reload current values or an
+  explicit Overwrite anyway; Delete refreshes the row and requires a second
+  reviewed confirmation. Rows without legacy audit metadata retain exact-ID
+  mutation behavior without claiming conflict protection.
   DDL remains a separately governed concern rather than sharing the frequent
   row-action surface: direct Alter/Drop is admin-only, while the idempotent
   migration contract retains its existing writer policy.

--- a/frontend/src/components/table-query-controls.tsx
+++ b/frontend/src/components/table-query-controls.tsx
@@ -424,7 +424,9 @@ function valuePlaceholder(type: string, operator: TableFilterOperator): string {
 }
 
 function valueHelp(type: string, operator: TableFilterOperator): string {
-  if (operator === "in") return "Separate multiple exact values with commas.";
+  if (operator === "in") {
+    return "Separate exact values with commas. Use “is” for one value that contains a comma.";
+  }
   if (type === "jsonb") return "Enter the JSON object or array that each matching row must contain.";
   if (type === "timestamp") return "Use an ISO 8601 timestamp including a timezone when possible.";
   return "Filtering is applied by the server across the entire table.";

--- a/frontend/src/components/table-query-controls.tsx
+++ b/frontend/src/components/table-query-controls.tsx
@@ -1,0 +1,431 @@
+import { useEffect, useId, useMemo, useState, type FormEvent } from "react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+  Filter,
+  RefreshCw,
+  X,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { SelectMenu } from "@/components/ui/select-menu";
+import { Textarea } from "@/components/ui/textarea";
+import type { VaultTableColumnInput } from "@/lib/api";
+import {
+  TABLE_PAGE_SIZES,
+  normalizeTableColumnType,
+  tableFilterLabel,
+  tableFilterNeedsValue,
+  tableFilterOperators,
+  validateTableFilter,
+  type TableFilter,
+  type TableFilterOperator,
+  type TablePageSize,
+} from "@/lib/table-query-state";
+
+const SYSTEM_COLUMN_NAMES = new Set(["id", "created_by", "created_at", "updated_at"]);
+
+export function TableFilterDialog({
+  open,
+  onOpenChange,
+  columns,
+  onAdd,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  columns: VaultTableColumnInput[];
+  onAdd: (filter: TableFilter) => void;
+}) {
+  const formId = useId();
+  const [columnName, setColumnName] = useState("");
+  const [operator, setOperator] = useState<TableFilterOperator>("contains");
+  const [value, setValue] = useState("");
+  const [error, setError] = useState("");
+
+  const preferredColumn = useMemo(
+    () => columns.find((column) => !SYSTEM_COLUMN_NAMES.has(column.name)) || columns[0],
+    [columns],
+  );
+
+  const selectedColumn = useMemo(
+    () => columns.find((column) => column.name === columnName) || preferredColumn,
+    [columnName, columns, preferredColumn],
+  );
+  const operatorOptions = useMemo(
+    () => (selectedColumn ? tableFilterOperators(selectedColumn) : []),
+    [selectedColumn],
+  );
+
+  useEffect(() => {
+    if (!open || !preferredColumn) return;
+    const first = preferredColumn;
+    setColumnName(first.name);
+    setOperator(tableFilterOperators(first)[0]?.value || "eq");
+    setValue("");
+    setError("");
+  }, [open, preferredColumn]);
+
+  function chooseColumn(nextName: string) {
+    const nextColumn = columns.find((column) => column.name === nextName);
+    if (!nextColumn) return;
+    setColumnName(nextName);
+    setOperator(tableFilterOperators(nextColumn)[0]?.value || "eq");
+    setValue("");
+    setError("");
+  }
+
+  function submit(event: FormEvent) {
+    event.preventDefault();
+    if (!selectedColumn) return;
+    const filter = { column: selectedColumn.name, operator, value };
+    const validationError = validateTableFilter(filter, selectedColumn);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    onAdd(filter);
+    onOpenChange(false);
+  }
+
+  const needsValue = tableFilterNeedsValue(operator);
+  const normalizedType = normalizeTableColumnType(selectedColumn?.type);
+  const isEnumValue =
+    (normalizedType === "enum" || Boolean(selectedColumn?.enum?.length)) &&
+    Boolean(selectedColumn?.enum?.length) &&
+    operator !== "in";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xl gap-0 overflow-hidden p-0">
+        <DialogHeader className="border-b border-border px-5 py-4 pr-14 sm:px-6">
+          <DialogTitle className="flex items-center gap-2">
+            <Filter className="h-5 w-5 text-primary" aria-hidden />
+            Add a filter
+          </DialogTitle>
+          <DialogDescription>
+            Narrow records with a condition that matches the selected column type.
+          </DialogDescription>
+        </DialogHeader>
+        <form id={formId} onSubmit={submit}>
+          <div className="grid gap-4 px-5 py-5 sm:grid-cols-2 sm:px-6">
+            <div className="space-y-2">
+              <Label htmlFor={`${formId}-column`}>Column</Label>
+              <SelectMenu
+                id={`${formId}-column`}
+                value={selectedColumn?.name || ""}
+                onValueChange={chooseColumn}
+                options={columns.map((column) => ({
+                  value: column.name,
+                  label: column.name,
+                  hint: normalizeTableColumnType(column.type),
+                }))}
+                mono
+                searchable
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor={`${formId}-operator`}>Condition</Label>
+              <SelectMenu
+                id={`${formId}-operator`}
+                value={operator}
+                onValueChange={(next) => {
+                  setOperator(next as TableFilterOperator);
+                  setError("");
+                }}
+                options={operatorOptions}
+              />
+            </div>
+            {needsValue && selectedColumn && (
+              <div className="space-y-2 sm:col-span-2">
+                <Label htmlFor={`${formId}-value`}>Value</Label>
+                {isEnumValue ? (
+                  <SelectMenu
+                    id={`${formId}-value`}
+                    value={value}
+                    onValueChange={(next) => {
+                      setValue(next);
+                      setError("");
+                    }}
+                    options={(selectedColumn.enum || []).map((item) => ({
+                      value: String(item),
+                      label: String(item),
+                    }))}
+                    placeholder="Select a value"
+                  />
+                ) : normalizedType === "jsonb" ? (
+                  <Textarea
+                    id={`${formId}-value`}
+                    value={value}
+                    onChange={(event) => {
+                      setValue(event.target.value);
+                      setError("");
+                    }}
+                    rows={5}
+                    className="font-mono text-xs"
+                    placeholder={'{"status":"open"}'}
+                    aria-invalid={Boolean(error) || undefined}
+                    aria-describedby={`${formId}-value-help${error ? ` ${formId}-value-error` : ""}`}
+                    autoFocus
+                  />
+                ) : (
+                  <Input
+                    id={`${formId}-value`}
+                    type={inputTypeFor(normalizedType, operator)}
+                    step={stepFor(normalizedType)}
+                    value={value}
+                    onChange={(event) => {
+                      setValue(event.target.value);
+                      setError("");
+                    }}
+                    placeholder={valuePlaceholder(normalizedType, operator)}
+                    aria-invalid={Boolean(error) || undefined}
+                    aria-describedby={`${formId}-value-help${error ? ` ${formId}-value-error` : ""}`}
+                    autoComplete="off"
+                    autoFocus
+                  />
+                )}
+                <p id={`${formId}-value-help`} className="text-xs text-foreground-muted">
+                  {valueHelp(normalizedType, operator)}
+                </p>
+                {error && (
+                  <p id={`${formId}-value-error`} role="alert" className="text-xs text-destructive">
+                    {error}
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+          <DialogFooter className="border-t border-border bg-surface-2 px-5 py-4 sm:px-6">
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="default" disabled={!selectedColumn}>
+              <Filter className="h-4 w-4" aria-hidden />
+              Apply filter
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function TableFilterBar({
+  filters,
+  onOpen,
+  onRemove,
+  onClear,
+  onRefresh,
+  refreshing = false,
+}: {
+  filters: TableFilter[];
+  onOpen: () => void;
+  onRemove: (index: number) => void;
+  onClear: () => void;
+  onRefresh: () => void;
+  refreshing?: boolean;
+}) {
+  return (
+    <div className="flex min-h-11 shrink-0 flex-wrap items-center gap-2 border-b border-border bg-surface px-3 py-1.5">
+      <Button type="button" variant="outline" size="sm" onClick={onOpen}>
+        <Filter className="h-3.5 w-3.5" aria-hidden />
+        Filters
+        {filters.length > 0 && <Badge variant="info-solid">{filters.length}</Badge>}
+      </Button>
+      {filters.length > 0 ? (
+        <>
+          <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5" aria-label="Active filters">
+            {filters.map((filter, index) => (
+              <span
+                key={`${filter.column}-${filter.operator}-${filter.value}-${index}`}
+                className="inline-flex min-w-0 max-w-72 items-center gap-1 rounded-[var(--radius-full)] border border-border bg-surface-selected py-1 pl-2.5 pr-1 text-xs text-surface-selected-foreground"
+              >
+                <span className="truncate">{tableFilterLabel(filter)}</span>
+                <button
+                  type="button"
+                  onClick={() => onRemove(index)}
+                  className="inline-flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-[var(--radius-full)] hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  aria-label={`Remove filter: ${tableFilterLabel(filter)}`}
+                >
+                  <X className="h-3.5 w-3.5" aria-hidden />
+                </button>
+              </span>
+            ))}
+          </div>
+          <Button type="button" variant="ghost" size="sm" onClick={onClear}>
+            Clear all
+          </Button>
+        </>
+      ) : (
+        <span className="text-xs text-foreground-muted">All records</span>
+      )}
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="ml-auto h-8 w-8"
+        onClick={onRefresh}
+        disabled={refreshing}
+        aria-label="Refresh records"
+      >
+        <RefreshCw className={refreshing ? "h-3.5 w-3.5 animate-spin" : "h-3.5 w-3.5"} aria-hidden />
+      </Button>
+    </div>
+  );
+}
+
+export function TablePagination({
+  pageIndex,
+  pageSize,
+  total,
+  itemCount,
+  onPageChange,
+  onPageSizeChange,
+}: {
+  pageIndex: number;
+  pageSize: TablePageSize;
+  total: number;
+  itemCount: number;
+  onPageChange: (pageIndex: number) => void;
+  onPageSizeChange: (pageSize: TablePageSize) => void;
+}) {
+  const pageCount = Math.max(1, Math.ceil(total / pageSize));
+  const start = total === 0 ? 0 : pageIndex * pageSize + 1;
+  const end = total === 0 ? 0 : Math.min(pageIndex * pageSize + itemCount, total);
+  const [pageDraft, setPageDraft] = useState(String(pageIndex + 1));
+
+  useEffect(() => setPageDraft(String(pageIndex + 1)), [pageIndex]);
+
+  function commitPage(event?: FormEvent) {
+    event?.preventDefault();
+    const parsed = Number(pageDraft);
+    const next = Number.isSafeInteger(parsed) ? Math.min(Math.max(parsed, 1), pageCount) : pageIndex + 1;
+    setPageDraft(String(next));
+    onPageChange(next - 1);
+  }
+
+  return (
+    <div className="flex min-h-12 shrink-0 flex-wrap items-center gap-3 border-t border-border bg-surface-2 px-3 py-1.5 text-xs text-foreground-muted">
+      <span className="min-w-32 tabular-nums" aria-live="polite">
+        {start}–{end} of {total}
+      </span>
+      <div className="ml-auto flex items-center gap-2">
+        <Label htmlFor="table-page-size" className="hidden text-xs font-normal sm:inline">
+          Rows per page
+        </Label>
+        <SelectMenu
+          id="table-page-size"
+          aria-label="Rows per page"
+          value={String(pageSize)}
+          onValueChange={(next) => onPageSizeChange(Number(next) as TablePageSize)}
+          options={TABLE_PAGE_SIZES.map((size) => ({ value: String(size), label: String(size) }))}
+          className="h-9 w-20"
+        />
+        <div className="flex items-center gap-1">
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="hidden h-9 w-9 sm:inline-flex"
+            onClick={() => onPageChange(0)}
+            disabled={pageIndex === 0}
+            aria-label="First page"
+          >
+            <ChevronsLeft className="h-4 w-4" aria-hidden />
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="h-9 w-9"
+            onClick={() => onPageChange(Math.max(0, pageIndex - 1))}
+            disabled={pageIndex === 0}
+            aria-label="Previous page"
+          >
+            <ChevronLeft className="h-4 w-4" aria-hidden />
+          </Button>
+          <form className="flex items-center gap-1.5" onSubmit={commitPage}>
+            <Label htmlFor="table-page-number" className="sr-only">
+              Page number
+            </Label>
+            <Input
+              id="table-page-number"
+              type="number"
+              min={1}
+              max={pageCount}
+              inputMode="numeric"
+              value={pageDraft}
+              onChange={(event) => setPageDraft(event.target.value)}
+              onBlur={() => commitPage()}
+              className="h-9 w-14 px-2 text-center tabular-nums"
+              aria-label={`Page number, ${pageCount} pages total`}
+            />
+            <span className="hidden whitespace-nowrap tabular-nums sm:inline">of {pageCount}</span>
+          </form>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="h-9 w-9"
+            onClick={() => onPageChange(Math.min(pageCount - 1, pageIndex + 1))}
+            disabled={pageIndex >= pageCount - 1}
+            aria-label="Next page"
+          >
+            <ChevronRight className="h-4 w-4" aria-hidden />
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="hidden h-9 w-9 sm:inline-flex"
+            onClick={() => onPageChange(pageCount - 1)}
+            disabled={pageIndex >= pageCount - 1}
+            aria-label="Last page"
+          >
+            <ChevronsRight className="h-4 w-4" aria-hidden />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function inputTypeFor(type: string, operator: TableFilterOperator): string {
+  if (operator === "in") return "text";
+  if (type === "date") return "date";
+  if (["int", "float", "numeric"].includes(type)) return "number";
+  return "text";
+}
+
+function stepFor(type: string): string | undefined {
+  if (type === "int") return "1";
+  if (["float", "numeric"].includes(type)) return "any";
+  return undefined;
+}
+
+function valuePlaceholder(type: string, operator: TableFilterOperator): string {
+  if (operator === "in") return "open, pending, resolved";
+  if (type === "uuid") return "00000000-0000-4000-8000-000000000000";
+  if (type === "timestamp") return "2026-09-02T13:45:00+09:00";
+  if (["int", "float", "numeric"].includes(type)) return "0";
+  return "Value";
+}
+
+function valueHelp(type: string, operator: TableFilterOperator): string {
+  if (operator === "in") return "Separate multiple exact values with commas.";
+  if (type === "jsonb") return "Enter the JSON object or array that each matching row must contain.";
+  if (type === "timestamp") return "Use an ISO 8601 timestamp including a timezone when possible.";
+  return "Filtering is applied by the server across the entire table.";
+}

--- a/frontend/src/components/table-row-dialog.tsx
+++ b/frontend/src/components/table-row-dialog.tsx
@@ -14,7 +14,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { SelectMenu } from "@/components/ui/select-menu";
 import { Textarea } from "@/components/ui/textarea";
-import type { VaultTableColumnInput } from "@/lib/api";
+import { TableRowConflictError, type VaultTableColumnInput } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
 type RowMode = "create" | "edit";
@@ -26,7 +26,11 @@ interface TableRowDialogProps {
   table: string;
   columns: VaultTableColumnInput[];
   row?: Record<string, unknown> | null;
-  onSave: (values: Record<string, unknown>) => Promise<void>;
+  onSave: (
+    values: Record<string, unknown>,
+    options?: { force?: boolean },
+  ) => Promise<void>;
+  onReloadConflict?: () => Promise<Record<string, unknown> | null>;
 }
 
 const UNSET_OPTION = "__akb_unset__";
@@ -41,6 +45,7 @@ export function TableRowDialog({
   columns,
   row,
   onSave,
+  onReloadConflict,
 }: TableRowDialogProps) {
   const formRef = useRef<HTMLFormElement>(null);
   const formId = useId();
@@ -50,6 +55,8 @@ export function TableRowDialog({
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [saving, setSaving] = useState(false);
   const [submitError, setSubmitError] = useState("");
+  const [conflict, setConflict] = useState(false);
+  const [pendingValues, setPendingValues] = useState<Record<string, unknown> | null>(null);
 
   const editableColumns = useMemo(
     () => columns.filter((column) => !isSystemColumn(column.name)),
@@ -70,6 +77,8 @@ export function TableRowDialog({
     setTouched(new Set());
     setErrors({});
     setSubmitError("");
+    setConflict(false);
+    setPendingValues(null);
   }, [editableColumns, mode, open, row]);
 
   function updateValue(column: VaultTableColumnInput, value: string) {
@@ -137,16 +146,58 @@ export function TableRowDialog({
       return;
     }
 
+    setPendingValues(payload);
+    await save(payload);
+  }
+
+  async function save(payload: Record<string, unknown>, force = false) {
     setSaving(true);
+    setSubmitError("");
     try {
-      await onSave(payload);
+      await onSave(payload, { force });
+      setConflict(false);
       onOpenChange(false);
     } catch (caught: unknown) {
-      setSubmitError(
-        caught instanceof Error
-          ? caught.message
-          : `The row could not be ${mode === "create" ? "added" : "updated"}.`,
-      );
+      if (caught instanceof TableRowConflictError) {
+        setConflict(true);
+      } else {
+        setSubmitError(
+          caught instanceof Error
+            ? caught.message
+            : `The row could not be ${mode === "create" ? "added" : "updated"}.`,
+        );
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function reloadCurrentValues() {
+    if (!onReloadConflict) return;
+    setSaving(true);
+    setSubmitError("");
+    try {
+      const latest = await onReloadConflict();
+      if (!latest) {
+        setConflict(false);
+        setSubmitError("This row no longer exists. Close the editor to return to the table.");
+        return;
+      }
+      const nextValues: Record<string, string> = {};
+      const nextNulls = new Set<string>();
+      for (const column of editableColumns) {
+        const current = latest[column.name];
+        if (current === null) nextNulls.add(column.name);
+        nextValues[column.name] = valueForInput(current, column.type);
+      }
+      setValues(nextValues);
+      setNullColumns(nextNulls);
+      setTouched(new Set());
+      setErrors({});
+      setPendingValues(null);
+      setConflict(false);
+    } catch (caught: unknown) {
+      setSubmitError(caught instanceof Error ? caught.message : "The current row could not be loaded.");
     } finally {
       setSaving(false);
     }
@@ -253,6 +304,33 @@ export function TableRowDialog({
                   );
                 })}
               </fieldset>
+            )}
+            {conflict && (
+              <Alert variant="warning" title="This row has newer changes" className="mt-4">
+                <p>
+                  Another update was saved after you opened this row. Your draft is still here.
+                </p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => void reloadCurrentValues()}
+                    disabled={saving || !onReloadConflict}
+                  >
+                    Reload current values
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="default"
+                    size="sm"
+                    onClick={() => pendingValues && void save(pendingValues, true)}
+                    disabled={saving || !pendingValues}
+                  >
+                    Overwrite anyway
+                  </Button>
+                </div>
+              </Alert>
             )}
             {submitError && (
               <Alert variant="destructive" title="Row could not be saved" className="mt-4">

--- a/frontend/src/components/table-row-dialog.tsx
+++ b/frontend/src/components/table-row-dialog.tsx
@@ -56,7 +56,6 @@ export function TableRowDialog({
   const [saving, setSaving] = useState(false);
   const [submitError, setSubmitError] = useState("");
   const [conflict, setConflict] = useState(false);
-  const [pendingValues, setPendingValues] = useState<Record<string, unknown> | null>(null);
 
   const editableColumns = useMemo(
     () => columns.filter((column) => !isSystemColumn(column.name)),
@@ -78,7 +77,6 @@ export function TableRowDialog({
     setErrors({});
     setSubmitError("");
     setConflict(false);
-    setPendingValues(null);
   }, [editableColumns, mode, open, row]);
 
   function updateValue(column: VaultTableColumnInput, value: string) {
@@ -113,6 +111,10 @@ export function TableRowDialog({
 
   async function submit(event: FormEvent) {
     event.preventDefault();
+    await saveCurrentDraft();
+  }
+
+  async function saveCurrentDraft(force = false) {
     setSubmitError("");
     const nextErrors: Record<string, string> = {};
     const payload: Record<string, unknown> = {};
@@ -146,8 +148,7 @@ export function TableRowDialog({
       return;
     }
 
-    setPendingValues(payload);
-    await save(payload);
+    await save(payload, force);
   }
 
   async function save(payload: Record<string, unknown>, force = false) {
@@ -194,7 +195,6 @@ export function TableRowDialog({
       setNullColumns(nextNulls);
       setTouched(new Set());
       setErrors({});
-      setPendingValues(null);
       setConflict(false);
     } catch (caught: unknown) {
       setSubmitError(caught instanceof Error ? caught.message : "The current row could not be loaded.");
@@ -324,8 +324,8 @@ export function TableRowDialog({
                     type="button"
                     variant="default"
                     size="sm"
-                    onClick={() => pendingValues && void save(pendingValues, true)}
-                    disabled={saving || !pendingValues}
+                    onClick={() => void saveCurrentDraft(true)}
+                    disabled={saving}
                   >
                     Overwrite anyway
                   </Button>

--- a/frontend/src/lib/__tests__/api-table-rows.test.ts
+++ b/frontend/src/lib/__tests__/api-table-rows.test.ts
@@ -3,9 +3,11 @@ import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import {
   deleteVaultTableRow,
+  getVaultTableRow,
   insertVaultTableRow,
   listVaultTableRows,
   setToken,
+  TableRowConflictError,
   updateVaultTableRow,
 } from "@/lib/api";
 
@@ -29,7 +31,7 @@ describe("Vault table row API contracts", () => {
         const url = new URL(request.url);
         expect(url.searchParams.get("limit")).toBe("50");
         expect(url.searchParams.get("offset")).toBe("0");
-        expect(url.searchParams.get("order")).toBe("created_at.desc");
+        expect(url.searchParams.get("order")).toBe("created_at.desc,id.desc");
         expect(request.headers.get("prefer")).toBe("count=exact");
         return HttpResponse.json({
           kind: "table_query",
@@ -43,6 +45,55 @@ describe("Vault table row API contracts", () => {
     const result = await listVaultTableRows("ops", "incidents");
     expect(result.total).toBe(1);
     expect(result.items[0].id).toBe(rowId);
+  });
+
+  it("sends server pagination, stable sorting, filters, and an abort signal", async () => {
+    server.use(
+      http.get(`*/api/v1/tables/ops/incidents/rows`, ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get("limit")).toBe("25");
+        expect(url.searchParams.get("offset")).toBe("50");
+        expect(url.searchParams.get("order")).toBe("severity.asc,id.asc");
+        expect(url.searchParams.getAll("severity")).toEqual(["eq.high", "neq.low"]);
+        return HttpResponse.json({
+          kind: "table_query",
+          columns: ["id", "severity"],
+          items: [{ id: rowId, severity: "high" }],
+          total: 73,
+        });
+      }),
+    );
+    const controller = new AbortController();
+    const result = await listVaultTableRows("ops", "incidents", {
+      limit: 25,
+      offset: 50,
+      order: "severity.asc,id.asc",
+      filters: [
+        { column: "severity", expression: "eq.high" },
+        { column: "severity", expression: "neq.low" },
+      ],
+      signal: controller.signal,
+    });
+    expect(result.total).toBe(73);
+  });
+
+  it("loads a current row by its stable system id", async () => {
+    server.use(
+      http.get(`*/api/v1/tables/ops/incidents/rows`, ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get("id")).toBe(`eq.${rowId}`);
+        expect(url.searchParams.get("limit")).toBe("1");
+        return HttpResponse.json({
+          kind: "table_query",
+          columns: ["id", "title"],
+          items: [{ id: rowId, title: "Current title" }],
+          total: 1,
+        });
+      }),
+    );
+    expect(await getVaultTableRow("ops", "incidents", rowId)).toMatchObject({
+      title: "Current title",
+    });
   });
 
   it("inserts a row through the structured writer endpoint", async () => {
@@ -102,5 +153,32 @@ describe("Vault table row API contracts", () => {
     await updateVaultTableRow("ops", "incidents", rowId, { severity: "critical" });
     const deleted = await deleteVaultTableRow("ops", "incidents", rowId);
     expect(deleted.items).toEqual([{ id: rowId }]);
+  });
+
+  it("guards updates with updated_at and reports a typed conflict", async () => {
+    const expectedUpdatedAt = "2026-09-02T04:00:00Z";
+    server.use(
+      http.patch(`*/api/v1/tables/ops/incidents/rows`, ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get("id")).toBe(`eq.${rowId}`);
+        expect(url.searchParams.get("updated_at")).toBe(`eq.${expectedUpdatedAt}`);
+        return HttpResponse.json({
+          kind: "table_query",
+          columns: [],
+          items: [],
+          total: 0,
+        });
+      }),
+    );
+
+    await expect(
+      updateVaultTableRow(
+        "ops",
+        "incidents",
+        rowId,
+        { severity: "critical" },
+        { expectedUpdatedAt },
+      ),
+    ).rejects.toBeInstanceOf(TableRowConflictError);
   });
 });

--- a/frontend/src/lib/__tests__/table-query-state.test.ts
+++ b/frontend/src/lib/__tests__/table-query-state.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  compileTableFilter,
+  parseTableQueryState,
+  tableFilterOperators,
+  tableOrder,
+  validateTableFilter,
+  writeTableQueryState,
+  type TableQueryState,
+} from "@/lib/table-query-state";
+
+describe("table query state", () => {
+  it("round-trips page, size, sort, repeated filters, and unrelated params", () => {
+    const state: TableQueryState = {
+      pageIndex: 2,
+      pageSize: 25,
+      sort: { column: "severity", direction: "asc" },
+      filters: [
+        { column: "severity", operator: "eq", value: "critical" },
+        { column: "title", operator: "contains", value: "API: gateway" },
+      ],
+    };
+    const params = writeTableQueryState(new URLSearchParams("view=compact"), state);
+    expect(parseTableQueryState(params)).toEqual(state);
+    expect(params.get("view")).toBe("compact");
+    expect(params.get("page")).toBe("3");
+  });
+
+  it("falls back safely when URL state is malformed", () => {
+    const state = parseTableQueryState(
+      new URLSearchParams("page=-2&size=999&sort=bad;drop.desc&f=oops"),
+    );
+    expect(state).toEqual({ pageIndex: 0, pageSize: 50, sort: null, filters: [] });
+  });
+
+  it("compiles user-facing conditions to the row API grammar", () => {
+    expect(
+      compileTableFilter({ column: "title", operator: "contains", value: "gateway" }),
+    ).toEqual({ column: "title", expression: "ilike.*gateway*" });
+    expect(
+      compileTableFilter({ column: "severity", operator: "in", value: "high, critical" }),
+    ).toEqual({ column: "severity", expression: "in.(high,critical)" });
+    expect(
+      compileTableFilter({
+        column: "metadata",
+        operator: "json_contains",
+        value: '{ "tier": "gold" }',
+      }),
+    ).toEqual({ column: "metadata", expression: 'cs.{"tier":"gold"}' });
+    expect(
+      compileTableFilter({ column: "metadata", operator: "json_contains", value: "{" }),
+    ).toEqual({ column: "metadata", expression: "cs.{" });
+  });
+
+  it("uses a stable id tie-breaker for every sort", () => {
+    expect(tableOrder(null)).toBe("created_at.desc,id.desc");
+    expect(tableOrder({ column: "severity", direction: "asc" })).toBe(
+      "severity.asc,id.asc",
+    );
+    expect(tableOrder({ column: "id", direction: "desc" })).toBe("id.desc");
+  });
+
+  it("offers and validates conditions based on the column type", () => {
+    expect(tableFilterOperators({ name: "enabled", type: "boolean" }).map((item) => item.value))
+      .toEqual(["is_true", "is_false", "is_null", "not_null"]);
+    expect(tableFilterOperators({ name: "metadata", type: "jsonb" }).map((item) => item.value))
+      .toEqual(["json_contains", "is_null", "not_null"]);
+    expect(
+      tableFilterOperators({ name: "severity", type: "text", enum: ["low", "high"] }).map(
+        (item) => item.value,
+      ),
+    ).toEqual(["eq", "neq", "in", "is_null", "not_null"]);
+    expect(
+      validateTableFilter(
+        { column: "score", operator: "gte", value: "not-a-number" },
+        { name: "score", type: "numeric" },
+      ),
+    ).toBe("Enter a valid number.");
+    expect(
+      validateTableFilter(
+        { column: "metadata", operator: "json_contains", value: "{" },
+        { name: "metadata", type: "jsonb" },
+      ),
+    ).toBe("Enter valid JSON.");
+  });
+});

--- a/frontend/src/lib/__tests__/table-query-state.test.ts
+++ b/frontend/src/lib/__tests__/table-query-state.test.ts
@@ -71,6 +71,19 @@ describe("table query state", () => {
       ),
     ).toEqual(["eq", "neq", "in", "is_null", "not_null"]);
     expect(
+      tableFilterOperators({
+        name: "severity",
+        type: "enum",
+        enum: ["low", "high, urgent"],
+      }).map((item) => item.value),
+    ).toEqual(["eq", "neq", "is_null", "not_null"]);
+    expect(
+      validateTableFilter(
+        { column: "severity", operator: "in", value: "low, high, urgent" },
+        { name: "severity", type: "enum", enum: ["low", "high, urgent"] },
+      ),
+    ).toBe("This choice list contains commas. Use “is” to match one exact choice.");
+    expect(
       validateTableFilter(
         { column: "score", operator: "gte", value: "not-a-number" },
         { name: "score", type: "numeric" },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1641,6 +1641,28 @@ export interface VaultTableQueryResult {
   total: number;
 }
 
+export interface VaultTableRowsQueryOptions {
+  limit?: number;
+  offset?: number;
+  order?: string;
+  filters?: Array<{ column: string; expression: string }>;
+  signal?: AbortSignal;
+}
+
+export class TableRowConflictError extends Error {
+  rowId: string;
+
+  constructor(rowId: string, action: "update" | "delete") {
+    super(
+      action === "update"
+        ? "This row changed after you opened it. Review the current values or overwrite them explicitly."
+        : "This row changed after you opened it. Its latest version must be reviewed before deletion.",
+    );
+    this.name = "TableRowConflictError";
+    this.rowId = rowId;
+  }
+}
+
 export const createVaultTable = (
   vault: string,
   input: VaultTableCreateInput,
@@ -1660,18 +1682,40 @@ export const listVaultTables = (vault: string) =>
 export const listVaultTableRows = (
   vault: string,
   table: string,
-  { limit = 50, offset = 0 }: { limit?: number; offset?: number } = {},
+  {
+    limit = 50,
+    offset = 0,
+    order = "created_at.desc,id.desc",
+    filters = [],
+    signal,
+  }: VaultTableRowsQueryOptions = {},
 ) => {
   const query = new URLSearchParams({
     limit: String(limit),
     offset: String(offset),
-    order: "created_at.desc",
+    order,
   });
+  for (const filter of filters) query.append(filter.column, filter.expression);
   return api<VaultTableQueryResult>(
     `/tables/${encodeURIComponent(vault)}/${encodeURIComponent(table)}/rows?${query}`,
-    { headers: { Prefer: "count=exact" } },
+    { headers: { Prefer: "count=exact" }, signal },
   );
 };
+
+export async function getVaultTableRow(
+  vault: string,
+  table: string,
+  rowId: string,
+  signal?: AbortSignal,
+): Promise<Record<string, unknown> | null> {
+  const result = await listVaultTableRows(vault, table, {
+    limit: 1,
+    order: "id.asc",
+    filters: [{ column: "id", expression: `eq.${rowId}` }],
+    signal,
+  });
+  return result.items[0] || null;
+}
 
 export const insertVaultTableRow = (
   vault: string,
@@ -1692,8 +1736,12 @@ export const updateVaultTableRow = (
   table: string,
   rowId: string,
   changes: Record<string, unknown>,
+  options: { expectedUpdatedAt?: string; force?: boolean } = {},
 ) => {
   const query = new URLSearchParams({ id: `eq.${rowId}`, select: "*" });
+  if (options.expectedUpdatedAt && !options.force) {
+    query.set("updated_at", `eq.${options.expectedUpdatedAt}`);
+  }
   return api<VaultTableQueryResult>(
     `/tables/${encodeURIComponent(vault)}/${encodeURIComponent(table)}/rows?${query}`,
     {
@@ -1701,22 +1749,36 @@ export const updateVaultTableRow = (
       headers: { Prefer: "return=representation" },
       body: JSON.stringify(changes),
     },
-  );
+  ).then((result) => {
+    if (options.expectedUpdatedAt && !options.force && result.items.length === 0) {
+      throw new TableRowConflictError(rowId, "update");
+    }
+    return result;
+  });
 };
 
 export const deleteVaultTableRow = (
   vault: string,
   table: string,
   rowId: string,
+  options: { expectedUpdatedAt?: string; force?: boolean } = {},
 ) => {
   const query = new URLSearchParams({ id: `eq.${rowId}`, select: "id" });
+  if (options.expectedUpdatedAt && !options.force) {
+    query.set("updated_at", `eq.${options.expectedUpdatedAt}`);
+  }
   return api<VaultTableQueryResult>(
     `/tables/${encodeURIComponent(vault)}/${encodeURIComponent(table)}/rows?${query}`,
     {
       method: "DELETE",
       headers: { Prefer: "return=representation" },
     },
-  );
+  ).then((result) => {
+    if (options.expectedUpdatedAt && !options.force && result.items.length === 0) {
+      throw new TableRowConflictError(rowId, "delete");
+    }
+    return result;
+  });
 };
 
 export const deleteVaultTable = (vault: string, tableName: string) =>

--- a/frontend/src/lib/table-query-state.ts
+++ b/frontend/src/lib/table-query-state.ts
@@ -1,0 +1,307 @@
+import type { VaultTableColumnInput } from "@/lib/api";
+
+export const TABLE_PAGE_SIZES = [25, 50, 100] as const;
+export type TablePageSize = (typeof TABLE_PAGE_SIZES)[number];
+export type TableSortDirection = "asc" | "desc";
+
+export type TableFilterOperator =
+  | "eq"
+  | "neq"
+  | "contains"
+  | "starts_with"
+  | "gt"
+  | "gte"
+  | "lt"
+  | "lte"
+  | "in"
+  | "is_null"
+  | "not_null"
+  | "is_true"
+  | "is_false"
+  | "json_contains";
+
+export interface TableFilter {
+  column: string;
+  operator: TableFilterOperator;
+  value: string;
+}
+
+export interface TableSort {
+  column: string;
+  direction: TableSortDirection;
+}
+
+export interface TableQueryState {
+  pageIndex: number;
+  pageSize: TablePageSize;
+  sort: TableSort | null;
+  filters: TableFilter[];
+}
+
+export interface TableApiFilter {
+  column: string;
+  expression: string;
+}
+
+export interface TableFilterOperatorOption {
+  value: TableFilterOperator;
+  label: string;
+}
+
+export const DEFAULT_TABLE_QUERY_STATE: TableQueryState = {
+  pageIndex: 0,
+  pageSize: 50,
+  sort: null,
+  filters: [],
+};
+
+export const DEFAULT_TABLE_SORT: TableSort = {
+  column: "created_at",
+  direction: "desc",
+};
+
+const FILTER_OPERATORS = new Set<TableFilterOperator>([
+  "eq",
+  "neq",
+  "contains",
+  "starts_with",
+  "gt",
+  "gte",
+  "lt",
+  "lte",
+  "in",
+  "is_null",
+  "not_null",
+  "is_true",
+  "is_false",
+  "json_contains",
+]);
+
+const OPERATOR_LABELS: Record<TableFilterOperator, string> = {
+  eq: "is",
+  neq: "is not",
+  contains: "contains",
+  starts_with: "starts with",
+  gt: "is greater than",
+  gte: "is at least",
+  lt: "is less than",
+  lte: "is at most",
+  in: "is one of",
+  is_null: "is empty",
+  not_null: "is not empty",
+  is_true: "is true",
+  is_false: "is false",
+  json_contains: "contains JSON",
+};
+
+const TEXT_OPERATORS: TableFilterOperator[] = [
+  "contains",
+  "eq",
+  "neq",
+  "starts_with",
+  "in",
+  "is_null",
+  "not_null",
+];
+const NUMBER_DATE_OPERATORS: TableFilterOperator[] = [
+  "eq",
+  "neq",
+  "gt",
+  "gte",
+  "lt",
+  "lte",
+  "is_null",
+  "not_null",
+];
+
+export function normalizeTableColumnType(type: string | undefined): string {
+  const normalized = (type || "text").toLowerCase();
+  if (normalized === "number") return "numeric";
+  if (normalized === "bool") return "boolean";
+  if (normalized === "json") return "jsonb";
+  return normalized;
+}
+
+export function tableFilterOperators(column: VaultTableColumnInput): TableFilterOperatorOption[] {
+  const type = normalizeTableColumnType(column.type);
+  let operators: TableFilterOperator[];
+  if (type === "boolean") {
+    operators = ["is_true", "is_false", "is_null", "not_null"];
+  } else if (type === "enum" || Boolean(column.enum?.length)) {
+    operators = ["eq", "neq", "in", "is_null", "not_null"];
+  } else if (["int", "float", "numeric", "date", "timestamp"].includes(type)) {
+    operators = NUMBER_DATE_OPERATORS;
+  } else if (type === "uuid") {
+    operators = ["eq", "neq", "in", "is_null", "not_null"];
+  } else if (type === "jsonb") {
+    operators = ["json_contains", "is_null", "not_null"];
+  } else if (type === "text[]") {
+    // The current row API exposes null checks for SQL arrays but does not yet
+    // provide a typed array-containment operator. Avoid offering a control
+    // that would compile to a query PostgreSQL cannot type safely.
+    operators = ["is_null", "not_null"];
+  } else {
+    operators = TEXT_OPERATORS;
+  }
+  return operators.map((value) => ({ value, label: OPERATOR_LABELS[value] }));
+}
+
+export function tableFilterNeedsValue(operator: TableFilterOperator): boolean {
+  return !["is_null", "not_null", "is_true", "is_false"].includes(operator);
+}
+
+export function validateTableFilter(
+  filter: TableFilter,
+  column: VaultTableColumnInput,
+): string | null {
+  if (!tableFilterNeedsValue(filter.operator)) return null;
+  const value = filter.value.trim();
+  if (!value) return "Enter a value for this filter.";
+
+  const type = normalizeTableColumnType(column.type);
+  const values = filter.operator === "in" ? splitListValue(value) : [value];
+  if (filter.operator === "in" && values.length === 0) {
+    return "Enter at least one comma-separated value.";
+  }
+  if (["int", "float", "numeric"].includes(type)) {
+    if (values.some((item) => !Number.isFinite(Number(item)))) {
+      return "Enter a valid number.";
+    }
+    if (type === "int" && values.some((item) => !Number.isSafeInteger(Number(item)))) {
+      return "Enter a whole number.";
+    }
+  }
+  if (type === "uuid") {
+    const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    if (values.some((item) => !uuidPattern.test(item))) return "Enter a valid UUID.";
+  }
+  if (filter.operator === "json_contains") {
+    try {
+      JSON.parse(value);
+    } catch {
+      return "Enter valid JSON.";
+    }
+  }
+  return null;
+}
+
+export function compileTableFilter(filter: TableFilter): TableApiFilter {
+  const value = filter.value.trim();
+  let expression: string;
+  switch (filter.operator) {
+    case "contains":
+      expression = `ilike.*${value}*`;
+      break;
+    case "starts_with":
+      expression = `ilike.${value}*`;
+      break;
+    case "in":
+      expression = `in.(${splitListValue(value).join(",")})`;
+      break;
+    case "is_null":
+      expression = "is.null";
+      break;
+    case "not_null":
+      expression = "not.is.null";
+      break;
+    case "is_true":
+      expression = "is.true";
+      break;
+    case "is_false":
+      expression = "is.false";
+      break;
+    case "json_contains": {
+      // UI-authored values are validated before they enter query state. A
+      // manually edited or stale URL can still carry malformed JSON, though;
+      // pass that through so the row API can return a recoverable query error
+      // instead of throwing while React builds the request.
+      try {
+        expression = `cs.${JSON.stringify(JSON.parse(value))}`;
+      } catch {
+        expression = `cs.${value}`;
+      }
+      break;
+    }
+    default:
+      expression = `${filter.operator}.${value}`;
+  }
+  return { column: filter.column, expression };
+}
+
+export function tableOrder(sort: TableSort | null): string {
+  const active = sort || DEFAULT_TABLE_SORT;
+  if (active.column === "id") return `id.${active.direction}`;
+  return `${active.column}.${active.direction},id.${active.direction}`;
+}
+
+export function tableFilterLabel(filter: TableFilter): string {
+  const operator = OPERATOR_LABELS[filter.operator];
+  if (!tableFilterNeedsValue(filter.operator)) return `${filter.column} ${operator}`;
+  const value = filter.value.trim();
+  const compact = value.length > 36 ? `${value.slice(0, 36)}…` : value;
+  return `${filter.column} ${operator} “${compact}”`;
+}
+
+export function parseTableQueryState(search: URLSearchParams): TableQueryState {
+  const rawPage = Number(search.get("page"));
+  const rawSize = Number(search.get("size"));
+  const pageSize = TABLE_PAGE_SIZES.includes(rawSize as TablePageSize)
+    ? (rawSize as TablePageSize)
+    : DEFAULT_TABLE_QUERY_STATE.pageSize;
+  const sort = parseSort(search.get("sort"));
+  const filters = search.getAll("f").flatMap((raw) => {
+    const parsed = parseFilter(raw);
+    return parsed ? [parsed] : [];
+  });
+  return {
+    pageIndex: Number.isSafeInteger(rawPage) && rawPage > 0 ? rawPage - 1 : 0,
+    pageSize,
+    sort,
+    filters,
+  };
+}
+
+export function writeTableQueryState(
+  current: URLSearchParams,
+  state: TableQueryState,
+): URLSearchParams {
+  const next = new URLSearchParams(current);
+  for (const key of ["page", "size", "sort", "f"]) next.delete(key);
+  if (state.pageIndex > 0) next.set("page", String(state.pageIndex + 1));
+  if (state.pageSize !== DEFAULT_TABLE_QUERY_STATE.pageSize) {
+    next.set("size", String(state.pageSize));
+  }
+  if (state.sort) next.set("sort", `${state.sort.column}.${state.sort.direction}`);
+  for (const filter of state.filters) next.append("f", serializeFilter(filter));
+  return next;
+}
+
+function parseSort(raw: string | null): TableSort | null {
+  if (!raw) return null;
+  const match = /^([a-z][a-z0-9_]*)\.(asc|desc)$/.exec(raw);
+  if (!match) return null;
+  return { column: match[1], direction: match[2] as TableSortDirection };
+}
+
+function serializeFilter(filter: TableFilter): string {
+  return `${filter.column}:${filter.operator}:${filter.value}`;
+}
+
+function parseFilter(raw: string): TableFilter | null {
+  const first = raw.indexOf(":");
+  const second = raw.indexOf(":", first + 1);
+  if (first <= 0 || second <= first) return null;
+  const column = raw.slice(0, first);
+  const operator = raw.slice(first + 1, second) as TableFilterOperator;
+  const value = raw.slice(second + 1);
+  if (!/^[a-z][a-z0-9_]*$/.test(column) || !FILTER_OPERATORS.has(operator)) return null;
+  if (tableFilterNeedsValue(operator) && !value.trim()) return null;
+  return { column, operator, value };
+}
+
+function splitListValue(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}

--- a/frontend/src/lib/table-query-state.ts
+++ b/frontend/src/lib/table-query-state.ts
@@ -128,7 +128,13 @@ export function tableFilterOperators(column: VaultTableColumnInput): TableFilter
   if (type === "boolean") {
     operators = ["is_true", "is_false", "is_null", "not_null"];
   } else if (type === "enum" || Boolean(column.enum?.length)) {
-    operators = ["eq", "neq", "in", "is_null", "not_null"];
+    operators = [
+      "eq",
+      "neq",
+      ...(enumSupportsListFilter(column) ? (["in"] as TableFilterOperator[]) : []),
+      "is_null",
+      "not_null",
+    ];
   } else if (["int", "float", "numeric", "date", "timestamp"].includes(type)) {
     operators = NUMBER_DATE_OPERATORS;
   } else if (type === "uuid") {
@@ -157,6 +163,9 @@ export function validateTableFilter(
   if (!tableFilterNeedsValue(filter.operator)) return null;
   const value = filter.value.trim();
   if (!value) return "Enter a value for this filter.";
+  if (filter.operator === "in" && !enumSupportsListFilter(column)) {
+    return "This choice list contains commas. Use “is” to match one exact choice.";
+  }
 
   const type = normalizeTableColumnType(column.type);
   const values = filter.operator === "in" ? splitListValue(value) : [value];
@@ -304,4 +313,8 @@ function splitListValue(value: string): string[] {
     .split(",")
     .map((item) => item.trim())
     .filter(Boolean);
+}
+
+function enumSupportsListFilter(column: VaultTableColumnInput): boolean {
+  return !(column.enum || []).some((item) => String(item).includes(","));
 }

--- a/frontend/src/pages/__tests__/resource-delete-pages.test.tsx
+++ b/frontend/src/pages/__tests__/resource-delete-pages.test.tsx
@@ -1,28 +1,42 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { VaultRefreshProvider } from "@/contexts/vault-refresh-context";
 import FilePage from "@/pages/file";
 import TablePage from "@/pages/table";
 
-vi.mock("@/lib/api", () => ({
-  authenticatedFetch: vi.fn(),
-  createPublication: vi.fn(),
-  createPublicationSnapshot: vi.fn(),
-  deletePublication: vi.fn(),
-  getVaultInfo: vi.fn(),
-  getDocument: vi.fn(),
-  listPublications: vi.fn(),
-  previewTablePublicationQuery: vi.fn(),
-  deleteVaultFile: vi.fn(),
-  deleteVaultTable: vi.fn(),
-  deleteVaultTableRow: vi.fn(),
-  insertVaultTableRow: vi.fn(),
-  listVaultTableRows: vi.fn(),
-  listVaultTables: vi.fn(),
-  updateVaultTableRow: vi.fn(),
-}));
+vi.mock("@/lib/api", () => {
+  class ApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.status = status;
+    }
+  }
+  class TableRowConflictError extends Error {}
+  return {
+    ApiError,
+    TableRowConflictError,
+    authenticatedFetch: vi.fn(),
+    createPublication: vi.fn(),
+    createPublicationSnapshot: vi.fn(),
+    deletePublication: vi.fn(),
+    getVaultInfo: vi.fn(),
+    getDocument: vi.fn(),
+    getVaultTableRow: vi.fn(),
+    listPublications: vi.fn(),
+    previewTablePublicationQuery: vi.fn(),
+    deleteVaultFile: vi.fn(),
+    deleteVaultTable: vi.fn(),
+    deleteVaultTableRow: vi.fn(),
+    insertVaultTableRow: vi.fn(),
+    listVaultTableRows: vi.fn(),
+    listVaultTables: vi.fn(),
+    updateVaultTableRow: vi.fn(),
+  };
+});
 
 import {
   authenticatedFetch,
@@ -62,19 +76,24 @@ function LocationProbe() {
 }
 
 function renderRoute(path: string, refetchTree = vi.fn()) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0 } },
+  });
   return {
     refetchTree,
     ...render(
-      <MemoryRouter initialEntries={[path]}>
-        <VaultRefreshProvider refetchVaults={vi.fn()} refetchTree={refetchTree}>
-          <Routes>
-            <Route path="/vault/:name/file/:id" element={<FilePage />} />
-            <Route path="/vault/:name/table/:table" element={<TablePage />} />
-            <Route path="/vault/:name" element={<div>Vault overview</div>} />
-          </Routes>
-          <LocationProbe />
-        </VaultRefreshProvider>
-      </MemoryRouter>,
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[path]}>
+          <VaultRefreshProvider refetchVaults={vi.fn()} refetchTree={refetchTree}>
+            <Routes>
+              <Route path="/vault/:name/file/:id" element={<FilePage />} />
+              <Route path="/vault/:name/table/:table" element={<TablePage />} />
+              <Route path="/vault/:name" element={<div>Vault overview</div>} />
+            </Routes>
+            <LocationProbe />
+          </VaultRefreshProvider>
+        </MemoryRouter>
+      </QueryClientProvider>,
     ),
   };
 }

--- a/frontend/src/pages/__tests__/table-row-management.test.tsx
+++ b/frontend/src/pages/__tests__/table-row-management.test.tsx
@@ -1,32 +1,48 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { VaultRefreshProvider } from "@/contexts/vault-refresh-context";
 import TablePage from "@/pages/table";
 
-vi.mock("@/lib/api", () => ({
-  createPublication: vi.fn(),
-  createPublicationSnapshot: vi.fn(),
-  deletePublication: vi.fn(),
-  deleteVaultTable: vi.fn(),
-  deleteVaultTableRow: vi.fn(),
-  getVaultInfo: vi.fn(),
-  insertVaultTableRow: vi.fn(),
-  listPublications: vi.fn(),
-  listVaultTableRows: vi.fn(),
-  listVaultTables: vi.fn(),
-  previewTablePublicationQuery: vi.fn(),
-  updateVaultTableRow: vi.fn(),
-}));
+vi.mock("@/lib/api", () => {
+  class ApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.status = status;
+    }
+  }
+  class TableRowConflictError extends Error {}
+  return {
+    ApiError,
+    TableRowConflictError,
+    createPublication: vi.fn(),
+    createPublicationSnapshot: vi.fn(),
+    deletePublication: vi.fn(),
+    deleteVaultTable: vi.fn(),
+    deleteVaultTableRow: vi.fn(),
+    getVaultInfo: vi.fn(),
+    getVaultTableRow: vi.fn(),
+    insertVaultTableRow: vi.fn(),
+    listPublications: vi.fn(),
+    listVaultTableRows: vi.fn(),
+    listVaultTables: vi.fn(),
+    previewTablePublicationQuery: vi.fn(),
+    updateVaultTableRow: vi.fn(),
+  };
+});
 
 import {
   deleteVaultTableRow,
+  getVaultTableRow,
   getVaultInfo,
   insertVaultTableRow,
   listVaultTableRows,
   listVaultTables,
   updateVaultTableRow,
+  TableRowConflictError,
 } from "@/lib/api";
 
 const vaultInfoMock = getVaultInfo as unknown as ReturnType<typeof vi.fn>;
@@ -35,19 +51,28 @@ const listRowsMock = listVaultTableRows as unknown as ReturnType<typeof vi.fn>;
 const insertRowMock = insertVaultTableRow as unknown as ReturnType<typeof vi.fn>;
 const updateRowMock = updateVaultTableRow as unknown as ReturnType<typeof vi.fn>;
 const deleteRowMock = deleteVaultTableRow as unknown as ReturnType<typeof vi.fn>;
+const getRowMock = getVaultTableRow as unknown as ReturnType<typeof vi.fn>;
 const rowId = "6ab163e8-6ea4-4d20-8765-bf912716384c";
 
-function renderTable(refetchTree = vi.fn()) {
+function renderTable(
+  refetchTree = vi.fn(),
+  initialEntry = "/vault/ops/table/incidents",
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0 } },
+  });
   return {
     refetchTree,
     ...render(
-      <MemoryRouter initialEntries={["/vault/ops/table/incidents"]}>
-        <VaultRefreshProvider refetchVaults={vi.fn()} refetchTree={refetchTree}>
-          <Routes>
-            <Route path="/vault/:name/table/:table" element={<TablePage />} />
-          </Routes>
-        </VaultRefreshProvider>
-      </MemoryRouter>,
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[initialEntry]}>
+          <VaultRefreshProvider refetchVaults={vi.fn()} refetchTree={refetchTree}>
+            <Routes>
+              <Route path="/vault/:name/table/:table" element={<TablePage />} />
+            </Routes>
+          </VaultRefreshProvider>
+        </MemoryRouter>
+      </QueryClientProvider>,
     ),
   };
 }
@@ -59,6 +84,7 @@ beforeEach(() => {
   insertRowMock.mockReset();
   updateRowMock.mockReset();
   deleteRowMock.mockReset();
+  getRowMock.mockReset();
   listTablesMock.mockResolvedValue({
     items: [{
       name: "incidents",
@@ -82,6 +108,7 @@ beforeEach(() => {
       score: "0.74",
       metadata: { service: "gateway" },
       created_at: "2026-08-31T04:45:00Z",
+      updated_at: "2026-09-01T04:45:00Z",
     }],
     total: 1,
   });
@@ -129,22 +156,29 @@ describe("table row management", () => {
       "incidents",
       rowId,
       { severity: "critical" },
+      { expectedUpdatedAt: "2026-09-01T04:45:00Z", force: false },
     ));
 
     await user.click(screen.getByRole("button", { name: "Actions for row 1" }));
     await user.click(screen.getByRole("menuitem", { name: "Delete row" }));
     await user.click(screen.getByRole("button", { name: "Delete row" }));
-    await waitFor(() => expect(deleteRowMock).toHaveBeenCalledWith("ops", "incidents", rowId));
+    await waitFor(() => expect(deleteRowMock).toHaveBeenCalledWith(
+      "ops",
+      "incidents",
+      rowId,
+      { expectedUpdatedAt: "2026-09-01T04:45:00Z" },
+    ));
   });
 
-  it("keeps row mutation controls hidden for readers", async () => {
+  it("explains row write restrictions to readers", async () => {
     vaultInfoMock.mockResolvedValue({ role: "reader", is_archived: false, is_external_git: false });
     renderTable();
 
     await screen.findByRole("heading", { name: "incidents" });
     await waitFor(() => expect(vaultInfoMock).toHaveBeenCalledWith("ops"));
     expect(screen.getByText("Read only")).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Add row" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add row" })).toBeDisabled();
+    expect(screen.getByText("Writer role required to add, edit, or delete rows.")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Actions for row 1" })).not.toBeInTheDocument();
   });
 
@@ -161,5 +195,135 @@ describe("table row management", () => {
 
     expect(await within(dialog).findByText("metadata must contain valid JSON.")).toBeInTheDocument();
     expect(insertRowMock).not.toHaveBeenCalled();
+  });
+
+  it("pages, sorts, and filters through server query options", async () => {
+    vaultInfoMock.mockResolvedValue({ role: "writer", is_archived: false, is_external_git: false });
+    listRowsMock.mockResolvedValue({
+      kind: "table_query",
+      columns: ["id", "title", "severity", "created_at", "updated_at"],
+      items: [{
+        id: rowId,
+        title: "API outage",
+        severity: "high",
+        created_at: "2026-08-31T04:45:00Z",
+        updated_at: "2026-09-01T04:45:00Z",
+      }],
+      total: 121,
+    });
+    const user = userEvent.setup();
+    renderTable();
+
+    await user.click(await screen.findByRole("button", { name: /Sort by title/ }));
+    await waitFor(() => expect(listRowsMock).toHaveBeenLastCalledWith(
+      "ops",
+      "incidents",
+      expect.objectContaining({ order: "title.asc,id.asc", offset: 0 }),
+    ));
+
+    await user.click(screen.getByRole("button", { name: "Filters" }));
+    const dialog = screen.getByRole("dialog", { name: "Add a filter" });
+    await user.click(within(dialog).getByLabelText("Column"));
+    await user.click(screen.getByRole("menuitemradio", { name: /severity/ }));
+    await user.type(within(dialog).getByLabelText("Value"), "high");
+    await user.click(within(dialog).getByRole("button", { name: "Apply filter" }));
+    await waitFor(() => expect(listRowsMock).toHaveBeenLastCalledWith(
+      "ops",
+      "incidents",
+      expect.objectContaining({
+        filters: [{ column: "severity", expression: "ilike.*high*" }],
+        offset: 0,
+      }),
+    ));
+
+    await user.click(screen.getByRole("button", { name: "Next page" }));
+    await waitFor(() => expect(listRowsMock).toHaveBeenLastCalledWith(
+      "ops",
+      "incidents",
+      expect.objectContaining({ offset: 50, limit: 50 }),
+    ));
+  });
+
+  it("preserves an edit draft when a concurrent update is detected", async () => {
+    vaultInfoMock.mockResolvedValue({ role: "writer", is_archived: false, is_external_git: false });
+    updateRowMock.mockRejectedValueOnce(new TableRowConflictError(rowId, "update"));
+    getRowMock.mockResolvedValue({
+      id: rowId,
+      title: "API outage",
+      severity: "medium",
+      score: "0.74",
+      metadata: { service: "gateway" },
+      updated_at: "2026-09-02T04:45:00Z",
+    });
+    const user = userEvent.setup();
+    renderTable();
+
+    await user.click(await screen.findByRole("button", { name: "Actions for row 1" }));
+    await user.click(screen.getByRole("menuitem", { name: "Edit row" }));
+    const dialog = screen.getByRole("dialog");
+    const severity = within(dialog).getByLabelText("severity");
+    await user.clear(severity);
+    await user.type(severity, "critical");
+    await user.click(within(dialog).getByRole("button", { name: "Save changes" }));
+
+    expect(await within(dialog).findByText("This row has newer changes")).toBeInTheDocument();
+    expect(severity).toHaveValue("critical");
+    await user.click(within(dialog).getByRole("button", { name: "Reload current values" }));
+    await waitFor(() => expect(getRowMock).toHaveBeenCalledWith("ops", "incidents", rowId));
+    expect(within(dialog).getByLabelText("severity")).toHaveValue("medium");
+  });
+
+  it("requires an explicit overwrite after a concurrent edit", async () => {
+    vaultInfoMock.mockResolvedValue({ role: "writer", is_archived: false, is_external_git: false });
+    updateRowMock
+      .mockRejectedValueOnce(new TableRowConflictError(rowId, "update"))
+      .mockResolvedValueOnce({ items: [{ id: rowId }], columns: ["id"], total: 1 });
+    const user = userEvent.setup();
+    renderTable();
+
+    await user.click(await screen.findByRole("button", { name: "Actions for row 1" }));
+    await user.click(screen.getByRole("menuitem", { name: "Edit row" }));
+    const dialog = screen.getByRole("dialog");
+    const severity = within(dialog).getByLabelText("severity");
+    await user.clear(severity);
+    await user.type(severity, "critical");
+    await user.click(within(dialog).getByRole("button", { name: "Save changes" }));
+    await user.click(await within(dialog).findByRole("button", { name: "Overwrite anyway" }));
+
+    await waitFor(() => expect(updateRowMock).toHaveBeenLastCalledWith(
+      "ops",
+      "incidents",
+      rowId,
+      { severity: "critical" },
+      { expectedUpdatedAt: "2026-09-01T04:45:00Z", force: true },
+    ));
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Edit row" })).not.toBeInTheDocument());
+  });
+
+  it("reloads a changed row before allowing deletion", async () => {
+    vaultInfoMock.mockResolvedValue({ role: "writer", is_archived: false, is_external_git: false });
+    deleteRowMock
+      .mockRejectedValueOnce(new TableRowConflictError(rowId, "delete"))
+      .mockResolvedValueOnce({ items: [{ id: rowId }], columns: ["id"], total: 1 });
+    getRowMock.mockResolvedValue({
+      id: rowId,
+      title: "Renamed incident",
+      updated_at: "2026-09-02T04:45:00Z",
+    });
+    const user = userEvent.setup();
+    renderTable();
+
+    await user.click(await screen.findByRole("button", { name: "Actions for row 1" }));
+    await user.click(screen.getByRole("menuitem", { name: "Delete row" }));
+    await user.click(screen.getByRole("button", { name: "Delete row" }));
+    expect(await screen.findByText(/latest version is now loaded/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Delete row" }));
+
+    await waitFor(() => expect(deleteRowMock).toHaveBeenLastCalledWith(
+      "ops",
+      "incidents",
+      rowId,
+      { expectedUpdatedAt: "2026-09-02T04:45:00Z" },
+    ));
   });
 });

--- a/frontend/src/pages/__tests__/table-row-management.test.tsx
+++ b/frontend/src/pages/__tests__/table-row-management.test.tsx
@@ -288,13 +288,16 @@ describe("table row management", () => {
     await user.clear(severity);
     await user.type(severity, "critical");
     await user.click(within(dialog).getByRole("button", { name: "Save changes" }));
+    const title = within(dialog).getByLabelText("title");
+    await user.clear(title);
+    await user.type(title, "API outage revised");
     await user.click(await within(dialog).findByRole("button", { name: "Overwrite anyway" }));
 
     await waitFor(() => expect(updateRowMock).toHaveBeenLastCalledWith(
       "ops",
       "incidents",
       rowId,
-      { severity: "critical" },
+      { title: "API outage revised", severity: "critical" },
       { expectedUpdatedAt: "2026-09-01T04:45:00Z", force: true },
     ));
     await waitFor(() => expect(screen.queryByRole("dialog", { name: "Edit row" })).not.toBeInTheDocument());

--- a/frontend/src/pages/table.tsx
+++ b/frontend/src/pages/table.tsx
@@ -1,7 +1,11 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
   Asterisk,
   Braces,
   CalendarClock,
@@ -42,20 +46,38 @@ import { ResourceDeleteDialog } from "@/components/resource-delete-dialog";
 import { PublicationSuccessBanner } from "@/components/publication-success-banner";
 import { TablePublishDialog } from "@/components/table-publish-dialog";
 import { TableRowDialog } from "@/components/table-row-dialog";
+import {
+  TableFilterBar,
+  TableFilterDialog,
+  TablePagination,
+} from "@/components/table-query-controls";
 import { useVaultRefresh } from "@/contexts/vault-refresh-context";
 import {
+  ApiError,
   deleteVaultTable,
   deleteVaultTableRow,
+  getVaultTableRow,
   getVaultInfo,
   insertVaultTableRow,
   listVaultTableRows,
   listVaultTables,
   updateVaultTableRow,
+  TableRowConflictError,
   type Publication,
   type VaultTableColumnInput,
   type VaultTableInfo,
 } from "@/lib/api";
 import { ROLE_RANK, type Role } from "@/lib/roles";
+import {
+  DEFAULT_TABLE_SORT,
+  compileTableFilter,
+  parseTableQueryState,
+  tableOrder,
+  writeTableQueryState,
+  type TablePageSize,
+  type TableQueryState,
+  type TableSort,
+} from "@/lib/table-query-state";
 import { cn } from "@/lib/utils";
 
 type Column = VaultTableColumnInput;
@@ -70,18 +92,11 @@ const SYSTEM_COLUMN_TYPES: Record<string, string> = {
 export default function TablePage() {
   const { name: vault, table } = useParams<{ name: string; table: string }>();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { refetchTree } = useVaultRefresh();
-  const [info, setInfo] = useState<VaultTableInfo | null>(null);
-  const [rows, setRows] = useState<Record<string, unknown>[]>([]);
-  const [cols, setCols] = useState<string[]>([]);
-  const [total, setTotal] = useState(0);
-  const [error, setError] = useState("");
-  const [loading, setLoading] = useState(true);
-  const [infoLoading, setInfoLoading] = useState(true);
   const [schemaOpen, setSchemaOpen] = useState(false);
-  const [canPublish, setCanPublish] = useState(false);
-  const [canDelete, setCanDelete] = useState(false);
-  const [canManageRows, setCanManageRows] = useState(false);
+  const [filtersOpen, setFiltersOpen] = useState(false);
   const [publishOpen, setPublishOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [published, setPublished] = useState<Publication | null>(null);
@@ -91,86 +106,68 @@ export default function TablePage() {
   const [rowNotice, setRowNotice] = useState("");
   const schemaToggleRef = useRef<HTMLButtonElement | null>(null);
   const schemaCloseRef = useRef<HTMLButtonElement | null>(null);
-  const dataRequestRef = useRef(0);
-  const limit = 50;
+  const queryState = useMemo(() => parseTableQueryState(searchParams), [searchParams]);
 
-  useEffect(() => {
-    if (!vault) return;
-    let cancelled = false;
-    setCanPublish(false);
-    setCanDelete(false);
-    setCanManageRows(false);
-    getVaultInfo(vault)
-      .then((data) => {
-        const roleRank = ROLE_RANK[data?.role as Role] ?? 0;
-        const writable = !data?.is_archived && !data?.is_external_git;
-        if (!cancelled) {
-          setCanPublish(roleRank >= ROLE_RANK.writer && writable);
-          setCanDelete(roleRank >= ROLE_RANK.admin && writable);
-          setCanManageRows(roleRank >= ROLE_RANK.writer && writable);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setCanPublish(false);
-          setCanDelete(false);
-          setCanManageRows(false);
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [vault]);
-
-  const refreshTableData = useCallback(
-    async (showLoading = false) => {
-      if (!vault || !table) return;
-      const requestId = ++dataRequestRef.current;
-      if (showLoading) {
-        setInfo(null);
-        setRows([]);
-        setCols([]);
-        setTotal(0);
-        setError("");
-        setLoading(true);
-        setInfoLoading(true);
-      }
-      try {
-        const [catalog, data] = await Promise.all([
-          listVaultTables(vault),
-          listVaultTableRows(vault, table, { limit }),
-        ]);
-        if (requestId !== dataRequestRef.current) return;
-        const found = catalog.items.find((item) => item.name === table) || null;
-        setInfo(found);
-        setRows(data.items || []);
-        setCols(data.columns || []);
-        setTotal(data.total ?? data.items?.length ?? 0);
-        setError("");
-      } catch (caught: unknown) {
-        if (requestId !== dataRequestRef.current) return;
-        setError(caught instanceof Error ? caught.message : "The table could not be loaded.");
-      } finally {
-        if (requestId === dataRequestRef.current) {
-          setLoading(false);
-          setInfoLoading(false);
-        }
-      }
+  const setQueryState = useCallback(
+    (next: TableQueryState) => {
+      setSearchParams(writeTableQueryState(searchParams, next), { replace: true });
     },
-    [limit, table, vault],
+    [searchParams, setSearchParams],
   );
+
+  const vaultInfoQuery = useQuery({
+    queryKey: ["vault-info", vault],
+    queryFn: () => getVaultInfo(vault!),
+    enabled: Boolean(vault),
+  });
+  const catalogQuery = useQuery({
+    queryKey: ["vault-tables", vault],
+    queryFn: () => listVaultTables(vault!),
+    enabled: Boolean(vault),
+  });
+  const rowsQuery = useQuery({
+    queryKey: [
+      "vault-table-rows",
+      vault,
+      table,
+      queryState.pageIndex,
+      queryState.pageSize,
+      queryState.sort,
+      queryState.filters,
+    ],
+    queryFn: async ({ signal }) => {
+      const result = await listVaultTableRows(vault!, table!, {
+        limit: queryState.pageSize,
+        offset: queryState.pageIndex * queryState.pageSize,
+        order: tableOrder(queryState.sort),
+        filters: queryState.filters.map(compileTableFilter),
+        signal,
+      });
+      return {
+        ...result,
+        queryPageIndex: queryState.pageIndex,
+        queryPageSize: queryState.pageSize,
+      };
+    },
+    enabled: Boolean(vault && table),
+    placeholderData: keepPreviousData,
+  });
+
+  const info: VaultTableInfo | null =
+    catalogQuery.data?.items.find((item) => item.name === table) || null;
+  const rows = rowsQuery.data?.items || [];
+  const cols = rowsQuery.data?.columns || [];
+  const total = rowsQuery.data?.total ?? 0;
+  const roleRank = ROLE_RANK[vaultInfoQuery.data?.role as Role] ?? 0;
+  const writeRestriction = rowWriteRestriction(vaultInfoQuery.data, roleRank);
+  const canManageRows = writeRestriction === null;
+  const canPublish = roleRank >= ROLE_RANK.writer && !writeRestriction;
+  const canDelete = roleRank >= ROLE_RANK.admin && !writeRestriction;
 
   const closeSchema = useCallback(() => {
     setSchemaOpen(false);
     window.requestAnimationFrame(() => schemaToggleRef.current?.focus());
   }, []);
-
-  useEffect(() => {
-    void refreshTableData(true);
-    return () => {
-      dataRequestRef.current += 1;
-    };
-  }, [refreshTableData]);
 
   useEffect(() => {
     if (!rowNotice) return;
@@ -193,6 +190,13 @@ export default function TablePage() {
     };
   }, [closeSchema, schemaOpen]);
 
+  useEffect(() => {
+    if (!rowsQuery.data || rowsQuery.isPlaceholderData) return;
+    const pageCount = Math.max(1, Math.ceil(total / queryState.pageSize));
+    if (queryState.pageIndex < pageCount) return;
+    setQueryState({ ...queryState, pageIndex: pageCount - 1 });
+  }, [queryState, rowsQuery.data, rowsQuery.isPlaceholderData, setQueryState, total]);
+
   const columnByName = useMemo(
     () =>
       new Map<string, Column>([
@@ -210,10 +214,37 @@ export default function TablePage() {
   const primaryKeyCount = info?.columns?.filter((column) => column.primary_key).length || 0;
   const requiredCount =
     info?.columns?.filter((column) => column.required || column.primary_key).length || 0;
-  const sampled = rowCount > rows.length;
+  const displayPageIndex = rowsQuery.data?.queryPageIndex ?? queryState.pageIndex;
+  const displayPageSize = rowsQuery.data?.queryPageSize ?? queryState.pageSize;
+  const pageStart = total === 0 ? 0 : displayPageIndex * displayPageSize + 1;
+  const pageEnd = total === 0 ? 0 : Math.min(pageStart + rows.length - 1, total);
+  const activeSort = queryState.sort || DEFAULT_TABLE_SORT;
+  const availableColumns = Array.from(columnByName.values());
+  const queryError = tableRowsError(rowsQuery.error, Boolean(info));
 
-  if (loading || infoLoading) {
+  if (vaultInfoQuery.isPending || catalogQuery.isPending || rowsQuery.isPending) {
     return <TablePageLoading />;
+  }
+
+  async function refreshTableData() {
+    await Promise.all([rowsQuery.refetch(), catalogQuery.refetch()]);
+  }
+
+  function updatePage(pageIndex: number) {
+    setQueryState({ ...queryState, pageIndex });
+  }
+
+  function updatePageSize(pageSize: TablePageSize) {
+    setQueryState({ ...queryState, pageIndex: 0, pageSize });
+  }
+
+  function updateSort(column: string) {
+    const next: TableSort = {
+      column,
+      direction:
+        activeSort.column === column && activeSort.direction === "asc" ? "desc" : "asc",
+    };
+    setQueryState({ ...queryState, pageIndex: 0, sort: next });
   }
 
   return (
@@ -245,22 +276,23 @@ export default function TablePage() {
                 {visibleColumnCount} columns
               </span>
             </div>
-            {canManageRows && (
-              <Button
-                type="button"
-                variant="accent"
-                size="sm"
-                onClick={() => {
-                  setSelectedRow(null);
-                  setRowDialogMode("create");
-                }}
-                disabled={!info?.columns?.length}
-                title={!info?.columns?.length ? "Schema metadata is required to add rows" : undefined}
-              >
-                <Plus className="h-4 w-4" aria-hidden />
-                <span className="hidden sm:inline">Add row</span>
-              </Button>
-            )}
+            <Button
+              type="button"
+              variant="accent"
+              size="sm"
+              onClick={() => {
+                setSelectedRow(null);
+                setRowDialogMode("create");
+              }}
+              disabled={!canManageRows || !info?.columns?.length}
+              title={
+                writeRestriction ||
+                (!info?.columns?.length ? "Schema metadata is required to add rows" : undefined)
+              }
+            >
+              <Plus className="h-4 w-4" aria-hidden />
+              <span className="hidden sm:inline">Add row</span>
+            </Button>
             <Button
               ref={schemaToggleRef}
               type="button"
@@ -310,7 +342,7 @@ export default function TablePage() {
               ) : (
                 <span className="inline-flex items-center gap-1.5 whitespace-nowrap tabular-nums">
                   <Rows3 className="h-3.5 w-3.5" aria-hidden />
-                  {sampled ? `${rows.length} of ${rowCount}` : `${rows.length} rows`}
+                  {pageStart}–{pageEnd} of {total}
                 </span>
               )
             }
@@ -318,19 +350,17 @@ export default function TablePage() {
             <div className="flex min-w-0 items-center gap-2 text-xs text-foreground-muted">
               <Info className="h-3.5 w-3.5 shrink-0 text-link" aria-hidden />
               <TooltipText
-                tip={
-                  info?.description ||
-                  (canManageRows
-                    ? "Add, edit, or remove records in this Vault table."
-                    : "A read-only view of this Vault table.")
-                }
+                tip={info?.description || "Browse records in this Vault table."}
                 className="truncate"
               >
-                {info?.description ||
-                  (canManageRows
-                    ? "Add, edit, or remove records in this Vault table."
-                    : "A read-only view of this Vault table.")}
+                {info?.description || "Browse records in this Vault table."}
               </TooltipText>
+              {writeRestriction && (
+                <>
+                  <span aria-hidden>·</span>
+                  <span className="truncate">{writeRestriction}</span>
+                </>
+              )}
             </div>
           </ResourceContextBar>
 
@@ -341,132 +371,213 @@ export default function TablePage() {
               <>
                 <span className="tabular-nums">{cols.length} columns</span>
                 <span className="hidden sm:inline">
-                  {sampled ? `Latest ${limit} rows` : "Complete result"}
+                  {queryState.filters.length > 0 ? `${total} matching` : `${total} rows`}
                 </span>
               </>
             }
             bodyClassName="overflow-hidden"
           >
-            {error ? (
-              <div className="p-4 sm:p-6">
-                <Alert variant="destructive" title="Query failed">
-                  <span className="font-mono">{error}</span>
-                </Alert>
-              </div>
-            ) : rows.length === 0 ? (
-              <div className="flex min-h-64 flex-col items-center justify-center px-6 py-12 text-center">
-                <Table2 className="h-9 w-9 text-foreground-muted" aria-hidden />
-                <h2 className="mt-4 text-sm font-semibold text-foreground">No rows yet</h2>
-                <p className="mt-1 max-w-sm text-sm text-foreground-muted">
-                  {canManageRows
-                    ? "The schema is ready. Add the first record to start using this table."
-                    : "The schema is ready, but this table does not contain any records."}
-                </p>
-                {canManageRows && info?.columns?.length ? (
-                  <Button
-                    type="button"
-                    variant="accent"
-                    size="sm"
-                    className="mt-5"
-                    onClick={() => {
-                      setSelectedRow(null);
-                      setRowDialogMode("create");
-                    }}
-                  >
-                    <Plus className="h-4 w-4" aria-hidden />
-                    Add first row
-                  </Button>
-                ) : null}
-              </div>
-            ) : (
-              <div
-                role="region"
-                aria-label={`Preview rows for ${table}`}
-                tabIndex={0}
-                className="h-full overflow-auto focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
-              >
-                <table className="min-w-full border-separate border-spacing-0 text-sm">
-                  <thead>
-                    <tr>
-                      <th
-                        scope="col"
-                        className="sticky left-0 top-0 z-[var(--z-sticky)] w-12 border-b border-r border-border bg-surface-2 px-3 py-2.5 text-left text-xs font-medium text-foreground-muted"
-                      >
-                        #
-                      </th>
-                      {cols.map((columnName) => (
+            <div className="flex h-full min-h-0 flex-col">
+              <TableFilterBar
+                filters={queryState.filters}
+                onOpen={() => setFiltersOpen(true)}
+                onRemove={(index) =>
+                  setQueryState({
+                    ...queryState,
+                    pageIndex: 0,
+                    filters: queryState.filters.filter((_, filterIndex) => filterIndex !== index),
+                  })
+                }
+                onClear={() => setQueryState({ ...queryState, pageIndex: 0, filters: [] })}
+                onRefresh={() => void refreshTableData()}
+                refreshing={rowsQuery.isFetching}
+              />
+              {queryError && rowsQuery.data && (
+                <div className="shrink-0 border-b border-border p-3">
+                  <Alert variant="destructive" title="Records could not be refreshed">
+                    {queryError}
+                  </Alert>
+                </div>
+              )}
+              {queryError && !rowsQuery.data ? (
+                <div className="p-4 sm:p-6">
+                  <Alert variant="destructive" title="Records could not be loaded">
+                    {queryError}
+                  </Alert>
+                </div>
+              ) : rows.length === 0 ? (
+                <div className="flex min-h-64 flex-1 flex-col items-center justify-center px-6 py-12 text-center">
+                  <Table2 className="h-9 w-9 text-foreground-muted" aria-hidden />
+                  <h2 className="mt-4 text-sm font-semibold text-foreground">
+                    {queryState.filters.length > 0 ? "No records match these filters" : "No rows yet"}
+                  </h2>
+                  <p className="mt-1 max-w-sm text-sm text-foreground-muted">
+                    {queryState.filters.length > 0
+                      ? "Remove a filter or change its value to broaden the result."
+                      : canManageRows
+                        ? "The schema is ready. Add the first record to start using this table."
+                        : "The schema is ready, but this table does not contain any records."}
+                  </p>
+                  {queryState.filters.length > 0 ? (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="mt-5"
+                      onClick={() => setQueryState({ ...queryState, pageIndex: 0, filters: [] })}
+                    >
+                      Clear filters
+                    </Button>
+                  ) : canManageRows && info?.columns?.length ? (
+                    <Button
+                      type="button"
+                      variant="accent"
+                      size="sm"
+                      className="mt-5"
+                      onClick={() => {
+                        setSelectedRow(null);
+                        setRowDialogMode("create");
+                      }}
+                    >
+                      <Plus className="h-4 w-4" aria-hidden />
+                      Add first row
+                    </Button>
+                  ) : null}
+                </div>
+              ) : (
+                <div
+                  role="region"
+                  aria-label={`Records for ${table}`}
+                  aria-busy={rowsQuery.isFetching || undefined}
+                  tabIndex={0}
+                  className="min-h-0 flex-1 overflow-auto focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+                >
+                  <table className="min-w-full border-separate border-spacing-0 text-sm">
+                    <thead>
+                      <tr>
                         <th
-                          key={columnName}
                           scope="col"
-                          className="sticky top-0 z-[var(--z-raised)] min-w-36 border-b border-r border-border bg-surface-2 px-3 py-2.5 text-left last:border-r-0"
+                          className="sticky left-0 top-0 z-[var(--z-sticky)] w-12 border-b border-r border-border bg-surface-2 px-3 py-2.5 text-left text-xs font-medium text-foreground-muted"
                         >
-                          <span className="block whitespace-nowrap font-mono text-xs font-medium text-foreground">
-                            {columnName}
-                          </span>
-                          {columnByName.get(columnName)?.type && (
-                            <span className="mt-0.5 block whitespace-nowrap text-xs font-normal text-foreground-muted">
-                              {columnByName.get(columnName)?.type}
-                            </span>
-                          )}
+                          #
                         </th>
-                      ))}
-                      {canManageRows && (
-                        <th
-                          scope="col"
-                          className="sticky right-0 top-0 z-[var(--z-sticky)] w-12 border-b border-l border-border bg-surface-2 px-2 py-2.5 text-center text-xs font-medium text-foreground-muted"
-                        >
-                          <span className="sr-only">Row actions</span>
-                        </th>
-                      )}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {rows.map((row, rowIndex) => (
-                      <tr
-                        key={typeof row.id === "string" ? row.id : rowIndex}
-                        className="group transition-colors hover:bg-surface-hover"
-                      >
-                        <td className="sticky left-0 z-[var(--z-raised)] border-b border-r border-border bg-surface px-3 py-2 text-xs text-foreground-muted tabular-nums group-hover:bg-surface-hover">
-                          {rowIndex + 1}
-                        </td>
                         {cols.map((columnName) => {
-                          const value = row[columnName];
-                          const numeric =
-                            typeof value === "number" ||
-                            isNumericColumnType(columnByName.get(columnName)?.type);
+                          const sorted = activeSort.column === columnName;
+                          const SortIcon = sorted
+                            ? activeSort.direction === "asc"
+                              ? ArrowUp
+                              : ArrowDown
+                            : ArrowUpDown;
                           return (
-                            <TooltipText key={columnName} asChild tip={formatCellFull(value)}>
-                              <td
-                                className={cn(
-                                  "max-w-md truncate whitespace-nowrap border-b border-r border-border px-3 py-2 text-foreground last:border-r-0",
-                                  numeric && "text-right tabular-nums",
-                                  value !== null && typeof value === "object" && "font-mono text-xs",
-                                  value === null && "italic text-foreground-muted",
-                                )}
+                            <th
+                              key={columnName}
+                              scope="col"
+                              aria-sort={
+                                sorted
+                                  ? activeSort.direction === "asc"
+                                    ? "ascending"
+                                    : "descending"
+                                  : "none"
+                              }
+                              className="sticky top-0 z-[var(--z-raised)] min-w-36 border-b border-r border-border bg-surface-2 p-0 text-left last:border-r-0"
+                            >
+                              <button
+                                type="button"
+                                className="flex min-h-11 w-full cursor-pointer items-center justify-between gap-3 px-3 py-2 text-left hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+                                onClick={() => updateSort(columnName)}
+                                aria-label={`Sort by ${columnName}, ${
+                                  sorted ? activeSort.direction : "not currently sorted"
+                                }`}
                               >
-                                {formatCell(value)}
-                              </td>
-                            </TooltipText>
+                                <span className="min-w-0">
+                                  <span className="block truncate whitespace-nowrap font-mono text-xs font-medium text-foreground">
+                                    {columnName}
+                                  </span>
+                                  {columnByName.get(columnName)?.type && (
+                                    <span className="mt-0.5 block whitespace-nowrap text-xs font-normal text-foreground-muted">
+                                      {columnByName.get(columnName)?.type}
+                                    </span>
+                                  )}
+                                </span>
+                                <SortIcon
+                                  className={cn(
+                                    "h-3.5 w-3.5 shrink-0",
+                                    sorted ? "text-link" : "text-foreground-muted",
+                                  )}
+                                  aria-hidden
+                                />
+                              </button>
+                            </th>
                           );
                         })}
                         {canManageRows && (
-                          <td className="sticky right-0 z-[var(--z-raised)] border-b border-l border-border bg-surface px-1 py-1 text-center group-hover:bg-surface-hover">
-                            <RowActionsMenu
-                              rowNumber={rowIndex + 1}
-                              onEdit={() => {
-                                setSelectedRow(row);
-                                setRowDialogMode("edit");
-                              }}
-                              onDelete={() => setRowToDelete(row)}
-                            />
-                          </td>
+                          <th
+                            scope="col"
+                            className="sticky right-0 top-0 z-[var(--z-sticky)] w-12 border-b border-l border-border bg-surface-2 px-2 py-2.5 text-center text-xs font-medium text-foreground-muted"
+                          >
+                            <span className="sr-only">Row actions</span>
+                          </th>
                         )}
                       </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
+                    </thead>
+                    <tbody>
+                      {rows.map((row, rowIndex) => (
+                        <tr
+                          key={typeof row.id === "string" ? row.id : rowIndex}
+                          className="group transition-colors hover:bg-surface-hover"
+                        >
+                          <td className="sticky left-0 z-[var(--z-raised)] border-b border-r border-border bg-surface px-3 py-2 text-xs text-foreground-muted tabular-nums group-hover:bg-surface-hover">
+                            {displayPageIndex * displayPageSize + rowIndex + 1}
+                          </td>
+                          {cols.map((columnName) => {
+                            const value = row[columnName];
+                            const numeric =
+                              typeof value === "number" ||
+                              isNumericColumnType(columnByName.get(columnName)?.type);
+                            return (
+                              <TooltipText key={columnName} asChild tip={formatCellFull(value)}>
+                                <td
+                                  className={cn(
+                                    "max-w-md truncate whitespace-nowrap border-b border-r border-border px-3 py-2 text-foreground last:border-r-0",
+                                    numeric && "text-right tabular-nums",
+                                    value !== null && typeof value === "object" && "font-mono text-xs",
+                                    value === null && "italic text-foreground-muted",
+                                  )}
+                                >
+                                  {formatCell(value)}
+                                </td>
+                              </TooltipText>
+                            );
+                          })}
+                          {canManageRows && (
+                            <td className="sticky right-0 z-[var(--z-raised)] border-b border-l border-border bg-surface px-1 py-1 text-center group-hover:bg-surface-hover">
+                              <RowActionsMenu
+                                rowNumber={displayPageIndex * displayPageSize + rowIndex + 1}
+                                onEdit={() => {
+                                  setSelectedRow(row);
+                                  setRowDialogMode("edit");
+                                }}
+                                onDelete={() => setRowToDelete(row)}
+                              />
+                            </td>
+                          )}
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+              {rowsQuery.data && total > 0 && (
+                <TablePagination
+                  pageIndex={displayPageIndex}
+                  pageSize={displayPageSize}
+                  total={total}
+                  itemCount={rows.length}
+                  onPageChange={updatePage}
+                  onPageSizeChange={updatePageSize}
+                />
+              )}
+            </div>
           </ResourceViewerFrame>
         </ResourceCanvas>
 
@@ -597,6 +708,18 @@ export default function TablePage() {
         columns={info?.columns || []}
         onPublished={setPublished}
       />
+      <TableFilterDialog
+        open={filtersOpen}
+        onOpenChange={setFiltersOpen}
+        columns={availableColumns}
+        onAdd={(filter) =>
+          setQueryState({
+            ...queryState,
+            pageIndex: 0,
+            filters: [...queryState.filters, filter],
+          })
+        }
+      />
       <TableRowDialog
         open={rowDialogMode !== null}
         onOpenChange={(open) => {
@@ -608,19 +731,40 @@ export default function TablePage() {
         table={table || "Table"}
         columns={info?.columns || []}
         row={selectedRow}
-        onSave={async (values) => {
+        onSave={async (values, options) => {
           if (!vault || !table) return;
           if (rowDialogMode === "edit") {
             const rowId = selectedRow?.id;
             if (typeof rowId !== "string") throw new Error("This row does not have a valid id.");
-            await updateVaultTableRow(vault, table, rowId, values);
+            await updateVaultTableRow(vault, table, rowId, values, {
+              expectedUpdatedAt:
+                typeof selectedRow?.updated_at === "string" ? selectedRow.updated_at : undefined,
+              force: options?.force,
+            });
             setRowNotice("Row updated");
           } else {
             await insertVaultTableRow(vault, table, values);
-            setRowNotice("Row added");
+            setRowNotice(
+              queryState.filters.length > 0
+                ? "Row added · current filters may hide it"
+                : "Row added",
+            );
+            if (queryState.filters.length === 0 && queryState.pageIndex !== 0) {
+              setQueryState({ ...queryState, pageIndex: 0 });
+            }
           }
-          await refreshTableData();
+          await Promise.all([
+            queryClient.invalidateQueries({ queryKey: ["vault-table-rows", vault, table] }),
+            queryClient.invalidateQueries({ queryKey: ["vault-tables", vault] }),
+          ]);
           refetchTree();
+        }}
+        onReloadConflict={async () => {
+          if (!vault || !table || typeof selectedRow?.id !== "string") return null;
+          const latest = await getVaultTableRow(vault, table, selectedRow.id);
+          if (latest) setSelectedRow(latest);
+          await queryClient.invalidateQueries({ queryKey: ["vault-table-rows", vault, table] });
+          return latest;
         }}
       />
       <ConfirmDialog
@@ -634,8 +778,32 @@ export default function TablePage() {
           if (!vault || !table || typeof rowToDelete?.id !== "string") {
             throw new Error("This row does not have a valid id.");
           }
-          await deleteVaultTableRow(vault, table, rowToDelete.id);
-          await refreshTableData();
+          try {
+            await deleteVaultTableRow(vault, table, rowToDelete.id, {
+              expectedUpdatedAt:
+                typeof rowToDelete.updated_at === "string" ? rowToDelete.updated_at : undefined,
+            });
+          } catch (caught: unknown) {
+            if (!(caught instanceof TableRowConflictError)) throw caught;
+            const latest = await getVaultTableRow(vault, table, rowToDelete.id);
+            if (!latest) {
+              setRowNotice("Row was already deleted");
+              setRowToDelete(null);
+              await queryClient.invalidateQueries({
+                queryKey: ["vault-table-rows", vault, table],
+              });
+              return;
+            }
+            setRowToDelete(latest);
+            throw new Error(
+              "This row changed after you opened it. The latest version is now loaded; review it and choose Delete row again.",
+              { cause: caught },
+            );
+          }
+          await Promise.all([
+            queryClient.invalidateQueries({ queryKey: ["vault-table-rows", vault, table] }),
+            queryClient.invalidateQueries({ queryKey: ["vault-tables", vault] }),
+          ]);
           refetchTree();
           setRowNotice("Row deleted");
           setRowToDelete(null);
@@ -643,6 +811,27 @@ export default function TablePage() {
       />
     </ResourceWorkspace>
   );
+}
+
+function rowWriteRestriction(
+  vaultInfo: { role?: string; is_archived?: boolean; is_external_git?: boolean } | undefined,
+  roleRank: number,
+): string | null {
+  if (!vaultInfo) return "Permissions could not be verified, so rows are read only.";
+  if (vaultInfo.is_archived) return "Archived Vaults are read only.";
+  if (vaultInfo.is_external_git) {
+    return "This Vault is managed from an external Git source, so rows are read only here.";
+  }
+  if (roleRank < ROLE_RANK.writer) return "Writer role required to add, edit, or delete rows.";
+  return null;
+}
+
+function tableRowsError(error: Error | null, tableExists: boolean): string | null {
+  if (!error) return null;
+  if (tableExists && error instanceof ApiError && [404, 405].includes(error.status)) {
+    return "Structured row browsing is not supported by the connected AKB server yet. The table schema is still available.";
+  }
+  return error.message || "The table records could not be loaded.";
 }
 
 function RowActionsMenu({


### PR DESCRIPTION
## Summary

- add server-driven sorting, schema-aware filters, and offset pagination to the table row workspace
- preserve query state in the URL and keep record ranges stable with an id tie-breaker
- add permission-aware row actions and recoverable loading, empty, compatibility, and error states
- protect row updates and deletes with updated_at conflict detection while preserving unsaved edits
- document the table workspace interaction contract and cover the API and UI behavior

## Motivation

Large tables could only expose the initial bounded row result, with no way to move through the dataset or narrow and order records from the UI. Row mutations also had no protection against overwriting a newer change loaded by another client.

This change makes the table page a complete data workspace while keeping the interaction model bounded and predictable.

## Design

The table page uses the structured row collection endpoint for browsing. Filters are selected from the declared column schema, sorting uses a stable id tie-breaker, and page, filter, and sort state is encoded in the URL so reloads and shared links preserve context.

Update and delete requests include the loaded updated_at value. If the row changed, the UI retains the draft, fetches the current record on request, and requires an explicit overwrite or a second delete confirmation.

## Compatibility

- no backend schema or endpoint changes are required
- existing row query parameters remain optional
- the arbitrary SQL contract is unchanged; akb_sql SELECT results are not implicitly paginated or truncated
- older servers without the row workspace surface receive a recoverable unavailable state instead of a broken page

## Review focus

- URL state and structured filter compilation
- stable ordering across page boundaries
- permission messaging and keyboard and ARIA behavior
- optimistic-concurrency recovery for edits and deletes

Implements AKB-225.