### PR TITLE
feat(helm): automate bundled secret manager bootstrap

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3683
+        "line_number": 3700
       }
     ],
     "backend/mcp_server/help.py": [
@@ -6987,5 +6987,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-02T08:06:11Z"
+  "generated_at": "2026-09-02T09:41:23Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3700
+        "line_number": 3704
       }
     ],
     "backend/mcp_server/help.py": [
@@ -6987,5 +6987,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-02T09:41:23Z"
+  "generated_at": "2026-09-02T10:51:01Z"
 }

--- a/README.md
+++ b/README.md
@@ -576,9 +576,9 @@ Kustomize-based profile installers.
   [`deploy/k8s/profiles/*/deploy.sh`](./deploy/k8s/profiles/README.md) when the
   installer should coordinate the complete lifecycle, including Secret
   Manager initialization where selected.
-- Use raw Helm or rendered Kustomize YAML only when the required Secrets,
-  cluster prerequisites, and any native Vault/OpenBao init/unseal/bootstrap
-  steps are already managed separately.
+- Raw Helm supports the complete bundled lifecycle when a Secret Manager
+  profile is selected and `--wait --wait-for-jobs` is used. Rendered Kustomize
+  YAML still expects its Secret Manager lifecycle to be managed separately.
 - Vault Secrets Operator is a cluster-scoped prerequisite. Its ownership and
   guarded removal are documented under
   [`deploy/helm/akb-cluster`](./deploy/helm/akb-cluster/README.md).

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -19,6 +19,10 @@ Kubernetes Secret that operators must copy to off-cluster custody and delete;
 generated shares and tokens are never Helm values or release metadata. PGP
 mode keeps shares/root authority encrypted and waits for key-holder input,
 while Auto Seal continues to depend on its configured KMS/HSM/Transit provider.
+The Job verifies the persisted recovery handoff before proceeding, binds its
+receipt to the actual Secret Manager cluster and immutable bootstrap settings,
+and receives named-resource patch access rather than namespace-wide Secret
+creation authority.
 
 SSO Helm profiles also expose the installation-owned Keycloak realm as the
 explicit `AKB account` login provider, so a freshly installed standalone SSO

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -7,6 +7,23 @@ specifically; the proxy has its own log in
 
 ## Unreleased
 
+### Added Helm-native bundled Secret Manager bootstrap
+
+The AKB Helm chart can now complete a new bundled OpenBao or HashiCorp Vault
+installation in one `helm upgrade --install --wait --wait-for-jobs` lifecycle.
+A short-lived, namespace-scoped bootstrap Job performs native initialization,
+the first plaintext-Shamir unseal, KV/Kubernetes-auth policy setup, Secret
+Contract generation, initial-root-token revocation, and the VSO projection
+gate. Native recovery material is handed off through a retained, one-time
+Kubernetes Secret that operators must copy to off-cluster custody and delete;
+generated shares and tokens are never Helm values or release metadata. PGP
+mode keeps shares/root authority encrypted and waits for key-holder input,
+while Auto Seal continues to depend on its configured KMS/HSM/Transit provider.
+
+SSO Helm profiles also expose the installation-owned Keycloak realm as the
+explicit `AKB account` login provider, so a freshly installed standalone SSO
+stack has a usable sign-in path without weakening broker-provider selection.
+
 ### Added the strict App Release Manifest v2 contract
 
 App release registration now requires a v2-only manifest with immutable app

--- a/backend/app/deployment_secret_material.py
+++ b/backend/app/deployment_secret_material.py
@@ -1,0 +1,90 @@
+"""Generate AKB Secret Contract v1 material for deployment bootstrap tools.
+
+This module deliberately contains no Vault/OpenBao client.  It only creates the
+runtime values that a deployment adapter can write to Kubernetes or an external
+secret store.
+"""
+
+from __future__ import annotations
+
+import base64
+import secrets
+import tempfile
+import uuid
+from pathlib import Path
+
+import yaml
+
+from app.services.local_session_keys import generate_local_session_keyset
+
+
+def _base64url_32_bytes() -> str:
+    return base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode("ascii")
+
+
+def generate_secret_contract_material(auth_profile: str = "local") -> dict[str, str]:
+    """Return one fresh Secret Contract v1 payload without persisting it."""
+
+    if auth_profile not in {"local", "sso"}:
+        raise ValueError("auth_profile must be local or sso")
+    database_password = secrets.token_urlsafe(48)
+    system_hmac_secret = secrets.token_urlsafe(64)
+    redis_password = secrets.token_urlsafe(48)
+    legacy_jwt_secret = secrets.token_urlsafe(64)
+
+    with tempfile.TemporaryDirectory(prefix="akb-local-session-") as directory:
+        root = Path(directory) / "keyset"
+        generate_local_session_keyset(root)
+        private_pem = (root / "private.pem").read_text(encoding="utf-8")
+        public_jwks = (root / "jwks.json").read_text(encoding="utf-8")
+
+    secret_config = {
+        "db_password": database_password,
+        "system_hmac_secret": system_hmac_secret,
+        "embed_api_key": "",
+        "llm_api_key": "",
+        "rerank_api_key": "",
+        "vector_api_key": "",
+        "s3_access_key": "",
+        "s3_secret_key": "",
+        "redis_password": redis_password,
+    }
+    material = {
+        "db_password": database_password,
+        "system_hmac_secret": system_hmac_secret,
+        "jwt_secret": legacy_jwt_secret,
+        "local_session_private_pem": private_pem,
+        "local_session_jwks_json": public_jwks,
+        "secret_yaml": yaml.safe_dump(secret_config, sort_keys=True),
+        "redis_password": redis_password,
+        "auth_runtime_contract": "local-session-rs256-v2",
+        "auth_runtime_generation": "1",
+        "auth_runtime_mode": auth_profile,
+    }
+    if auth_profile == "sso":
+        sso_material = {
+            "keycloak_client_secret": secrets.token_urlsafe(48),
+            "keycloak_admin_client_secret": secrets.token_urlsafe(48),
+            "keycloak_management_client_secret": secrets.token_urlsafe(48),
+            "sso_browser_session_encryption_key": _base64url_32_bytes(),
+            "sso_session_epoch": str(uuid.uuid4()),
+            "keycloak_db_password": secrets.token_urlsafe(48),
+            "keycloak_bootstrap_client_secret": secrets.token_urlsafe(48),
+            "product_admin_bootstrap_password": secrets.token_urlsafe(32),
+        }
+        secret_config.update(
+            {
+                key: sso_material[key]
+                for key in (
+                    "keycloak_client_secret",
+                    "keycloak_admin_client_secret",
+                    "keycloak_management_client_secret",
+                    "sso_browser_session_encryption_key",
+                    "sso_session_epoch",
+                )
+            }
+        )
+        material.update(sso_material)
+        material["secret_yaml"] = yaml.safe_dump(secret_config, sort_keys=True)
+        material["auth_runtime_contract"] = "sso-keycloak-broker-v3"
+    return material

--- a/backend/app/secret_manager_bootstrap.py
+++ b/backend/app/secret_manager_bootstrap.py
@@ -131,18 +131,12 @@ class KubernetesClient:
         return response.json()
 
     def upsert(self, plural: str, name: str, resource: dict[str, Any]) -> None:
-        existing = self.get(plural, name)
-        if existing is None:
-            response = self.client.post(self._resource_path(plural), json=resource)
-            expected = 201
-        else:
-            response = self.client.patch(
-                self._resource_path(plural, name),
-                json=resource,
-                headers={"Content-Type": "application/merge-patch+json"},
-            )
-            expected = 200
-        if response.status_code != expected:
+        response = self.client.patch(
+            self._resource_path(plural, name),
+            json=resource,
+            headers={"Content-Type": "application/merge-patch+json"},
+        )
+        if response.status_code != 200:
             raise BootstrapError(f"Kubernetes write {plural}/{name} failed with HTTP {response.status_code}")
 
     def delete(self, plural: str, name: str) -> None:
@@ -265,11 +259,15 @@ class Settings:
 
     def receipt_contract(self) -> dict[str, str]:
         return {
-            "contract": "akb-secret-manager-bootstrap-v2",
+            "contract": "akb-secret-manager-bootstrap-v3",
             "engine": self.engine,
             "seal-mode": self.seal_mode,
             "auth-profile": self.auth_profile,
             "kv-path": f"{self.kv_mount}/{self.kv_path}",
+            "auth-mount": self.auth_mount,
+            "runtime-role": self.runtime_role,
+            "key-shares": str(self.key_shares),
+            "key-threshold": str(self.key_threshold),
             "operator-role": self.operator_role,
             "operator-service-account": self.operator_service_account,
         }
@@ -382,8 +380,10 @@ def _write_recovery_secret(
     settings: Settings,
     recovery: dict[str, Any],
     root_token: str,
+    deadline: float,
 ) -> None:
-    data = {"recovery.json": _b64(json.dumps(recovery, separators=(",", ":")))}
+    recovery_json = json.dumps(recovery, separators=(",", ":"))
+    data = {"recovery.json": _b64(recovery_json)}
     if not settings.pgp_root_key:
         data["bootstrap-root-token"] = _b64(root_token)
     resource = {
@@ -404,7 +404,23 @@ def _write_recovery_secret(
         "type": "Opaque",
         "data": data,
     }
-    kube.upsert("secrets", settings.recovery_secret, resource)
+    # Initialization cannot be rolled back. Keep the only copy in memory and
+    # retry transient Kubernetes failures until a read-after-write confirms
+    # the exact native recovery payload. Exiting after an ambiguous API error
+    # could otherwise leave an initialized cluster without recoverable shares.
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            kube.upsert("secrets", settings.recovery_secret, resource)
+            stored = kube.decoded_secret(settings.recovery_secret) or {}
+            if stored.get("recovery.json") == recovery_json and (
+                settings.pgp_root_key or stored.get("bootstrap-root-token") == root_token
+            ):
+                return
+        except (BootstrapError, httpx.HTTPError) as exc:
+            last_error = exc
+        time.sleep(2)
+    raise BootstrapError("Timed out persisting Secret Manager recovery material") from last_error
 
 
 def _load_root_token(kube: KubernetesClient, settings: Settings, deadline: float) -> str:
@@ -591,20 +607,32 @@ def _write_receipt(
     kube.upsert("configmaps", settings.receipt, resource)
 
 
-def _validate_receipt(settings: Settings, receipt: dict[str, Any]) -> str:
+def _validate_receipt(settings: Settings, receipt: dict[str, Any], current_cluster_id: str = "") -> str:
     data = receipt.get("data", {})
     contract = data.get("contract")
     if contract not in {
         "akb-secret-manager-bootstrap-v1",
         "akb-secret-manager-bootstrap-v2",
+        "akb-secret-manager-bootstrap-v3",
     }:
         raise BootstrapError("Existing bootstrap receipt has an unsupported contract")
     expected_contract = settings.receipt_contract()
-    for key, expected in expected_contract.items():
-        if key == "contract":
-            continue
+    legacy_keys = {
+        "engine",
+        "seal-mode",
+        "auth-profile",
+        "kv-path",
+        "operator-role",
+        "operator-service-account",
+    }
+    keys = expected_contract.keys() - {"contract"} if contract.endswith("-v3") else legacy_keys
+    for key in keys:
+        expected = expected_contract[key]
         if data.get(key) != expected:
             raise BootstrapError(f"Existing bootstrap receipt conflicts at {key}; refusing reinterpretation")
+    recorded_cluster_id = str(data.get("cluster-id", ""))
+    if current_cluster_id and recorded_cluster_id != current_cluster_id:
+        raise BootstrapError("Existing bootstrap receipt belongs to a different Secret Manager cluster")
     if contract == "akb-secret-manager-bootstrap-v1":
         return "complete" if data.get("root-token-revoked") == "true" else "bootstrapped"
     return str(data.get("status", ""))
@@ -636,13 +664,23 @@ def run() -> None:
 
     leader_status = _wait_for_status(bootstrap_node, deadline)
     receipt = kube.get("configmaps", settings.receipt)
-    receipt_status = _validate_receipt(settings, receipt) if receipt else ""
+    current_cluster_id = str(leader_status.get("cluster_id", ""))
+    has_receipt = bool(receipt and receipt.get("data", {}).get("contract"))
+    receipt_status = _validate_receipt(settings, receipt or {}, current_cluster_id) if has_receipt else ""
     if receipt_status == "complete":
         if leader_status.get("sealed") is True:
             raise BootstrapError(
                 "Secret Manager is sealed after completed bootstrap; use stored shares or repair Auto Seal"
             )
         _wait_for_contract(kube, settings, deadline)
+        if receipt and receipt.get("data", {}).get("contract") != settings.receipt_contract()["contract"]:
+            _write_receipt(
+                kube,
+                settings,
+                status="complete",
+                cluster_id=current_cluster_id,
+                root_token_revoked=True,
+            )
         print("Secret Manager bootstrap is already complete", flush=True)
         return
 
@@ -652,7 +690,7 @@ def run() -> None:
     if leader_status.get("initialized") is not True:
         init_data = bootstrap_node.request("PUT", "sys/init", body=_init_payload(settings)).json()
         recovery, root_token = _extract_recovery(settings, init_data)
-        _write_recovery_secret(kube, settings, recovery, root_token)
+        _write_recovery_secret(kube, settings, recovery, root_token, deadline)
         print(
             f"Recovery material is ready in Secret/{settings.recovery_secret}; "
             "store it off-cluster and delete the Secret after verification",
@@ -688,6 +726,12 @@ def run() -> None:
         root_token = (kube.decoded_secret(settings.recovery_secret) or {}).get("bootstrap-root-token", "")
     if not root_token and settings.pgp_root_key:
         root_token = _load_root_token(kube, settings, deadline)
+    recovery_resource = kube.get("secrets", settings.recovery_secret)
+    if recovery_resource is None:
+        raise BootstrapError("Recovery handoff was removed before bootstrap completed")
+    recovery_data = recovery_resource.get("data", {}).get("recovery.json")
+    if not recovery_data:
+        raise BootstrapError("Recovery handoff is missing its native recovery payload")
     if root_token:
         leader.request(
             "POST",
@@ -700,20 +744,29 @@ def run() -> None:
             allowed={200, 204, 403} if receipt_status == "bootstrapped" else {200, 204},
         )
     kube.delete("secrets", settings.input_secret)
-    recovery_resource = kube.get("secrets", settings.recovery_secret)
-    if recovery_resource is not None:
-        kube.upsert(
-            "secrets",
-            settings.recovery_secret,
-            {
-                "metadata": {
-                    "name": settings.recovery_secret,
-                    "namespace": settings.namespace,
-                    "annotations": {"akb.dnotitia.com/bootstrap-status": "complete"},
+    kube.upsert(
+        "secrets",
+        settings.recovery_secret,
+        {
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": {
+                "name": settings.recovery_secret,
+                "namespace": settings.namespace,
+                "labels": {
+                    "app.kubernetes.io/name": "akb",
+                    "app.kubernetes.io/component": "secret-manager-recovery",
                 },
-                "data": {"bootstrap-root-token": None},
+                "annotations": {
+                    "akb.dnotitia.com/recovery-material": "store-off-cluster-then-delete",
+                    "akb.dnotitia.com/bootstrap-status": "complete",
+                    "helm.sh/resource-policy": "keep",
+                },
             },
-        )
+            "type": "Opaque",
+            "data": {"recovery.json": recovery_data, "bootstrap-root-token": None},
+        },
+    )
     status = leader.seal_status()
     _write_receipt(
         kube,

--- a/backend/app/secret_manager_bootstrap.py
+++ b/backend/app/secret_manager_bootstrap.py
@@ -1,0 +1,739 @@
+"""Chart-native bootstrap for a bundled Vault-compatible Secret Manager.
+
+The command runs only in the short-lived Helm-managed bootstrap Job.  It keeps
+runtime application code independent from Vault/OpenBao while allowing a plain
+``helm install`` to finish initialization, first unseal, policy setup, and VSO
+projection without Docker or kubectl inside the Pod.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from app.deployment_secret_material import generate_secret_contract_material
+
+
+class BootstrapError(RuntimeError):
+    """A safe-to-report bootstrap failure that never embeds secret values."""
+
+
+def _required_env(name: str) -> str:
+    value = os.getenv(name, "").strip()
+    if not value:
+        raise BootstrapError(f"{name} is required")
+    return value
+
+
+def _positive_int(name: str, default: int) -> int:
+    raw = os.getenv(name, str(default))
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise BootstrapError(f"{name} must be an integer") from exc
+    if value < 1:
+        raise BootstrapError(f"{name} must be positive")
+    return value
+
+
+def _b64(value: str) -> str:
+    return base64.b64encode(value.encode("utf-8")).decode("ascii")
+
+
+def _unb64(value: str) -> str:
+    return base64.b64decode(value.encode("ascii"), validate=True).decode("utf-8")
+
+
+def _load_json_list(path: str) -> list[str]:
+    if not path:
+        return []
+    candidate = Path(path)
+    if not candidate.exists():
+        return []
+    data = json.loads(candidate.read_text(encoding="utf-8"))
+    if not isinstance(data, list) or not all(isinstance(item, str) for item in data):
+        raise BootstrapError(f"{path} must contain a JSON string array")
+    return [item for item in data if item.strip()]
+
+
+def _load_text(path: str) -> str:
+    if not path:
+        return ""
+    candidate = Path(path)
+    if not candidate.exists():
+        return ""
+    return candidate.read_text(encoding="utf-8").strip()
+
+
+def normalize_pgp_public_key(value: str) -> str:
+    """Return the base64 OpenPGP packet accepted by the native init API."""
+
+    stripped = value.strip()
+    if "-----BEGIN PGP PUBLIC KEY BLOCK-----" not in stripped:
+        compact = "".join(stripped.split())
+        try:
+            base64.b64decode(compact, validate=True)
+        except ValueError as exc:
+            raise BootstrapError("PGP public keys must be ASCII-armoured or base64") from exc
+        return compact
+
+    body: list[str] = []
+    in_body = False
+    for line in stripped.splitlines():
+        line = line.strip()
+        if line == "-----BEGIN PGP PUBLIC KEY BLOCK-----":
+            continue
+        if not in_body:
+            if not line:
+                in_body = True
+            continue
+        if line.startswith("=") or line == "-----END PGP PUBLIC KEY BLOCK-----":
+            break
+        if line:
+            body.append(line)
+    packet = "".join(body)
+    if not packet:
+        raise BootstrapError("PGP public key armour contains no packet data")
+    return packet
+
+
+class KubernetesClient:
+    def __init__(self, namespace: str) -> None:
+        host = _required_env("KUBERNETES_SERVICE_HOST")
+        port = os.getenv("KUBERNETES_SERVICE_PORT_HTTPS", "443")
+        token = Path("/var/run/secrets/kubernetes.io/serviceaccount/token").read_text(encoding="utf-8")
+        ca_path = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+        self.namespace = namespace
+        self.client = httpx.Client(
+            base_url=f"https://{host}:{port}",
+            verify=ca_path,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=20.0,
+        )
+
+    def _resource_path(self, plural: str, name: str | None = None) -> str:
+        path = f"/api/v1/namespaces/{self.namespace}/{plural}"
+        return f"{path}/{name}" if name else path
+
+    def get(self, plural: str, name: str) -> dict[str, Any] | None:
+        response = self.client.get(self._resource_path(plural, name))
+        if response.status_code == 404:
+            return None
+        if response.status_code != 200:
+            raise BootstrapError(f"Kubernetes GET {plural}/{name} failed with HTTP {response.status_code}")
+        return response.json()
+
+    def upsert(self, plural: str, name: str, resource: dict[str, Any]) -> None:
+        existing = self.get(plural, name)
+        if existing is None:
+            response = self.client.post(self._resource_path(plural), json=resource)
+            expected = 201
+        else:
+            response = self.client.patch(
+                self._resource_path(plural, name),
+                json=resource,
+                headers={"Content-Type": "application/merge-patch+json"},
+            )
+            expected = 200
+        if response.status_code != expected:
+            raise BootstrapError(f"Kubernetes write {plural}/{name} failed with HTTP {response.status_code}")
+
+    def delete(self, plural: str, name: str) -> None:
+        response = self.client.delete(self._resource_path(plural, name))
+        if response.status_code not in {200, 202, 404}:
+            raise BootstrapError(f"Kubernetes DELETE {plural}/{name} failed with HTTP {response.status_code}")
+
+    def decoded_secret(self, name: str) -> dict[str, str] | None:
+        secret = self.get("secrets", name)
+        if secret is None:
+            return None
+        return {key: _unb64(value) for key, value in secret.get("data", {}).items()}
+
+
+class VaultClient:
+    def __init__(self, address: str, ca_path: str) -> None:
+        self.client = httpx.Client(base_url=address, verify=ca_path, timeout=20.0)
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        token: str = "",
+        body: dict[str, Any] | None = None,
+        allowed: set[int] | None = None,
+    ) -> httpx.Response:
+        headers = {"X-Vault-Token": token} if token else {}
+        response = self.client.request(method, f"/v1/{path.lstrip('/')}", headers=headers, json=body)
+        if response.status_code not in (allowed or {200, 204}):
+            raise BootstrapError(f"Secret Manager {method} {path} failed with HTTP {response.status_code}")
+        return response
+
+    def seal_status(self) -> dict[str, Any]:
+        return self.request("GET", "sys/seal-status").json()
+
+
+@dataclass(frozen=True)
+class Settings:
+    namespace: str
+    engine: str
+    seal_mode: str
+    auth_profile: str
+    replicas: int
+    key_shares: int
+    key_threshold: int
+    kv_mount: str
+    kv_path: str
+    auth_mount: str
+    runtime_role: str
+    operator_role: str
+    operator_service_account: str
+    recovery_secret: str
+    input_secret: str
+    receipt: str
+    secret_contract: str
+    secret_store_base: str
+    ca_path: str
+    wait_seconds: int
+    pgp_unseal_keys: tuple[str, ...]
+    pgp_recovery_keys: tuple[str, ...]
+    pgp_root_key: str
+
+    @classmethod
+    def from_environment(cls) -> "Settings":
+        engine = _required_env("SECRET_ENGINE")
+        seal_mode = _required_env("SECRET_SEAL_MODE")
+        auth_profile = _required_env("AUTH_PROFILE")
+        if engine not in {"openbao", "hashicorp-vault"}:
+            raise BootstrapError("SECRET_ENGINE must be openbao or hashicorp-vault")
+        if seal_mode not in {"plaintext", "pgp", "auto"}:
+            raise BootstrapError("SECRET_SEAL_MODE must be plaintext, pgp, or auto")
+        if auth_profile not in {"local", "sso"}:
+            raise BootstrapError("AUTH_PROFILE must be local or sso")
+
+        shares = _positive_int("SECRET_KEY_SHARES", 5)
+        threshold = _positive_int("SECRET_KEY_THRESHOLD", 3)
+        if threshold > shares:
+            raise BootstrapError("SECRET_KEY_THRESHOLD cannot exceed SECRET_KEY_SHARES")
+
+        unseal_keys = _load_json_list(os.getenv("PGP_UNSEAL_KEYS_FILE", ""))
+        recovery_keys = _load_json_list(os.getenv("PGP_RECOVERY_KEYS_FILE", ""))
+        root_key = _load_text(os.getenv("PGP_ROOT_KEY_FILE", ""))
+        if seal_mode == "pgp" and (len(unseal_keys) != shares or not root_key):
+            raise BootstrapError("PGP mode requires one unseal public key per share and a root-token public key")
+        if seal_mode == "auto" and recovery_keys and len(recovery_keys) != shares:
+            raise BootstrapError("Auto Seal recovery public-key count must match key shares")
+
+        return cls(
+            namespace=_required_env("POD_NAMESPACE"),
+            engine=engine,
+            seal_mode=seal_mode,
+            auth_profile=auth_profile,
+            replicas=_positive_int("SECRET_STORE_REPLICAS", 1),
+            key_shares=shares,
+            key_threshold=threshold,
+            kv_mount=os.getenv("KV_MOUNT", "kv"),
+            kv_path=os.getenv("KV_PATH", "akb/runtime"),
+            auth_mount=os.getenv("KUBERNETES_AUTH_MOUNT", "kubernetes"),
+            runtime_role=os.getenv("VAULT_ROLE", "akb-runtime-reader"),
+            operator_role=os.getenv("SECRET_OPERATOR_ROLE", "akb-operator-admin"),
+            operator_service_account=os.getenv("SECRET_OPERATOR_SERVICE_ACCOUNT", "akb-secret-admin"),
+            recovery_secret=os.getenv("RECOVERY_SECRET_NAME", "akb-secret-manager-recovery"),
+            input_secret=os.getenv("BOOTSTRAP_INPUT_SECRET_NAME", "akb-secret-manager-bootstrap-input"),
+            receipt=os.getenv("BOOTSTRAP_RECEIPT_NAME", "akb-secret-manager-bootstrap"),
+            secret_contract=os.getenv("SECRET_CONTRACT_NAME", "akb-secret"),
+            secret_store_base=os.getenv(
+                "SECRET_STORE_POD_ADDRESS_TEMPLATE",
+                "https://akb-secret-store-{index}.akb-secret-store-internal:8200",
+            ),
+            ca_path=os.getenv("SECRET_STORE_CA_PATH", "/var/run/akb-secret-manager/ca/ca.crt"),
+            wait_seconds=_positive_int("BOOTSTRAP_WAIT_SECONDS", 1800),
+            pgp_unseal_keys=tuple(normalize_pgp_public_key(item) for item in unseal_keys),
+            pgp_recovery_keys=tuple(normalize_pgp_public_key(item) for item in recovery_keys),
+            pgp_root_key=normalize_pgp_public_key(root_key) if root_key else "",
+        )
+
+    def pod_address(self, index: int) -> str:
+        return self.secret_store_base.format(index=index)
+
+    def receipt_contract(self) -> dict[str, str]:
+        return {
+            "contract": "akb-secret-manager-bootstrap-v2",
+            "engine": self.engine,
+            "seal-mode": self.seal_mode,
+            "auth-profile": self.auth_profile,
+            "kv-path": f"{self.kv_mount}/{self.kv_path}",
+            "operator-role": self.operator_role,
+            "operator-service-account": self.operator_service_account,
+        }
+
+
+def _wait_for_status(client: VaultClient, deadline: float) -> dict[str, Any]:
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            return client.seal_status()
+        except (BootstrapError, httpx.HTTPError) as exc:
+            last_error = exc
+            time.sleep(2)
+    raise BootstrapError("Timed out waiting for Secret Manager status") from last_error
+
+
+def _wait_for_initialized(client: VaultClient, deadline: float) -> dict[str, Any]:
+    while time.monotonic() < deadline:
+        status = _wait_for_status(client, deadline)
+        if status.get("initialized") is True:
+            return status
+        time.sleep(2)
+    raise BootstrapError("Timed out waiting for a Raft member to initialize")
+
+
+def _wait_for_unsealed(client: VaultClient, deadline: float) -> dict[str, Any]:
+    while time.monotonic() < deadline:
+        status = _wait_for_status(client, deadline)
+        if status.get("sealed") is False:
+            return status
+        time.sleep(2)
+    raise BootstrapError("Timed out waiting for a Secret Manager member to unseal")
+
+
+def _wait_for_active(clients: list[VaultClient], deadline: float) -> tuple[VaultClient, dict[str, Any]]:
+    """Wait past the post-unseal Raft election and return the active member."""
+
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        for client in clients:
+            try:
+                status = client.request("GET", "sys/leader", allowed={200}).json()
+            except (BootstrapError, httpx.HTTPError) as exc:
+                last_error = exc
+                continue
+            if status.get("ha_enabled") is False or status.get("is_self") is True:
+                return client, status
+        time.sleep(2)
+    raise BootstrapError("Timed out waiting for an active Secret Manager member") from last_error
+
+
+def _init_payload(settings: Settings) -> dict[str, Any]:
+    if settings.seal_mode in {"plaintext", "pgp"}:
+        payload: dict[str, Any] = {
+            "secret_shares": settings.key_shares,
+            "secret_threshold": settings.key_threshold,
+        }
+        if settings.seal_mode == "pgp":
+            payload["pgp_keys"] = list(settings.pgp_unseal_keys)
+            payload["root_token_pgp_key"] = settings.pgp_root_key
+        return payload
+
+    payload = {
+        "recovery_shares": settings.key_shares,
+        "recovery_threshold": settings.key_threshold,
+    }
+    if settings.pgp_recovery_keys:
+        payload["recovery_pgp_keys"] = list(settings.pgp_recovery_keys)
+    if settings.pgp_root_key:
+        payload["root_token_pgp_key"] = settings.pgp_root_key
+    return payload
+
+
+def _extract_recovery(settings: Settings, init_data: dict[str, Any]) -> tuple[dict[str, Any], str]:
+    if settings.seal_mode == "auto":
+        shares = init_data.get("recovery_keys_base64") or init_data.get("recovery_keys_b64")
+        share_type = "recovery_keys_b64"
+        encrypted = bool(settings.pgp_recovery_keys)
+    else:
+        shares = init_data.get("keys_base64") or init_data.get("unseal_keys_b64")
+        share_type = "unseal_keys_b64"
+        encrypted = settings.seal_mode == "pgp"
+    if not isinstance(shares, list) or len(shares) != settings.key_shares:
+        raise BootstrapError("Secret Manager initialization returned an invalid share set")
+    root_token = init_data.get("root_token", "")
+    if not isinstance(root_token, str) or not root_token:
+        raise BootstrapError("Secret Manager initialization returned no initial root token")
+    recovery = {
+        "format": "vault-compatible-native-init-v1",
+        "engine": settings.engine,
+        "seal_mode": settings.seal_mode,
+        "share_type": share_type,
+        "shares": shares,
+        "shares_encrypted": encrypted,
+        "key_shares": settings.key_shares,
+        "key_threshold": settings.key_threshold,
+        "root_token_encrypted": bool(settings.pgp_root_key),
+    }
+    if settings.pgp_root_key:
+        recovery["encrypted_initial_root_token"] = root_token
+    # Native init returns ciphertext in the root_token field when
+    # root_token_pgp_key was supplied. It is custody output, not an authority
+    # token. Wait for a key holder to provide the decrypted value instead of
+    # accidentally presenting ciphertext to the API.
+    return recovery, "" if settings.pgp_root_key else root_token
+
+
+def _write_recovery_secret(
+    kube: KubernetesClient,
+    settings: Settings,
+    recovery: dict[str, Any],
+    root_token: str,
+) -> None:
+    data = {"recovery.json": _b64(json.dumps(recovery, separators=(",", ":")))}
+    if not settings.pgp_root_key:
+        data["bootstrap-root-token"] = _b64(root_token)
+    resource = {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {
+            "name": settings.recovery_secret,
+            "namespace": settings.namespace,
+            "labels": {
+                "app.kubernetes.io/name": "akb",
+                "app.kubernetes.io/component": "secret-manager-recovery",
+            },
+            "annotations": {
+                "akb.dnotitia.com/recovery-material": "store-off-cluster-then-delete",
+                "helm.sh/resource-policy": "keep",
+            },
+        },
+        "type": "Opaque",
+        "data": data,
+    }
+    kube.upsert("secrets", settings.recovery_secret, resource)
+
+
+def _load_root_token(kube: KubernetesClient, settings: Settings, deadline: float) -> str:
+    recovery = kube.decoded_secret(settings.recovery_secret) or {}
+    root_token = recovery.get("bootstrap-root-token", "")
+    if root_token:
+        return root_token
+
+    print(
+        "AwaitingKeyHolderBootstrap: decrypt the initial root token and create "
+        f"Secret/{settings.input_secret} with key root-token",
+        flush=True,
+    )
+    while time.monotonic() < deadline:
+        supplied = kube.decoded_secret(settings.input_secret) or {}
+        root_token = supplied.get("root-token", "")
+        if root_token:
+            return root_token
+        time.sleep(3)
+    raise BootstrapError("Timed out waiting for the key-holder bootstrap input Secret")
+
+
+def _unseal_members(
+    settings: Settings,
+    clients: list[VaultClient],
+    shares: list[str],
+    deadline: float,
+) -> None:
+    for index, client in enumerate(clients):
+        _wait_for_initialized(client, deadline)
+        status = client.seal_status()
+        if status.get("sealed") is False:
+            continue
+        if settings.seal_mode == "auto":
+            _wait_for_unsealed(client, deadline)
+            continue
+        if settings.seal_mode == "pgp":
+            print(
+                f"AwaitingKeyHolderUnseal: akb-secret-store-{index} requires {settings.key_threshold} decrypted shares",
+                flush=True,
+            )
+            _wait_for_unsealed(client, deadline)
+            continue
+        for share in shares:
+            response = client.request("PUT", "sys/unseal", body={"key": share}, allowed={200}).json()
+            if response.get("sealed") is False:
+                break
+        if client.seal_status().get("sealed") is not False:
+            raise BootstrapError(f"Unseal threshold was not reached for member {index}")
+
+
+def _ensure_mount(client: VaultClient, token: str, mount: str) -> None:
+    response = client.request("GET", "sys/mounts", token=token).json()
+    mounts = response.get("data", response)
+    if f"{mount}/" not in mounts:
+        client.request(
+            "POST",
+            f"sys/mounts/{mount}",
+            token=token,
+            body={"type": "kv", "options": {"version": "2"}},
+            allowed={200, 204},
+        )
+
+
+def _ensure_auth(client: VaultClient, token: str, mount: str) -> None:
+    response = client.request("GET", "sys/auth", token=token).json()
+    auth = response.get("data", response)
+    if f"{mount}/" not in auth:
+        client.request(
+            "POST",
+            f"sys/auth/{mount}",
+            token=token,
+            body={"type": "kubernetes"},
+            allowed={200, 204},
+        )
+
+
+def _configure(client: VaultClient, token: str, settings: Settings) -> None:
+    _ensure_mount(client, token, settings.kv_mount)
+    _ensure_auth(client, token, settings.auth_mount)
+
+    kubernetes_ca = Path("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt").read_text(encoding="utf-8")
+    client.request(
+        "POST",
+        f"auth/{settings.auth_mount}/config",
+        token=token,
+        body={
+            "kubernetes_host": "https://kubernetes.default.svc:443",
+            "kubernetes_ca_cert": kubernetes_ca,
+            "disable_iss_validation": True,
+        },
+    )
+
+    runtime_policy = f'''path "{settings.kv_mount}/data/{settings.kv_path}" {{
+  capabilities = ["read"]
+}}
+path "auth/token/lookup-self" {{ capabilities = ["read"] }}
+path "auth/token/renew-self" {{ capabilities = ["update"] }}
+path "auth/token/revoke-self" {{ capabilities = ["update"] }}
+'''
+    client.request(
+        "PUT",
+        "sys/policies/acl/akb-runtime-reader",
+        token=token,
+        body={"policy": runtime_policy},
+    )
+    client.request(
+        "POST",
+        f"auth/{settings.auth_mount}/role/{settings.runtime_role}",
+        token=token,
+        body={
+            "bound_service_account_names": ["akb-secret-sync"],
+            "bound_service_account_namespaces": [settings.namespace],
+            "audience": "vault",
+            "token_policies": ["akb-runtime-reader"],
+            "token_ttl": "10m",
+            "token_max_ttl": "1h",
+            "token_no_default_policy": True,
+        },
+    )
+
+    client.request(
+        "PUT",
+        f"sys/policies/acl/{settings.operator_role}",
+        token=token,
+        body={"policy": 'path "*" { capabilities = ["create", "read", "update", "patch", "delete", "list", "sudo"] }'},
+    )
+    client.request(
+        "POST",
+        f"auth/{settings.auth_mount}/role/{settings.operator_role}",
+        token=token,
+        body={
+            "bound_service_account_names": [settings.operator_service_account],
+            "bound_service_account_namespaces": [settings.namespace],
+            "audience": "vault",
+            "token_policies": [settings.operator_role],
+            "token_ttl": "30m",
+            "token_max_ttl": "4h",
+            "token_no_default_policy": True,
+        },
+    )
+
+    path = f"{settings.kv_mount}/data/{settings.kv_path}"
+    existing = client.request("GET", path, token=token, allowed={200, 404})
+    if existing.status_code == 200:
+        mode = existing.json().get("data", {}).get("data", {}).get("auth_runtime_mode", "local")
+        if mode != settings.auth_profile:
+            raise BootstrapError(f"Existing runtime material uses auth profile {mode}; refusing replacement")
+        print("Preserving existing AKB Secret Contract v1 material", flush=True)
+    else:
+        material = generate_secret_contract_material(settings.auth_profile)
+        client.request("POST", path, token=token, body={"data": material})
+        print("AKB Secret Contract v1 material created", flush=True)
+
+
+def _write_receipt(
+    kube: KubernetesClient,
+    settings: Settings,
+    *,
+    status: str,
+    cluster_id: str,
+    root_token_revoked: bool,
+) -> None:
+    data = {
+        **settings.receipt_contract(),
+        "status": status,
+        "cluster-id": cluster_id,
+        "root-token-revoked": str(root_token_revoked).lower(),
+    }
+    resource = {
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {
+            "name": settings.receipt,
+            "namespace": settings.namespace,
+            "labels": {
+                "app.kubernetes.io/name": "akb",
+                "app.kubernetes.io/component": "secret-manager-bootstrap",
+            },
+            "annotations": {"helm.sh/resource-policy": "keep"},
+        },
+        "data": data,
+    }
+    kube.upsert("configmaps", settings.receipt, resource)
+
+
+def _validate_receipt(settings: Settings, receipt: dict[str, Any]) -> str:
+    data = receipt.get("data", {})
+    contract = data.get("contract")
+    if contract not in {
+        "akb-secret-manager-bootstrap-v1",
+        "akb-secret-manager-bootstrap-v2",
+    }:
+        raise BootstrapError("Existing bootstrap receipt has an unsupported contract")
+    expected_contract = settings.receipt_contract()
+    for key, expected in expected_contract.items():
+        if key == "contract":
+            continue
+        if data.get(key) != expected:
+            raise BootstrapError(f"Existing bootstrap receipt conflicts at {key}; refusing reinterpretation")
+    if contract == "akb-secret-manager-bootstrap-v1":
+        return "complete" if data.get("root-token-revoked") == "true" else "bootstrapped"
+    return str(data.get("status", ""))
+
+
+def _wait_for_contract(kube: KubernetesClient, settings: Settings, deadline: float) -> None:
+    required = [settings.secret_contract, "redis-credentials"]
+    if settings.auth_profile == "sso":
+        required.extend(
+            [
+                "akb-keycloak-db-credentials",
+                "akb-keycloak-bootstrap",
+                "akb-product-admin-bootstrap",
+            ]
+        )
+    while time.monotonic() < deadline:
+        if all(kube.get("secrets", name) is not None for name in required):
+            return
+        time.sleep(2)
+    raise BootstrapError("Timed out waiting for VSO to project AKB runtime Secrets")
+
+
+def run() -> None:
+    settings = Settings.from_environment()
+    kube = KubernetesClient(settings.namespace)
+    deadline = time.monotonic() + settings.wait_seconds
+    clients = [VaultClient(settings.pod_address(index), settings.ca_path) for index in range(settings.replicas)]
+    bootstrap_node = clients[0]
+
+    leader_status = _wait_for_status(bootstrap_node, deadline)
+    receipt = kube.get("configmaps", settings.receipt)
+    receipt_status = _validate_receipt(settings, receipt) if receipt else ""
+    if receipt_status == "complete":
+        if leader_status.get("sealed") is True:
+            raise BootstrapError(
+                "Secret Manager is sealed after completed bootstrap; use stored shares or repair Auto Seal"
+            )
+        _wait_for_contract(kube, settings, deadline)
+        print("Secret Manager bootstrap is already complete", flush=True)
+        return
+
+    recovery_secret = kube.decoded_secret(settings.recovery_secret) or {}
+    recovery: dict[str, Any]
+    root_token: str
+    if leader_status.get("initialized") is not True:
+        init_data = bootstrap_node.request("PUT", "sys/init", body=_init_payload(settings)).json()
+        recovery, root_token = _extract_recovery(settings, init_data)
+        _write_recovery_secret(kube, settings, recovery, root_token)
+        print(
+            f"Recovery material is ready in Secret/{settings.recovery_secret}; "
+            "store it off-cluster and delete the Secret after verification",
+            flush=True,
+        )
+    else:
+        raw_recovery = recovery_secret.get("recovery.json", "")
+        if not raw_recovery:
+            raise BootstrapError("Initialized cluster has no bootstrap receipt or recovery checkpoint")
+        recovery = json.loads(raw_recovery)
+        root_token = recovery_secret.get("bootstrap-root-token", "")
+
+    shares = recovery.get("shares", [])
+    if not isinstance(shares, list):
+        raise BootstrapError("Recovery checkpoint has an invalid share set")
+    _unseal_members(settings, clients, shares, deadline)
+    leader, _ = _wait_for_active(clients, deadline)
+
+    if receipt_status != "bootstrapped":
+        if not root_token:
+            root_token = _load_root_token(kube, settings, deadline)
+        _configure(leader, root_token, settings)
+        status = leader.seal_status()
+        _write_receipt(
+            kube,
+            settings,
+            status="bootstrapped",
+            cluster_id=str(status.get("cluster_id", "unknown")),
+            root_token_revoked=False,
+        )
+
+    if not root_token:
+        root_token = (kube.decoded_secret(settings.recovery_secret) or {}).get("bootstrap-root-token", "")
+    if not root_token and settings.pgp_root_key:
+        root_token = _load_root_token(kube, settings, deadline)
+    if root_token:
+        leader.request(
+            "POST",
+            "auth/token/revoke-self",
+            token=root_token,
+            body={},
+            # A crash can occur after revocation but before the final receipt.
+            # Only that resumable state may interpret 403 as "already gone";
+            # the first execution must observe a successful revocation.
+            allowed={200, 204, 403} if receipt_status == "bootstrapped" else {200, 204},
+        )
+    kube.delete("secrets", settings.input_secret)
+    recovery_resource = kube.get("secrets", settings.recovery_secret)
+    if recovery_resource is not None:
+        kube.upsert(
+            "secrets",
+            settings.recovery_secret,
+            {
+                "metadata": {
+                    "name": settings.recovery_secret,
+                    "namespace": settings.namespace,
+                    "annotations": {"akb.dnotitia.com/bootstrap-status": "complete"},
+                },
+                "data": {"bootstrap-root-token": None},
+            },
+        )
+    status = leader.seal_status()
+    _write_receipt(
+        kube,
+        settings,
+        status="complete",
+        cluster_id=str(status.get("cluster_id", "unknown")),
+        root_token_revoked=True,
+    )
+    _wait_for_contract(kube, settings, deadline)
+    print("Secret Manager init, first unseal, bootstrap, and VSO projection completed", flush=True)
+
+
+def main() -> int:
+    try:
+        run()
+    except (BootstrapError, httpx.HTTPError, json.JSONDecodeError) as exc:
+        print(f"Secret Manager bootstrap failed: {exc}", flush=True)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_helm_deployment_unit.py
+++ b/backend/tests/test_helm_deployment_unit.py
@@ -129,7 +129,12 @@ def test_chart_dependencies_are_pinned_and_source_installable():
 )
 def test_profiles_render_one_coherent_stack(profile: str, wants_sso: bool, wants_secret_manager: bool):
     resources = _render(profile)
-    assert not _names(resources, "Secret")
+    secret_names = _names(resources, "Secret")
+    if wants_secret_manager:
+        assert secret_names == {"akb-secret-manager-recovery"}
+        assert _one(resources, "Secret", "akb-secret-manager-recovery")["data"] == {}
+    else:
+        assert not secret_names
     assert {"backend", "frontend"}.issubset(_names(resources, "Deployment"))
     backend = _one(resources, "Deployment", "backend")
     assert _container_env(backend, "backend")["AKB_TOKENIZER_PROCESSES"] == "1"
@@ -205,12 +210,42 @@ def test_bundled_profile_renders_chart_native_bootstrap_job_and_scoped_rbac():
     assert env["SECRET_SEAL_MODE"] == "plaintext"  # pragma: allowlist secret
     assert env["SECRET_STORE_REPLICAS"] == "3"
     assert env["RECOVERY_SECRET_NAME"] == "akb-secret-manager-recovery"  # pragma: allowlist secret
+    assert pod_spec["securityContext"]["runAsNonRoot"] is True
+    assert pod_spec["securityContext"]["seccompProfile"] == {"type": "RuntimeDefault"}
+    assert container["securityContext"] == {
+        "allowPrivilegeEscalation": False,
+        "readOnlyRootFilesystem": True,
+        "capabilities": {"drop": ["ALL"]},
+    }
+    assert any(mount == {"name": "tmp", "mountPath": "/tmp"} for mount in container["volumeMounts"])
 
     role = _one(resources, "Role", "akb-secret-manager-bootstrap")
     assert not any("list" in rule["verbs"] for rule in role["rules"])
-    assert {"secrets", "configmaps"} == set(role["rules"][0]["resources"])
-    assert role["rules"][0]["verbs"] == ["create"]
-    assert "akb-secret" in role["rules"][1]["resourceNames"]
+    assert not any("create" in rule["verbs"] for rule in role["rules"])
+    assert all(rule.get("resourceNames") for rule in role["rules"])
+    secret_rules = [rule for rule in role["rules"] if rule["resources"] == ["secrets"]]
+    recovery_rule = next(rule for rule in secret_rules if rule["resourceNames"] == ["akb-secret-manager-recovery"])
+    input_rule = next(rule for rule in secret_rules if rule["resourceNames"] == ["akb-secret-manager-bootstrap-input"])
+    projection_rule = next(rule for rule in secret_rules if "akb-secret" in rule["resourceNames"])
+    assert recovery_rule["verbs"] == ["get", "patch"]
+    assert input_rule["verbs"] == ["get", "delete"]
+    assert projection_rule["verbs"] == ["get"]
+
+
+def test_bootstrap_job_name_changes_with_immutable_pod_inputs():
+    baseline = next(
+        item["metadata"]["name"] for item in _render("standalone-secret-manager") if item.get("kind") == "Job"
+    )
+    variants = (
+        ("--set-string", "secretContract.name=other-akb-secret"),
+        ("--set-string", "secretManager.tls.secretName=other-tls"),
+        ("--set-string", "images.backend.pullPolicy=IfNotPresent"),
+        ("--set-string", "global.imagePullSecrets[0].name=private-registry"),
+    )
+    for extra in variants:
+        rendered = _render("standalone-secret-manager", *extra)
+        job_name = next(item["metadata"]["name"] for item in rendered if item.get("kind") == "Job")
+        assert job_name != baseline
 
 
 def test_non_bundled_profiles_do_not_render_bootstrap_job():

--- a/backend/tests/test_helm_deployment_unit.py
+++ b/backend/tests/test_helm_deployment_unit.py
@@ -154,6 +154,8 @@ def test_profiles_render_one_coherent_stack(profile: str, wants_sso: bool, wants
         assert _container_env(keycloak_postgres, "postgres")["PGDATA"] == ("/var/lib/postgresql/data/pgdata")
         assert app["keycloak_internal_url"] == "http://keycloak:8080"
         assert backend["spec"]["template"]["spec"]["initContainers"][0]["name"] == ("bootstrap-standalone-sso")
+        assert app["sso_local_realm_login_enabled"] is True
+        assert app["sso_local_realm_display_name"] == "AKB account"
 
 
 def test_bundled_openbao_renders_production_raft_tls_and_vso_contract():
@@ -184,6 +186,62 @@ def test_bundled_openbao_renders_production_raft_tls_and_vso_contract():
             "namespace": "akb-helm-test",
         }
     ]
+
+
+def test_bundled_profile_renders_chart_native_bootstrap_job_and_scoped_rbac():
+    resources = _render("standalone-secret-manager")
+    jobs = [item for item in resources if item.get("kind") == "Job"]
+    bootstrap_jobs = [
+        item for item in jobs if item.get("metadata", {}).get("name", "").startswith("akb-secret-manager-bootstrap-")
+    ]
+    assert len(bootstrap_jobs) == 1
+    job = bootstrap_jobs[0]
+    pod_spec = job["spec"]["template"]["spec"]
+    assert pod_spec["serviceAccountName"] == "akb-secret-manager-bootstrap"
+    container = pod_spec["containers"][0]
+    assert container["command"] == ["python", "-m", "app.secret_manager_bootstrap"]
+    env = {item["name"]: item.get("value") for item in container["env"]}
+    assert env["SECRET_ENGINE"] == "openbao"  # pragma: allowlist secret
+    assert env["SECRET_SEAL_MODE"] == "plaintext"  # pragma: allowlist secret
+    assert env["SECRET_STORE_REPLICAS"] == "3"
+    assert env["RECOVERY_SECRET_NAME"] == "akb-secret-manager-recovery"  # pragma: allowlist secret
+
+    role = _one(resources, "Role", "akb-secret-manager-bootstrap")
+    assert not any("list" in rule["verbs"] for rule in role["rules"])
+    assert {"secrets", "configmaps"} == set(role["rules"][0]["resources"])
+    assert role["rules"][0]["verbs"] == ["create"]
+    assert "akb-secret" in role["rules"][1]["resourceNames"]
+
+
+def test_non_bundled_profiles_do_not_render_bootstrap_job():
+    for profile in ("standalone", "standalone-sso"):
+        resources = _render(profile)
+        assert not any(
+            item.get("kind") == "Job"
+            and item.get("metadata", {}).get("name", "").startswith("akb-secret-manager-bootstrap-")
+            for item in resources
+        )
+
+
+def test_chart_native_pgp_requires_public_keys_at_render_time():
+    result = subprocess.run(
+        [
+            _helm(),
+            "template",
+            "akb",
+            str(_CHART),
+            "--values",
+            str(_CHART / "profiles" / "standalone-secret-manager.yaml"),
+            "--set-string",
+            "secretManager.sealMode=pgp",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0
+    assert "PGP bootstrap requires one unsealPublicKey per key share" in result.stderr
 
 
 def test_bundled_secret_manager_cluster_bindings_are_unique_per_instance():

--- a/backend/tests/test_secret_manager_bootstrap_unit.py
+++ b/backend/tests/test_secret_manager_bootstrap_unit.py
@@ -14,6 +14,7 @@ from app.secret_manager_bootstrap import (
     _init_payload,
     _validate_receipt,
     _wait_for_active,
+    _write_recovery_secret,
     normalize_pgp_public_key,
 )
 
@@ -120,6 +121,47 @@ def test_receipt_accepts_completed_v1_but_rejects_profile_reinterpretation():
     data["auth-profile"] = "sso"
     with pytest.raises(BootstrapError, match="auth-profile"):
         _validate_receipt(settings, {"data": data})
+
+
+def test_current_receipt_rejects_cluster_or_immutable_bootstrap_changes():
+    settings = _settings()
+    data = {
+        **settings.receipt_contract(),
+        "cluster-id": "cluster-a",
+        "status": "complete",
+        "root-token-revoked": "true",
+    }
+    with pytest.raises(BootstrapError, match="different Secret Manager cluster"):
+        _validate_receipt(settings, {"data": data}, "cluster-b")
+
+    changed = dict(data)
+    changed["key-threshold"] = "4"
+    with pytest.raises(BootstrapError, match="key-threshold"):
+        _validate_receipt(settings, {"data": changed}, "cluster-a")
+
+
+def test_recovery_handoff_retries_until_read_after_write_succeeds(monkeypatch):
+    class Kube:
+        def __init__(self):
+            self.calls = 0
+            self.stored = None
+
+        def upsert(self, _plural, _name, resource):
+            self.calls += 1
+            if self.calls == 1:
+                raise BootstrapError("transient Kubernetes write failure")
+            self.stored = {key: base64.b64decode(value).decode("utf-8") for key, value in resource["data"].items()}
+
+        def decoded_secret(self, _name):
+            return self.stored
+
+    monkeypatch.setattr("app.secret_manager_bootstrap.time.sleep", lambda _seconds: None)
+    kube = Kube()
+    settings = _settings()
+    recovery = {"shares": ["one", "two", "three", "four", "five"]}
+    _write_recovery_secret(kube, settings, recovery, "root", time.monotonic() + 1)
+    assert kube.calls == 2
+    assert kube.stored["bootstrap-root-token"] == "root"  # pragma: allowlist secret
 
 
 def test_wait_for_active_skips_transient_standby_member():

--- a/backend/tests/test_secret_manager_bootstrap_unit.py
+++ b/backend/tests/test_secret_manager_bootstrap_unit.py
@@ -1,0 +1,144 @@
+"""Focused contracts for the chart-native Secret Manager bootstrap command."""
+
+from __future__ import annotations
+
+import base64
+import time
+
+import pytest
+
+from app.secret_manager_bootstrap import (
+    BootstrapError,
+    Settings,
+    _extract_recovery,
+    _init_payload,
+    _validate_receipt,
+    _wait_for_active,
+    normalize_pgp_public_key,
+)
+
+
+def _settings(**overrides) -> Settings:
+    values = {
+        "namespace": "akb-test",
+        "engine": "openbao",
+        "seal_mode": "plaintext",
+        "auth_profile": "local",
+        "replicas": 3,
+        "key_shares": 5,
+        "key_threshold": 3,
+        "kv_mount": "kv",
+        "kv_path": "akb/runtime",
+        "auth_mount": "kubernetes",
+        "runtime_role": "akb-runtime-reader",
+        "operator_role": "akb-operator-admin",
+        "operator_service_account": "akb-secret-admin",
+        "recovery_secret": "akb-secret-manager-recovery",  # pragma: allowlist secret
+        "input_secret": "akb-secret-manager-bootstrap-input",  # pragma: allowlist secret
+        "receipt": "akb-secret-manager-bootstrap",
+        "secret_contract": "akb-secret",  # pragma: allowlist secret
+        "secret_store_base": "https://store-{index}.internal:8200",  # pragma: allowlist secret
+        "ca_path": "/tmp/ca.crt",
+        "wait_seconds": 60,
+        "pgp_unseal_keys": (),
+        "pgp_recovery_keys": (),
+        "pgp_root_key": "",
+    }
+    values.update(overrides)
+    return Settings(**values)
+
+
+def test_plaintext_init_uses_native_shamir_fields_and_extracts_only_native_shares():
+    settings = _settings()
+    assert _init_payload(settings) == {"secret_shares": 5, "secret_threshold": 3}
+    recovery, root_token = _extract_recovery(
+        settings,
+        {"keys_base64": [f"share-{index}" for index in range(5)], "root_token": "root"},
+    )
+    assert root_token == "root"
+    assert recovery == {
+        "format": "vault-compatible-native-init-v1",
+        "engine": "openbao",
+        "seal_mode": "plaintext",
+        "share_type": "unseal_keys_b64",
+        "shares": [f"share-{index}" for index in range(5)],
+        "shares_encrypted": False,
+        "key_shares": 5,
+        "key_threshold": 3,
+        "root_token_encrypted": False,
+    }
+
+
+def test_auto_seal_uses_recovery_fields_and_preserves_encryption_metadata():
+    settings = _settings(
+        seal_mode="auto",
+        pgp_recovery_keys=("key-a", "key-b", "key-c", "key-d", "key-e"),
+        pgp_root_key="root-key",
+    )
+    assert _init_payload(settings) == {
+        "recovery_shares": 5,
+        "recovery_threshold": 3,
+        "recovery_pgp_keys": ["key-a", "key-b", "key-c", "key-d", "key-e"],
+        "root_token_pgp_key": "root-key",
+    }
+    recovery, bootstrap_token = _extract_recovery(
+        settings,
+        {
+            "recovery_keys_base64": [f"share-{index}" for index in range(5)],
+            "root_token": "encrypted-root",
+        },
+    )
+    assert recovery["shares_encrypted"] is True
+    assert recovery["root_token_encrypted"] is True
+    assert recovery["encrypted_initial_root_token"] == "encrypted-root"
+    assert bootstrap_token == ""
+
+
+def test_ascii_armoured_pgp_key_is_normalized_to_packet_base64():
+    packet = base64.b64encode(b"public-key-packet").decode("ascii")
+    armoured = "\n".join(
+        [
+            "-----BEGIN PGP PUBLIC KEY BLOCK-----",
+            "Version: test",
+            "",
+            packet,
+            "=abcd",
+            "-----END PGP PUBLIC KEY BLOCK-----",
+        ]
+    )
+    assert normalize_pgp_public_key(armoured) == packet
+
+
+def test_receipt_accepts_completed_v1_but_rejects_profile_reinterpretation():
+    settings = _settings()
+    data = {
+        **settings.receipt_contract(),
+        "contract": "akb-secret-manager-bootstrap-v1",
+        "root-token-revoked": "true",
+    }
+    assert _validate_receipt(settings, {"data": data}) == "complete"
+    data["auth-profile"] = "sso"
+    with pytest.raises(BootstrapError, match="auth-profile"):
+        _validate_receipt(settings, {"data": data})
+
+
+def test_wait_for_active_skips_transient_standby_member():
+    class Response:
+        def __init__(self, payload):
+            self.payload = payload
+
+        def json(self):
+            return self.payload
+
+    class Client:
+        def __init__(self, payload):
+            self.payload = payload
+
+        def request(self, *_args, **_kwargs):
+            return Response(self.payload)
+
+    standby = Client({"ha_enabled": True, "is_self": False})
+    active = Client({"ha_enabled": True, "is_self": True})
+    selected, status = _wait_for_active([standby, active], time.monotonic() + 1)
+    assert selected is active
+    assert status["is_self"] is True

--- a/deploy/helm/akb/Chart.yaml
+++ b/deploy/helm/akb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: akb
 description: AKB standalone stack with optional owned SSO and Secret Manager
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "0.14.2"
 kubeVersion: ">=1.29.0-0"
 home: https://github.com/dnotitia/akb

--- a/deploy/helm/akb/README.md
+++ b/deploy/helm/akb/README.md
@@ -97,8 +97,10 @@ Job performs native init, the first unseal, policy/KV setup, Secret Contract v1
 generation, initial-root-token revocation, and the VSO projection gate. The
 application starts only after the projected Secrets exist.
 
-For the default plaintext-Shamir mode, Helm stores native initialization output
-once in the retained `akb-secret-manager-recovery` Secret. The Job uses those
+For the default plaintext-Shamir mode, Helm declares an empty, retained
+`akb-secret-manager-recovery` Secret and the Job patches native initialization
+output into it once. This lets the Job hold only named-resource patch access;
+the generated values still never enter Helm release metadata. The Job uses the
 shares in memory for the first unseal and removes the transient root token after
 bootstrap. Copy `recovery.json` to an approved off-cluster password manager or
 secret custody system, verify the copy, and delete the Kubernetes Secret:

--- a/deploy/helm/akb/README.md
+++ b/deploy/helm/akb/README.md
@@ -24,14 +24,14 @@ contract so incompatible combinations fail during `helm template`.
 
 ## Prerequisites
 
-- Helm 3 and `kubectl`; the source-tree installer also uses `jq`, OpenSSL, and
-  standard POSIX command-line tools.
+- Helm 3 and `kubectl`; the source-tree installer also uses standard POSIX
+  command-line tools.
 - Kubernetes 1.29 or later for the AKB chart. Bundled OpenBao requires
   Kubernetes 1.30 or later because of the selected upstream chart.
 - A default StorageClass or `STORAGE_CLASS`, plus an ingress controller and
   operator-managed DNS/TLS for browser access.
-- Docker only when `install.sh` must generate bootstrap material from the
-  backend image on the operator workstation.
+- Docker only for the optional manual-Secret generator. Bundled Secret Manager
+  bootstrap runs inside the chart-managed Job from the backend image.
 - Cluster-administrator authority for `VSO_MODE=managed`. Use
   `VSO_MODE=external` when a separate platform team owns an existing compatible
   Vault Secrets Operator.
@@ -91,10 +91,27 @@ administrator identity first, route them to the ingresses, and replace every
 `example.com` placeholder before production use. The installer generates the
 one-time password separately; the username and email are not credentials.
 
-The first Helm pass creates the declarative release without waiting for a
-sealed server. The installer then performs native init/unseal/bootstrap in the
-trusted terminal, waits for VSO to project Secret Contract v1, and executes a
-second idempotent `helm upgrade --install --wait` to gate the complete stack.
+The installer validates inputs, reconciles VSO when requested, and performs one
+`helm upgrade --install --wait --wait-for-jobs`. The chart-managed bootstrap
+Job performs native init, the first unseal, policy/KV setup, Secret Contract v1
+generation, initial-root-token revocation, and the VSO projection gate. The
+application starts only after the projected Secrets exist.
+
+For the default plaintext-Shamir mode, Helm stores native initialization output
+once in the retained `akb-secret-manager-recovery` Secret. The Job uses those
+shares in memory for the first unseal and removes the transient root token after
+bootstrap. Copy `recovery.json` to an approved off-cluster password manager or
+secret custody system, verify the copy, and delete the Kubernetes Secret:
+
+```bash
+kubectl get secret akb-secret-manager-recovery -n akb \
+  -o jsonpath='{.data.recovery\.json}' | base64 --decode
+kubectl delete secret akb-secret-manager-recovery -n akb
+```
+
+Run the first command only in a trusted, non-recorded terminal; its output is
+the real native unseal/recovery material. Losing enough shares to fall below
+the threshold makes Shamir-sealed data unrecoverable.
 
 PGP mode requires the public keys before any namespace or release mutation:
 
@@ -108,9 +125,11 @@ SECRET_ROOT_TOKEN_PGP_KEY=/secure/bootstrap-root.asc \
 bash deploy/helm/akb/install.sh
 ```
 
-The encrypted shares are native OpenBao/Vault output. Threshold holders still
-decrypt and submit them interactively; no private key enters Helm or the
-installer.
+The encrypted shares are native OpenBao/Vault output. The Job publishes only
+those encrypted values, then waits. Threshold holders decrypt and submit the
+required shares directly to the engine and place the decrypted initial root
+token in the named bootstrap-input Secret so the Job can finish. No private
+key enters Helm, the Job, or the installer.
 
 ## Direct Helm usage
 
@@ -125,22 +144,26 @@ helm upgrade --install akb deploy/helm/akb \
   --set-string images.backend.tag=0.14.2 \
   --set-string images.frontend.repository=ghcr.io/example/akb-frontend \
   --set-string images.frontend.tag=0.14.1 \
-  --wait
+  --wait --wait-for-jobs --timeout 35m
 ```
 
-The command above requires an existing namespace-local `akb-secret`. For an SSO
-profile it must also contain the SSO Secret Contract fields and projections
-described in the [Secret management guide](../../k8s/secrets/README.md).
+The command above uses a manual-Secret profile and therefore requires an
+existing namespace-local `akb-secret`. For an SSO profile it must also contain
+the SSO Secret Contract fields and projections described in the
+[Secret management guide](../../k8s/secrets/README.md).
 
 Before directly installing a Secret Manager profile, install or validate VSO
-as described below. Raw Helm creates the Vault/OpenBao resources but correctly
-leaves a production server sealed. Run
-`scripts/initialize-secret-manager.sh` with the same release and namespace
-(plus the required key-holder inputs for PGP mode), then repeat the original
-`helm upgrade --install --wait`; or use
-`install.sh` for that complete two-phase flow. A Helm hook is intentionally not
-used because hook logs and release history are inappropriate custody channels
-for root or recovery material.
+as described below. Then select `standalone-secret-manager.yaml` or
+`standalone-sso-secret-manager.yaml` and add `--wait --wait-for-jobs`. A normal
+chart-managed Job completes the same lifecycle as `install.sh`; it is not a
+Helm hook, does not log generated values, and does not place generated values
+in Helm release metadata. The one-time recovery Secret is the explicit custody
+handoff.
+
+Set `secretManager.bootstrap.enabled=false` only when another operator owns
+initialization. In that advanced mode, `scripts/initialize-secret-manager.sh`
+remains a manual recovery/bring-your-own-bootstrap tool; Helm will install the
+components but cannot make a sealed store ready on its own.
 
 To review static resources without applying them:
 
@@ -152,8 +175,10 @@ helm template akb deploy/helm/akb \
   > rendered-akb.yaml
 ```
 
-This rendered file contains declarative resources only. It does not create
-external credentials or perform Vault/OpenBao init, unseal, or bootstrap.
+This rendered file contains the declarative bootstrap Job but does not execute
+it. Applying the complete rendered YAML does execute the Job, but unlike
+`helm --wait --wait-for-jobs`, plain `kubectl apply` does not wait for or report
+its completion automatically.
 
 ## VSO ownership
 
@@ -205,10 +230,11 @@ remain native engine output.
 
 ## Upgrade and uninstall
 
-Use the same profile values on every upgrade. The chart never generates or
-rotates application secrets. `akb-vaultdata` and Secret Manager Raft PVCs are
-retained; deleting retained data is a separate, explicit operator action. VSO
-is upgraded only through the `akb-cluster` release. Use
+Use the same profile values on every upgrade. Bootstrap generates application
+secrets only when the configured KV record is absent and otherwise preserves
+it; upgrades do not rotate values implicitly. `akb-vaultdata` and Secret
+Manager Raft PVCs are retained; deleting retained data is a separate, explicit
+operator action. VSO is upgraded only through the `akb-cluster` release. Use
 `deploy/cluster/status-vso.sh` to list AKB consumers and
 `deploy/cluster/uninstall-vso.sh` for guarded removal; the latter refuses to
 run while any VSO custom resource remains.

--- a/deploy/helm/akb/install.sh
+++ b/deploy/helm/akb/install.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Thin source-tree installer for the AKB Helm chart. Helm owns declarative
-# resources; the native Secret Manager script owns only init/unseal/bootstrap.
+# Optional convenience wrapper for the AKB Helm chart. The chart-managed
+# bootstrap Job owns native init/unseal/bootstrap; this script only validates
+# source-tree inputs, reconciles the shared VSO prerequisite, and passes values.
 
 set -euo pipefail
 
@@ -133,6 +134,8 @@ HELM_ARGS=(
   --set-string "secretManager.profile=${SECRET_PROFILE}"
   --set-string "secretManager.sealMode=${SECRET_SEAL_MODE}"
   --set-string "secretManager.topology=${SECRET_TOPOLOGY}"
+  --set "secretManager.bootstrap.keyShares=${SECRET_KEY_SHARES}"
+  --set "secretManager.bootstrap.keyThreshold=${SECRET_KEY_THRESHOLD}"
 )
 
 if [[ -n "${BACKEND_IMAGE:-}" ]]; then
@@ -198,6 +201,28 @@ if [[ "${SECRET_MODE}" == "external" ]]; then
   exit 0
 fi
 
+append_public_key_files() {
+  local setting="$1"
+  local csv="$2"
+  local item index=0
+  local old_ifs="${IFS}"
+  IFS=','
+  for item in ${csv}; do
+    IFS="${old_ifs}"
+    item="${item#${item%%[![:space:]]*}}"
+    item="${item%${item##*[![:space:]]}}"
+    [[ -n "${item}" ]] || continue
+    if [[ "${item}" == keybase:* || ! -s "${item}" ]]; then
+      echo "Chart-native bootstrap requires a readable local PGP public-key file: ${item}" >&2
+      exit 2
+    fi
+    HELM_ARGS+=(--set-file "${setting}[${index}]=${item}")
+    index=$((index + 1))
+    IFS=','
+  done
+  IFS="${old_ifs}"
+}
+
 case "${SECRET_ENGINE}" in
   openbao)
     HELM_ARGS+=(
@@ -243,6 +268,19 @@ if [[ "${SECRET_SEAL_MODE}" == "auto" ]]; then
     --set-string "${engine_values_prefix}.server.extraArgs=-config=${engine_home}/userconfig/${SECRET_STORE_SEAL_CONFIG_SECRET}/seal.hcl"
   )
 fi
+if [[ -n "${SECRET_PGP_KEYS:-}" ]]; then
+  append_public_key_files "secretManager.bootstrap.pgp.unsealPublicKeys" "${SECRET_PGP_KEYS}"
+fi
+if [[ -n "${SECRET_RECOVERY_PGP_KEYS:-}" ]]; then
+  append_public_key_files "secretManager.bootstrap.pgp.recoveryPublicKeys" "${SECRET_RECOVERY_PGP_KEYS}"
+fi
+if [[ -n "${SECRET_ROOT_TOKEN_PGP_KEY:-}" ]]; then
+  if [[ "${SECRET_ROOT_TOKEN_PGP_KEY}" == keybase:* || ! -s "${SECRET_ROOT_TOKEN_PGP_KEY}" ]]; then
+    echo "Chart-native bootstrap requires a readable root-token PGP public-key file" >&2
+    exit 2
+  fi
+  HELM_ARGS+=(--set-file "secretManager.bootstrap.pgp.rootTokenPublicKey=${SECRET_ROOT_TOKEN_PGP_KEY}")
+fi
 if [[ -n "${SECRET_STORE_CERT_ISSUER_NAME:-}" ]]; then
   HELM_ARGS+=(
     --set secretManager.tls.certificate.create=true
@@ -250,19 +288,9 @@ if [[ -n "${SECRET_STORE_CERT_ISSUER_NAME:-}" ]]; then
     --set-string "secretManager.tls.certificate.issuerKind=${SECRET_STORE_CERT_ISSUER_KIND:-ClusterIssuer}"
   )
 fi
-# The first pass intentionally does not --wait: a production Vault-compatible
-# server is sealed and AKB workloads wait for the Secret contract.
-"${HELM[@]}" "${HELM_ARGS[@]}" "$@"
-
-RELEASE="${RELEASE}" NAMESPACE="${NAMESPACE}" KUBE_CONTEXT="${KUBE_CONTEXT}" \
-SECRET_KEY_SHARES="${SECRET_KEY_SHARES}" \
-SECRET_KEY_THRESHOLD="${SECRET_KEY_THRESHOLD}" \
-SECRET_PGP_KEYS="${SECRET_PGP_KEYS:-}" \
-SECRET_ROOT_TOKEN_PGP_KEY="${SECRET_ROOT_TOKEN_PGP_KEY:-}" \
-SECRET_RECOVERY_PGP_KEYS="${SECRET_RECOVERY_PGP_KEYS:-}" \
-BOOTSTRAP_DOCKER_PLATFORM="${BOOTSTRAP_DOCKER_PLATFORM}" \
-  bash "${SCRIPT_DIR}/scripts/initialize-secret-manager.sh"
-
-# Reconcile once more and gate the complete stack after the Secret contract is
-# available. Helm remains the sole owner of declarative resources.
-"${HELM[@]}" "${HELM_ARGS[@]}" --wait --timeout 15m "$@"
+# The chart-managed Job initializes and unseals the bundled server, stores the
+# one-time recovery handoff, bootstraps the Secret Contract, and lets VSO start
+# the application. --wait-for-jobs makes this wrapper return only when that
+# lifecycle and all workloads are ready. Plain helm install remains supported.
+"${HELM[@]}" "${HELM_ARGS[@]}" --wait --wait-for-jobs \
+  --timeout "${HELM_INSTALL_TIMEOUT:-35m}" "$@"

--- a/deploy/helm/akb/profiles/standalone-secret-manager.yaml
+++ b/deploy/helm/akb/profiles/standalone-secret-manager.yaml
@@ -7,6 +7,8 @@ secretManager:
   profile: production
   sealMode: plaintext
   topology: production-ha
+  bootstrap:
+    enabled: true
 secretSync:
   enabled: true
 openbao:

--- a/deploy/helm/akb/profiles/standalone-sso-secret-manager.yaml
+++ b/deploy/helm/akb/profiles/standalone-sso-secret-manager.yaml
@@ -1,12 +1,17 @@
 profile: standalone-sso-secret-manager
 sso:
   enabled: true
+  localRealmLogin:
+    enabled: true
+    displayName: AKB account
 secretManager:
   mode: bundled
   engine: openbao
   profile: production
   sealMode: plaintext
   topology: production-ha
+  bootstrap:
+    enabled: true
 secretSync:
   enabled: true
 openbao:

--- a/deploy/helm/akb/profiles/standalone-sso.yaml
+++ b/deploy/helm/akb/profiles/standalone-sso.yaml
@@ -1,6 +1,9 @@
 profile: standalone-sso
 sso:
   enabled: true
+  localRealmLogin:
+    enabled: true
+    displayName: AKB account
 secretManager:
   mode: manual
   engine: ""

--- a/deploy/helm/akb/templates/000-validate.yaml
+++ b/deploy/helm/akb/templates/000-validate.yaml
@@ -32,6 +32,23 @@
   {{- if not .Values.secretSync.enabled -}}
   {{- fail "bundled Secret Manager requires secretSync.enabled=true" -}}
   {{- end -}}
+  {{- if gt (int .Values.secretManager.bootstrap.keyThreshold) (int .Values.secretManager.bootstrap.keyShares) -}}
+  {{- fail "secretManager.bootstrap.keyThreshold cannot exceed keyShares" -}}
+  {{- end -}}
+  {{- if and .Values.secretManager.bootstrap.enabled (eq .Values.secretManager.sealMode "pgp") -}}
+    {{- if ne (len .Values.secretManager.bootstrap.pgp.unsealPublicKeys) (int .Values.secretManager.bootstrap.keyShares) -}}
+    {{- fail "PGP bootstrap requires one unsealPublicKey per key share" -}}
+    {{- end -}}
+    {{- if not .Values.secretManager.bootstrap.pgp.rootTokenPublicKey -}}
+    {{- fail "PGP bootstrap requires rootTokenPublicKey" -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if and .Values.secretManager.bootstrap.enabled (eq .Values.secretManager.sealMode "auto") (gt (len .Values.secretManager.bootstrap.pgp.recoveryPublicKeys) 0) (ne (len .Values.secretManager.bootstrap.pgp.recoveryPublicKeys) (int .Values.secretManager.bootstrap.keyShares)) -}}
+  {{- fail "Auto Seal recoveryPublicKeys must be empty or match keyShares" -}}
+  {{- end -}}
+{{- end -}}
+{{- if and (ne .Values.secretManager.mode "bundled") .Values.secretManager.bootstrap.enabled -}}
+{{- fail "chart-native bootstrap is only valid for bundled Secret Manager mode" -}}
 {{- end -}}
 {{- if eq .Values.secretManager.mode "external" -}}
   {{- if not .Values.secretSync.enabled -}}

--- a/deploy/helm/akb/templates/NOTES.txt
+++ b/deploy/helm/akb/templates/NOTES.txt
@@ -8,14 +8,29 @@ not persist its values in release metadata.
 VSO will project Secret/{{ .Values.secretContract.name }} from
 {{ .Values.secretManager.connection.address }}.
 {{- else }}
-The bundled {{ .Values.secretManager.engine }} server starts sealed. Complete
-native init/unseal/bootstrap from the source tree with:
+{{- if .Values.secretManager.bootstrap.enabled }}
+The chart-managed Bootstrap Job initializes and performs the first unseal of
+the bundled {{ .Values.secretManager.engine }} server, configures the Secret
+Contract, revokes the initial root token, and waits for VSO projection.
+
+Store the recovery material off-cluster, then delete its one-time handoff:
+
+  kubectl get secret {{ .Values.secretManager.bootstrap.recoverySecretName }} \
+    -n {{ .Release.Namespace }} \
+    -o jsonpath='{.data.recovery\.json}' | base64 --decode
+  printf '\n'
+  kubectl delete secret {{ .Values.secretManager.bootstrap.recoverySecretName }} \
+    -n {{ .Release.Namespace }}
+
+The Secret is annotated with helm.sh/resource-policy=keep. Helm uninstall does
+not delete recovery material that has not yet been handed off.
+{{- else }}
+The bundled {{ .Values.secretManager.engine }} server starts sealed and
+chart-native bootstrap is disabled. Run the source-tree interactive initializer:
 
   RELEASE={{ .Release.Name }} NAMESPACE={{ .Release.Namespace }} \
     bash deploy/helm/akb/scripts/initialize-secret-manager.sh
-
-For a new installation prefer deploy/helm/akb/install.sh, which performs this
-two-phase lifecycle without putting recovery material in Helm hook logs.
+{{- end }}
 {{- end }}
 
 Application URL: {{ .Values.global.publicUrl }}

--- a/deploy/helm/akb/templates/secret-manager-bootstrap.yaml
+++ b/deploy/helm/akb/templates/secret-manager-bootstrap.yaml
@@ -1,0 +1,141 @@
+{{- if and (eq .Values.secretManager.mode "bundled") .Values.secretManager.bootstrap.enabled }}
+{{- $bootstrap := .Values.secretManager.bootstrap -}}
+{{- $replicas := 3 -}}
+{{- if eq .Values.secretManager.engine "openbao" -}}
+  {{- $replicas = int .Values.openbao.server.ha.replicas -}}
+{{- else -}}
+  {{- $replicas = int .Values.hashicorpVault.server.ha.replicas -}}
+{{- end -}}
+{{- $jobInput := dict "image" (printf "%s:%s" .Values.images.backend.repository .Values.images.backend.tag) "engine" .Values.secretManager.engine "sealMode" .Values.secretManager.sealMode "authProfile" (ternary "sso" "local" .Values.sso.enabled) "replicas" $replicas "bootstrap" $bootstrap "kv" .Values.secretManager.kv "auth" .Values.secretManager.auth -}}
+{{- $jobName := printf "akb-secret-manager-bootstrap-%s" (toJson $jobInput | sha256sum | trunc 10) -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: akb-secret-manager-bootstrap
+  labels:
+    {{- include "akb.labels" . | nindent 4 }}
+    app.kubernetes.io/component: secret-manager-bootstrap
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: akb-secret-manager-bootstrap
+  labels:
+    {{- include "akb.labels" . | nindent 4 }}
+    app.kubernetes.io/component: secret-manager-bootstrap
+rules:
+  - apiGroups: [""]
+    resources: [secrets, configmaps]
+    verbs: [create]
+  - apiGroups: [""]
+    resources: [secrets]
+    resourceNames:
+      - {{ $bootstrap.recoverySecretName }}
+      - {{ $bootstrap.inputSecretName }}
+      - {{ .Values.secretContract.name }}
+      - redis-credentials
+      {{- if .Values.sso.enabled }}
+      - akb-keycloak-db-credentials
+      - akb-keycloak-bootstrap
+      - akb-product-admin-bootstrap
+      {{- end }}
+    verbs: [get, update, patch, delete]
+  - apiGroups: [""]
+    resources: [configmaps]
+    resourceNames: [{{ $bootstrap.receiptConfigMapName }}]
+    verbs: [get, update, patch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: akb-secret-manager-bootstrap
+  labels:
+    {{- include "akb.labels" . | nindent 4 }}
+    app.kubernetes.io/component: secret-manager-bootstrap
+subjects:
+  - kind: ServiceAccount
+    name: akb-secret-manager-bootstrap
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: akb-secret-manager-bootstrap
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: akb-secret-manager-bootstrap-public-keys
+  labels:
+    {{- include "akb.labels" . | nindent 4 }}
+    app.kubernetes.io/component: secret-manager-bootstrap
+data:
+  unseal-public-keys.json: {{ toJson $bootstrap.pgp.unsealPublicKeys | quote }}
+  recovery-public-keys.json: {{ toJson $bootstrap.pgp.recoveryPublicKeys | quote }}
+  root-token-public-key.asc: |
+    {{- $bootstrap.pgp.rootTokenPublicKey | nindent 4 }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $jobName }}
+  labels:
+    {{- include "akb.labels" . | nindent 4 }}
+    app.kubernetes.io/component: secret-manager-bootstrap
+  annotations:
+    akb.dnotitia.com/bootstrap-contract: v2
+spec:
+  backoffLimit: {{ $bootstrap.job.backoffLimit }}
+  activeDeadlineSeconds: {{ $bootstrap.waitSeconds }}
+  ttlSecondsAfterFinished: {{ $bootstrap.job.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      labels:
+        {{- include "akb.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: secret-manager-bootstrap
+    spec:
+      serviceAccountName: akb-secret-manager-bootstrap
+      automountServiceAccountToken: true
+      restartPolicy: Never
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: bootstrap
+          image: {{ printf "%s:%s" .Values.images.backend.repository .Values.images.backend.tag | quote }}
+          imagePullPolicy: {{ .Values.images.backend.pullPolicy }}
+          command: [python, -m, app.secret_manager_bootstrap]
+          env:
+            - name: POD_NAMESPACE
+              valueFrom: {fieldRef: {fieldPath: metadata.namespace}}
+            - {name: SECRET_ENGINE, value: {{ .Values.secretManager.engine | quote }}}
+            - {name: SECRET_SEAL_MODE, value: {{ .Values.secretManager.sealMode | quote }}}
+            - {name: AUTH_PROFILE, value: {{ ternary "sso" "local" .Values.sso.enabled | quote }}}
+            - {name: SECRET_STORE_REPLICAS, value: {{ $replicas | quote }}}
+            - {name: SECRET_KEY_SHARES, value: {{ $bootstrap.keyShares | quote }}}
+            - {name: SECRET_KEY_THRESHOLD, value: {{ $bootstrap.keyThreshold | quote }}}
+            - {name: BOOTSTRAP_WAIT_SECONDS, value: {{ $bootstrap.waitSeconds | quote }}}
+            - {name: RECOVERY_SECRET_NAME, value: {{ $bootstrap.recoverySecretName | quote }}}
+            - {name: BOOTSTRAP_INPUT_SECRET_NAME, value: {{ $bootstrap.inputSecretName | quote }}}
+            - {name: BOOTSTRAP_RECEIPT_NAME, value: {{ $bootstrap.receiptConfigMapName | quote }}}
+            - {name: SECRET_CONTRACT_NAME, value: {{ .Values.secretContract.name | quote }}}
+            - {name: KV_MOUNT, value: {{ .Values.secretManager.kv.mount | quote }}}
+            - {name: KV_PATH, value: {{ .Values.secretManager.kv.path | quote }}}
+            - {name: KUBERNETES_AUTH_MOUNT, value: {{ .Values.secretManager.auth.mount | quote }}}
+            - {name: VAULT_ROLE, value: {{ .Values.secretManager.auth.role | quote }}}
+            - {name: PGP_UNSEAL_KEYS_FILE, value: /etc/akb-bootstrap-keys/unseal-public-keys.json}
+            - {name: PGP_RECOVERY_KEYS_FILE, value: /etc/akb-bootstrap-keys/recovery-public-keys.json}
+            - {name: PGP_ROOT_KEY_FILE, value: /etc/akb-bootstrap-keys/root-token-public-key.asc}
+          volumeMounts:
+            - {name: secret-store-ca, mountPath: /var/run/akb-secret-manager/ca, readOnly: true}
+            - {name: public-keys, mountPath: /etc/akb-bootstrap-keys, readOnly: true}
+          resources:
+            {{- toYaml $bootstrap.job.resources | nindent 12 }}
+      volumes:
+        - name: secret-store-ca
+          secret:
+            secretName: {{ .Values.secretManager.tls.secretName }}
+            items: [{key: ca.crt, path: ca.crt}]
+        - name: public-keys
+          configMap: {name: akb-secret-manager-bootstrap-public-keys}
+{{- end }}

--- a/deploy/helm/akb/templates/secret-manager-bootstrap.yaml
+++ b/deploy/helm/akb/templates/secret-manager-bootstrap.yaml
@@ -6,7 +6,7 @@
 {{- else -}}
   {{- $replicas = int .Values.hashicorpVault.server.ha.replicas -}}
 {{- end -}}
-{{- $jobInput := dict "image" (printf "%s:%s" .Values.images.backend.repository .Values.images.backend.tag) "engine" .Values.secretManager.engine "sealMode" .Values.secretManager.sealMode "authProfile" (ternary "sso" "local" .Values.sso.enabled) "replicas" $replicas "bootstrap" $bootstrap "kv" .Values.secretManager.kv "auth" .Values.secretManager.auth -}}
+{{- $jobInput := dict "chartVersion" .Chart.Version "image" (printf "%s:%s" .Values.images.backend.repository .Values.images.backend.tag) "imagePullPolicy" .Values.images.backend.pullPolicy "imagePullSecrets" .Values.global.imagePullSecrets "engine" .Values.secretManager.engine "sealMode" .Values.secretManager.sealMode "authProfile" (ternary "sso" "local" .Values.sso.enabled) "replicas" $replicas "bootstrap" $bootstrap "kv" .Values.secretManager.kv "auth" .Values.secretManager.auth "secretContract" .Values.secretContract.name "tlsSecret" .Values.secretManager.tls.secretName -}}
 {{- $jobName := printf "akb-secret-manager-bootstrap-%s" (toJson $jobInput | sha256sum | trunc 10) -}}
 apiVersion: v1
 kind: ServiceAccount
@@ -17,6 +17,30 @@ metadata:
     app.kubernetes.io/component: secret-manager-bootstrap
 automountServiceAccountToken: true
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $bootstrap.recoverySecretName }}
+  labels:
+    {{- include "akb.labels" . | nindent 4 }}
+    app.kubernetes.io/component: secret-manager-recovery
+  annotations:
+    akb.dnotitia.com/recovery-material: store-off-cluster-then-delete
+    helm.sh/resource-policy: keep
+type: Opaque
+data: {}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $bootstrap.receiptConfigMapName }}
+  labels:
+    {{- include "akb.labels" . | nindent 4 }}
+    app.kubernetes.io/component: secret-manager-bootstrap
+  annotations:
+    helm.sh/resource-policy: keep
+data: {}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -26,13 +50,16 @@ metadata:
     app.kubernetes.io/component: secret-manager-bootstrap
 rules:
   - apiGroups: [""]
-    resources: [secrets, configmaps]
-    verbs: [create]
+    resources: [secrets]
+    resourceNames: [{{ $bootstrap.recoverySecretName }}]
+    verbs: [get, patch]
+  - apiGroups: [""]
+    resources: [secrets]
+    resourceNames: [{{ $bootstrap.inputSecretName }}]
+    verbs: [get, delete]
   - apiGroups: [""]
     resources: [secrets]
     resourceNames:
-      - {{ $bootstrap.recoverySecretName }}
-      - {{ $bootstrap.inputSecretName }}
       - {{ .Values.secretContract.name }}
       - redis-credentials
       {{- if .Values.sso.enabled }}
@@ -40,11 +67,11 @@ rules:
       - akb-keycloak-bootstrap
       - akb-product-admin-bootstrap
       {{- end }}
-    verbs: [get, update, patch, delete]
+    verbs: [get]
   - apiGroups: [""]
     resources: [configmaps]
     resourceNames: [{{ $bootstrap.receiptConfigMapName }}]
-    verbs: [get, update, patch]
+    verbs: [get, patch]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -82,7 +109,7 @@ metadata:
     {{- include "akb.labels" . | nindent 4 }}
     app.kubernetes.io/component: secret-manager-bootstrap
   annotations:
-    akb.dnotitia.com/bootstrap-contract: v2
+    akb.dnotitia.com/bootstrap-contract: v3
 spec:
   backoffLimit: {{ $bootstrap.job.backoffLimit }}
   activeDeadlineSeconds: {{ $bootstrap.waitSeconds }}
@@ -96,6 +123,12 @@ spec:
       serviceAccountName: akb-secret-manager-bootstrap
       automountServiceAccountToken: true
       restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile: {type: RuntimeDefault}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -105,6 +138,10 @@ spec:
           image: {{ printf "%s:%s" .Values.images.backend.repository .Values.images.backend.tag | quote }}
           imagePullPolicy: {{ .Values.images.backend.pullPolicy }}
           command: [python, -m, app.secret_manager_bootstrap]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: {drop: [ALL]}
           env:
             - name: POD_NAMESPACE
               valueFrom: {fieldRef: {fieldPath: metadata.namespace}}
@@ -129,6 +166,7 @@ spec:
           volumeMounts:
             - {name: secret-store-ca, mountPath: /var/run/akb-secret-manager/ca, readOnly: true}
             - {name: public-keys, mountPath: /etc/akb-bootstrap-keys, readOnly: true}
+            - {name: tmp, mountPath: /tmp}
           resources:
             {{- toYaml $bootstrap.job.resources | nindent 12 }}
       volumes:
@@ -138,4 +176,6 @@ spec:
             items: [{key: ca.crt, path: ca.crt}]
         - name: public-keys
           configMap: {name: akb-secret-manager-bootstrap-public-keys}
+        - name: tmp
+          emptyDir: {}
 {{- end }}

--- a/deploy/helm/akb/values.schema.json
+++ b/deploy/helm/akb/values.schema.json
@@ -58,7 +58,48 @@
         "engine": {"type": "string", "enum": ["", "openbao", "hashicorp-vault"]},
         "profile": {"type": "string", "enum": ["production"]},
         "sealMode": {"type": "string", "enum": ["plaintext", "pgp", "auto"]},
-        "topology": {"type": "string", "enum": ["onprem-small", "production-ha"]}
+        "topology": {"type": "string", "enum": ["onprem-small", "production-ha"]},
+        "bootstrap": {
+          "type": "object",
+          "required": [
+            "enabled",
+            "keyShares",
+            "keyThreshold",
+            "waitSeconds",
+            "recoverySecretName",
+            "inputSecretName",
+            "receiptConfigMapName",
+            "pgp",
+            "job"
+          ],
+          "properties": {
+            "enabled": {"type": "boolean"},
+            "keyShares": {"type": "integer", "minimum": 1},
+            "keyThreshold": {"type": "integer", "minimum": 1},
+            "waitSeconds": {"type": "integer", "minimum": 60},
+            "recoverySecretName": {"type": "string", "pattern": "^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$"},
+            "inputSecretName": {"type": "string", "pattern": "^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$"},
+            "receiptConfigMapName": {"type": "string", "pattern": "^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$"},
+            "pgp": {
+              "type": "object",
+              "required": ["unsealPublicKeys", "recoveryPublicKeys", "rootTokenPublicKey"],
+              "properties": {
+                "unsealPublicKeys": {"type": "array", "items": {"type": "string"}},
+                "recoveryPublicKeys": {"type": "array", "items": {"type": "string"}},
+                "rootTokenPublicKey": {"type": "string"}
+              }
+            },
+            "job": {
+              "type": "object",
+              "required": ["backoffLimit", "ttlSecondsAfterFinished", "resources"],
+              "properties": {
+                "backoffLimit": {"type": "integer", "minimum": 0},
+                "ttlSecondsAfterFinished": {"type": "integer", "minimum": 0},
+                "resources": {"type": "object"}
+              }
+            }
+          }
+        }
       }
     }
   },

--- a/deploy/helm/akb/values.yaml
+++ b/deploy/helm/akb/values.yaml
@@ -157,6 +157,30 @@ secretManager:
       issuerKind: ClusterIssuer
       issuerName: ""
       clusterDomain: cluster.local
+  # A normal, chart-managed Job owns native init, first unseal, policy/KV
+  # bootstrap, root-token revocation, and the VSO projection gate. Recovery
+  # material is written once to recoverySecretName for explicit off-cluster
+  # custody; Helm release metadata never contains generated secret values.
+  bootstrap:
+    enabled: false
+    keyShares: 5
+    keyThreshold: 3
+    waitSeconds: 1800
+    recoverySecretName: akb-secret-manager-recovery # pragma: allowlist secret
+    inputSecretName: akb-secret-manager-bootstrap-input # pragma: allowlist secret
+    receiptConfigMapName: akb-secret-manager-bootstrap
+    pgp:
+      # Public keys are safe Helm inputs. PGP Shamir requires one unseal key
+      # per share plus rootTokenPublicKey. Auto Seal may use recoveryPublicKeys.
+      unsealPublicKeys: []
+      recoveryPublicKeys: []
+      rootTokenPublicKey: ""
+    job:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400
+      resources:
+        requests: {cpu: 100m, memory: 128Mi}
+        limits: {cpu: "1", memory: 512Mi}
 
 # Render namespace-scoped VSO connection/auth/sync resources. The
 # cluster-scoped controller is owned separately by the akb-cluster release.

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -8,14 +8,16 @@ automation:
 |---|---|
 | `profiles/<name>/kustomization.yaml` | Static AKB application resources only; suitable for rendering or an operator-owned overlay |
 | `profiles/<name>/deploy.sh` | Image build/reuse, Secret Contract preparation, optional VSO and bundled Secret Manager lifecycle, then Kustomize apply |
-| `deploy/helm/akb` | Declarative AKB, PostgreSQL, optional Keycloak, optional Vault/OpenBao, and namespace-local VSO resources |
-| `deploy/helm/akb/install.sh` | Helm release plus optional VSO prerequisite and native Vault/OpenBao init/unseal/bootstrap |
+| `deploy/helm/akb` | Declarative AKB, PostgreSQL, optional Keycloak/Vault/OpenBao, namespace-local VSO resources, and a native bootstrap Job |
+| `deploy/helm/akb/install.sh` | Thin Helm wrapper that validates inputs and optionally reconciles the shared VSO prerequisite |
 | `deploy/helm/akb-cluster` | Cluster-scoped Vault Secrets Operator shared by AKB namespaces |
 
 Kustomize operators can compose the canonical base and reusable components
-without copying complete manifest trees. Static YAML cannot safely encode a
-production Vault/OpenBao initialization ceremony, so use a complete installer
-or perform that lifecycle separately.
+without copying complete manifest trees. The AKB Helm chart additionally owns
+a namespace-scoped bootstrap Job, so one plain Helm installation can complete
+native initialization, first unseal, bootstrap, and Secret projection. Static
+Kustomize application profiles still require their lifecycle installer or an
+equivalent external operator.
 
 Vault Secrets Operator is a cluster prerequisite shared across AKB namespaces.
 It is owned by the separate
@@ -42,7 +44,7 @@ cluster prerequisite.
 
 - `kubectl`, `jq`, and standard POSIX command-line tools for a complete profile
   installer. Helm 3 is additionally required for bundled Secret Manager or
-  managed-VSO workflows; bundled bootstrap also uses OpenSSL.
+  managed-VSO workflows.
 - Docker Buildx when the profile installer builds images, and Docker when it
   generates application bootstrap material from the backend image.
 - A default StorageClass, or an explicit `STORAGE_CLASS`.
@@ -196,11 +198,13 @@ with the explicit load-restrictor option as shown above, review the resulting
 plain YAML, and apply it with `kubectl apply -f`.
 
 Use an overlay to change the namespace, image references, public origins,
-storage classes, or provider configuration. For `*-secret-manager` profiles,
-the static output still contains only the application layer: install VSO,
-install and initialize Vault/OpenBao, bootstrap its policy/KV record, and wait
-for `akb-secret` before applying it. The matching `deploy.sh` automates those
-steps. Raw Helm has the same native initialization boundary; see the
+storage classes, or provider configuration. For `*-secret-manager` Kustomize
+profiles, the static output still contains only the application layer: install
+VSO, install and initialize Vault/OpenBao, bootstrap its policy/KV record, and
+wait for `akb-secret` before applying it. The matching `deploy.sh` automates
+those steps. The Helm chart is different: its rendered resources include the
+bootstrap Job, and `helm upgrade --install --wait --wait-for-jobs` gates the
+full lifecycle. See the
 [`AKB Helm guide`](../helm/akb/README.md#direct-helm-usage).
 
 ## Operator-specific overlay (`internal/`)

--- a/deploy/k8s/secrets/README.md
+++ b/deploy/k8s/secrets/README.md
@@ -107,8 +107,9 @@ No second Helm pass, workstation Docker helper, or AKB-specific recovery format
 is involved.
 
 Generated native output is not a Helm value, hook log, or release-metadata
-field. It is written once to retained Secret
-`akb-secret-manager-recovery/recovery.json` as an explicit custody handoff.
+field. Helm declares the retained handoff Secret without data; the Job has
+named-resource patch access and writes the native output once to
+`akb-secret-manager-recovery/recovery.json`.
 For plaintext Shamir the Job uses the shares in memory for the first unseal and
 removes its transient root-token field after bootstrap. An operator must then
 copy `recovery.json` to approved off-cluster custody, verify the copy, and

--- a/deploy/k8s/secrets/README.md
+++ b/deploy/k8s/secrets/README.md
@@ -95,6 +95,32 @@ the corresponding existing AKB tree. `deploy/all-in-one` remains the separate
 single-container demo image and does not bundle this production Secret Manager
 lifecycle.
 
+### Helm-native bundled lifecycle
+
+The umbrella Helm chart includes a normal, namespace-scoped bootstrap Job for
+both bundled profiles. One
+`helm upgrade --install --wait --wait-for-jobs` therefore installs the engine,
+performs native initialization and the first unseal, configures KV v2 and
+Kubernetes auth, creates Secret Contract v1, revokes the initial root token,
+waits for VSO projection, and finally allows the AKB workloads to become ready.
+No second Helm pass, workstation Docker helper, or AKB-specific recovery format
+is involved.
+
+Generated native output is not a Helm value, hook log, or release-metadata
+field. It is written once to retained Secret
+`akb-secret-manager-recovery/recovery.json` as an explicit custody handoff.
+For plaintext Shamir the Job uses the shares in memory for the first unseal and
+removes its transient root-token field after bootstrap. An operator must then
+copy `recovery.json` to approved off-cluster custody, verify the copy, and
+delete the Kubernetes Secret. Helm cannot verify a human's password-manager or
+HSM custody and deliberately does not pretend otherwise.
+
+PGP mode puts only native encrypted shares/root output in the handoff and waits
+for key holders to decrypt and submit the threshold. Auto Seal waits for the
+configured KMS/HSM/Transit provider. These waits are security properties, not
+missing automation. Set `secretManager.bootstrap.enabled=false` only when an
+external operator owns the lifecycle.
+
 ### Manual Secret ownership
 
 In manual mode, the operator owns the Secret lifecycle. Before adopting this
@@ -314,12 +340,14 @@ SECRET_TOPOLOGY=production-ha \
 bash deploy/k8s/profiles/standalone-sso-secret-manager/deploy.sh
 ```
 
-The installer prints the official `operator init` values once and waits for
-the operator to type `STORED`. It then uses the same in-memory shares to unseal
-all Raft members, configures KV and Kubernetes auth, seeds Secret Contract v1,
-creates the short-lived operator-admin login boundary described below, revokes
-the initial root token, verifies revocation, and lets VSO project the contract
-before databases or applications start. It creates no durable local key file.
+The Kustomize profile installer prints the official `operator init` values once
+and waits for the operator to type `STORED`. The Helm chart instead stores the
+same native output in its one-time recovery Secret so a non-interactive Helm
+client can finish. Both paths use the shares for the first unseal, configure KV
+and Kubernetes auth, seed Secret Contract v1, create the short-lived
+operator-admin login boundary described below, revoke the initial root token,
+and let VSO project the contract before databases or applications start.
+Neither creates a local AKB recovery file.
 
 #### PGP Shamir
 
@@ -363,11 +391,11 @@ The bootstrap administrator performs the same operation for the separately
 encrypted initial root token, enters it only when the installer asks, and does
 not retain it as day-2 authority after revocation succeeds.
 
-Because the installer cannot decrypt those shares, this mode intentionally
-requires key-holder participation during initial installation and every
-Shamir restart. Repeating one administrator's public key technically works but
-does not provide multi-party control; use plaintext mode for a single-holder
-installation instead.
+Because neither installer nor chart Job can decrypt those shares, this mode
+intentionally requires key-holder participation during initial installation
+and every Shamir restart. Repeating one administrator's public key technically
+works but does not provide multi-party control; use plaintext mode for a
+single-holder installation instead.
 
 #### Auto Seal
 
@@ -413,10 +441,12 @@ recovery policy are mandatory.
 
 ### Idempotency and recovery
 
-Successful production bootstrap records only a non-sensitive ConfigMap receipt
+Successful production bootstrap records a non-sensitive ConfigMap receipt
 (`akb-secret-manager-bootstrap`): cluster ID, engine, seal type, contract
 version, operator-role identity, and the fact that the initial root token was
-revoked. Reruns never call `operator init` again.
+revoked. Helm mode additionally retains the native recovery handoff Secret
+until its operator has copied and deleted it. Reruns never call `operator init`
+again and preserve an existing Secret Contract KV record.
 
 If a Shamir cluster is already initialized but sealed, the installer shows the
 native `operator unseal` command and waits for the operator or key holders. If

--- a/deploy/k8s/secrets/bootstrap_material.py
+++ b/deploy/k8s/secrets/bootstrap_material.py
@@ -7,92 +7,13 @@ The normal caller pipes stdout directly into a Vault-compatible KV v2 CLI or
 from __future__ import annotations
 
 import argparse
-import base64
 import json
-import secrets
-import tempfile
-import uuid
-from pathlib import Path
-
-import yaml
-
-from app.services.local_session_keys import generate_local_session_keyset
+from app.deployment_secret_material import generate_secret_contract_material
 
 
-def _base64url_32_bytes() -> str:
-    return base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode("ascii")
-
-
-def _material(auth_profile: str = "local") -> dict[str, str]:
-    if auth_profile not in {"local", "sso"}:
-        raise ValueError("auth_profile must be local or sso")
-    database_password = secrets.token_urlsafe(48)
-    system_hmac_secret = secrets.token_urlsafe(64)
-    redis_password = secrets.token_urlsafe(48)
-    legacy_jwt_secret = secrets.token_urlsafe(64)
-
-    with tempfile.TemporaryDirectory(prefix="akb-local-session-") as directory:
-        root = Path(directory) / "keyset"
-        generate_local_session_keyset(root)
-        private_pem = (root / "private.pem").read_text(encoding="utf-8")
-        public_jwks = (root / "jwks.json").read_text(encoding="utf-8")
-
-    secret_config = {
-        "db_password": database_password,
-        "system_hmac_secret": system_hmac_secret,
-        "embed_api_key": "",
-        "llm_api_key": "",
-        "rerank_api_key": "",
-        "vector_api_key": "",
-        "s3_access_key": "",
-        "s3_secret_key": "",
-        "redis_password": redis_password,
-    }
-    material = {
-        "db_password": database_password,
-        "system_hmac_secret": system_hmac_secret,
-        # Kept as a top-level compatibility projection, matching the latest
-        # akb-platform-owned Secret. It is deliberately absent from secret.yaml.
-        "jwt_secret": legacy_jwt_secret,
-        "local_session_private_pem": private_pem,
-        "local_session_jwks_json": public_jwks,
-        "secret_yaml": yaml.safe_dump(secret_config, sort_keys=True),
-        "redis_password": redis_password,
-        "auth_runtime_contract": "local-session-rs256-v2",
-        "auth_runtime_generation": "1",
-        "auth_runtime_mode": auth_profile,
-    }
-    if auth_profile == "sso":
-        sso_material = {
-            "keycloak_client_secret": secrets.token_urlsafe(48),
-            "keycloak_admin_client_secret": secrets.token_urlsafe(48),
-            "keycloak_management_client_secret": secrets.token_urlsafe(48),
-            "sso_browser_session_encryption_key": _base64url_32_bytes(),
-            "sso_session_epoch": str(uuid.uuid4()),
-            "keycloak_db_password": secrets.token_urlsafe(48),
-            "keycloak_bootstrap_client_secret": secrets.token_urlsafe(48),
-            "product_admin_bootstrap_password": secrets.token_urlsafe(32),
-        }
-        # The three client credentials, session boundary, and encryption key
-        # are durable AKB runtime inputs. Keycloak DB and first-install values
-        # stay outside secret.yaml and are projected into narrowly scoped
-        # Kubernetes Secrets by the SSO adapter.
-        secret_config.update(
-            {
-                key: sso_material[key]
-                for key in (
-                    "keycloak_client_secret",
-                    "keycloak_admin_client_secret",
-                    "keycloak_management_client_secret",
-                    "sso_browser_session_encryption_key",
-                    "sso_session_epoch",
-                )
-            }
-        )
-        material.update(sso_material)
-        material["secret_yaml"] = yaml.safe_dump(secret_config, sort_keys=True)
-        material["auth_runtime_contract"] = "sso-keycloak-broker-v3"
-    return material
+# Retain the source-tree helper name used by existing deployment contract tests
+# and downstream scripts while the implementation lives in the backend image.
+_material = generate_secret_contract_material
 
 
 def _kubernetes_list(material: dict[str, str], namespace: str) -> dict:
@@ -217,7 +138,7 @@ def main() -> int:
     parser.add_argument("--auth-profile", choices=("local", "sso"), default="local")
     parser.add_argument("--namespace")
     args = parser.parse_args()
-    material = _material(args.auth_profile)
+    material = generate_secret_contract_material(args.auth_profile)
     if args.format == "kubernetes":
         if not args.namespace:
             parser.error("--namespace is required for kubernetes output")


### PR DESCRIPTION
## Summary

- make a single Helm install complete bundled OpenBao/Vault initialization, first unseal, policy/KV bootstrap, and Vault Secrets Operator projection
- add a namespace-scoped bootstrap Job with resumable, idempotent receipts
- retain native recovery material in an explicit one-time Kubernetes Secret handoff instead of Helm values, release metadata, or logs
- enable the installation-owned Keycloak realm login provider in standalone SSO profiles
- document recovery custody, PGP, Auto Seal, upgrades, and the shared VSO prerequisite

## Motivation

The bundled Secret Manager profiles previously required a two-phase workflow: install a sealed server, run a host-side initializer, and then apply Helm again. That made plain Helm installs incomplete and split lifecycle ownership between the chart and a shell orchestrator.

This change makes the chart the lifecycle boundary. After cluster prerequisites are present, `helm upgrade --install --wait --wait-for-jobs` waits until Secret Manager bootstrap, secret projection, SSO, and the application are ready.

## How it works

The chart creates a normal Kubernetes Job, rather than a Helm hook. The Job:

1. performs the engine's native initialization
2. stores native recovery output in `Secret/akb-secret-manager-recovery`
3. performs the first unseal for plaintext Shamir mode
4. waits for an active Raft member
5. configures KV v2, Kubernetes auth, runtime/operator policies, and AKB Secret Contract v1
6. revokes the initial root token and removes the transient bootstrap token
7. records a non-secret completion receipt
8. waits for every required VSO-projected Secret

A hash in the Job name creates a new Job when its specification changes. The receipt prevents a Helm upgrade from reinitializing an existing store.

## Recovery and seal behavior

- **Plaintext Shamir:** the first unseal is automatic. Native unseal shares are handed off once through the retained recovery Secret. Operators must copy them to approved off-cluster custody, verify the copy, and delete the Kubernetes Secret.
- **PGP:** one public key per share and a root-token public key are required at render time. Encrypted shares are never interpreted as plaintext credentials.
- **Auto Seal:** the Job waits for the configured KMS/HSM/Transit seal provider. Provider identity and key lifecycle remain operator-owned.

The recovery Secret uses `helm.sh/resource-policy=keep` so uninstall cannot silently destroy material that has not been handed off. Helm NOTES show the exact retrieval and deletion commands.

## Security boundaries

- generated values are not placed in Helm values, rendered manifests, release metadata, or Job logs
- bootstrap RBAC is namespace-scoped and restricted to named Secrets and ConfigMaps
- application workloads receive projected runtime credentials, not Kubernetes API permissions or root tokens
- the initial root token is revoked after bootstrap
- the backend remains independent of Vault/OpenBao APIs

VSO remains a cluster prerequisite because one controller can reconcile namespace-local connections and authentication resources for multiple releases. The application chart does not install or mutate cluster-scoped VSO resources.

## Review hardening

A second review and isolated upgrade rehearsal added the following safeguards:

- bind bootstrap receipt v3 to the actual Secret Manager cluster ID and immutable initialization/auth settings
- retry and read-after-write verify the recovery handoff before allowing bootstrap to continue
- predeclare an empty recovery Secret and receipt ConfigMap so the Job needs no namespace-wide create permission
- split Secret RBAC by operation: patch only the recovery handoff, delete only key-holder input, and read only projected runtime Secrets
- run the bootstrap container as UID/GID 1000 with a read-only root filesystem, dropped capabilities, and RuntimeDefault seccomp
- include every immutable Pod input and the chart version in the Job-name hash
- keep Helm-owned fields separate from Job-owned bootstrap status to avoid Server-Side Apply conflicts on upgrade

The tightened chart was installed in a new namespace, upgraded repeatedly through revision 5, and rechecked through the full SSO required-password-update and OIDC callback flow. The bootstrap identity was also verified to reject arbitrary Secret creation and mutation.

## Validation

Rebased onto the current `main` and verified with:

- `bash scripts/check.sh`
  - Ruff, mypy, Bandit, TypeScript, SDK/proxy contracts, frontend tests, and detect-secrets passed
  - frontend: 105 files / 732 tests passed
- `uv run pytest -q tests/test_secret_manager_bootstrap_unit.py tests/test_helm_deployment_unit.py tests/test_secret_management_deployment_unit.py`
  - 43 passed
- `helm lint` with the combined standalone SSO + Secret Manager profile
- fresh isolated Kubernetes deployment using bundled OpenBao and standalone Keycloak SSO
- repeated Helm upgrade without reinitialization
- browser redirect to the installation-owned Keycloak login form
- OIDC callback, browser session, CSRF-bound PAT creation, MCP initialization, vault/document CRUD, cleanup, and unauthenticated rejection

The live deployment exercised OpenBao + plaintext Shamir. HashiCorp Vault, PGP, and Auto Seal paths are covered by schema/render/unit validation but require their respective license acceptance, key holders, or external seal provider for live validation.

## Operator impact

Bundled profiles now finish with one Helm lifecycle. After a plaintext Shamir installation, operators must follow the Helm NOTES to transfer recovery shares off-cluster and delete the one-time recovery Secret. Future unattended restarts still require Auto Seal; automatic first unseal does not change Shamir's long-term custody model.

## Checklist

- [x] CI-equivalent static and contract checks pass
- [x] focused bootstrap/deployment tests pass
- [x] Helm lint passes
- [x] isolated deployment, upgrade, login, and CRUD scenarios pass
- [x] no credentials, private endpoints, or environment-specific deployment values are included
- [x] user-facing deployment and recovery behavior is documented
