### PR TITLE
Fit an over-long vault+table identifier instead of refusing it

### DIFF
--- a/backend/app/repositories/table_data_repo.py
+++ b/backend/app/repositories/table_data_repo.py
@@ -175,6 +175,12 @@ def pg_table_name(vault_name: str, table_name: str) -> str:
     The vault side is the side that gives way. In the case this is for,
     it is the generated one and the table name is the one a reader
     recognises.
+
+    Fitting the PAIR is not the same as accepting any table name.
+    ``create_table`` still refuses a table name that is on its own longer
+    than an identifier can be: that half is the caller's, it is what
+    ``pg_short_name`` hands back as ``sql_name``, and it is a mistake they
+    can fix. Only the half they cannot fix is absorbed here.
     """
     vault = _sanitize_pg_part(vault_name)
     table = _sanitize_pg_part(table_name)

--- a/backend/app/repositories/table_data_repo.py
+++ b/backend/app/repositories/table_data_repo.py
@@ -123,21 +123,76 @@ def _sanitize_pg_part(s: str) -> str:
 
 
 # PostgreSQL truncates identifiers past NAMEDATALEN-1 (63 bytes by
-# default) *silently*. A truncated `vt_*` name could collide with a
-# different table — so we refuse, rather than truncate, names that
-# don't fit. `role_sync._is_safe_pg_table_name` enforces the same bound
-# as defense-in-depth; this constant is the single source for both.
+# default) *silently*, and a truncated `vt_*` name could collide with a
+# different table. `pg_table_name` below therefore never emits one over
+# this bound — it truncates deliberately and appends a digest of the
+# original pair, which is what makes the truncation collision-safe.
+# `role_sync._is_safe_pg_table_name` enforces the same bound as
+# defense-in-depth; this constant is the single source for both.
 # Note the bound is in *bytes*: `_sanitize_pg_part` maps every non-ASCII
 # character to `_`, so the identifier is pure ASCII and a `len()`
 # char-count equals PG's byte count — the equivalence breaks if a future
 # change ever lets multibyte characters through.
 PG_IDENT_MAX_LEN = 63
 
+# Reserved by the composed form itself: `vt_` and the `__` separator.
+_VT_FRAMING_LEN = len("vt_") + len("__")
+# `_` plus eight hex characters of digest, appended only when truncating.
+_VT_DIGEST_LEN = 9
+
 
 def pg_table_name(vault_name: str, table_name: str) -> str:
     """Return the PG table name for a vault-scoped table:
-    `vt_{sanitised_vault}__{sanitised_table}`."""
-    return f"vt_{_sanitize_pg_part(vault_name)}__{_sanitize_pg_part(table_name)}"
+    `vt_{sanitised_vault}__{sanitised_table}`, always within
+    ``PG_IDENT_MAX_LEN``.
+
+    Composing two names inside one 63-byte identifier means the pair can
+    exceed it, and this used to be refused. Refusing is a defensible
+    answer for a name a person chose and a useless one for a name a
+    program derived: a caller whose vault names are generated spends most
+    of the budget before naming a table at all, and then ordinary table
+    names cannot be created — not intermittently, but on an identifier
+    computed before any work is attempted.
+
+    So an over-long pair is fitted rather than refused, the same way
+    ``_constraint_name`` below already fits index and constraint names.
+    The rule is chosen for three properties, and each is load-bearing:
+
+    * **A pair that already fits is byte-identical.** Every table that
+      exists was created under the old rule, so it fits by construction;
+      leaving those alone is what makes this change need no migration.
+    * **The framing survives.** ``role_sync`` interpolates this name into
+      raw SQL behind ``^vt_[a-z0-9_]+__[a-z0-9_]+$``, so both sides and
+      the separator have to remain — truncating the composed string
+      blindly would cut before the `__` for a long enough vault name,
+      which is exactly the case this exists for.
+    * **The digest is over the ORIGINAL pair, not the truncated form.**
+      Two different pairs that truncate to the same prefix would
+      otherwise become one name. The physical-name fusion preflight in
+      ``table_service`` still guards the pre-existing collision case; this
+      keeps truncation from adding a new one.
+
+    The vault side is the side that gives way. In the case this is for,
+    it is the generated one and the table name is the one a reader
+    recognises.
+    """
+    vault = _sanitize_pg_part(vault_name)
+    table = _sanitize_pg_part(table_name)
+    composed = f"vt_{vault}__{table}"
+    if len(composed) <= PG_IDENT_MAX_LEN:
+        return composed
+
+    # usedforsecurity=False: a collision-avoidance tag for a PG identifier,
+    # not a security primitive — the same reasoning `_constraint_name` uses.
+    digest = hashlib.sha1(
+        "\x00".join([vault, table]).encode(), usedforsecurity=False
+    ).hexdigest()[:8]
+    budget = PG_IDENT_MAX_LEN - _VT_FRAMING_LEN - _VT_DIGEST_LEN
+    # Both sides must stay non-empty for the grammar above, so the table
+    # keeps at most all but one byte and the vault takes what is left.
+    table_keep = min(len(table), budget - 1)
+    vault_keep = min(len(vault), budget - table_keep)
+    return f"vt_{vault[:vault_keep]}__{table[:table_keep]}_{digest}"
 
 
 def pg_short_name(table_name: str) -> str:

--- a/backend/app/services/role_sync.py
+++ b/backend/app/services/role_sync.py
@@ -166,9 +166,10 @@ def _is_safe_pg_table_name(name: str) -> bool:
     """Guard before interpolating a `vt_*` name into raw SQL. Upstream
     `pg_table_name` already sanitizes; this is defense-in-depth.
 
-    Over-long names are refused here too, but `table_service.create_table`
-    pre-validates the length and returns a clean 422 — so a well-formed
-    request never reaches this guard with an over-long name."""
+    The length bound is kept here even though `pg_table_name` now fits an
+    over-long pair rather than emitting one: this guard exists for a name
+    that reached raw SQL by some path that did not go through it, and a
+    bound it no longer enforces would be a bound nobody notices losing."""
     return bool(_VT_TABLE_RE.match(name)) and len(name) <= PG_IDENT_MAX_LEN
 
 

--- a/backend/app/services/table_service.py
+++ b/backend/app/services/table_service.py
@@ -917,19 +917,14 @@ async def create_table(
                     vault_id, collection_path, conn=conn,
                 )
 
+            # Always within NAMEDATALEN: `pg_table_name` fits an over-long
+            # pair rather than refusing it, so there is no length check to
+            # make here. There used to be one, and it was correct while the
+            # composition could overflow — a clean 422 beat PG truncating
+            # silently and role_sync then failing to GRANT deep in the stack.
+            # What it could not do is let the table exist, and a vault named
+            # by a generator leaves too little room for ordinary table names.
             pg_name = table_data_repo.pg_table_name(vault["name"], name)
-            # Refuse names whose PG identifier would overflow NAMEDATALEN.
-            # PG truncates silently, and role_sync then refuses to GRANT on
-            # the over-long name (raising deep in the stack as a 500). Catch
-            # it here as a clean 422 that names the culprit, before any DDL.
-            if len(pg_name) > table_data_repo.PG_IDENT_MAX_LEN:
-                raise ValidationError(
-                    f"Table name too long: the PostgreSQL identifier "
-                    f"{pg_name!r} is {len(pg_name)} chars, over the "
-                    f"{table_data_repo.PG_IDENT_MAX_LEN}-char limit. Shorten "
-                    f"the vault name ({vault['name']!r}) or table name "
-                    f"({name!r})."
-                )
 
             # Cross-vault physical-name fusion preflight (issue #285).
             # `_sanitize_pg_part` maps `-` → `_` and `__` is also the

--- a/backend/app/services/table_service.py
+++ b/backend/app/services/table_service.py
@@ -917,13 +917,20 @@ async def create_table(
                     vault_id, collection_path, conn=conn,
                 )
 
-            # Always within NAMEDATALEN: `pg_table_name` fits an over-long
-            # pair rather than refusing it, so there is no length check to
-            # make here. There used to be one, and it was correct while the
-            # composition could overflow — a clean 422 beat PG truncating
-            # silently and role_sync then failing to GRANT deep in the stack.
-            # What it could not do is let the table exist, and a vault named
-            # by a generator leaves too little room for ordinary table names.
+            # The caller's own name still has to fit a PostgreSQL identifier.
+            #
+            # `pg_table_name` fits an over-long PAIR rather than refusing it,
+            # because the vault side is often generated and the caller cannot
+            # shorten it. That is not true of the table name: it is theirs, it
+            # is what `pg_short_name` hands back as `sql_name`, and a name
+            # longer than any identifier can be is a mistake they can fix. So
+            # the refusal stays for this half and is gone for the other.
+            if len(name.encode()) > table_data_repo.PG_IDENT_MAX_LEN:
+                raise ValidationError(
+                    f"Table name too long: {name!r} is {len(name.encode())} bytes, "
+                    f"over the {table_data_repo.PG_IDENT_MAX_LEN}-byte PostgreSQL "
+                    f"identifier limit."
+                )
             pg_name = table_data_repo.pg_table_name(vault["name"], name)
 
             # Cross-vault physical-name fusion preflight (issue #285).

--- a/backend/tests/test_pg_table_name_fitting_unit.py
+++ b/backend/tests/test_pg_table_name_fitting_unit.py
@@ -1,0 +1,95 @@
+"""`pg_table_name` fits a vault+table pair into one PG identifier.
+
+Property tests rather than golden strings: a golden string pins the
+scheme, and what has to hold is the four things below. The one golden
+assertion that IS worth having is that a pair which already fits is
+byte-identical, because that is the whole reason this change needs no
+migration — every table that exists was created under the old rule, so
+it fits by construction.
+
+The service-level behaviour that used to refuse an over-long pair lives
+in ``test_table_name_length_unit.py``.
+"""
+from __future__ import annotations
+
+from app.repositories import table_data_repo
+from app.services import role_sync
+
+_LIMIT = table_data_repo.PG_IDENT_MAX_LEN
+
+
+
+
+def test_a_pair_that_fits_is_untouched():
+    """Every table that exists was created under the old rule, so it fits
+    by construction. If any of these changed, this would be a migration."""
+    for vault, table in [
+        ("manager", "teams"),
+        ("manager", "team_resource_assignments"),
+        ("internal-s3-source-c9c29c38490ff905", "s3_akb_collector_dev"),
+        ("gdn-state", "slack_distill_runs"),
+        ("a", "b"),
+    ]:
+        composed = f"vt_{vault.lower().replace('-', '_')}__{table.lower().replace('-', '_')}"
+        assert len(composed) <= _LIMIT, "fixture is not a fitting pair"
+        assert table_data_repo.pg_table_name(vault, table) == composed
+
+
+def test_an_overlong_pair_fits_and_keeps_the_grammar():
+    """`role_sync` interpolates this name into raw SQL behind a grammar
+    that needs both sides and the separator. Truncating the composed
+    string blindly would cut before the `__` for a long enough vault."""
+    for vault, table in [
+        ("internal-confluence-source-d6d4b0950261786c", "confluence_akbe2e"),
+        ("v" * 70, "t"),
+        ("v", "t" * 70),
+        ("v" * 70, "t" * 70),
+    ]:
+        name = table_data_repo.pg_table_name(vault, table)
+        assert len(name) <= _LIMIT, name
+        assert role_sync._is_safe_pg_table_name(name), name
+
+
+def test_the_rule_is_deterministic():
+    """The name is derived at every call site rather than stored —
+    including role_sync's GRANTs. A name that differed between calls
+    would grant on one relation and query another."""
+    vault, table = "internal-confluence-source-d6d4b0950261786c", "confluence_akbe2e"
+    first = table_data_repo.pg_table_name(vault, table)
+    assert all(table_data_repo.pg_table_name(vault, table) == first for _ in range(5))
+
+
+def test_two_pairs_that_truncate_alike_stay_distinct():
+    """The digest is over the ORIGINAL pair, not the truncated form.
+
+    The pairs below are chosen so that EVERYTHING kept is identical — the
+    same vault prefix, the same table — and they differ only in bytes the
+    truncation throws away. That is the only shape that can tell the two
+    digests apart: a first version of this test used vaults that already
+    differed near the front, so a digest over the truncated string passed
+    it, and the mutation that introduced exactly that bug survived."""
+    table = "t" * 10
+    a = table_data_repo.pg_table_name("v" * 60 + "aaa", table)
+    b = table_data_repo.pg_table_name("v" * 60 + "bbb", table)
+    assert a[: -8] == b[: -8], "fixture no longer shares the kept prefix"
+    assert a != b, "two vaults differing only past the truncation became one name"
+
+    long_vault = "v" * 60 + "aaa"
+    c = table_data_repo.pg_table_name(long_vault, "t" * 9 + "c")
+    d = table_data_repo.pg_table_name(long_vault, "t" * 9 + "d")
+    assert c != d, "two tables composed to one physical name"
+
+
+def test_the_boundary_is_where_it_says_it_is():
+    """63 is untouched and 64 is fitted — an off-by-one either way would
+    rename an existing table or leave the failing case failing."""
+    vault = "prod-conc-1780908249-8ml717"  # 27
+    at_limit = "report_metrics_1780908249_8ml71"  # 31 → 63
+    over = "report_metrics_1780908249_8ml717"  # 32 → 64
+
+    assert table_data_repo.pg_table_name(vault, at_limit) == f"vt_{vault.replace('-', '_')}__{at_limit}"
+    assert len(table_data_repo.pg_table_name(vault, at_limit)) == 63
+
+    fitted = table_data_repo.pg_table_name(vault, over)
+    assert fitted != f"vt_{vault.replace('-', '_')}__{over}"
+    assert len(fitted) <= _LIMIT

--- a/backend/tests/test_table_identifier_unit.py
+++ b/backend/tests/test_table_identifier_unit.py
@@ -216,11 +216,19 @@ def test_pg_ident_max_len_is_namedatalen_minus_one():
 
 
 def test_pg_table_name_length_boundary():
-    """E08 regression: a long vault + long table name can push
-    `vt_<vault>__<table>` exactly one byte over the limit, where PG
-    would silently truncate (risking a GRANT collision). Pin the math
-    that `create_table`'s pre-check guards against."""
+    """A long vault + long table name composes one byte over the limit,
+    where PG would silently truncate and risk a GRANT collision.
+
+    This used to assert that `pg_table_name` RETURNED the 64-byte name,
+    because `create_table` refused it a moment later. It no longer does:
+    refusing left the table uncreatable, so the pair is fitted here
+    instead and the collision the truncation risks is carried by a digest
+    over the original pair. What still has to hold is the boundary — the
+    63-byte name is untouched, which is what makes the change need no
+    migration."""
     fits = pg_table_name("a" * 27, "b" * 31)  # 3 + 27 + 2 + 31 = 63
-    over = pg_table_name("a" * 27, "b" * 32)  # 3 + 27 + 2 + 32 = 64
+    over = pg_table_name("a" * 27, "b" * 32)  # composes to 64
+    assert fits == "vt_" + "a" * 27 + "__" + "b" * 31
     assert len(fits) == PG_IDENT_MAX_LEN
-    assert len(over) == PG_IDENT_MAX_LEN + 1
+    assert len(over) <= PG_IDENT_MAX_LEN
+    assert over != fits

--- a/backend/tests/test_table_name_length_unit.py
+++ b/backend/tests/test_table_name_length_unit.py
@@ -154,3 +154,48 @@ async def test_create_table_invalid_name_is_422_not_500():
             actor_id="tester",
         )
     assert ei.value.status_code == 422
+
+
+async def test_create_table_still_refuses_a_table_name_over_the_limit(monkeypatch):
+    """The half that is the caller's stays refused.
+
+    Fitting the PAIR is not the same as accepting any table name: the vault
+    side is often generated and cannot be shortened, but the table name is
+    theirs, it is what `pg_short_name` hands back as `sql_name`, and one
+    longer than any identifier can be is a mistake they can fix.
+
+    This was found by CI, not here: `tests/test_mcp_e2e.sh` asserts a
+    70-character name comes back `invalid_argument`, and removing the
+    composed-length check removed the only thing refusing it — because the
+    other two length checks in this module guard constraint and index
+    names, not the table's. A local sweep grepping for the message text
+    missed it; the shell suite asserts the error CODE.
+    """
+    vault_name = "short"
+    table_name = "a" * 70
+
+    async def _fake_get_pool():
+        return _FakePool(_FakeConn(vault_name))
+
+    monkeypatch.setattr(table_service, "get_pool", _fake_get_pool)
+
+    async def _must_not_run(*a, **k):
+        raise AssertionError("create_dynamic_table must not run for an over-long table name")
+
+    monkeypatch.setattr(table_service.table_data_repo, "create_dynamic_table", _must_not_run)
+
+    with pytest.raises(ValidationError) as ei:
+        await table_service.create_table(
+            uuid.uuid4(),
+            table_name,
+            [{"name": "amount", "type": "int"}],
+            actor_id="tester",
+        )
+
+    assert ei.value.status_code == 422
+    assert "too long" in ei.value.message.lower()
+    # And the pair-fitting is untouched by it: the same vault with a table
+    # that only overflows once composed is still created.
+    assert len(
+        table_service.table_data_repo.pg_table_name("v" * 60, "t" * 20)
+    ) <= table_service.table_data_repo.PG_IDENT_MAX_LEN

--- a/backend/tests/test_table_name_length_unit.py
+++ b/backend/tests/test_table_name_length_unit.py
@@ -1,12 +1,20 @@
-"""Regression test for E08: `create_table` must refuse a vault+table
-name combination whose PG identifier (`vt_<vault>__<table>`) overflows
-NAMEDATALEN, returning a clean ``ValidationError`` (HTTP 422) *before*
-any DDL — instead of letting ``role_sync`` raise deep in the GRANT path
-and surface as an opaque 500.
+"""`create_table` and a vault+table pair whose composed PG identifier
+(`vt_<vault>__<table>`) would overflow NAMEDATALEN.
+
+This began as E08's regression: the pair was REFUSED with a clean 422
+before any DDL, which beat PG truncating silently and ``role_sync`` then
+failing to GRANT deep in the stack. That judgement held while the only
+names in play were ones a person chose. It stopped holding for a vault
+named by a generator, which spends most of a 63-byte budget before a
+table is named at all — ordinary table names then became uncreatable,
+not intermittently but on an identifier computed before any work.
+
+So the pair is now FITTED rather than refused, and these tests changed
+with it. What did not change is the property underneath: a name that
+reaches PG is within NAMEDATALEN and is not another table's.
 
 DB-free: a minimal fake pool/conn carries the create path as far as the
-length guard. ``create_dynamic_table`` is stubbed to blow up so the test
-also proves the guard short-circuits before touching PG.
+DDL call, which is stubbed so nothing touches PG.
 """
 from __future__ import annotations
 
@@ -64,23 +72,31 @@ class _FakePool:
         return _AsyncCtx(self._conn)
 
 
-async def test_create_table_rejects_overlong_pg_name(monkeypatch):
-    """The exact E08 trigger: vault(27) + table(32) → 64-char identifier."""
+async def test_create_table_fits_an_overlong_pair_instead_of_refusing(monkeypatch):
+    """The exact E08 trigger, which used to be a 422: vault(27) +
+    table(32) composes to 64 characters. It now reaches DDL under a name
+    that fits, because refusing left the table uncreatable and that is
+    the failure this surface actually has."""
     vault_name = "prod-conc-1780908249-8ml717"        # 27 chars
     table_name = "report_metrics_1780908249_8ml717"   # 32 chars
-    assert len(table_service.table_data_repo.pg_table_name(vault_name, table_name)) == 64
+
+    fitted = table_service.table_data_repo.pg_table_name(vault_name, table_name)
+    assert len(fitted) <= table_service.table_data_repo.PG_IDENT_MAX_LEN
 
     async def _fake_get_pool():
         return _FakePool(_FakeConn(vault_name))
 
     monkeypatch.setattr(table_service, "get_pool", _fake_get_pool)
 
-    async def _must_not_run(*a, **k):
-        raise AssertionError("create_dynamic_table must not run for an over-long name")
+    reached = {}
 
-    monkeypatch.setattr(table_service.table_data_repo, "create_dynamic_table", _must_not_run)
+    async def _reached_then_stop(conn, pg_name, *a, **k):
+        reached["pg_name"] = pg_name
+        raise RuntimeError("stop after naming")
 
-    with pytest.raises(ValidationError) as ei:
+    monkeypatch.setattr(table_service.table_data_repo, "create_dynamic_table", _reached_then_stop)
+
+    with pytest.raises(RuntimeError, match="stop after naming"):
         await table_service.create_table(
             uuid.uuid4(),
             table_name,
@@ -88,9 +104,9 @@ async def test_create_table_rejects_overlong_pg_name(monkeypatch):
             actor_id="tester",
         )
 
-    assert ei.value.status_code == 422
-    assert "too long" in ei.value.message.lower()
-    assert str(table_service.table_data_repo.PG_IDENT_MAX_LEN) in ei.value.message
+    # The DDL is reached, and with the fitted name rather than the raw one.
+    assert reached.get("pg_name") == fitted
+    assert len(reached["pg_name"]) <= table_service.table_data_repo.PG_IDENT_MAX_LEN
 
 
 async def test_create_table_accepts_pg_name_at_limit(monkeypatch):


### PR DESCRIPTION
Composing two names inside one 63-byte PostgreSQL identifier means the pair
can exceed it, and `create_table` refused when it did. Refusing is a
defensible answer for a name a person chose and a useless one for a name a
program derived: a caller whose vault names are generated spends most of the
budget before naming a table at all, and ordinary table names then cannot be
created — not intermittently, but on an identifier computed before any work is
attempted.

`pg_table_name` now fits such a pair the same way `_constraint_name` in the
same file already fits index and constraint names: truncate, and append a
digest that keeps the truncation collision-safe.

Three properties make it safe, and each is a test:

- **A pair that already fits is byte-identical.** Every table that exists was
  created under the old rule, so it fits by construction — which is why this
  needs no migration and touches no existing name.
- **The framing survives.** `role_sync` interpolates this name into raw SQL
  behind `^vt_[a-z0-9_]+__[a-z0-9_]+$`, so both sides and the separator have to
  remain. Truncating the composed string blindly cuts before the `__` for a
  long enough vault name, which is exactly the case this exists for.
- **The digest is over the original pair, not the truncated form.** Two pairs
  that truncate to the same prefix would otherwise become one name.

The composed-length pre-check in `create_table` becomes unreachable and goes
with it, but the refusal for the caller's OWN name stays and is now explicit:

* the VAULT side is often generated and cannot be shortened, so an over-long
  pair is fitted;
* the TABLE name is theirs, it is what `pg_short_name` hands back as
  `sql_name`, and one longer than an identifier can be is a mistake they can
  fix — so that stays a 422.

An earlier revision of this branch removed both, on a claim in this description
that was wrong: the two other length checks in `table_service` guard constraint
and index names (`_resolve_unique_keys`, `_resolve_indexes`), not the table's.
`tests/test_mcp_e2e.sh` caught it — it asserts a 70-character name comes back
`invalid_argument`, by error CODE rather than message, which is why a local
sweep grepping for the message text missed it.

The bound also stays in `role_sync._is_safe_pg_table_name`: it is there for a
name that reached raw SQL by some path that did not go through `pg_table_name`,
and a bound it no longer enforces would be one nobody notices losing.

Three existing tests stated the judgement being changed — two in Python and
the shell e2e above — that the function
RETURNS a 64-byte name and that `create_table` answers 422 for it — and are
rewritten rather than added to.

Verification, and the part of it that is missing is worth naming:

- `ruff==0.15.16` all checks passed; `mypy==2.1.0 --python-version 3.14`
  success, no issues in 351 source files; `bandit==1.9.4` no issues, 0 files
  skipped. Pinned versions matter here — an unpinned ruff reported 1343 errors
  on this tree, all of them its own rule set.
- 269 passed / 1 failed / 1 skipped across the 19 test files that mention the
  identifier, against a real PostgreSQL. The failure is
  `test_vault_write_policy_unit.py::TestContextVar::test_jwt_resolution_leaves_token_id_none`
  and it fails identically with this change reverted; the skip is one test
  needing `AKB_TEST_REDIS_URL`.
- Five mutations, each red on its own case: a fitting pair rewritten, the digest
  taken over the truncated form, the framing dropped, the vault side allowed to
  vanish, and the bound removed. The digest mutation survived a first version of
  its test, whose two vaults already differed before the truncation point; the
  case was retargeted at pairs that differ only in bytes the truncation
  discards.
- `scripts/check.sh` was not run end to end. It requires `node_modules` in three
  node projects and refuses without them, and this change is Python-only, so the
  analyzers it would run over this diff are the three above. It also runs no
  tests at all, so the counts above are not something it would have produced.

Closes #469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
