### PR TITLE
test(mcp): add pytest scenarios through Inspector CLI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,7 +50,7 @@ jobs:
           uv run --locked --project backend python -c \
             'import sys; assert sys.version_info[:2] == (3, 14), sys.version'
 
-      - name: Run the repository-owned E2E runtime
+      - name: Run repository-owned pytest and shell E2E runtime
         env:
           UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}/akb-e2e-python
           UV_CACHE_DIR: ${{ runner.temp }}/akb-e2e-uv-cache

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -176,7 +176,7 @@
         "filename": "backend/scripts/ci/README.md",
         "hashed_secret": "f017223a0417e247cdef8c5c3e5681c6d5439219",
         "is_verified": false,
-        "line_number": 106
+        "line_number": 130
       }
     ],
     "backend/scripts/ci/dependency-compose.yaml": [
@@ -6987,5 +6987,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-02T08:06:11Z"
+  "generated_at": "2026-09-03T01:46:36Z"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,7 @@ AKB_URL=http://localhost:8000 bash backend/tests/test_security_edge_e2e.sh
 # CI-equivalent isolated full gate (uses the repository-owned runtime and
 # its private PostgreSQL/MinIO dependency stack, not the root Compose app)
 uv sync --locked --extra dev --project backend
+(cd packages/akb-mcp-client && npm ci)
 RUNTIME_ROOT="$(mktemp -d /tmp/akb-e2e-runtime.XXXXXX)"
 export AKB_E2E_USERNAME="$(uv run --locked --project backend python -c \
   'import secrets; print(f"akb-e2e-{secrets.token_hex(8)}")')"
@@ -94,6 +95,18 @@ unset AKB_E2E_USERNAME AKB_E2E_PASSWORD
 # Frontend
 cd frontend && pnpm test
 ```
+
+The authenticated MCP pytest seam is run by the repository-owned runtime gate
+and can also consume a ready schema-v2 descriptor directly. Local and hosted
+CI use the same command and the same `akb_list_vaults({})` assertion:
+
+```bash
+uv run --locked --project backend python -m pytest \
+  backend/tests/mcp_e2e -v --tb=short --runtime-descriptor -
+```
+
+The descriptor must come from `backend/scripts/ci/e2e_runtime.py serve` or the
+Ubuntu bootstrap; this command does not start or tear down a backend.
 
 The E2E suites create ephemeral users and vaults and clean up after
 themselves. They poll `/health` for indexing completion before running search

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ and can also consume a ready schema-v2 descriptor directly. Local and hosted
 CI use the same command and the same `akb_list_vaults({})` assertion:
 
 ```bash
-uv run --locked --project backend python -m pytest \
+uv run --locked --extra dev --project backend python -m pytest \
   backend/tests/mcp_e2e -v --tb=short --runtime-descriptor -
 ```
 

--- a/backend/scripts/ci/README.md
+++ b/backend/scripts/ci/README.md
@@ -43,6 +43,28 @@ fails the gate. `EMPTY_COUNT_ALLOWED` is intentionally empty. Hosted CI,
 the isolated runtime, and `scripts/run_canonical_e2e.sh` all execute this same
 runner, so there is no second suite array to keep synchronized.
 
+### MCP pytest behavior suite
+
+The first MCP behavior scenario is a pytest seam for the authenticated
+`akb_list_vaults({})` flow. The scenario owns its public assertions while the
+driver interface hides process orchestration; the concrete adapter invokes the
+exact-pinned Inspector CLI from `packages/akb-mcp-client`.
+
+The repository runtime remains the owner of backend startup, readiness,
+fixture reset, credentials, and teardown. Give the same schema-v2 descriptor
+to the local and hosted command through stdin:
+
+```bash
+uv run --locked --project backend python -m pytest \
+  backend/tests/mcp_e2e -v --tb=short --runtime-descriptor -
+```
+
+`e2e_runtime.py gate` invokes this exact pytest command before the existing
+shell and transport checks. A direct invocation must be run while a
+repository-owned `serve` runtime is ready and must receive its one descriptor
+line on stdin; it must not start another backend, database, port topology, or
+credential fixture.
+
 ### 2. Repository-owned isolated runtime
 
 The runtime supervisor is `e2e_runtime.py`. It owns the test infrastructure
@@ -62,6 +84,7 @@ The topology is deliberately small:
 | embedding stub | Ubuntu host process | `127.0.0.1:8888` | deterministic `/v1/embeddings` responses |
 | backend | Ubuntu host process | `127.0.0.1:8000` | AKB application under test |
 | fixture control | supervisor-owned in-process app | `127.0.0.1:8889` | health, discovery, and empty reset |
+| MCP pytest behavior suite | Ubuntu host process | no public listener | authenticated `akb_list_vaults` scenario through Inspector |
 | curated suite runner | Ubuntu host process | no public listener | exact 15-suite gate and count semantics |
 
 Only PostgreSQL and MinIO are managed by
@@ -79,8 +102,9 @@ unchanged for the canonical local and CI paths.
 The supervisor has two modes:
 
 - `gate`: starts dependencies, fixture control, embedding stub, and backend;
-  waits for readiness; prints the schema v2 descriptor; runs the shared
-  curated suite runner; then stops child processes and dependency resources.
+  waits for readiness; prints the schema v2 descriptor; runs the shared pytest
+  behavior suite, curated suite runner, and selected transport checks; then
+  stops child processes and dependency resources.
 - `serve`: starts the same stack, prints the ready descriptor, and remains in
   the foreground until SIGINT/SIGTERM. The fixture's `POST /reset` performs a
   safe empty reset and waits for backend readiness again.
@@ -204,10 +228,13 @@ to the descriptor, logs, argv, or committed files.
 contain runtime lifecycle logic. On a clean Ubuntu 24.04 host it:
 
 1. verifies the base image and installs `curl`/CA certificates as needed;
-2. installs the Ubuntu archive's `nodejs`/`npm` packages and verifies both
-   executables before any selected stdio profile is validated;
+2. installs the Ubuntu archive's `nodejs`/`npm` packages, verifies Node.js
+   `>=22.19.0` (using a checksum-verified host-wide Node `22.19.0` runtime
+   when the archive is older), and runs the locked `npm ci` for
+   `packages/akb-mcp-client`;
 3. installs and starts Docker Engine plus Compose v2 idempotently;
-4. installs/verifies `uv` and Python 3.14 under the private runtime root;
+4. installs/verifies `uv` on the host PATH and Python 3.14 under the private
+   runtime root;
 5. runs `uv sync --locked --extra dev --project backend`; and
 6. `exec`s the same Python supervisor in `gate` or `serve` mode.
 

--- a/backend/scripts/ci/README.md
+++ b/backend/scripts/ci/README.md
@@ -55,7 +55,7 @@ fixture reset, credentials, and teardown. Give the same schema-v2 descriptor
 to the local and hosted command through stdin:
 
 ```bash
-uv run --locked --project backend python -m pytest \
+uv run --locked --extra dev --project backend python -m pytest \
   backend/tests/mcp_e2e -v --tb=short --runtime-descriptor -
 ```
 

--- a/backend/scripts/ci/e2e_runtime.py
+++ b/backend/scripts/ci/e2e_runtime.py
@@ -3389,6 +3389,7 @@ class E2ERuntime:
 
     async def _run_gate(self) -> int:
         suite_path = self.config.backend_dir / "scripts" / "ci" / "e2e_suite_runner.py"
+        mcp_pytest_path = self.config.checkout / "backend" / "tests" / "mcp_e2e"
         log_path = self.config.logs_dir / "gate.log"
         emit_gate_event(
             {
@@ -3401,6 +3402,47 @@ class E2ERuntime:
                 "capabilities": list(self.selected_capabilities),
                 "source_revision": self._source_revision(),
             },
+        )
+
+        emit_gate_event(
+            {
+                "event": "mcp_pytest_start",
+                "process": "mcp_pytest",
+                "scenario": "akb_list_vaults",
+                "suite": str(mcp_pytest_path),
+                "stage": "product_assertion",
+                "profile": self.profile.name,
+            }
+        )
+        try:
+            await self._run_logged_command(
+                [
+                    sys.executable,
+                    "-m",
+                    "pytest",
+                    str(mcp_pytest_path),
+                    "-v",
+                    "--tb=short",
+                    "--runtime-descriptor",
+                    "-",
+                ],
+                log_path=self.config.logs_dir / "mcp-pytest.log",
+                stdin_data=json.dumps(
+                    self.descriptor(), separators=(",", ":"), ensure_ascii=False
+                ).encode(),
+            )
+        except ProvisioningFailure as exc:
+            raise ProductAssertionFailure("MCP pytest E2E scenario failed") from exc
+        emit_gate_event(
+            {
+                "event": "mcp_pytest_complete",
+                "process": "mcp_pytest",
+                "scenario": "akb_list_vaults",
+                "suite": str(mcp_pytest_path),
+                "stage": "product_assertion",
+                "profile": self.profile.name,
+                "returncode": 0,
+            }
         )
 
         if self.profile.needs_stdio:

--- a/backend/scripts/ci/ubuntu_e2e_bootstrap.sh
+++ b/backend/scripts/ci/ubuntu_e2e_bootstrap.sh
@@ -81,10 +81,9 @@ source /etc/os-release 2>/dev/null || die "cannot inspect /etc/os-release"
 "${SUDO[@]}" apt-get install -y curl ca-certificates \
   || die "curl/CA package installation failed"
 
-# The transport profiles execute the repository's real zero-dependency Node
-# consumer after this host layer completes.  Use the Ubuntu 24.04 archive
-# rather than an unpinned third-party installer so a clean VM gets the same
-# package-managed node/npm toolchain as the rest of its base image.
+# The MCP pytest driver executes the repository's pinned Inspector package
+# after this host layer completes.  Keep the host package install idempotent,
+# then fail closed if the image's Node major is too old for that package.
 "${SUDO[@]}" apt-get install -y nodejs npm \
   || die "Node.js/npm package installation failed"
 command -v node >/dev/null 2>&1 \
@@ -93,9 +92,75 @@ command -v npm >/dev/null 2>&1 \
   || die "npm executable is unavailable after package installation"
 NODE_VERSION=$(node --version) \
   || die "Node.js version check failed"
-NPM_VERSION=$(npm --version) \
+node_version_meets_floor() {
+  local version=${1#v} major minor patch extra
+  IFS=. read -r major minor patch extra <<< "$version"
+  [[ "$major" =~ ^[0-9]+$ && "$minor" =~ ^[0-9]+$ && "$patch" =~ ^[0-9]+$ ]] || return 1
+  [ "$major" -gt 22 ] \
+    || { [ "$major" -eq 22 ] && [ "$minor" -gt 19 ]; } \
+    || { [ "$major" -eq 22 ] && [ "$minor" -eq 19 ] && [ "$patch" -ge 0 ]; }
+}
+
+NODE_BIN=$(command -v node)
+NPM_BIN=$(command -v npm)
+if ! node_version_meets_floor "$NODE_VERSION"; then
+  # Ubuntu 24.04's archive may still provide Node 18. Install the exact
+  # fallback system-wide so a later operator shell, which does not inherit
+  # this process's PATH, resolves the same runtime.
+  NODE_RELEASE=22.19.0
+  case "$(uname -m)" in
+    x86_64)
+      NODE_ARCH=x64
+      NODE_SHA256=c0649af18e6a24f6fe5535a3e86b341dd49a8e71117c8b68bde973ef834f16f2
+      ;;
+    aarch64|arm64)
+      NODE_ARCH=arm64
+      NODE_SHA256=0b2d9f564b6594222a62c82e1df2efe119dd4a4aff29644f4dd325bf360b6bcc
+      ;;
+    *)
+      die "Node.js >=22.19.0 is unavailable for host architecture $(uname -m)"
+      ;;
+  esac
+  NODE_ARCHIVE="$RUNTIME_ROOT/node-v${NODE_RELEASE}-linux-${NODE_ARCH}.tar.xz"
+  NODE_URL="https://nodejs.org/dist/v${NODE_RELEASE}/node-v${NODE_RELEASE}-linux-${NODE_ARCH}.tar.xz"
+  curl --fail --location --silent --show-error "$NODE_URL" --output "$NODE_ARCHIVE" \
+    || die "Node.js ${NODE_RELEASE} download failed"
+  chmod 600 -- "$NODE_ARCHIVE" \
+    || die "could not make the Node.js archive private"
+  command -v sha256sum >/dev/null 2>&1 \
+    || die "sha256sum is required to verify the Node.js archive"
+  printf '%s  %s\n' "$NODE_SHA256" "$NODE_ARCHIVE" | sha256sum --check --status - \
+    || die "Node.js ${NODE_RELEASE} archive checksum failed"
+  "${SUDO[@]}" tar -xJf "$NODE_ARCHIVE" -C /usr/local/lib \
+    || die "Node.js ${NODE_RELEASE} archive extraction failed"
+  NODE_PREFIX="/usr/local/lib/node-v${NODE_RELEASE}-linux-${NODE_ARCH}"
+  NODE_BIN="$NODE_PREFIX/bin/node"
+  NPM_BIN="$NODE_PREFIX/bin/npm"
+  NPMX_BIN="$NODE_PREFIX/bin/npx"
+  [ -x "$NODE_BIN" ] && [ -x "$NPM_BIN" ] && [ -x "$NPMX_BIN" ] \
+    || die "Node.js ${NODE_RELEASE} installation is incomplete"
+  "${SUDO[@]}" ln -sfn "$NODE_BIN" /usr/local/bin/node \
+    || die "could not expose Node.js on PATH"
+  "${SUDO[@]}" ln -sfn "$NPM_BIN" /usr/local/bin/npm \
+    || die "could not expose npm on PATH"
+  "${SUDO[@]}" ln -sfn "$NPMX_BIN" /usr/local/bin/npx \
+    || die "could not expose npx on PATH"
+  export PATH="/usr/local/bin:$(dirname "$NODE_BIN"):$PATH"
+  NODE_VERSION=$("$NODE_BIN" --version) \
+    || die "private Node.js version check failed"
+  node_version_meets_floor "$NODE_VERSION" \
+    || die "private Node.js >=22.19.0 verification failed"
+fi
+NPM_VERSION=$("$NPM_BIN" --version) \
   || die "npm version check failed"
 echo "Node.js ${NODE_VERSION}, npm ${NPM_VERSION} ready" >&2
+
+[ -f "$CHECKOUT/packages/akb-mcp-client/package.json" ] \
+  || die "checkout is missing packages/akb-mcp-client/package.json"
+[ -f "$CHECKOUT/packages/akb-mcp-client/package-lock.json" ] \
+  || die "checkout is missing packages/akb-mcp-client/package-lock.json"
+"$NPM_BIN" ci --prefix "$CHECKOUT/packages/akb-mcp-client" \
+  || die "locked MCP Inspector installation failed"
 
 if ! command -v docker >/dev/null 2>&1; then
   "${SUDO[@]}" apt-get install -y docker.io \
@@ -146,6 +211,8 @@ chmod 700 -- "$RUNTIME_ROOT/bin" "$RUNTIME_ROOT/uv-cache" \
 UV_BIN="${UV_BIN:-}"
 if [ -n "$UV_BIN" ] && command -v "$UV_BIN" >/dev/null 2>&1; then
   UV_BIN=$(command -v "$UV_BIN")
+elif command -v uv >/dev/null 2>&1; then
+  UV_BIN=$(command -v uv)
 else
   UV_BIN="$RUNTIME_ROOT/bin/uv"
   if [ ! -x "$UV_BIN" ]; then
@@ -156,6 +223,12 @@ else
   fi
 fi
 [ -x "$UV_BIN" ] || die "uv executable was not installed"
+if [ "$UV_BIN" != "/usr/local/bin/uv" ]; then
+  "${SUDO[@]}" install -m 0755 "$UV_BIN" /usr/local/bin/uv \
+    || die "could not expose uv on PATH"
+fi
+UV_BIN=/usr/local/bin/uv
+export PATH="/usr/local/bin:$PATH"
 "$UV_BIN" --version >/dev/null \
   || die "uv is installed but cannot execute"
 

--- a/backend/tests/mcp_e2e/__init__.py
+++ b/backend/tests/mcp_e2e/__init__.py
@@ -1,0 +1,1 @@
+"""Pytest scenarios for the authenticated MCP behavior surface."""

--- a/backend/tests/mcp_e2e/conftest.py
+++ b/backend/tests/mcp_e2e/conftest.py
@@ -1,0 +1,70 @@
+"""Fixtures that connect one product scenario to the repository runtime."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from .driver import McpClientDriver
+from .inspector_adapter import InspectorAdapterError, InspectorCliAdapter
+from .runtime import RuntimeSession, RuntimeSetupError
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--runtime-descriptor",
+        default=None,
+        help="schema-v2 runtime descriptor path, or '-' to read it from stdin",
+    )
+
+
+def _read_descriptor(source: str) -> str:
+    if source == "-":
+        try:
+            with os.fdopen(os.dup(0), "r", encoding="utf-8") as stream:
+                return stream.read()
+        except OSError:
+            raise RuntimeSetupError("runtime descriptor stdin could not be read") from None
+    try:
+        return Path(source).read_text(encoding="utf-8")
+    except OSError:
+        raise RuntimeSetupError("runtime descriptor file could not be read") from None
+
+
+@pytest.fixture
+def runtime_session(request: pytest.FixtureRequest) -> Iterator[RuntimeSession]:
+    source = request.config.getoption("--runtime-descriptor")
+    if not source:
+        pytest.fail("--runtime-descriptor is required for the live MCP scenario")
+    session: RuntimeSession | None = None
+    try:
+        session = RuntimeSession.from_json(_read_descriptor(source))
+        session.prepare()
+    except RuntimeSetupError as exc:
+        if session is not None:
+            session.close()
+        pytest.fail(str(exc))
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def mcp_driver(runtime_session: RuntimeSession) -> Iterator[McpClientDriver]:
+    try:
+        driver = InspectorCliAdapter(
+            mcp_url=runtime_session.descriptor.mcp_url,
+            pat=runtime_session.pat,
+            secrets=runtime_session.secrets,
+            secret_env_names=runtime_session.credential_env_names,
+        )
+    except InspectorAdapterError as exc:
+        pytest.fail(f"scenario=akb_list_vaults transport=http setup: {exc}")
+    try:
+        yield driver
+    finally:
+        driver.close()

--- a/backend/tests/mcp_e2e/conftest.py
+++ b/backend/tests/mcp_e2e/conftest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -21,13 +22,20 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
-def _read_descriptor(source: str) -> str:
+def _read_descriptor(source: str, capture_manager: Any = None) -> str:
     if source == "-":
+        suspended = False
         try:
+            if capture_manager is not None:
+                capture_manager.suspend_global_capture(in_=True)
+                suspended = True
             with os.fdopen(os.dup(0), "r", encoding="utf-8") as stream:
                 return stream.read()
         except OSError:
             raise RuntimeSetupError("runtime descriptor stdin could not be read") from None
+        finally:
+            if suspended:
+                capture_manager.resume_global_capture()
     try:
         return Path(source).read_text(encoding="utf-8")
     except OSError:
@@ -41,7 +49,8 @@ def runtime_session(request: pytest.FixtureRequest) -> Iterator[RuntimeSession]:
         pytest.fail("--runtime-descriptor is required for the live MCP scenario")
     session: RuntimeSession | None = None
     try:
-        session = RuntimeSession.from_json(_read_descriptor(source))
+        capture_manager = request.config.pluginmanager.getplugin("capturemanager")
+        session = RuntimeSession.from_json(_read_descriptor(source, capture_manager))
         session.prepare()
     except RuntimeSetupError as exc:
         if session is not None:

--- a/backend/tests/mcp_e2e/driver.py
+++ b/backend/tests/mcp_e2e/driver.py
@@ -1,0 +1,39 @@
+"""The small client seam consumed by MCP behavior scenarios."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class DriverResult:
+    """A sanitized result from one MCP client operation."""
+
+    transport: str
+    operation: str
+    status: str
+    exit_code: int | None
+    output: dict[str, Any] | None = None
+    diagnostics: str | None = None
+    error: str | None = None
+
+    @property
+    def passed(self) -> bool:
+        return self.status == "passed" and self.exit_code == 0 and self.output is not None
+
+
+class McpClientDriver(Protocol):
+    """Minimum MCP client behavior exposed to a product scenario."""
+
+    transport: str
+
+    def initialize(self) -> DriverResult:
+        """Negotiate the MCP protocol and return the structured result."""
+
+    def list_tools(self) -> DriverResult:
+        """Read the server tool catalog."""
+
+    def call_tool(self, name: str, arguments: Mapping[str, Any]) -> DriverResult:
+        """Call one MCP tool with a JSON object of arguments."""

--- a/backend/tests/mcp_e2e/inspector_adapter.py
+++ b/backend/tests/mcp_e2e/inspector_adapter.py
@@ -1,0 +1,462 @@
+"""MCP client driver backed by the repository's pinned Inspector CLI.
+
+The adapter deliberately knows about Inspector's public command line only. A
+scenario sees :class:`McpClientDriver` and never needs to know how the child
+process, temporary config, or credentials are managed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import tempfile
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .driver import DriverResult
+
+INSPECTOR_PACKAGE = "@modelcontextprotocol/inspector"
+INSPECTOR_VERSION = "2.4.0"
+MIN_NODE_VERSION = "22.19.0"
+INSPECTOR_BIN = "clients/launcher/build/index.js"
+SERVER_NAME = "akb"
+PROTOCOL_VERSION = "2026-07-28"
+
+_REDACTED = "[REDACTED]"
+_ENV_NAMES_TO_CLEAR = (
+    "AKB_PAT",
+    "AKB_MCP_URL",
+    "DANGEROUSLY_OMIT_AUTH",
+    "MCP_CATALOG_PATH",
+    "MCP_CLIENT_CONFIG_PATH",
+    "MCP_INSPECTOR_SECRET_FILE",
+    "MCP_INSPECTOR_SECRET_KEY",
+    "MCP_INSPECTOR_API_TOKEN",
+)
+
+
+class InspectorAdapterError(RuntimeError):
+    """Raised when the pinned Inspector installation cannot be used."""
+
+
+@dataclass(frozen=True, slots=True)
+class InspectorInstallation:
+    """Validated paths and versions for the public Inspector executable."""
+
+    package_root: Path
+    node: str
+    node_version: str
+    entry: Path
+
+
+def _json_file(path: Path, label: str) -> dict[str, Any]:
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except OSError, ValueError, TypeError:
+        raise InspectorAdapterError(f"{label} is missing or invalid") from None
+    if not isinstance(parsed, dict):
+        raise InspectorAdapterError(f"{label} must be an object")
+    return parsed
+
+
+def _version_tuple(value: str) -> tuple[int, int, int] | None:
+    match = re.fullmatch(r"v?(\d+)\.(\d+)\.(\d+)", value.strip())
+    if match is None:
+        return None
+    major, minor, patch = (int(part) for part in match.groups())
+    return major, minor, patch
+
+
+def _node_meets_floor(value: str, floor: str = MIN_NODE_VERSION) -> bool:
+    actual = _version_tuple(value)
+    minimum = _version_tuple(floor)
+    return actual is not None and minimum is not None and actual >= minimum
+
+
+def _node_version(node: str) -> str:
+    try:
+        completed = subprocess.run(
+            [node, "--version"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except OSError, subprocess.SubprocessError:
+        raise InspectorAdapterError("Node.js version check failed") from None
+    version = completed.stdout.strip()
+    if not _node_meets_floor(version):
+        raise InspectorAdapterError(f"Node.js {MIN_NODE_VERSION} or newer is required")
+    return version.removeprefix("v")
+
+
+def _declared_dependency(manifest: Mapping[str, Any]) -> str | None:
+    for section in ("dependencies", "devDependencies", "optionalDependencies"):
+        dependencies = manifest.get(section)
+        if isinstance(dependencies, dict) and INSPECTOR_PACKAGE in dependencies:
+            value = dependencies[INSPECTOR_PACKAGE]
+            return value if isinstance(value, str) else None
+    return None
+
+
+def inspect_installation(
+    *,
+    package_root: Path | None = None,
+    node: str | Path | None = None,
+) -> InspectorInstallation:
+    """Validate the exact package, lock entry, Node floor, and public bin."""
+
+    if package_root is None:
+        package_root = Path(__file__).resolve().parents[3] / "packages" / "akb-mcp-client"
+    package_root = package_root.resolve()
+    package_manifest = _json_file(package_root / "package.json", "akb-mcp package manifest")
+    if _declared_dependency(package_manifest) != INSPECTOR_VERSION:
+        raise InspectorAdapterError("the MCP Inspector dependency is not pinned to version 2.4.0")
+
+    lock = _json_file(package_root / "package-lock.json", "akb-mcp package lock")
+    lock_packages = lock.get("packages")
+    locked_inspector = (
+        lock_packages.get(f"node_modules/{INSPECTOR_PACKAGE}") if isinstance(lock_packages, dict) else None
+    )
+    if not isinstance(locked_inspector, dict) or locked_inspector.get("version") != INSPECTOR_VERSION:
+        raise InspectorAdapterError("the package lock does not pin MCP Inspector to version 2.4.0")
+
+    inspector_root = package_root / "node_modules" / INSPECTOR_PACKAGE
+    inspector_manifest = _json_file(inspector_root / "package.json", "installed MCP Inspector manifest")
+    if inspector_manifest.get("name") != INSPECTOR_PACKAGE or inspector_manifest.get("version") != INSPECTOR_VERSION:
+        raise InspectorAdapterError("installed MCP Inspector is not exactly version 2.4.0")
+    engines = inspector_manifest.get("engines")
+    if not isinstance(engines, dict) or engines.get("node") != f">={MIN_NODE_VERSION}":
+        raise InspectorAdapterError("MCP Inspector Node.js engine contract is unexpected")
+    bins = inspector_manifest.get("bin")
+    declared_bin = bins.get("mcp-inspector") if isinstance(bins, dict) else None
+    if not isinstance(declared_bin, str) or declared_bin.removeprefix("./") != INSPECTOR_BIN:
+        raise InspectorAdapterError("MCP Inspector public bin is unexpected")
+    entry = (inspector_root / declared_bin).resolve()
+    if not entry.is_relative_to(inspector_root) or not entry.is_file():
+        raise InspectorAdapterError("MCP Inspector public launcher is missing")
+
+    node_path = str(node) if node is not None else shutil.which("node")
+    if not node_path:
+        raise InspectorAdapterError("Node.js executable is unavailable")
+    return InspectorInstallation(
+        package_root=package_root,
+        node=node_path,
+        node_version=_node_version(node_path),
+        entry=entry,
+    )
+
+
+def _redact_text(value: str, secrets: Iterable[str]) -> str:
+    output = value
+    for secret in sorted({secret for secret in secrets if secret}, key=len, reverse=True):
+        output = output.replace(secret, _REDACTED)
+    return re.sub(r"Bearer\s+[^\s,}]+", "Bearer [REDACTED]", output, flags=re.IGNORECASE)
+
+
+def _redact_json(value: Any, secrets: Iterable[str]) -> Any:
+    if isinstance(value, str):
+        return _redact_text(value, secrets)
+    if isinstance(value, list):
+        return [_redact_json(item, secrets) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _redact_json(item, secrets) for key, item in value.items()}
+    return value
+
+
+def _text(value: str | bytes | None) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value or ""
+
+
+def _terminate_process(process: Any) -> None:
+    """Stop only the process group created for one Inspector operation."""
+
+    if process.poll() is not None:
+        return
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except OSError, ProcessLookupError:
+        with_exception = getattr(process, "terminate", None)
+        if callable(with_exception):
+            with_exception()
+    try:
+        process.wait(timeout=2)
+    except OSError, subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except OSError, ProcessLookupError:
+            with_exception = getattr(process, "kill", None)
+            if callable(with_exception):
+                with_exception()
+        with_exception = getattr(process, "wait", None)
+        if callable(with_exception):
+            with_exception()
+
+
+class InspectorCliAdapter:
+    """Implement the MCP driver seam with the pinned Inspector CLI."""
+
+    transport = "http"
+
+    def __init__(
+        self,
+        *,
+        mcp_url: str,
+        pat: str,
+        secrets: Iterable[str] = (),
+        secret_env_names: Iterable[str] = (),
+        package_root: Path | None = None,
+        node: str | Path | None = None,
+        timeout_seconds: float = 30,
+        installation: InspectorInstallation | None = None,
+        popen_factory: Callable[..., Any] | None = None,
+    ) -> None:
+        if not isinstance(pat, str) or not pat:
+            raise InspectorAdapterError("MCP credential is missing")
+        self._mcp_url = self._validate_mcp_url(mcp_url)
+        self._pat = pat
+        self._secrets = tuple(dict.fromkeys(secret for secret in (*secrets, pat) if secret))
+        self._secret_env_names = tuple({name for name in secret_env_names if name})
+        self._timeout_seconds = timeout_seconds
+        self._popen = popen_factory or subprocess.Popen
+        self.installation = installation or inspect_installation(package_root=package_root, node=node)
+        self._workspace: Path | None = None
+        self._config_path: Path | None = None
+        self._active_process: Any | None = None
+
+    @staticmethod
+    def _validate_mcp_url(value: str) -> str:
+        from urllib.parse import urlsplit
+
+        if not isinstance(value, str):
+            raise InspectorAdapterError("MCP endpoint is invalid")
+        try:
+            parsed = urlsplit(value)
+        except ValueError:
+            raise InspectorAdapterError("MCP endpoint is invalid") from None
+        if (
+            parsed.scheme not in {"http", "https"}
+            or not parsed.netloc
+            or parsed.username
+            or parsed.password
+            or parsed.fragment
+        ):
+            raise InspectorAdapterError("MCP endpoint is invalid")
+        return value
+
+    def _ensure_workspace(self) -> tuple[Path, Path]:
+        if self._workspace is not None and self._config_path is not None:
+            return self._workspace, self._config_path
+        workspace = Path(tempfile.mkdtemp(prefix="akb-mcp-inspector-"))
+        os.chmod(workspace, 0o700)
+        config_path = workspace / "config.json"
+        config = {
+            "mcpServers": {
+                SERVER_NAME: {
+                    "type": "http",
+                    "url": self._mcp_url,
+                    "headers": {"Authorization": f"Bearer {self._pat}"},
+                    "protocolEra": "modern",
+                }
+            }
+        }
+        try:
+            config_path.write_text(json.dumps(config, separators=(",", ":")) + "\n", encoding="utf-8")
+            os.chmod(config_path, 0o600)
+        except OSError:
+            shutil.rmtree(workspace, ignore_errors=True)
+            raise InspectorAdapterError("Inspector temporary config could not be created") from None
+        self._workspace = workspace
+        self._config_path = config_path
+        return workspace, config_path
+
+    def _environment(self, workspace: Path) -> dict[str, str]:
+        env = os.environ.copy()
+        for name in (*_ENV_NAMES_TO_CLEAR, *self._secret_env_names):
+            env.pop(name, None)
+        env["MCP_STORAGE_DIR"] = str(workspace)
+        env["MCP_INSPECTOR_SECRET_STORE"] = "memory"  # pragma: allowlist secret
+        return env
+
+    @staticmethod
+    def _arguments(
+        operation: str, config_path: Path, *, name: str | None = None, arguments: str | None = None
+    ) -> list[str]:
+        args = [
+            "--cli",
+            "--config",
+            str(config_path),
+            "--stored-auth-only",
+            "--server",
+            SERVER_NAME,
+            "--method",
+            operation,
+        ]
+        if operation == "tools/list":
+            args.append("--strict")
+        args += ["--format", "json"]
+        if operation == "tools/call":
+            assert name is not None and arguments is not None
+            args += ["--tool-name", name, "--tool-args-json", arguments]
+        return args
+
+    def _failure(
+        self,
+        operation: str,
+        *,
+        exit_code: int | None,
+        error: str,
+        diagnostics: str = "",
+        output: dict[str, Any] | None = None,
+    ) -> DriverResult:
+        return DriverResult(
+            transport=self.transport,
+            operation=operation,
+            status="failed",
+            exit_code=exit_code,
+            output=output,
+            diagnostics=_redact_text(diagnostics, self._secrets) or None,
+            error=_redact_text(error, self._secrets),
+        )
+
+    def _run(
+        self,
+        operation: str,
+        *,
+        name: str | None = None,
+        arguments: str | None = None,
+    ) -> DriverResult:
+        workspace, config_path = self._ensure_workspace()
+        command = [
+            self.installation.node,
+            str(self.installation.entry),
+            *self._arguments(operation, config_path, name=name, arguments=arguments),
+        ]
+        try:
+            process = self._popen(
+                command,
+                cwd=str(self.installation.package_root.parent.parent),
+                env=self._environment(workspace),
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                start_new_session=True,
+            )
+        except OSError:
+            return self._failure(operation, exit_code=None, error="Inspector process could not start")
+        self._active_process = process
+        try:
+            try:
+                stdout, stderr = process.communicate(timeout=self._timeout_seconds)
+            except subprocess.TimeoutExpired:
+                _terminate_process(process)
+                stdout, stderr = process.communicate()
+                return self._failure(
+                    operation,
+                    exit_code=process.returncode,
+                    error="Inspector process timed out",
+                    diagnostics=_text(stderr),
+                )
+            except BaseException:
+                _terminate_process(process)
+                with_exception = getattr(process, "communicate", None)
+                if callable(with_exception):
+                    with_exception()
+                raise
+        finally:
+            self._active_process = None
+
+        diagnostics = _text(stderr)
+        exit_code = process.returncode
+        lines = [line for line in _text(stdout).splitlines() if line.strip()]
+        if len(lines) != 1:
+            return self._failure(
+                operation,
+                exit_code=exit_code,
+                error="Inspector returned invalid JSON output",
+                diagnostics=diagnostics,
+            )
+        try:
+            parsed = json.loads(lines[0])
+        except TypeError, ValueError:
+            return self._failure(
+                operation,
+                exit_code=exit_code,
+                error="Inspector returned invalid JSON output",
+                diagnostics=diagnostics,
+            )
+        if not isinstance(parsed, dict):
+            return self._failure(
+                operation,
+                exit_code=exit_code,
+                error="Inspector output is not an object",
+                diagnostics=diagnostics,
+            )
+        output = _redact_json(parsed, self._secrets)
+        if not isinstance(parsed.get("result"), dict):
+            return self._failure(
+                operation,
+                exit_code=exit_code,
+                error="Inspector result is not an object",
+                diagnostics=diagnostics,
+                output=output,
+            )
+        if exit_code != 0:
+            return self._failure(
+                operation,
+                exit_code=exit_code,
+                error="Inspector process failed",
+                diagnostics=diagnostics,
+                output=output,
+            )
+        return DriverResult(
+            transport=self.transport,
+            operation=operation,
+            status="passed",
+            exit_code=exit_code,
+            output=output,
+            diagnostics=_redact_text(diagnostics, self._secrets) or None,
+        )
+
+    def initialize(self) -> DriverResult:
+        return self._run("initialize")
+
+    def list_tools(self) -> DriverResult:
+        return self._run("tools/list")
+
+    def call_tool(self, name: str, arguments: Mapping[str, Any]) -> DriverResult:
+        if not isinstance(name, str) or not name:
+            return self._failure("tools/call", exit_code=None, error="tool name is required")
+        if not isinstance(arguments, Mapping):
+            return self._failure("tools/call", exit_code=None, error="tool arguments must be a JSON object")
+        try:
+            encoded = json.dumps(dict(arguments), separators=(",", ":"), ensure_ascii=False)
+        except TypeError, ValueError:
+            return self._failure("tools/call", exit_code=None, error="tool arguments are not JSON serializable")
+        return self._run("tools/call", name=name, arguments=encoded)
+
+    def close(self) -> None:
+        if self._active_process is not None:
+            _terminate_process(self._active_process)
+            self._active_process = None
+        if self._workspace is not None:
+            shutil.rmtree(self._workspace, ignore_errors=True)
+            self._workspace = None
+            self._config_path = None
+        self._pat = ""
+        self._secrets = ()
+
+    def __enter__(self) -> "InspectorCliAdapter":
+        return self
+
+    def __exit__(self, _exc_type: Any, _exc_value: Any, _traceback: Any) -> None:
+        self.close()

--- a/backend/tests/mcp_e2e/runtime.py
+++ b/backend/tests/mcp_e2e/runtime.py
@@ -1,0 +1,265 @@
+"""Runtime descriptor and authenticated fixture setup for MCP scenarios."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urljoin, urlsplit
+
+import httpx
+
+
+class RuntimeSetupError(RuntimeError):
+    """Raised when the repository-owned runtime is not consumable."""
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeDescriptor:
+    """Validated, credential-free coordinates from the schema-v2 descriptor."""
+
+    scenario: str
+    app_origin: str
+    app_health_url: str
+    fixture_health_url: str
+    reset_url: str
+    reset_body: dict[str, Any]
+    discovery_url: str
+    username_env: str
+    password_env: str
+    pat_env: str | None
+    login_path: str
+
+    @property
+    def mcp_url(self) -> str:
+        return urljoin(f"{self.app_origin}/", "mcp/")
+
+    @classmethod
+    def from_json(cls, raw: str) -> "RuntimeDescriptor":
+        try:
+            descriptor = json.loads(raw)
+        except TypeError, ValueError:
+            raise RuntimeSetupError("runtime descriptor is invalid JSON") from None
+        if not isinstance(descriptor, dict):
+            raise RuntimeSetupError("runtime descriptor must be an object")
+        if descriptor.get("schema_version") != 2 or descriptor.get("status") != "ready":
+            raise RuntimeSetupError("runtime descriptor must be a ready schema-v2 descriptor")
+        scenario = _required_string(descriptor.get("scenario"), "descriptor scenario")
+        services = _required_object(descriptor.get("services"), "descriptor services")
+        app = _required_object(services.get("app"), "app service")
+        fixture = _required_object(services.get("fixture"), "fixture service")
+        app_origin = _origin(app.get("origin"), "app origin")
+        fixture_origin = _origin(fixture.get("origin"), "fixture origin")
+        app_health_url = _same_origin(app.get("health"), app_origin, "app health")
+        fixture_health_url = _same_origin(fixture.get("health"), fixture_origin, "fixture health")
+        reset = _required_object(fixture.get("reset"), "fixture reset")
+        if reset.get("method") != "POST":
+            raise RuntimeSetupError("fixture reset must use POST")
+        reset_url = _same_origin(reset, fixture_origin, "fixture reset")
+        reset_body = _required_object(reset.get("body"), "fixture reset body")
+        if reset_body.get("scenario") != scenario:
+            raise RuntimeSetupError("fixture reset scenario does not match descriptor")
+        discovery_url = _same_origin(fixture.get("discovery"), fixture_origin, "fixture discovery")
+        credentials = _required_object(descriptor.get("credentials"), "descriptor credentials")
+        username_env = _environment_name(credentials.get("username_env"), "username environment name")
+        password_env = _environment_name(credentials.get("password_env"), "password environment name")
+        pat_env_value = credentials.get("pat_env")
+        pat_env = _environment_name(pat_env_value, "PAT environment name") if pat_env_value is not None else None
+        login_path = _path(credentials.get("login_path"), "credential login path")
+        return cls(
+            scenario=scenario,
+            app_origin=app_origin,
+            app_health_url=app_health_url,
+            fixture_health_url=fixture_health_url,
+            reset_url=reset_url,
+            reset_body=dict(reset_body),
+            discovery_url=discovery_url,
+            username_env=username_env,
+            password_env=password_env,
+            pat_env=pat_env,
+            login_path=login_path,
+        )
+
+
+def _required_object(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise RuntimeSetupError(f"{label} must be an object")
+    return value
+
+
+def _required_string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise RuntimeSetupError(f"{label} is required")
+    return value
+
+
+def _origin(value: Any, label: str) -> str:
+    candidate = _required_string(value, label)
+    try:
+        parsed = urlsplit(candidate)
+    except ValueError:
+        raise RuntimeSetupError(f"{label} must be an HTTP(S) origin") from None
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.netloc
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise RuntimeSetupError(f"{label} must be an HTTP(S) origin")
+    if parsed.path not in {"", "/"}:
+        raise RuntimeSetupError(f"{label} must be an HTTP(S) origin")
+    return candidate.rstrip("/")
+
+
+def _same_origin(value: Any, base: str, label: str) -> str:
+    item = _required_object(value, label)
+    raw_url = _required_string(item.get("url"), label)
+    candidate = urljoin(f"{base}/", raw_url)
+    try:
+        parsed = urlsplit(candidate)
+        base_parsed = urlsplit(base)
+    except ValueError:
+        raise RuntimeSetupError(f"{label} must stay on its declared origin") from None
+    if (
+        parsed.scheme != base_parsed.scheme
+        or parsed.netloc != base_parsed.netloc
+        or parsed.username
+        or parsed.password
+        or parsed.fragment
+    ):
+        raise RuntimeSetupError(f"{label} must stay on its declared origin")
+    return candidate
+
+
+def _path(value: Any, label: str) -> str:
+    path = _required_string(value, label)
+    if not path.startswith("/") or path.startswith("//") or "#" in path:
+        raise RuntimeSetupError(f"{label} is invalid")
+    return path
+
+
+def _environment_name(value: Any, label: str) -> str:
+    name = _required_string(value, label)
+    if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name) is None:
+        raise RuntimeSetupError(f"{label} is invalid")
+    return name
+
+
+class RuntimeSession:
+    """Reset the existing runtime and obtain one in-memory read credential."""
+
+    def __init__(self, descriptor: RuntimeDescriptor, client: httpx.Client | None = None) -> None:
+        self.descriptor = descriptor
+        self.client = client or httpx.Client(timeout=30.0)
+        self.pat = ""
+        self.secrets: tuple[str, ...] = ()
+        self._closed = False
+
+    @classmethod
+    def from_json(cls, raw: str, client: httpx.Client | None = None) -> "RuntimeSession":
+        return cls(RuntimeDescriptor.from_json(raw), client=client)
+
+    @property
+    def credential_env_names(self) -> tuple[str, ...]:
+        return tuple(
+            name
+            for name in (self.descriptor.username_env, self.descriptor.password_env, self.descriptor.pat_env)
+            if name is not None
+        )
+
+    def _request_json(
+        self,
+        method: str,
+        url: str,
+        *,
+        stage: str,
+        body: Mapping[str, Any] | None = None,
+        authorization: str | None = None,
+    ) -> dict[str, Any]:
+        headers = {"Authorization": authorization} if authorization else None
+        try:
+            response = self.client.request(method, url, json=body, headers=headers)
+        except httpx.HTTPError:
+            raise RuntimeSetupError(f"{stage} request failed") from None
+        if response.status_code != 200:
+            raise RuntimeSetupError(f"{stage} returned HTTP {response.status_code}")
+        try:
+            value = response.json()
+        except ValueError:
+            raise RuntimeSetupError(f"{stage} returned invalid JSON") from None
+        if not isinstance(value, dict):
+            raise RuntimeSetupError(f"{stage} returned an invalid object")
+        return value
+
+    def _ready(self, stage: str) -> None:
+        app = self._request_json("GET", self.descriptor.app_health_url, stage=f"{stage} app health")
+        fixture = self._request_json("GET", self.descriptor.fixture_health_url, stage=f"{stage} fixture health")
+        if app.get("status") != "ready" or fixture.get("status") != "ready":
+            raise RuntimeSetupError(f"{stage} runtime is not ready")
+
+    def prepare(self) -> None:
+        self._ready("before reset")
+        discovery = self._request_json("GET", self.descriptor.discovery_url, stage="fixture discovery")
+        if discovery.get("status") != "ready" or discovery.get("scenario") != self.descriptor.scenario:
+            raise RuntimeSetupError("fixture discovery is not ready for this scenario")
+        access = _required_object(discovery.get("access"), "fixture access")
+        login = _required_object(access.get("login"), "fixture login")
+        if login.get("path") != self.descriptor.login_path:
+            raise RuntimeSetupError("descriptor and discovery login paths disagree")
+        runtime = _required_object(discovery.get("runtime"), "fixture runtime")
+        pat = _required_object(runtime.get("pat"), "fixture PAT")
+        mint = _required_object(pat.get("mint"), "fixture PAT mint")
+        mint_path = _path(mint.get("path"), "fixture PAT mint path")
+
+        reset_result = self._request_json(
+            "POST",
+            self.descriptor.reset_url,
+            stage="fixture reset",
+            body=self.descriptor.reset_body,
+        )
+        if reset_result.get("status") != "ready" or reset_result.get("scenario") != self.descriptor.scenario:
+            raise RuntimeSetupError("fixture reset did not return the selected ready scenario")
+        self._ready("after reset")
+        after_reset = self._request_json("GET", self.descriptor.discovery_url, stage="fixture discovery after reset")
+        if after_reset.get("status") != "ready" or after_reset.get("scenario") != self.descriptor.scenario:
+            raise RuntimeSetupError("fixture discovery is not ready after reset")
+
+        username = os.environ.get(self.descriptor.username_env, "")
+        password = os.environ.get(self.descriptor.password_env, "")
+        if not username or not password:
+            raise RuntimeSetupError("declared credential environment values are missing")
+        self.secrets = (username, password)
+        login_response = self._request_json(
+            "POST",
+            urljoin(f"{self.descriptor.app_origin}/", self.descriptor.login_path.lstrip("/")),
+            stage="credential login",
+            body={"username": username, "password": password},
+        )
+        session = login_response.get("token")
+        if not isinstance(session, str) or not session:
+            raise RuntimeSetupError("credential login returned no session token")
+        self.secrets = (*self.secrets, session)
+        mint_response = self._request_json(
+            "POST",
+            urljoin(f"{self.descriptor.app_origin}/", mint_path.lstrip("/")),
+            stage="credential mint",
+            authorization=f"Bearer {session}",
+            body={"name": "mcp-pytest"},
+        )
+        token = mint_response.get("token")
+        if not isinstance(token, str) or not token.startswith("akb_"):
+            raise RuntimeSetupError("credential mint returned an invalid PAT")
+        self.pat = token
+        self.secrets = (*self.secrets, token)
+
+    def close(self) -> None:
+        if not self._closed:
+            self._closed = True
+            self.client.close()
+            self.pat = ""
+            self.secrets = ()

--- a/backend/tests/mcp_e2e/test_inspector_adapter.py
+++ b/backend/tests/mcp_e2e/test_inspector_adapter.py
@@ -1,0 +1,186 @@
+"""Focused regression tests for the Inspector driver adapter."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from .inspector_adapter import (
+    INSPECTOR_BIN,
+    INSPECTOR_PACKAGE,
+    INSPECTOR_VERSION,
+    MIN_NODE_VERSION,
+    InspectorCliAdapter,
+    InspectorInstallation,
+    inspect_installation,
+)
+
+
+def _fake_installation(tmp_path: Path) -> InspectorInstallation:
+    package_root = tmp_path / "client"
+    inspector_root = package_root / "node_modules" / INSPECTOR_PACKAGE
+    inspector_root.mkdir(parents=True)
+    entry = inspector_root / INSPECTOR_BIN
+    entry.parent.mkdir(parents=True, exist_ok=True)
+    entry.write_text("// public launcher\n", encoding="utf-8")
+    (package_root / "package.json").write_text(
+        json.dumps({"devDependencies": {INSPECTOR_PACKAGE: INSPECTOR_VERSION}}),
+        encoding="utf-8",
+    )
+    (package_root / "package-lock.json").write_text(
+        json.dumps({"packages": {f"node_modules/{INSPECTOR_PACKAGE}": {"version": INSPECTOR_VERSION}}}),
+        encoding="utf-8",
+    )
+    (inspector_root / "package.json").write_text(
+        json.dumps(
+            {
+                "name": INSPECTOR_PACKAGE,
+                "version": INSPECTOR_VERSION,
+                "engines": {"node": f">={MIN_NODE_VERSION}"},
+                "bin": {"mcp-inspector": f"./{INSPECTOR_BIN}"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    node = tmp_path / "node"
+    node.write_text("#!/bin/sh\nprintf 'v22.19.0\\n'\n", encoding="utf-8")
+    node.chmod(node.stat().st_mode | stat.S_IXUSR)
+    return InspectorInstallation(
+        package_root=package_root,
+        node=str(node),
+        node_version="22.19.0",
+        entry=entry,
+    )
+
+
+def test_installation_requires_exact_package_and_public_bin(tmp_path: Path) -> None:
+    installation = _fake_installation(tmp_path)
+    checked = inspect_installation(package_root=installation.package_root, node=installation.node)
+    assert checked.entry == installation.entry.resolve()
+    assert checked.node_version == "22.19.0"
+
+
+class _FakeProcess:
+    def __init__(self, output: dict[str, Any], *, returncode: int = 0, stderr: str = "") -> None:
+        self.output = output
+        self.returncode = returncode
+        self.stderr = stderr
+        self.pid = os.getpid()
+        self.command: list[str] | None = None
+        self.options: dict[str, Any] | None = None
+
+    def poll(self) -> int:
+        return self.returncode
+
+    def communicate(self, timeout: float | None = None) -> tuple[str, str]:
+        del timeout
+        return json.dumps(self.output) + "\n", self.stderr
+
+    def wait(self, timeout: float | None = None) -> int:
+        del timeout
+        return self.returncode
+
+
+def test_adapter_uses_public_cli_and_cleans_redacted_state(tmp_path: Path) -> None:
+    installation = _fake_installation(tmp_path)
+    marker = "akb_test_secret_marker"
+    processes: list[_FakeProcess] = []
+
+    def popen(command: list[str], **options: Any) -> _FakeProcess:
+        method = command[command.index("--method") + 1]
+        config = Path(command[command.index("--config") + 1])
+        assert config.stat().st_mode & 0o777 == 0o600
+        assert config.parent.stat().st_mode & 0o777 == 0o700
+        assert (
+            json.loads(config.read_text(encoding="utf-8"))["mcpServers"]["akb"]["headers"]["Authorization"]
+            == f"Bearer {marker}"
+        )
+        assert marker not in command
+        assert options["env"].get("AKB_TEST_PASSWORD") is None
+        assert options["env"].get("AKB_TEST_PAT") is None
+        payload: dict[str, Any]
+        if method == "initialize":
+            payload = {"result": {"protocolVersion": "2026-07-28", "serverInfo": {"name": "akb", "version": "1"}}}
+        elif method == "tools/list":
+            payload = {"result": {"tools": [{"name": "akb_list_vaults", "inputSchema": {"type": "object"}}]}}
+        else:
+            payload = {
+                "result": {
+                    "content": [
+                        {"type": "text", "text": json.dumps({"vaults": [], "total": 0, "returned": 0, "token": marker})}
+                    ],
+                    "isError": False,
+                }
+            }
+        process = _FakeProcess(payload, stderr=f"diagnostic {marker}")
+        process.command = command
+        process.options = options
+        processes.append(process)
+        return process
+
+    adapter = InspectorCliAdapter(
+        mcp_url="http://127.0.0.1:8000/mcp/",
+        pat=marker,
+        secrets=(marker, "fixture-password"),
+        secret_env_names=("AKB_TEST_PASSWORD", "AKB_TEST_PAT"),
+        installation=installation,
+        popen_factory=popen,
+    )
+    try:
+        assert adapter.initialize().passed
+        assert adapter.list_tools().passed
+        result = adapter.call_tool("akb_list_vaults", {})
+        assert result.passed
+        assert marker not in json.dumps(result.output)
+        assert marker not in (result.diagnostics or "")
+        assert processes[2].command is not None
+        assert processes[2].command[-4:] == ["--tool-name", "akb_list_vaults", "--tool-args-json", "{}"]
+        assert all(process.options["env"].get("AKB_TEST_PASSWORD") is None for process in processes if process.options)
+        first_options = processes[0].options
+        assert first_options is not None
+        workspace = first_options["env"]["MCP_STORAGE_DIR"]
+    finally:
+        adapter.close()
+    assert not Path(workspace).exists()
+
+
+@pytest.mark.parametrize(
+    ("output", "returncode", "expected"),
+    [
+        ({"error": {"message": "failed"}}, 0, "Inspector result is not an object"),
+        (None, 0, "Inspector returned invalid JSON output"),
+        ({"result": {}}, 7, "Inspector process failed"),
+    ],
+)
+def test_adapter_fails_closed_for_bad_output_and_exit(
+    tmp_path: Path,
+    output: dict[str, Any] | None,
+    returncode: int,
+    expected: str,
+) -> None:
+    installation = _fake_installation(tmp_path)
+
+    def popen(_command: list[str], **_options: Any) -> _FakeProcess:
+        if output is None:
+            process = _FakeProcess({}, returncode=returncode)
+            process.communicate = lambda timeout=None: ("not-json\n", "")  # type: ignore[method-assign]
+            return process
+        return _FakeProcess(output, returncode=returncode)
+
+    adapter = InspectorCliAdapter(
+        mcp_url="http://127.0.0.1:8000/mcp/",
+        pat="akb_test_token",
+        installation=installation,
+        popen_factory=popen,
+    )
+    try:
+        result = adapter.initialize()
+        assert result.status == "failed"
+        assert result.error == expected
+    finally:
+        adapter.close()

--- a/backend/tests/mcp_e2e/test_list_vaults_e2e.py
+++ b/backend/tests/mcp_e2e/test_list_vaults_e2e.py
@@ -1,0 +1,84 @@
+"""The first product behavior scenario: authenticated list-vaults."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from .driver import DriverResult, McpClientDriver
+
+SCENARIO = "akb_list_vaults"
+PROTOCOL_VERSION = "2026-07-28"
+
+
+def _payload(driver: McpClientDriver, operation: str, result: DriverResult) -> dict[str, Any]:
+    if not result.passed:
+        detail = result.error or "operation failed"
+        pytest.fail(f"scenario={SCENARIO} transport={driver.transport} operation={operation}: {detail}")
+    assert result.output is not None
+    payload = result.output.get("result")
+    if not isinstance(payload, dict):
+        pytest.fail(f"scenario={SCENARIO} transport={driver.transport} operation={operation}: missing result object")
+    return payload
+
+
+def test_akb_list_vaults_mcp_e2e(mcp_driver: McpClientDriver) -> None:
+    initialize = _payload(mcp_driver, "initialize", mcp_driver.initialize())
+    if initialize.get("protocolVersion") != PROTOCOL_VERSION:
+        pytest.fail(f"scenario={SCENARIO} transport={mcp_driver.transport} operation=initialize: unsupported protocol")
+    server_info = initialize.get("serverInfo")
+    if not isinstance(server_info, Mapping):
+        metadata = initialize.get("_meta")
+        server_info = metadata.get("io.modelcontextprotocol/serverInfo") if isinstance(metadata, Mapping) else None
+    if (
+        not isinstance(server_info, Mapping)
+        or server_info.get("name") != "akb"
+        or not isinstance(server_info.get("version"), str)
+    ):
+        pytest.fail(f"scenario={SCENARIO} transport={mcp_driver.transport} operation=initialize: unexpected server")
+
+    tools = _payload(mcp_driver, "tools/list", mcp_driver.list_tools())
+    catalog = tools.get("tools")
+    if not isinstance(catalog, list) or not any(
+        isinstance(tool, Mapping)
+        and tool.get("name") == "akb_list_vaults"
+        and isinstance(tool.get("inputSchema"), Mapping)
+        for tool in catalog
+    ):
+        pytest.fail(
+            f"scenario={SCENARIO} transport={mcp_driver.transport} operation=tools/list: akb_list_vaults is missing"
+        )
+
+    call = _payload(mcp_driver, "tools/call", mcp_driver.call_tool("akb_list_vaults", {}))
+    if call.get("isError") is not False:
+        pytest.fail(
+            f"scenario={SCENARIO} transport={mcp_driver.transport} operation=tools/call: tool returned an error"
+        )
+    content = call.get("content")
+    text = content[0].get("text") if isinstance(content, list) and content and isinstance(content[0], Mapping) else None
+    if not isinstance(text, str):
+        pytest.fail(f"scenario={SCENARIO} transport={mcp_driver.transport} operation=tools/call: missing public JSON")
+    try:
+        public = json.loads(text)
+    except TypeError, ValueError:
+        pytest.fail(f"scenario={SCENARIO} transport={mcp_driver.transport} operation=tools/call: invalid public JSON")
+    if not isinstance(public, Mapping):
+        pytest.fail(
+            f"scenario={SCENARIO} transport={mcp_driver.transport} operation=tools/call: result is not an object"
+        )
+    vaults = public.get("vaults")
+    total = public.get("total")
+    returned = public.get("returned")
+    if (
+        not isinstance(vaults, list)
+        or type(total) is not int
+        or type(returned) is not int
+        or returned != len(vaults)
+        or total < returned
+    ):
+        pytest.fail(
+            f"scenario={SCENARIO} transport={mcp_driver.transport} operation=tools/call: invalid list-vaults result"
+        )

--- a/backend/tests/mcp_e2e/test_runtime.py
+++ b/backend/tests/mcp_e2e/test_runtime.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import sys
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -90,6 +94,32 @@ def test_runtime_session_reuses_descriptor_reset_and_redacts_pat_environment(mon
     assert mint[3] == {"Authorization": "Bearer session-secret"}
     session.close()
     assert client.closed
+
+
+def test_descriptor_stdin_survives_pytest_capture(tmp_path: Path) -> None:
+    probe = tmp_path / "test_descriptor_pipe.py"
+    probe.write_text(
+        "import json\n"
+        "from mcp_e2e.conftest import _read_descriptor\n"
+        "\n"
+        "def test_pipe(request):\n"
+        "    manager = request.config.pluginmanager.getplugin('capturemanager')\n"
+        "    assert json.loads(_read_descriptor('-', manager)) == {'ok': True}\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    test_root = Path(__file__).resolve().parents[1]
+    env["PYTHONPATH"] = f"{test_root}{os.pathsep}{env.get('PYTHONPATH', '')}"
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", str(probe), "-q"],
+        cwd=tmp_path,
+        env=env,
+        input='{"ok":true}\n',
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/mcp_e2e/test_runtime.py
+++ b/backend/tests/mcp_e2e/test_runtime.py
@@ -1,0 +1,107 @@
+"""Focused regression tests for descriptor and fixture boundaries."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from .runtime import RuntimeSession, RuntimeSetupError
+
+
+def _descriptor() -> dict[str, Any]:
+    return {
+        "schema_version": 2,
+        "status": "ready",
+        "scenario": "empty",
+        "services": {
+            "app": {
+                "origin": "http://127.0.0.1:8000",
+                "health": {"method": "GET", "url": "http://127.0.0.1:8000/readyz"},
+            },
+            "fixture": {
+                "origin": "http://127.0.0.1:8889",
+                "health": {"method": "GET", "url": "http://127.0.0.1:8889/health"},
+                "reset": {
+                    "method": "POST",
+                    "url": "http://127.0.0.1:8889/reset",
+                    "body": {"scenario": "empty"},
+                },
+                "discovery": {"method": "GET", "url": "http://127.0.0.1:8889/discover"},
+            },
+        },
+        "credentials": {
+            "username_env": "AKB_TEST_USERNAME",
+            "password_env": "AKB_TEST_PASSWORD",  # pragma: allowlist secret
+            "pat_env": "AKB_TEST_PAT",
+            "login_path": "/api/v1/auth/login",
+        },
+    }
+
+
+class _FixtureClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any] | None, dict[str, str] | None]] = []
+        self.closed = False
+
+    def request(
+        self, method: str, url: str, *, json: dict[str, Any] | None = None, headers: dict[str, str] | None = None
+    ) -> httpx.Response:
+        self.calls.append((method, url, json, headers))
+        if url.endswith("/readyz") or url.endswith("/health"):
+            body: dict[str, Any] = {"status": "ready"}
+        elif url.endswith("/discover"):
+            body = {
+                "status": "ready",
+                "scenario": "empty",
+                "access": {"login": {"path": "/api/v1/auth/login"}},
+                "runtime": {"pat": {"mint": {"path": "/api/v1/auth/tokens"}}},
+            }
+        elif url.endswith("/reset"):
+            body = {"status": "ready", "scenario": "empty"}
+        elif url.endswith("/auth/login"):
+            body = {"token": "session-secret"}
+        elif url.endswith("/auth/tokens"):
+            body = {"token": "akb_pat-secret"}
+        else:
+            body = {}
+        return httpx.Response(200, json=body, request=httpx.Request(method, url))
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_runtime_session_reuses_descriptor_reset_and_redacts_pat_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AKB_TEST_USERNAME", "fixture-user")
+    monkeypatch.setenv("AKB_TEST_PASSWORD", "fixture-password")
+    monkeypatch.setenv("AKB_TEST_PAT", "stale-pat")
+    client = _FixtureClient()
+    session = RuntimeSession.from_json(json.dumps(_descriptor()), client=client)  # type: ignore[arg-type]
+
+    session.prepare()
+
+    assert session.pat == "akb_pat-secret"
+    assert session.credential_env_names == ("AKB_TEST_USERNAME", "AKB_TEST_PASSWORD", "AKB_TEST_PAT")
+    reset = next(call for call in client.calls if call[1].endswith("/reset"))
+    assert reset[0] == "POST" and reset[2] == {"scenario": "empty"}
+    mint = next(call for call in client.calls if call[1].endswith("/auth/tokens"))
+    assert mint[3] == {"Authorization": "Bearer session-secret"}
+    session.close()
+    assert client.closed
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        lambda value: value["services"]["fixture"]["reset"].update({"method": "GET"}),
+        lambda value: value["services"]["fixture"]["reset"].update({"body": {"scenario": "other"}}),
+        lambda value: value["services"]["fixture"]["reset"].update({"url": "http://evil.example/reset"}),
+    ],
+)
+def test_runtime_descriptor_rejects_incompatible_fixture_contract(change: Any) -> None:
+    value = _descriptor()
+    change(value)
+    with pytest.raises(RuntimeSetupError):
+        RuntimeSession.from_json(json.dumps(value))

--- a/backend/tests/test_e2e_runtime_unit.py
+++ b/backend/tests/test_e2e_runtime_unit.py
@@ -488,6 +488,18 @@ async def test_gate_child_stdout_is_private_and_stderr_is_inherited(tmp_path, ca
         "\"suite\":\"test_fake.sh\",\"returncode\":132}', file=sys.stderr)\n",
         encoding="utf-8",
     )
+    mcp_pytest_path = checkout / "backend" / "tests" / "mcp_e2e"
+    mcp_pytest_path.mkdir(parents=True)
+    (mcp_pytest_path / "conftest.py").write_text(
+        "def pytest_addoption(parser):\n"
+        "    parser.addoption('--runtime-descriptor')\n",
+        encoding="utf-8",
+    )
+    (mcp_pytest_path / "test_fake.py").write_text(
+        "def test_fake():\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
     config = RuntimeConfig(
         checkout=checkout,
         runtime_root=tmp_path / "runtime",
@@ -1043,6 +1055,11 @@ def test_ubuntu_bootstrap_is_bash_safe_and_keeps_descriptor_stdout_clean():
     assert 'apt-get install -y nodejs npm' in text
     assert 'command -v node' in text
     assert 'command -v npm' in text
+    assert 'Node.js >=22.19.0 is unavailable' in text
+    assert 'sha256sum --check --status' in text
+    assert 'ln -sfn "$NODE_BIN" /usr/local/bin/node' in text
+    assert 'install -m 0755 "$UV_BIN" /usr/local/bin/uv' in text
+    assert 'ci --prefix "$CHECKOUT/packages/akb-mcp-client"' in text
     assert "Node.js/npm package installation failed" in text
     assert "uv sync --locked" in text
     assert "exec 1>&3 3>&-" in text


### PR DESCRIPTION
기존 인증 HTTP runtime에서 `akb_list_vaults({})`를 검증하는 pytest 시나리오와 exact-pinned Inspector CLI adapter를 연결합니다. 시나리오는 공개 응답 assertion을, adapter는 client process와 정리를 소유하며, 기존 supervisor는 runtime lifecycle을 계속 관리합니다.

로컬·CI가 같은 pytest entrypoint를 사용하고 기존 Inspector consumer smoke와 transport/shell 검증을 유지합니다. Ubuntu bootstrap은 새 operator shell에서도 필요한 Node와 uv를 사용할 수 있게 준비합니다.

검증한 최종 커밋의 [전체 E2E](https://github.com/dnotitia/akb/actions/runs/33708230347), [backend·pgvector 검사](https://github.com/dnotitia/akb/actions/runs/33708230339), [정적 분석·프론트엔드·보안 검사](https://github.com/dnotitia/akb/actions/runs/33708230435)가 모두 통과했습니다. 전체 E2E에는 새 pytest 호출 성공과 기존 shell 검사 831개 통과가 포함됩니다. 집중·runtime 테스트 44개와 독립 정확성·복잡성 리뷰도 완료했습니다.

별도 격리 환경의 독립 행동 검증 결과:

- 정상 실행과 fixture 초기화 후 반복 실행: 각각 11개 통과, 종료 코드 0.
- 잘못된 자격 증명: 종료 코드 1, 성공으로 오인하지 않음.
- SIGINT 중단 후 재실행: 11개 통과, Inspector 잔존 프로세스 없음, backend·fixture 준비 상태 유지.
- 캡처 및 runtime의 비밀정보 검사: 누출 0건.

[검증한 커밋](https://github.com/dnotitia/akb/commit/86a43986418eb1b560e4225a3013edf4fc0cda94)에서 마지막 변경은 실행 명령을 보완한 문서 두 곳이며, 독립 검증 runtime과 모든 실행 파일·테스트·lockfile이 동일함을 확인했습니다.

관련 이슈: AKB-252
