### PR TITLE
Fix Native cutover history indexing and authority fencing

### DIFF
--- a/backend/app/db/migrations/096_native_revision_cutover_fence.py
+++ b/backend/app/db/migrations/096_native_revision_cutover_fence.py
@@ -1,0 +1,163 @@
+"""Migration 096: durable two-phase Native cutover fence state."""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("akb.migration.096")
+
+
+async def migrate(conn=None):
+    if conn is None:
+        from app.db.postgres import get_pool
+
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _run(conn):
+    required = (
+        "native_revision_cutover_runs",
+        "native_revision_legacy_write_fence",
+    )
+    missing = [
+        name
+        for name in required
+        if await conn.fetchval("SELECT to_regclass($1) IS NULL", f"public.{name}")
+    ]
+    if missing:
+        logger.info(
+            "Migration 096 skipped: required cutover table(s) are absent: %s",
+            ", ".join(missing),
+        )
+        return
+
+    authority_table_present = await conn.fetchval(
+        "SELECT to_regclass('public.native_revision_existing_authority') IS NOT NULL"
+    )
+
+    async with conn.transaction():
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS native_revision_existing_authority_fence (
+                fence_key BOOLEAN PRIMARY KEY DEFAULT TRUE,
+                fence_token UUID NOT NULL UNIQUE,
+                cutover_id UUID NOT NULL UNIQUE
+                    REFERENCES native_revision_cutover_runs(cutover_id) ON DELETE RESTRICT,
+                legacy_write_epoch BIGINT NOT NULL,
+                tenant_id TEXT NOT NULL,
+                namespace TEXT NOT NULL,
+                database_id UUID NOT NULL,
+                current_database TEXT NOT NULL,
+                runtime_image_digest TEXT NOT NULL,
+                inventory_digest TEXT NOT NULL,
+                verification_digest TEXT NOT NULL,
+                vault_binding_digest TEXT NOT NULL,
+                fenced_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                CONSTRAINT native_revision_existing_authority_fence_singleton_check
+                    CHECK (fence_key),
+                CONSTRAINT native_revision_existing_authority_fence_epoch_check
+                    CHECK (legacy_write_epoch > 0),
+                CONSTRAINT native_revision_existing_authority_fence_tenant_check
+                    CHECK (btrim(tenant_id) <> ''),
+                CONSTRAINT native_revision_existing_authority_fence_namespace_check
+                    CHECK (btrim(namespace) <> ''),
+                CONSTRAINT native_revision_existing_authority_fence_database_check
+                    CHECK (btrim(current_database) <> ''),
+                CONSTRAINT native_revision_existing_authority_fence_image_check
+                    CHECK (runtime_image_digest ~ '^sha256:[0-9a-f]{64}$'),
+                CONSTRAINT native_revision_existing_authority_fence_inventory_check
+                    CHECK (inventory_digest ~ '^[0-9a-f]{64}$'),
+                CONSTRAINT native_revision_existing_authority_fence_verification_check
+                    CHECK (verification_digest ~ '^[0-9a-f]{64}$'),
+                CONSTRAINT native_revision_existing_authority_fence_binding_check
+                    CHECK (vault_binding_digest ~ '^[0-9a-f]{64}$')
+            );
+
+            -- Databases that already completed the pre-096 one-transaction
+            -- cutover need a durable phase-A receipt before the new API is
+            -- allowed to inspect or resume that authority.  This is a
+            -- one-time compatibility backfill; future rows are inserted by
+            -- phase A and are never updated.
+
+            CREATE OR REPLACE FUNCTION guard_native_revision_existing_authority_fence_mutation()
+            RETURNS TRIGGER LANGUAGE plpgsql AS $guard$
+            BEGIN
+                IF TG_OP = 'DELETE' THEN
+                    RAISE EXCEPTION 'existing database authority fence cannot be deleted'
+                        USING ERRCODE = '55000';
+                END IF;
+                RAISE EXCEPTION 'existing database authority fence is immutable'
+                    USING ERRCODE = '55000';
+            END;
+            $guard$;
+
+            DROP TRIGGER IF EXISTS guard_native_revision_existing_authority_fence
+                ON native_revision_existing_authority_fence;
+            CREATE TRIGGER guard_native_revision_existing_authority_fence
+                BEFORE UPDATE OR DELETE ON native_revision_existing_authority_fence
+                FOR EACH ROW EXECUTE FUNCTION
+                    guard_native_revision_existing_authority_fence_mutation();
+
+            CREATE OR REPLACE FUNCTION reject_fenced_native_revision_cutover_write()
+            RETURNS TRIGGER LANGUAGE plpgsql AS $guard$
+            DECLARE
+                fence_state TEXT;
+                fence_epoch BIGINT;
+            BEGIN
+                SELECT state, epoch
+                  INTO fence_state, fence_epoch
+                  FROM native_revision_legacy_write_fence
+                 WHERE fence_key = TRUE;
+                IF NOT FOUND THEN
+                    RAISE EXCEPTION 'Native Legacy write fence is missing'
+                        USING ERRCODE = '55000';
+                END IF;
+                IF fence_state = 'fenced' THEN
+                    RAISE EXCEPTION 'Native cutover writes are fenced at epoch %', fence_epoch
+                        USING ERRCODE = '55000';
+                END IF;
+                IF TG_OP = 'TRUNCATE' THEN
+                    RETURN NULL;
+                END IF;
+                IF TG_OP = 'DELETE' THEN
+                    RETURN OLD;
+                END IF;
+                RETURN NEW;
+            END;
+            $guard$;
+            """
+        )
+        if authority_table_present:
+            await conn.execute(
+                """
+                INSERT INTO native_revision_existing_authority_fence (
+                    fence_key, fence_token, cutover_id, legacy_write_epoch,
+                    tenant_id, namespace, database_id, current_database,
+                    runtime_image_digest, inventory_digest, verification_digest,
+                    vault_binding_digest, fenced_at, created_at
+                )
+                SELECT TRUE, uuid_generate_v4(), authority.cutover_id,
+                       authority.legacy_write_epoch, authority.tenant_id,
+                       authority.namespace, authority.database_id,
+                       authority.current_database, authority.runtime_image_digest,
+                       authority.inventory_digest, authority.verification_digest,
+                       authority.vault_binding_digest,
+                       COALESCE(legacy.fenced_at, authority.created_at, NOW()),
+                       COALESCE(authority.created_at, NOW())
+                  FROM native_revision_existing_authority authority
+                  JOIN native_revision_legacy_write_fence legacy
+                    ON legacy.fence_key = TRUE
+                   AND legacy.state = 'committed'
+                   AND legacy.epoch = authority.legacy_write_epoch
+                   AND legacy.cutover_id = authority.cutover_id
+                 WHERE authority.marker_id = TRUE
+                   AND authority.status = 'committed'
+                ON CONFLICT (fence_key) DO NOTHING
+                """
+            )
+    logger.info("Migration 096: two-phase Native cutover fence state ready")

--- a/backend/app/db/migrations/097_native_revision_migration_inventory.py
+++ b/backend/app/db/migrations/097_native_revision_migration_inventory.py
@@ -1,0 +1,111 @@
+"""Migration 097: persist one immutable fixed-ref inventory per migration run."""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("akb.migration.097")
+
+
+async def migrate(conn=None):
+    if conn is None:
+        from app.db.postgres import get_pool
+
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _run(conn):
+    if await conn.fetchval("SELECT to_regclass('public.native_revision_migration_runs')") is None:
+        logger.info("Migration 097 skipped: native revision migration runs are absent")
+        return
+
+    async with conn.transaction():
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS native_revision_migration_inventories (
+                run_id UUID PRIMARY KEY,
+                namespace_id UUID NOT NULL,
+                fixed_git_oid TEXT NOT NULL,
+                coverage_version TEXT NOT NULL,
+                inventory_digest TEXT NOT NULL,
+                payload JSONB NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                CONSTRAINT native_revision_migration_inventories_run_fkey
+                    FOREIGN KEY (run_id, namespace_id)
+                    REFERENCES native_revision_migration_runs(run_id, namespace_id)
+                    ON DELETE CASCADE,
+                CONSTRAINT native_revision_migration_inventories_fixed_oid_shape
+                    CHECK (fixed_git_oid ~ '^[0-9a-f]{40}$'),
+                CONSTRAINT native_revision_migration_inventories_coverage_check
+                    CHECK (btrim(coverage_version) <> ''),
+                CONSTRAINT native_revision_migration_inventories_digest_shape
+                    CHECK (inventory_digest ~ '^[0-9a-f]{64}$'),
+                CONSTRAINT native_revision_migration_inventories_payload_shape
+                    CHECK (
+                        jsonb_typeof(payload) = 'object'
+                        AND payload->>'schema' = 'c9-fixed-ref-inventory-v1'
+                        AND jsonb_typeof(payload->'documents') = 'array'
+                    )
+            );
+
+            CREATE OR REPLACE FUNCTION akb_check_native_revision_migration_inventory()
+            RETURNS TRIGGER
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1
+                      FROM native_revision_migration_runs run
+                     WHERE run.run_id = NEW.run_id
+                       AND run.namespace_id = NEW.namespace_id
+                       AND run.fixed_git_oid = NEW.fixed_git_oid
+                       AND run.coverage_version = NEW.coverage_version
+                       AND run.inventory_digest = NEW.inventory_digest
+                ) THEN
+                    RAISE EXCEPTION
+                        'migration inventory does not match its run authority'
+                        USING ERRCODE = '23514';
+                END IF;
+                RETURN NEW;
+            END;
+            $$;
+
+            DROP TRIGGER IF EXISTS native_revision_migration_inventory_binding
+                ON native_revision_migration_inventories;
+            CREATE TRIGGER native_revision_migration_inventory_binding
+                BEFORE INSERT ON native_revision_migration_inventories
+                FOR EACH ROW
+                EXECUTE FUNCTION akb_check_native_revision_migration_inventory();
+
+            CREATE OR REPLACE FUNCTION akb_reject_native_revision_inventory_update()
+            RETURNS TRIGGER
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                RAISE EXCEPTION 'migration inventory snapshots are immutable'
+                    USING ERRCODE = '55000';
+            END;
+            $$;
+
+            DROP TRIGGER IF EXISTS native_revision_migration_inventory_immutable
+                ON native_revision_migration_inventories;
+            CREATE TRIGGER native_revision_migration_inventory_immutable
+                BEFORE UPDATE ON native_revision_migration_inventories
+                FOR EACH ROW
+                EXECUTE FUNCTION akb_reject_native_revision_inventory_update();
+
+            REVOKE EXECUTE
+                ON FUNCTION akb_check_native_revision_migration_inventory()
+                FROM PUBLIC;
+            REVOKE EXECUTE
+                ON FUNCTION akb_reject_native_revision_inventory_update()
+                FROM PUBLIC;
+            REVOKE UPDATE ON TABLE native_revision_migration_inventories FROM PUBLIC;
+            """
+        )
+
+    logger.info("Migration 097 persisted immutable fixed-ref migration inventories")

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -318,6 +318,8 @@ async def _apply_pending_migrations(conn, applied: set[str]) -> None:
         "093_external_git_retirement.py",  # durable offline retirement receipt for a Collector-adopted external Git mirror
         "094_native_revision_completed_reservation_transfer.py",  # let a fresh coverage run adopt completed work from an aborted pre-authority cutover
         "095_app_release_manifest_v2.py",  # strict app release manifest v2 registry shape
+        "096_native_revision_cutover_fence.py",  # short durable two-phase authority fence
+        "097_native_revision_migration_inventory.py",  # one immutable fixed-ref inventory per run
     ):
         if filename in applied:
             continue

--- a/backend/app/repositories/native_revision_migration_repo.py
+++ b/backend/app/repositories/native_revision_migration_repo.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import re
 import secrets
+import json
 import uuid
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
@@ -148,7 +149,10 @@ class NativeRevisionMigrationRepository:
         self.pool = pool
 
     async def get_manual_vault(
-        self, namespace_id: uuid.UUID, *, conn: asyncpg.Connection | None = None,
+        self,
+        namespace_id: uuid.UUID,
+        *,
+        conn: asyncpg.Connection | None = None,
     ) -> dict | None:
         sql = """
             SELECT v.id, v.name, v.git_path,
@@ -167,7 +171,8 @@ class NativeRevisionMigrationRepository:
 
     @staticmethod
     async def list_documents(
-        conn: asyncpg.Connection, namespace_id: uuid.UUID,
+        conn: asyncpg.Connection,
+        namespace_id: uuid.UUID,
     ) -> list[dict]:
         rows = await conn.fetch(
             """
@@ -182,7 +187,9 @@ class NativeRevisionMigrationRepository:
 
     @staticmethod
     async def list_document_aliases(
-        conn: asyncpg.Connection, namespace_id: uuid.UUID, resource_id: uuid.UUID,
+        conn: asyncpg.Connection,
+        namespace_id: uuid.UUID,
+        resource_id: uuid.UUID,
     ) -> list[dict]:
         rows = await conn.fetch(
             """
@@ -198,8 +205,28 @@ class NativeRevisionMigrationRepository:
         )
         return [dict(row) for row in rows]
 
+    @staticmethod
+    async def list_namespace_document_aliases(
+        conn: asyncpg.Connection,
+        namespace_id: uuid.UUID,
+    ) -> list[dict]:
+        rows = await conn.fetch(
+            """
+            SELECT resource_id, old_ref, created_at
+              FROM resource_aliases
+             WHERE vault_id = $1
+               AND resource_type = 'document'
+             ORDER BY resource_id, created_at, old_ref
+            """,
+            namespace_id,
+        )
+        return [dict(row) for row in rows]
+
     async def get_run(
-        self, run_id: uuid.UUID, *, conn: asyncpg.Connection | None = None,
+        self,
+        run_id: uuid.UUID,
+        *,
+        conn: asyncpg.Connection | None = None,
     ) -> MigrationRun | None:
         sql = """
             SELECT run_id, namespace_id, fixed_git_oid, coverage_version,
@@ -214,6 +241,99 @@ class NativeRevisionMigrationRepository:
             async with self.pool.acquire() as acquired:
                 row = await acquired.fetchrow(sql, run_id)
         return _run(row) if row is not None else None
+
+    async def store_inventory_snapshot(
+        self,
+        run: MigrationRun,
+        payload: dict[str, Any],
+        *,
+        conn: asyncpg.Connection | None = None,
+    ) -> None:
+        """Persist the canonical fixed-ref inventory once for later phases."""
+
+        async def _store(acquired: asyncpg.Connection) -> None:
+            encoded = json.dumps(
+                payload,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=False,
+            )
+            await acquired.execute(
+                """
+                INSERT INTO native_revision_migration_inventories (
+                    run_id, namespace_id, fixed_git_oid, coverage_version,
+                    inventory_digest, payload
+                ) VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+                ON CONFLICT (run_id) DO NOTHING
+                """,
+                run.run_id,
+                run.namespace_id,
+                run.fixed_git_oid,
+                run.coverage_version,
+                run.inventory_digest,
+                encoded,
+            )
+            observed = await acquired.fetchrow(
+                """
+                SELECT namespace_id, fixed_git_oid, coverage_version,
+                       inventory_digest, payload
+                  FROM native_revision_migration_inventories
+                 WHERE run_id = $1
+                """,
+                run.run_id,
+            )
+            if observed is None:
+                raise MigrationIntegrityError("migration inventory snapshot disappeared")
+            observed_payload = observed["payload"]
+            if isinstance(observed_payload, str):
+                observed_payload = json.loads(observed_payload)
+            if (
+                observed["namespace_id"] != run.namespace_id
+                or observed["fixed_git_oid"] != run.fixed_git_oid
+                or observed["coverage_version"] != run.coverage_version
+                or observed["inventory_digest"] != run.inventory_digest
+                or observed_payload != payload
+            ):
+                raise MigrationInventoryDriftError("persisted fixed-ref migration inventory drifted")
+
+        if conn is not None:
+            await _store(conn)
+            return
+        async with self.pool.acquire() as acquired:
+            async with acquired.transaction():
+                await _store(acquired)
+
+    async def get_inventory_snapshot(
+        self,
+        run_id: uuid.UUID,
+        *,
+        conn: asyncpg.Connection | None = None,
+    ) -> dict[str, Any] | None:
+        sql = """
+            SELECT namespace_id, fixed_git_oid, coverage_version,
+                   inventory_digest, payload
+              FROM native_revision_migration_inventories
+             WHERE run_id = $1
+        """
+        if conn is not None:
+            row = await conn.fetchrow(sql, run_id)
+        else:
+            async with self.pool.acquire() as acquired:
+                row = await acquired.fetchrow(sql, run_id)
+        if row is None:
+            return None
+        payload = row["payload"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        if not isinstance(payload, dict):
+            raise MigrationIntegrityError("migration inventory snapshot is not an object")
+        return {
+            "namespace_id": row["namespace_id"],
+            "fixed_git_oid": row["fixed_git_oid"],
+            "coverage_version": row["coverage_version"],
+            "inventory_digest": row["inventory_digest"],
+            "payload": payload,
+        }
 
     async def get_or_create_run(
         self,
@@ -279,9 +399,7 @@ class NativeRevisionMigrationRepository:
             if row["inventory_digest"] != inventory_digest:
                 raise MigrationInventoryDriftError()
             if row["status"] == "superseded":
-                raise MigrationIntegrityError(
-                    "migration run was superseded; plan with a new coverage version"
-                )
+                raise MigrationIntegrityError("migration run was superseded; plan with a new coverage version")
             return _run(row)
 
         if conn is not None:
@@ -490,10 +608,7 @@ class NativeRevisionMigrationRepository:
                                 *expected,
                             )
                     except asyncpg.UniqueViolationError as exc:
-                        if (
-                            exc.constraint_name
-                            != "native_revision_migration_items_active_resource_head_key"
-                        ):
+                        if exc.constraint_name != "native_revision_migration_items_active_resource_head_key":
                             raise
                         adopted = await self._adopt_aborted_completed_reservation(
                             acquired,
@@ -518,9 +633,7 @@ class NativeRevisionMigrationRepository:
                         row["byte_size"],
                     )
                     if observed_identity != expected:
-                        raise MigrationInventoryDriftError(
-                            "migration item facts differ from the frozen inventory"
-                        )
+                        raise MigrationInventoryDriftError("migration item facts differ from the frozen inventory")
                     if row["status"] == "failed":
                         await acquired.execute(
                             """
@@ -556,7 +669,10 @@ class NativeRevisionMigrationRepository:
                 return await _ensure(acquired)
 
     async def list_items(
-        self, run_id: uuid.UUID, *, conn: asyncpg.Connection | None = None,
+        self,
+        run_id: uuid.UUID,
+        *,
+        conn: asyncpg.Connection | None = None,
     ) -> list[MigrationItem]:
         sql = """
             SELECT run_id, namespace_id, legacy_document_id, native_resource_id,
@@ -651,13 +767,16 @@ class NativeRevisionMigrationRepository:
         for_update: bool = False,
     ) -> MigrationItem | None:
         suffix = " FOR UPDATE" if for_update else ""
-        sql = """
+        sql = (
+            """
             SELECT run_id, namespace_id, legacy_document_id, native_resource_id,
                    captured_path, legacy_head_oid, native_head_revision_id,
                    body_digest, byte_size, status, error_code
               FROM native_revision_migration_items
              WHERE run_id = $1 AND legacy_document_id = $2
-        """ + suffix
+        """
+            + suffix
+        )
         if conn is not None:
             row = await conn.fetchrow(sql, run_id, legacy_document_id)
         else:
@@ -788,7 +907,8 @@ class NativeRevisionMigrationRepository:
 
     @staticmethod
     async def all_items_complete(
-        conn: asyncpg.Connection, run_id: uuid.UUID,
+        conn: asyncpg.Connection,
+        run_id: uuid.UUID,
     ) -> bool:
         return bool(
             await conn.fetchval(
@@ -874,9 +994,7 @@ class NativeRevisionMigrationRepository:
                 row["lineage_ordinal"],
             )
             if observed != expected:
-                raise MigrationIntegrityError(
-                    "legacy revision mapping conflicts with frozen lineage"
-                )
+                raise MigrationIntegrityError("legacy revision mapping conflicts with frozen lineage")
         row = await conn.fetchrow(
             """
             SELECT m.namespace_id, m.resource_id, m.legacy_git_oid,
@@ -946,6 +1064,32 @@ class NativeRevisionMigrationRepository:
                AND m.lineage_ordinal = 0
                AND r.status = 'complete'
              ORDER BY m.resource_id, m.legacy_git_oid
+        """
+        if conn is not None:
+            rows = await conn.fetch(sql, namespace_id)
+        else:
+            async with self.pool.acquire() as acquired:
+                rows = await acquired.fetch(sql, namespace_id)
+        return [_mapping(row) for row in rows]
+
+    async def list_namespace_completed_mappings(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        conn: asyncpg.Connection | None = None,
+    ) -> list[LegacyRevisionMapping]:
+        """List the complete published Legacy selector closure for one vault."""
+
+        sql = """
+            SELECT m.namespace_id, m.resource_id, m.legacy_git_oid,
+                   m.path_at_revision, m.resolution, m.native_revision_id,
+                   m.run_id, m.lineage_ordinal, r.fixed_git_oid
+              FROM legacy_revision_mappings m
+              JOIN native_revision_migration_runs r
+                ON r.run_id = m.run_id AND r.namespace_id = m.namespace_id
+             WHERE m.namespace_id = $1
+               AND r.status = 'complete'
+             ORDER BY m.resource_id, m.lineage_ordinal, m.legacy_git_oid
         """
         if conn is not None:
             rows = await conn.fetch(sql, namespace_id)

--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -27,6 +27,7 @@ environment, pins DNS, and blocks non-https transports. See
 from __future__ import annotations
 
 import fcntl
+import hashlib
 import logging
 import os
 import re
@@ -37,7 +38,7 @@ import subprocess
 import threading
 import time
 import uuid
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator, Mapping
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
@@ -271,6 +272,16 @@ class GitHistoryCommandError(AKBError, RuntimeError):
             status_code=503,
             code=GIT_HISTORY_FAILED,
         )
+
+
+class _FixedRefHistoryIndex:
+    """Call-local full-ref name history plus lazy per-commit read caches."""
+
+    def __init__(self, commits: tuple[tuple[str, datetime, tuple[dict[str, str | None], ...]], ...]):
+        self.commits = commits
+        self.lock = threading.RLock()
+        self.metadata_by_oid: dict[str, dict[str, Any]] = {}
+        self.diff_tree_by_oid: dict[str, tuple[dict[str, str | None], ...]] = {}
 
 
 class GitService:
@@ -1677,6 +1688,463 @@ class GitService:
                 return self._stream_path_at_revision(repo, fixed_ref, file_path, target)
         except (BadName, BadObject, FileNotFoundError, ValueError):
             return None
+
+    @staticmethod
+    def _parse_name_status_changes(output: str) -> tuple[dict[str, str | None], ...]:
+        """Parse one Git name-status stream into path changes."""
+        changes: list[dict[str, str | None]] = []
+        for line in str(output).splitlines():
+            fields = line.split("\t")
+            if len(fields) < 2:
+                continue
+            status = fields[0]
+            if status.startswith(("R", "C")) and len(fields) >= 3:
+                changes.append(
+                    {
+                        "status": status,
+                        "path_from": fields[-2],
+                        "path_to": fields[-1],
+                    }
+                )
+            else:
+                changes.append(
+                    {
+                        "status": status,
+                        "path_from": None,
+                        "path_to": fields[-1],
+                    }
+                )
+        return tuple(changes)
+
+    @staticmethod
+    def _parse_fixed_ref_history_log(
+        output: str,
+    ) -> tuple[tuple[str, datetime, tuple[dict[str, str | None], ...]], ...]:
+        """Parse a full ``git log --name-status -z`` stream.
+
+        The commit format contributes ``oid<NUL>epoch<NUL>`` and ``-z`` makes
+        each status/path field NUL-delimited. A full OID followed by a decimal
+        epoch is therefore the only commit-boundary marker needed; paths are
+        consumed according to the status arity before the next boundary is
+        inspected.
+        """
+        tokens = str(output).split("\x00")
+        commits: list[tuple[str, datetime, tuple[dict[str, str | None], ...]]] = []
+        position = 0
+        full_oid = re.compile(r"^[0-9a-f]{40}$")
+
+        def is_commit_header(offset: int) -> bool:
+            return (
+                offset + 1 < len(tokens)
+                and full_oid.fullmatch(tokens[offset]) is not None
+                and re.fullmatch(r"-?[0-9]+", tokens[offset + 1]) is not None
+            )
+
+        while position < len(tokens):
+            while position < len(tokens) and not tokens[position]:
+                position += 1
+            if position >= len(tokens):
+                break
+            if not is_commit_header(position):
+                raise ValueError("fixed-ref history has a malformed commit header")
+            oid = tokens[position]
+            epoch = tokens[position + 1]
+            position += 2
+            try:
+                committed_at = datetime.fromtimestamp(int(epoch), tz=timezone.utc)
+            except (TypeError, ValueError, OverflowError) as exc:
+                raise ValueError("fixed-ref history has an invalid commit timestamp") from exc
+
+            changes: list[dict[str, str | None]] = []
+            while position < len(tokens) and not is_commit_header(position):
+                if not tokens[position]:
+                    position += 1
+                    continue
+                status = tokens[position].lstrip("\r\n")
+                position += 1
+                if not status:
+                    continue
+                if status.startswith(("R", "C")):
+                    if position + 1 >= len(tokens):
+                        raise ValueError("fixed-ref history has a malformed rename")
+                    changes.append(
+                        {
+                            "status": status,
+                            "path_from": tokens[position],
+                            "path_to": tokens[position + 1],
+                        }
+                    )
+                    position += 2
+                else:
+                    if position >= len(tokens):
+                        raise ValueError("fixed-ref history has a malformed path change")
+                    changes.append(
+                        {
+                            "status": status,
+                            "path_from": None,
+                            "path_to": tokens[position],
+                        }
+                    )
+                    position += 1
+            commits.append((oid, committed_at, tuple(changes)))
+        return tuple(commits)
+
+    def _build_fixed_ref_history_index(
+        self,
+        repo: Repo,
+        fixed_ref: str,
+    ) -> _FixedRefHistoryIndex:
+        """Build the immutable full-ref index with exactly one Git log walk."""
+        try:
+            output = repo.git.log(
+                "-M",
+                "--name-status",
+                "-z",
+                "--format=%H%x00%ct",
+                fixed_ref,
+                "--",
+            )
+            commits = self._parse_fixed_ref_history_log(output)
+        except (GitError, ValueError) as exc:
+            raise FixedRefHistoryError("fixed-ref history could not be read") from exc
+        return _FixedRefHistoryIndex(commits)
+
+    def _indexed_commit_metadata(
+        self,
+        repo: Repo,
+        index: _FixedRefHistoryIndex,
+        oid: str,
+    ) -> dict[str, Any]:
+        """Load and cache display/activity metadata once per commit."""
+        with index.lock:
+            cached = index.metadata_by_oid.get(oid)
+            if cached is not None:
+                return cached
+            try:
+                commit = repo.commit(oid)
+                cached = {
+                    "message": str(commit.message).strip(),
+                    "author": str(commit.author),
+                    "legacy": self._legacy_commit_metadata(commit),
+                }
+            except (BadName, BadObject, GitError, KeyError, TypeError, ValueError) as exc:
+                raise FixedRefHistoryError("fixed-ref history could not read commit metadata") from exc
+            index.metadata_by_oid[oid] = cached
+            return cached
+
+    def _indexed_diff_tree_changes(
+        self,
+        repo: Repo,
+        index: _FixedRefHistoryIndex,
+        commit_oid: str,
+    ) -> tuple[dict[str, str | None], ...]:
+        """Load and cache one commit's diff-tree path changes."""
+        with index.lock:
+            cached = index.diff_tree_by_oid.get(commit_oid)
+            if cached is not None:
+                return cached
+            try:
+                output = repo.git.diff_tree(
+                    "--root",
+                    "-r",
+                    "--name-status",
+                    "-M",
+                    commit_oid,
+                )
+                cached = self._parse_name_status_changes(output)
+            except (GitError, ValueError) as exc:
+                raise FixedRefHistoryError(
+                    "fixed-ref current commit activity could not be read"
+                ) from exc
+            index.diff_tree_by_oid[commit_oid] = cached
+            return cached
+
+    @staticmethod
+    def _indexed_path_change(
+        changes: tuple[dict[str, str | None], ...],
+        active_path: str,
+    ) -> dict[str, str | None] | None:
+        """Project one full-ref change as ``git log --follow`` would see it."""
+        for change in changes:
+            status = change.get("status") or ""
+            path_from = change.get("path_from")
+            path_to = change.get("path_to")
+            if status.startswith("R"):
+                if path_to == active_path:
+                    return {
+                        "path_at_revision": path_to,
+                        "action": "move",
+                        "next_path": path_from,
+                    }
+                if path_from == active_path:
+                    # A path-specific log asked for the old side of a rename
+                    # sees Git's synthesized deletion rather than the R row.
+                    return {
+                        "path_at_revision": path_from,
+                        "action": "delete",
+                        "next_path": None,
+                    }
+                continue
+            if path_to != active_path:
+                continue
+            return {
+                "path_at_revision": path_to,
+                "action": {
+                    "A": "create",
+                    "M": "update",
+                    "D": "delete",
+                }.get(status[:1]),
+                "next_path": None,
+            }
+        return None
+
+    def _manual_fixed_ref_activity_from_changes(
+        self,
+        *,
+        commit_oid: str,
+        committed_at: datetime,
+        file_path: str,
+        metadata: dict[str, str],
+        changes: tuple[dict[str, str | None], ...],
+    ) -> dict:
+        """Apply the legacy activity validation to cached diff-tree rows."""
+        declared_action = metadata["action"]
+        supported_actions = {"create", "update", "move", "delete"}
+        if declared_action and declared_action not in supported_actions:
+            raise FixedRefHistoryError(
+                "fixed-ref current commit has no supported public activity action"
+            )
+        if not metadata["subject"] or not metadata["agent"]:
+            raise FixedRefHistoryError(
+                "fixed-ref current commit has incomplete activity identity"
+            )
+
+        selected_changes: list[dict[str, str | None]] = []
+        for change in changes:
+            status = change.get("status") or ""
+            path_to = change.get("path_to")
+            if status.startswith(("R", "C")) and path_to == file_path:
+                selected_changes.append(
+                    {
+                        "change": "move",
+                        "path_from": change.get("path_from"),
+                        "path_to": path_to,
+                    }
+                )
+            elif path_to == file_path:
+                change_kind = {
+                    "A": "create",
+                    "M": "update",
+                    "D": "delete",
+                }.get(status[:1])
+                if change_kind is not None:
+                    selected_changes.append(
+                        {
+                            "change": change_kind,
+                            "path_from": None,
+                            "path_to": file_path,
+                        }
+                    )
+        if len(selected_changes) != 1:
+            raise FixedRefHistoryError(
+                "fixed-ref current commit activity does not match the file action"
+            )
+        selected_change = selected_changes[0]
+        inferred_action = selected_change["change"]
+        action = declared_action or inferred_action
+        if action != inferred_action:
+            raise FixedRefHistoryError(
+                "fixed-ref current commit activity does not match the file action"
+            )
+        return {
+            "legacy_git_oid": commit_oid,
+            "committed_at": committed_at,
+            "actor": metadata["agent"],
+            "subject": metadata["subject"],
+            "summary": metadata["summary"],
+            "action": action,
+            "path_from": selected_change["path_from"],
+            "path_to": selected_change["path_to"],
+            "changed_paths": selected_changes,
+        }
+
+    def manual_fixed_ref_history_batch(
+        self,
+        vault_name: str,
+        fixed_ref: str,
+        requests: Iterable[Mapping[str, object]],
+        *,
+        include_bodies: bool = True,
+    ) -> list[dict]:
+        """Read many manual documents from one cached fixed-ref history index.
+
+        ``requests`` is an iterable of mappings containing ``file_path``,
+        ``current_commit`` and optional ``since_epoch``. Results preserve input
+        order and use the exact snapshot shape returned by
+        :meth:`manual_fixed_ref_history`. One full ``git log --name-status``
+        walk is performed for this batch's ``(vault_name, fixed_ref)``; commit
+        metadata and diff-tree rows are memoized by commit within that index.
+        Body reads are intentionally performed per request. Callers that only
+        need immutable inventory facts may set ``include_bodies=False`` to
+        retain only each body's digest and byte size instead of all bodies.
+        """
+        full_oid = re.compile(r"^[0-9a-f]{40}$")
+        if not full_oid.fullmatch(fixed_ref):
+            raise FixedRefHistoryError("fixed_ref must be a full lowercase 40-hex commit OID")
+
+        normalized: list[tuple[str, str, int | None]] = []
+        for request in requests:
+            if not isinstance(request, Mapping):
+                raise FixedRefHistoryError("fixed-ref history request must be a mapping")
+            file_path = request.get("file_path")
+            current_commit = request.get("current_commit")
+            since_epoch = request.get("since_epoch")
+            if not isinstance(file_path, str):
+                raise FixedRefHistoryError("fixed-ref history file_path must be a string")
+            if not isinstance(current_commit, str) or not full_oid.fullmatch(current_commit):
+                raise FixedRefHistoryError(
+                    "current_commit must be a full lowercase 40-hex commit OID"
+                )
+            if since_epoch is not None and not isinstance(since_epoch, int):
+                raise FixedRefHistoryError("fixed-ref history since_epoch must be an integer")
+            normalized.append((file_path, current_commit, since_epoch))
+
+        if not normalized:
+            return []
+        if self._is_mirror(vault_name):
+            raise FixedRefHistoryError("fixed-ref history is limited to manual vaults")
+
+        try:
+            with _managed_repo(self._get_repo(vault_name)) as repo:
+                repo.commit(fixed_ref)
+                validated_current: dict[str, Any] = {}
+                for _file_path, current_commit, _since_epoch in normalized:
+                    if current_commit in validated_current:
+                        continue
+                    try:
+                        current = repo.commit(current_commit)
+                        repo.git.merge_base("--is-ancestor", current_commit, fixed_ref)
+                    except (
+                        BadName,
+                        BadObject,
+                        FileNotFoundError,
+                        GitError,
+                        KeyError,
+                        TypeError,
+                        ValueError,
+                    ) as exc:
+                        raise FixedRefHistoryError(
+                            "fixed-ref history could not resolve the requested commit or body"
+                        ) from exc
+                    validated_current[current_commit] = current
+                index = self._build_fixed_ref_history_index(repo, fixed_ref)
+                snapshots: list[dict] = []
+                for file_path, current_commit, since_epoch in normalized:
+                    current = validated_current[current_commit]
+                    try:
+                        blob = current.tree / file_path
+                        body = blob.data_stream.read()
+                    except (
+                        BadName,
+                        BadObject,
+                        FileNotFoundError,
+                        GitError,
+                        KeyError,
+                        TypeError,
+                        ValueError,
+                    ) as exc:
+                        raise FixedRefHistoryError(
+                            "fixed-ref history could not resolve the requested commit or body"
+                        ) from exc
+
+                    try:
+                        body.decode("utf-8", errors="strict")
+                    except UnicodeDecodeError as exc:
+                        raise FixedRefHistoryError("fixed-ref body is not valid UTF-8") from exc
+
+                    effective_since = (
+                        since_epoch
+                        if since_epoch is not None and current.committed_date >= since_epoch
+                        else None
+                    )
+                    history: list[dict] = []
+                    active_path = file_path
+                    for oid, committed_at, changes in index.commits:
+                        if (
+                            effective_since is not None
+                            and int(committed_at.timestamp()) < effective_since
+                        ):
+                            continue
+                        selected = self._indexed_path_change(changes, active_path)
+                        if selected is None:
+                            continue
+                        entry = {
+                            "legacy_git_oid": oid,
+                            "committed_at": committed_at,
+                            "path_at_revision": selected["path_at_revision"],
+                        }
+                        action = selected.get("action")
+                        if action is not None:
+                            entry["action"] = action
+                        metadata = self._indexed_commit_metadata(repo, index, oid)
+                        entry["message"] = metadata["message"]
+                        entry["author"] = metadata["author"]
+                        declared_action = metadata["legacy"].get("action")
+                        if declared_action in {"create", "update", "move", "delete"}:
+                            entry["action"] = declared_action
+                        history.append(entry)
+                        next_path = selected.get("next_path")
+                        if next_path is not None:
+                            active_path = next_path
+
+                    current_metadata = self._indexed_commit_metadata(
+                        repo,
+                        index,
+                        current_commit,
+                    )
+                    activity_changes = self._indexed_diff_tree_changes(
+                        repo,
+                        index,
+                        commit_oid=current_commit,
+                    )
+                    activity = self._manual_fixed_ref_activity_from_changes(
+                        commit_oid=current_commit,
+                        committed_at=datetime.fromtimestamp(
+                            current.committed_date,
+                            tz=timezone.utc,
+                        ),
+                        file_path=file_path,
+                        metadata=current_metadata["legacy"],
+                        changes=activity_changes,
+                    )
+                    snapshot: dict[str, Any] = {
+                        "fixed_ref": fixed_ref,
+                        "current_commit": current_commit,
+                        "history": history,
+                        "activity": activity,
+                    }
+                    if include_bodies:
+                        snapshot["body"] = body
+                    else:
+                        if b"\x00" in body:
+                            raise FixedRefHistoryError(
+                                "fixed-ref body contains NUL bytes"
+                            )
+                        snapshot["body_digest"] = hashlib.sha256(body).hexdigest()
+                        snapshot["byte_size"] = len(body)
+                    snapshots.append(snapshot)
+                return snapshots
+        except (
+            BadName,
+            BadObject,
+            FileNotFoundError,
+            GitError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            raise FixedRefHistoryError(
+                "fixed-ref history could not resolve the requested commit or body"
+            ) from exc
 
     def manual_fixed_ref_history(
         self,

--- a/backend/app/services/legacy_revision_bridge.py
+++ b/backend/app/services/legacy_revision_bridge.py
@@ -7,12 +7,12 @@ import hashlib
 import json
 import re
 import uuid
-from collections.abc import AsyncIterator, Iterable, Mapping
+from collections.abc import AsyncIterator, Iterable, Mapping, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from types import MappingProxyType
-from typing import Literal
+from typing import Any, Literal, cast
 
 import asyncpg
 
@@ -151,13 +151,41 @@ class SelectorResolution:
 
 def _require_oid(value: str, field: str) -> None:
     if not isinstance(value, str) or _OID_RE.fullmatch(value) is None:
-        raise InventoryEligibilityError(
-            f"{field} must be a full lowercase 40-hex commit OID"
-        )
+        raise InventoryEligibilityError(f"{field} must be a full lowercase 40-hex commit OID")
 
 
 def _iso(value: datetime) -> str:
     return value.astimezone(UTC).isoformat()
+
+
+def _datetime(value: object, field: str) -> datetime:
+    if not isinstance(value, str):
+        raise InventoryEligibilityError(f"{field} must be an ISO-8601 timestamp")
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise InventoryEligibilityError(f"{field} must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise InventoryEligibilityError(f"{field} must be timezone-aware")
+    return parsed.astimezone(UTC)
+
+
+def _mapping(value: object, field: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise InventoryEligibilityError(f"{field} must be an object")
+    return value
+
+
+def _sequence(value: object, field: str) -> list[object]:
+    if not isinstance(value, list):
+        raise InventoryEligibilityError(f"{field} must be an array")
+    return value
+
+
+def _string(value: object, field: str, *, allow_empty: bool = False) -> str:
+    if not isinstance(value, str) or (not allow_empty and not value.strip()):
+        raise InventoryEligibilityError(f"{field} must be a non-empty string")
+    return value
 
 
 def project_logical_lineage(
@@ -177,8 +205,7 @@ def project_logical_lineage(
     created_at_utc = created_at.astimezone(UTC)
     entries = tuple(history)
     use_create_boundary = oldest_anchor_oid is None and any(
-        isinstance(entry, Mapping) and entry.get("action") == "create"
-        for entry in entries
+        isinstance(entry, Mapping) and entry.get("action") == "create" for entry in entries
     )
     newest: list[LegacyLineageEntry] = []
     seen: set[str] = set()
@@ -192,29 +219,19 @@ def project_logical_lineage(
             raise LogicalLineageProjectionError("history contains an invalid OID")
         if anchor_found:
             if oid == oldest_anchor_oid:
-                raise LogicalLineageProjectionError(
-                    "history contains a duplicate oldest anchor"
-                )
+                raise LogicalLineageProjectionError("history contains a duplicate oldest anchor")
             continue
         if create_found:
             continue
         committed_at = entry.get("committed_at")
-        if (
-            not isinstance(committed_at, datetime)
-            or committed_at.tzinfo is None
-            or committed_at.utcoffset() is None
-        ):
-            raise LogicalLineageProjectionError(
-                "history contains an invalid commit timestamp"
-            )
+        if not isinstance(committed_at, datetime) or committed_at.tzinfo is None or committed_at.utcoffset() is None:
+            raise LogicalLineageProjectionError("history contains an invalid commit timestamp")
         path = current_path if oid == current_commit else entry.get("path_at_revision")
         if not isinstance(path, str) or not path.strip():
             raise LogicalLineageProjectionError("history contains an invalid path")
         if oid in seen:
             if oid == oldest_anchor_oid:
-                raise LogicalLineageProjectionError(
-                    "history contains a duplicate oldest anchor"
-                )
+                raise LogicalLineageProjectionError("history contains a duplicate oldest anchor")
             continue
         seen.add(oid)
         if (
@@ -236,9 +253,7 @@ def project_logical_lineage(
         if use_create_boundary and entry.get("action") == "create":
             create_found = True
     if oldest_anchor_oid is not None and not anchor_found:
-        raise LogicalLineageProjectionError(
-            "completed oldest anchor is absent from fixed-ref history"
-        )
+        raise LogicalLineageProjectionError("completed oldest anchor is absent from fixed-ref history")
     return tuple(reversed(newest))
 
 
@@ -259,15 +274,15 @@ class LegacyRevisionBridge:
         self.repository = repository or NativeRevisionMigrationRepository(pool)
 
     @classmethod
-    def canonical_inventory_digest(
+    def canonical_inventory_payload(
         cls,
         *,
         namespace_id: uuid.UUID,
         fixed_git_oid: str,
         coverage_version: str,
         documents: tuple[LegacyInventoryDocument, ...],
-    ) -> str:
-        payload = {
+    ) -> dict[str, Any]:
+        return {
             "schema": cls.inventory_schema,
             "namespace_id": str(namespace_id),
             "fixed_git_oid": fixed_git_oid,
@@ -304,73 +319,339 @@ class LegacyRevisionBridge:
                         "action": document.activity.action,
                         "path_from": document.activity.path_from,
                         "path_to": document.activity.path_to,
-                        "changed_paths": [
-                            dict(change) for change in document.activity.changed_paths
-                        ],
+                        "changed_paths": [dict(change) for change in document.activity.changed_paths],
                     },
                 }
                 for document in documents
             ],
         }
+
+    @classmethod
+    def canonical_inventory_digest(
+        cls,
+        *,
+        namespace_id: uuid.UUID,
+        fixed_git_oid: str,
+        coverage_version: str,
+        documents: tuple[LegacyInventoryDocument, ...],
+    ) -> str:
         canonical = json.dumps(
-            payload,
+            cls.canonical_inventory_payload(
+                namespace_id=namespace_id,
+                fixed_git_oid=fixed_git_oid,
+                coverage_version=coverage_version,
+                documents=documents,
+            ),
             ensure_ascii=False,
             separators=(",", ":"),
             sort_keys=True,
         ).encode("utf-8")
         return hashlib.sha256(canonical).hexdigest()
 
-    async def _capture_source_metadata(
-        self,
-        *,
-        vault_name: str,
-        fixed_ref: str,
-        resource_id: uuid.UUID,
-        current_path: str,
-        current_commit: str,
-        created_at: datetime,
-    ) -> tuple[list[dict], dict, str, int]:
-        """Read one source body and return only frozen metadata about it."""
+    @classmethod
+    def inventory_from_payload(cls, payload: Mapping[str, object]) -> LegacyInventory:
+        """Rehydrate one immutable run inventory without rescanning Git history."""
 
+        if payload.get("schema") != cls.inventory_schema:
+            raise InventoryEligibilityError("persisted inventory schema is unsupported")
         try:
-            snapshot = await asyncio.to_thread(
-                self.git.manual_fixed_ref_history,
-                vault_name,
-                fixed_ref,
-                current_path,
+            namespace_id = uuid.UUID(_string(payload.get("namespace_id"), "namespace_id"))
+        except ValueError as exc:
+            raise InventoryEligibilityError("namespace_id must be a UUID") from exc
+        fixed_git_oid = _string(payload.get("fixed_git_oid"), "fixed_git_oid")
+        _require_oid(fixed_git_oid, "fixed_git_oid")
+        coverage_version = _string(payload.get("coverage_version"), "coverage_version")
+
+        documents: list[LegacyInventoryDocument] = []
+        for index, raw_document in enumerate(_sequence(payload.get("documents"), "documents")):
+            prefix = f"documents[{index}]"
+            document = _mapping(raw_document, prefix)
+            try:
+                resource_id = uuid.UUID(_string(document.get("resource_id"), f"{prefix}.resource_id"))
+            except ValueError as exc:
+                raise InventoryEligibilityError(f"{prefix}.resource_id must be a UUID") from exc
+            current_path = _string(document.get("current_path"), f"{prefix}.current_path")
+            current_commit = _string(document.get("current_commit"), f"{prefix}.current_commit")
+            _require_oid(current_commit, f"{prefix}.current_commit")
+            created_at = _datetime(document.get("created_at"), f"{prefix}.created_at")
+            body_digest = _string(document.get("body_digest"), f"{prefix}.body_digest")
+            if re.fullmatch(r"[0-9a-f]{64}", body_digest) is None:
+                raise InventoryEligibilityError(f"{prefix}.body_digest must be a lowercase SHA-256 digest")
+            byte_size = document.get("byte_size")
+            if not isinstance(byte_size, int) or isinstance(byte_size, bool) or byte_size < 0:
+                raise InventoryEligibilityError(f"{prefix}.byte_size must be a non-negative integer")
+
+            aliases: list[LegacyInventoryAlias] = []
+            for alias_index, raw_alias in enumerate(_sequence(document.get("aliases"), f"{prefix}.aliases")):
+                alias = _mapping(raw_alias, f"{prefix}.aliases[{alias_index}]")
+                aliases.append(
+                    LegacyInventoryAlias(
+                        old_ref=_string(
+                            alias.get("old_ref"),
+                            f"{prefix}.aliases[{alias_index}].old_ref",
+                        ),
+                        created_at=_datetime(
+                            alias.get("created_at"),
+                            f"{prefix}.aliases[{alias_index}].created_at",
+                        ),
+                    )
+                )
+
+            lineage: list[LegacyLineageEntry] = []
+            for lineage_index, raw_entry in enumerate(_sequence(document.get("lineage"), f"{prefix}.lineage")):
+                entry = _mapping(raw_entry, f"{prefix}.lineage[{lineage_index}]")
+                legacy_git_oid = _string(
+                    entry.get("legacy_git_oid"),
+                    f"{prefix}.lineage[{lineage_index}].legacy_git_oid",
+                )
+                _require_oid(
+                    legacy_git_oid,
+                    f"{prefix}.lineage[{lineage_index}].legacy_git_oid",
+                )
+                lineage.append(
+                    LegacyLineageEntry(
+                        legacy_git_oid=legacy_git_oid,
+                        path_at_revision=_string(
+                            entry.get("path_at_revision"),
+                            f"{prefix}.lineage[{lineage_index}].path_at_revision",
+                        ),
+                        committed_at=_datetime(
+                            entry.get("committed_at"),
+                            f"{prefix}.lineage[{lineage_index}].committed_at",
+                        ),
+                    )
+                )
+            if not lineage or lineage[-1].legacy_git_oid != current_commit:
+                raise InventoryEligibilityError(f"{prefix}.lineage does not end at current_commit")
+
+            raw_activity = _mapping(document.get("activity"), f"{prefix}.activity")
+            action = raw_activity.get("action")
+            if action not in {"create", "update", "move", "delete"}:
+                raise InventoryEligibilityError(f"{prefix}.activity.action is unsupported")
+            activity_oid = _string(
+                raw_activity.get("legacy_git_oid"),
+                f"{prefix}.activity.legacy_git_oid",
+            )
+            _require_oid(activity_oid, f"{prefix}.activity.legacy_git_oid")
+            path_from = raw_activity.get("path_from")
+            path_to = raw_activity.get("path_to")
+            if path_from is not None and not isinstance(path_from, str):
+                raise InventoryEligibilityError(f"{prefix}.activity.path_from must be a string or null")
+            if path_to is not None and not isinstance(path_to, str):
+                raise InventoryEligibilityError(f"{prefix}.activity.path_to must be a string or null")
+            changed_paths: list[Mapping[str, str | None]] = []
+            for change_index, raw_change in enumerate(
+                _sequence(
+                    raw_activity.get("changed_paths"),
+                    f"{prefix}.activity.changed_paths",
+                )
+            ):
+                change = _mapping(
+                    raw_change,
+                    f"{prefix}.activity.changed_paths[{change_index}]",
+                )
+                if any(
+                    not isinstance(key, str) or (value is not None and not isinstance(value, str))
+                    for key, value in change.items()
+                ):
+                    raise InventoryEligibilityError(f"{prefix}.activity.changed_paths[{change_index}] is invalid")
+                changed_paths.append(
+                    MappingProxyType(
+                        {
+                            cast(str, key): cast(str | None, value)
+                            for key, value in change.items()
+                        }
+                    )
+                )
+
+            documents.append(
+                LegacyInventoryDocument(
+                    resource_id=resource_id,
+                    current_path=current_path,
+                    current_commit=current_commit,
+                    created_at=created_at,
+                    body_digest=body_digest,
+                    byte_size=byte_size,
+                    aliases=tuple(aliases),
+                    lineage=tuple(lineage),
+                    activity=LegacyActivitySemantics(
+                        legacy_git_oid=activity_oid,
+                        committed_at=_datetime(
+                            raw_activity.get("committed_at"),
+                            f"{prefix}.activity.committed_at",
+                        ),
+                        actor=_string(raw_activity.get("actor"), f"{prefix}.activity.actor"),
+                        subject=_string(raw_activity.get("subject"), f"{prefix}.activity.subject"),
+                        summary=_string(
+                            raw_activity.get("summary"),
+                            f"{prefix}.activity.summary",
+                            allow_empty=True,
+                        ),
+                        action=cast(Literal["create", "update", "move", "delete"], action),
+                        path_from=path_from,
+                        path_to=path_to,
+                        changed_paths=tuple(changed_paths),
+                    ),
+                )
+            )
+
+        frozen_documents = tuple(documents)
+        inventory_digest = cls.canonical_inventory_digest(
+            namespace_id=namespace_id,
+            fixed_git_oid=fixed_git_oid,
+            coverage_version=coverage_version,
+            documents=frozen_documents,
+        )
+        canonical_payload = cls.canonical_inventory_payload(
+            namespace_id=namespace_id,
+            fixed_git_oid=fixed_git_oid,
+            coverage_version=coverage_version,
+            documents=frozen_documents,
+        )
+        if dict(payload) != canonical_payload:
+            raise InventoryEligibilityError("persisted inventory is not canonical")
+        return LegacyInventory(
+            namespace_id=namespace_id,
+            fixed_git_oid=fixed_git_oid,
+            coverage_version=coverage_version,
+            documents=frozen_documents,
+            inventory_digest=inventory_digest,
+        )
+
+    @staticmethod
+    def _document_from_fixed_snapshot(
+        *,
+        row: Mapping[str, object],
+        raw_aliases: Sequence[Mapping[str, object]],
+        raw_snapshot: object,
+        oldest_anchor_oid: str | None,
+    ) -> LegacyInventoryDocument:
+        resource_id = row["id"]
+        current_commit = row.get("current_commit")
+        current_path = row.get("path")
+        created_at = row.get("created_at")
+        if not isinstance(resource_id, uuid.UUID):
+            raise InventoryEligibilityError("document inventory contains an invalid resource id")
+        if not isinstance(current_commit, str) or _OID_RE.fullmatch(current_commit) is None:
+            raise InventoryEligibilityError(f"document {resource_id} has no full current_commit")
+        if not isinstance(current_path, str) or not current_path:
+            raise InventoryEligibilityError(f"document {resource_id} has no usable path")
+        if not isinstance(created_at, datetime):
+            raise InventoryEligibilityError(f"document {resource_id} has no usable created_at")
+        if not isinstance(raw_snapshot, Mapping):
+            raise InventoryEligibilityError(f"document {resource_id} returned invalid fixed-ref metadata")
+        history = raw_snapshot.get("history")
+        raw_activity = raw_snapshot.get("activity")
+        body = raw_snapshot.get("body")
+        body_digest = raw_snapshot.get("body_digest")
+        byte_size = raw_snapshot.get("byte_size")
+        if not isinstance(history, list) or not isinstance(raw_activity, Mapping):
+            raise InventoryEligibilityError(f"document {resource_id} returned invalid fixed-ref metadata")
+        if isinstance(body, bytes):
+            if b"\x00" in body:
+                raise InventoryEligibilityError(f"document {resource_id} body contains NUL bytes")
+            try:
+                body.decode("utf-8", errors="strict")
+            except UnicodeDecodeError as exc:
+                raise InventoryEligibilityError(f"document {resource_id} body is not valid UTF-8") from exc
+            body_digest = hashlib.sha256(body).hexdigest()
+            byte_size = len(body)
+        elif (
+            not isinstance(body_digest, str)
+            or re.fullmatch(r"[0-9a-f]{64}", body_digest) is None
+            or not isinstance(byte_size, int)
+            or isinstance(byte_size, bool)
+            or byte_size < 0
+        ):
+            raise InventoryEligibilityError(f"document {resource_id} is not readable at the fixed ref")
+        if not history or history[0].get("legacy_git_oid") != current_commit:
+            raise InventoryEligibilityError(
+                f"document {resource_id} current_commit is not the fixed-ref file head"
+            )
+
+        aliases: list[LegacyInventoryAlias] = []
+        for alias in raw_aliases:
+            old_ref = alias.get("old_ref")
+            alias_created_at = alias.get("created_at")
+            if not isinstance(old_ref, str) or not old_ref.strip():
+                raise InventoryEligibilityError(f"document {resource_id} has an invalid resource alias")
+            if not isinstance(alias_created_at, datetime):
+                raise InventoryEligibilityError(
+                    f"document {resource_id} has an alias without a usable timestamp"
+                )
+            aliases.append(LegacyInventoryAlias(old_ref=old_ref, created_at=alias_created_at))
+
+        activity_action = raw_activity.get("action")
+        if activity_action not in {"create", "update", "move", "delete"}:
+            raise InventoryEligibilityError(
+                f"document {resource_id} has an unsupported current activity action"
+            )
+        activity_oid = raw_activity.get("legacy_git_oid")
+        activity_time = raw_activity.get("committed_at")
+        activity_actor = raw_activity.get("actor")
+        activity_subject = raw_activity.get("subject")
+        activity_summary = raw_activity.get("summary")
+        path_from = raw_activity.get("path_from")
+        path_to = raw_activity.get("path_to")
+        changed_paths = raw_activity.get("changed_paths")
+        if (
+            activity_oid != current_commit
+            or not isinstance(activity_time, datetime)
+            or activity_time != history[0].get("committed_at")
+            or not isinstance(activity_actor, str)
+            or not activity_actor
+            or not isinstance(activity_subject, str)
+            or not activity_subject
+            or not isinstance(activity_summary, str)
+            or not isinstance(path_to, str)
+            or not isinstance(changed_paths, list)
+            or not all(isinstance(change, dict) for change in changed_paths)
+        ):
+            raise InventoryEligibilityError(
+                f"document {resource_id} has incomplete current activity semantics"
+            )
+        if activity_action == "move" and not isinstance(path_from, str):
+            raise InventoryEligibilityError(f"document {resource_id} move activity has no source path")
+        if activity_action != "move" and path_from is not None:
+            raise InventoryEligibilityError(f"document {resource_id} non-move activity has a source path")
+        activity = LegacyActivitySemantics(
+            legacy_git_oid=activity_oid,
+            committed_at=activity_time,
+            actor=activity_actor,
+            subject=activity_subject,
+            summary=activity_summary,
+            action=activity_action,
+            path_from=path_from,
+            path_to=path_to,
+            changed_paths=tuple(MappingProxyType(dict(change)) for change in changed_paths),
+        )
+        try:
+            lineage = project_logical_lineage(
+                history,
                 current_commit=current_commit,
-                since_epoch=int(created_at.timestamp()),
+                current_path=current_path,
+                created_at=created_at,
+                oldest_anchor_oid=oldest_anchor_oid,
             )
-        except FixedRefHistoryError as exc:
+        except LogicalLineageProjectionError as exc:
+            raise InventoryEligibilityError(f"document {resource_id} history is invalid") from exc
+        if current_commit not in {entry.legacy_git_oid for entry in lineage}:
             raise InventoryEligibilityError(
-                f"document {resource_id} is not readable at the fixed ref"
-            ) from exc
-        if not isinstance(snapshot, dict):
-            raise InventoryEligibilityError(
-                f"document {resource_id} returned invalid fixed-ref metadata"
+                f"document {resource_id} current_commit is absent from fixed-ref history"
             )
-        history = snapshot.get("history")
-        activity = snapshot.get("activity")
-        body = snapshot.get("body")
-        if not isinstance(history, list) or not isinstance(activity, dict):
-            raise InventoryEligibilityError(
-                f"document {resource_id} returned invalid fixed-ref metadata"
-            )
-        if not isinstance(body, bytes):
-            raise InventoryEligibilityError(
-                f"document {resource_id} is not readable at the fixed ref"
-            )
-        if b"\x00" in body:
-            raise InventoryEligibilityError(
-                f"document {resource_id} body contains NUL bytes"
-            )
-        try:
-            body.decode("utf-8", errors="strict")
-        except UnicodeDecodeError as exc:
-            raise InventoryEligibilityError(
-                f"document {resource_id} body is not valid UTF-8"
-            ) from exc
-        return history, activity, hashlib.sha256(body).hexdigest(), len(body)
+        if not lineage or lineage[-1].legacy_git_oid != current_commit:
+            raise InventoryEligibilityError(f"document {resource_id} lineage does not end at current_commit")
+        return LegacyInventoryDocument(
+            resource_id=resource_id,
+            current_path=current_path,
+            current_commit=current_commit,
+            created_at=created_at,
+            body_digest=body_digest,
+            byte_size=byte_size,
+            aliases=tuple(aliases),
+            lineage=lineage,
+            activity=activity,
+        )
 
     async def capture_inventory_scope(
         self,
@@ -399,150 +680,59 @@ class LegacyRevisionBridge:
                 # vault-level external-Git marker above remains a hard reject.
                 rows = [row for row in rows if row.get("source") == "manual"]
 
-                completed_anchor_rows = (
-                    await self.repository.list_completed_lineage_anchors(
-                        namespace_id=namespace_id,
-                        conn=conn,
-                    )
+                completed_anchor_rows = await self.repository.list_completed_lineage_anchors(
+                    namespace_id=namespace_id,
+                    conn=conn,
                 )
                 completed_anchors: dict[uuid.UUID, str] = {}
                 for anchor in completed_anchor_rows:
                     if anchor.resource_id in completed_anchors:
-                        raise InventoryEligibilityError(
-                            "completed lineage has duplicate ordinal-zero anchors"
-                        )
+                        raise InventoryEligibilityError("completed lineage has duplicate ordinal-zero anchors")
                     completed_anchors[anchor.resource_id] = anchor.legacy_git_oid
 
-                documents: list[LegacyInventoryDocument] = []
-                for row in rows:
-                    aliases: list[LegacyInventoryAlias] = []
-                    for alias in await self.repository.list_document_aliases(
-                        conn, namespace_id, row["id"]
-                    ):
-                        old_ref = alias.get("old_ref")
-                        created_at = alias.get("created_at")
-                        if not isinstance(old_ref, str) or not old_ref.strip():
-                            raise InventoryEligibilityError(
-                                f"document {row['id']} has an invalid resource alias"
-                            )
-                        if not isinstance(created_at, datetime):
-                            raise InventoryEligibilityError(
-                                f"document {row['id']} has an alias without a usable timestamp"
-                            )
-                        aliases.append(
-                            LegacyInventoryAlias(
-                                old_ref=old_ref,
-                                created_at=created_at,
-                            )
-                        )
-                    current_commit = row.get("current_commit")
-                    if not isinstance(current_commit, str) or _OID_RE.fullmatch(current_commit) is None:
-                        raise InventoryEligibilityError(
-                            f"document {row['id']} has no full current_commit"
-                        )
-                    created_at = row.get("created_at")
-                    if not isinstance(created_at, datetime):
-                        raise InventoryEligibilityError(
-                            f"document {row['id']} has no usable created_at"
-                        )
-                    history, raw_activity, body_digest, byte_size = (
-                        await self._capture_source_metadata(
-                            vault_name=vault["name"],
-                            fixed_ref=fixed_ref,
-                            resource_id=row["id"],
-                            current_path=row["path"],
-                            current_commit=current_commit,
-                            created_at=created_at,
-                        )
-                    )
-                    if not history or history[0]["legacy_git_oid"] != current_commit:
-                        raise InventoryEligibilityError(
-                            f"document {row['id']} current_commit is not the fixed-ref file head"
-                        )
-                    activity_action = raw_activity.get("action")
-                    if activity_action not in {"create", "update", "move", "delete"}:
-                        raise InventoryEligibilityError(
-                            f"document {row['id']} has an unsupported current activity action"
-                        )
-                    activity_oid = raw_activity.get("legacy_git_oid")
-                    activity_time = raw_activity.get("committed_at")
-                    activity_actor = raw_activity.get("actor")
-                    activity_subject = raw_activity.get("subject")
-                    activity_summary = raw_activity.get("summary")
-                    path_from = raw_activity.get("path_from")
-                    path_to = raw_activity.get("path_to")
-                    changed_paths = raw_activity.get("changed_paths")
-                    if (
-                        activity_oid != current_commit
-                        or not isinstance(activity_time, datetime)
-                        or activity_time != history[0]["committed_at"]
-                        or not isinstance(activity_actor, str)
-                        or not activity_actor
-                        or not isinstance(activity_subject, str)
-                        or not activity_subject
-                        or not isinstance(activity_summary, str)
-                        or not isinstance(path_to, str)
-                        or not isinstance(changed_paths, list)
-                        or not all(isinstance(change, dict) for change in changed_paths)
-                    ):
-                        raise InventoryEligibilityError(
-                            f"document {row['id']} has incomplete current activity semantics"
-                        )
-                    if activity_action == "move" and not isinstance(path_from, str):
-                        raise InventoryEligibilityError(
-                            f"document {row['id']} move activity has no source path"
-                        )
-                    if activity_action != "move" and path_from is not None:
-                        raise InventoryEligibilityError(
-                            f"document {row['id']} non-move activity has a source path"
-                        )
-                    activity = LegacyActivitySemantics(
-                        legacy_git_oid=activity_oid,
-                        committed_at=activity_time,
-                        actor=activity_actor,
-                        subject=activity_subject,
-                        summary=activity_summary,
-                        action=activity_action,
-                        path_from=path_from,
-                        path_to=path_to,
-                        changed_paths=tuple(
-                            MappingProxyType(dict(change)) for change in changed_paths
-                        ),
-                    )
-                    try:
-                        lineage = project_logical_lineage(
-                            history,
-                            current_commit=current_commit,
-                            current_path=row["path"],
-                            created_at=created_at,
-                            oldest_anchor_oid=completed_anchors.get(row["id"]),
-                        )
-                    except LogicalLineageProjectionError as exc:
-                        raise InventoryEligibilityError(
-                            f"document {row['id']} history is invalid"
-                        ) from exc
-                    seen = {entry.legacy_git_oid for entry in lineage}
-                    if current_commit not in seen:
-                        raise InventoryEligibilityError(
-                            f"document {row['id']} current_commit is absent from fixed-ref history"
-                        )
-                    if not lineage or lineage[-1].legacy_git_oid != current_commit:
-                        raise InventoryEligibilityError(
-                            f"document {row['id']} lineage does not end at current_commit"
-                        )
-                    documents.append(
-                        LegacyInventoryDocument(
-                            resource_id=row["id"],
-                            current_path=row["path"],
-                            current_commit=current_commit,
-                            created_at=created_at,
-                            body_digest=body_digest,
-                            byte_size=byte_size,
-                            aliases=tuple(aliases),
-                            lineage=lineage,
-                            activity=activity,
-                        )
-                    )
+                aliases_by_resource: dict[uuid.UUID, list[dict]] = {}
+                for alias in await self.repository.list_namespace_document_aliases(
+                    conn,
+                    namespace_id,
+                ):
+                    aliases_by_resource.setdefault(alias["resource_id"], []).append(alias)
+
+        requests = []
+        for row in rows:
+            current_commit = row.get("current_commit")
+            created_at = row.get("created_at")
+            if not isinstance(current_commit, str) or _OID_RE.fullmatch(current_commit) is None:
+                raise InventoryEligibilityError(f"document {row['id']} has no full current_commit")
+            if not isinstance(created_at, datetime):
+                raise InventoryEligibilityError(f"document {row['id']} has no usable created_at")
+            requests.append(
+                {
+                    "file_path": row["path"],
+                    "current_commit": current_commit,
+                    "since_epoch": int(created_at.timestamp()),
+                }
+            )
+        try:
+            snapshots = await asyncio.to_thread(
+                self.git.manual_fixed_ref_history_batch,
+                vault["name"],
+                fixed_ref,
+                requests,
+                include_bodies=False,
+            )
+        except FixedRefHistoryError as exc:
+            raise InventoryEligibilityError("fixed-ref inventory history could not be read") from exc
+        if len(snapshots) != len(rows):
+            raise InventoryEligibilityError("fixed-ref inventory history is incomplete")
+        documents = [
+            self._document_from_fixed_snapshot(
+                row=row,
+                raw_aliases=aliases_by_resource.get(row["id"], []),
+                raw_snapshot=snapshot,
+                oldest_anchor_oid=completed_anchors.get(row["id"]),
+            )
+            for row, snapshot in zip(rows, snapshots, strict=True)
+        ]
 
         frozen_documents = tuple(documents)
         inventory = LegacyInventory(
@@ -582,9 +772,7 @@ class LegacyRevisionBridge:
         documents_by_id: dict[uuid.UUID, LegacyInventoryDocument] = {}
         for document in inventory.documents:
             if document.resource_id in documents_by_id:
-                raise InventoryEligibilityError(
-                    "frozen inventory contains duplicate document resources"
-                )
+                raise InventoryEligibilityError("frozen inventory contains duplicate document resources")
             documents_by_id[document.resource_id] = document
         return LegacyInventoryScope(
             inventory=inventory,
@@ -593,9 +781,96 @@ class LegacyRevisionBridge:
             documents_by_id=MappingProxyType(documents_by_id),
         )
 
+    async def _validated_current_catalog(
+        self,
+        inventory: LegacyInventory,
+        *,
+        conn: asyncpg.Connection | None = None,
+    ) -> str:
+        """Check mutable catalog facts without traversing immutable Git history."""
+
+        async def validate(acquired: asyncpg.Connection) -> str:
+            vault = await self.repository.get_manual_vault(
+                inventory.namespace_id,
+                conn=acquired,
+            )
+            if vault is None:
+                raise NotFoundError("Vault", str(inventory.namespace_id))
+            if vault["has_external_git"]:
+                raise ManualVaultRequiredError()
+
+            rows = [
+                row
+                for row in await self.repository.list_documents(
+                    acquired,
+                    inventory.namespace_id,
+                )
+                if row.get("source") == "manual"
+            ]
+            if len(rows) != len(inventory.documents):
+                raise MigrationInventoryDriftError("manual document membership drifted from the fixed inventory")
+            documents_by_id = {document.resource_id: document for document in inventory.documents}
+            aliases_by_resource: dict[uuid.UUID, list[dict]] = {}
+            for alias in await self.repository.list_namespace_document_aliases(
+                acquired,
+                inventory.namespace_id,
+            ):
+                aliases_by_resource.setdefault(alias["resource_id"], []).append(alias)
+
+            for row in rows:
+                document = documents_by_id.get(row["id"])
+                created_at = row.get("created_at")
+                if (
+                    document is None
+                    or row.get("path") != document.current_path
+                    or row.get("current_commit") != document.current_commit
+                    or not isinstance(created_at, datetime)
+                    or created_at.astimezone(UTC) != document.created_at.astimezone(UTC)
+                ):
+                    raise MigrationInventoryDriftError("manual document catalog drifted from the fixed inventory")
+                aliases = aliases_by_resource.get(document.resource_id, [])
+                observed_aliases_list: list[tuple[object, datetime | None]] = []
+                for alias in aliases:
+                    alias_created_at = alias.get("created_at")
+                    observed_aliases_list.append(
+                        (
+                            alias.get("old_ref"),
+                            alias_created_at.astimezone(UTC)
+                            if isinstance(alias_created_at, datetime)
+                            else None,
+                        )
+                    )
+                observed_aliases = tuple(observed_aliases_list)
+                expected_aliases = tuple(
+                    (alias.old_ref, alias.created_at.astimezone(UTC)) for alias in document.aliases
+                )
+                if observed_aliases != expected_aliases:
+                    raise MigrationInventoryDriftError("manual document aliases drifted from the fixed inventory")
+
+            completed_anchors = {
+                anchor.resource_id: anchor.legacy_git_oid
+                for anchor in await self.repository.list_completed_lineage_anchors(
+                    namespace_id=inventory.namespace_id,
+                    conn=acquired,
+                )
+            }
+            for resource_id, anchor_oid in completed_anchors.items():
+                document = documents_by_id.get(resource_id)
+                if document is None or not document.lineage or document.lineage[0].legacy_git_oid != anchor_oid:
+                    raise MigrationInventoryDriftError("completed lineage anchor drifted from the fixed inventory")
+            return vault["name"]
+
+        if conn is not None:
+            return await validate(conn)
+        async with self.pool.acquire() as acquired:
+            async with acquired.transaction(isolation="repeatable_read", readonly=True):
+                return await validate(acquired)
+
     async def validated_inventory_scope(
         self,
         inventory: LegacyInventory,
+        *,
+        conn: asyncpg.Connection | None = None,
     ) -> LegacyInventoryScope:
         """Validate externally held inventory facts once before body reads."""
 
@@ -609,12 +884,8 @@ class LegacyRevisionBridge:
             != inventory.inventory_digest
         ):
             raise InventoryEligibilityError("body materialization inventory digest is invalid")
-        vault = await self.repository.get_manual_vault(inventory.namespace_id)
-        if vault is None:
-            raise NotFoundError("Vault", str(inventory.namespace_id))
-        if vault["has_external_git"]:
-            raise ManualVaultRequiredError()
-        return self._scope_from_validated_inventory(inventory, vault_name=vault["name"])
+        vault_name = await self._validated_current_catalog(inventory, conn=conn)
+        return self._scope_from_validated_inventory(inventory, vault_name=vault_name)
 
     @asynccontextmanager
     async def materialize_body(
@@ -628,9 +899,7 @@ class LegacyRevisionBridge:
             scope.fixed_git_oid != scope.inventory.fixed_git_oid
             or scope.documents_by_id.get(document.resource_id) is not document
         ):
-            raise InventoryEligibilityError(
-                "body materialization requires a document from the frozen inventory"
-            )
+            raise InventoryEligibilityError("body materialization requires a document from the frozen inventory")
         try:
             text = await asyncio.to_thread(
                 self.git.read_file,
@@ -643,28 +912,17 @@ class LegacyRevisionBridge:
                 f"document {document.resource_id} is not readable at the fixed ref"
             ) from exc
         if not isinstance(text, str):
-            raise InventoryEligibilityError(
-                f"document {document.resource_id} is not readable at the fixed ref"
-            )
+            raise InventoryEligibilityError(f"document {document.resource_id} is not readable at the fixed ref")
         body = text.encode("utf-8")
         del text
-        if (
-            len(body) != document.byte_size
-            or hashlib.sha256(body).hexdigest() != document.body_digest
-        ):
-            raise InventoryEligibilityError(
-                f"document {document.resource_id} body differs from the frozen inventory"
-            )
+        if len(body) != document.byte_size or hashlib.sha256(body).hexdigest() != document.body_digest:
+            raise InventoryEligibilityError(f"document {document.resource_id} body differs from the frozen inventory")
         if b"\x00" in body:
-            raise InventoryEligibilityError(
-                f"document {document.resource_id} body contains NUL bytes"
-            )
+            raise InventoryEligibilityError(f"document {document.resource_id} body contains NUL bytes")
         try:
             body.decode("utf-8", errors="strict")
         except UnicodeDecodeError as exc:
-            raise InventoryEligibilityError(
-                f"document {document.resource_id} body is not valid UTF-8"
-            ) from exc
+            raise InventoryEligibilityError(f"document {document.resource_id} body is not valid UTF-8") from exc
         try:
             yield body
         finally:
@@ -685,6 +943,7 @@ class LegacyRevisionBridge:
         inventory = scope.inventory
         async with self.pool.acquire() as conn:
             async with conn.transaction():
+                await self._validated_current_catalog(inventory, conn=conn)
                 run = await self.repository.get_or_create_run(
                     namespace_id=namespace_id,
                     fixed_git_oid=fixed_ref,
@@ -697,16 +956,72 @@ class LegacyRevisionBridge:
                     (document.item_facts() for document in inventory.documents),
                     conn=conn,
                 )
+                await self.repository.store_inventory_snapshot(
+                    run,
+                    self.canonical_inventory_payload(
+                        namespace_id=inventory.namespace_id,
+                        fixed_git_oid=inventory.fixed_git_oid,
+                        coverage_version=inventory.coverage_version,
+                        documents=inventory.documents,
+                    ),
+                    conn=conn,
+                )
         return run, inventory
 
-    async def inventory_scope_for_run(self, run: MigrationRun) -> LegacyInventoryScope:
-        scope = await self.capture_inventory_scope(
-            namespace_id=run.namespace_id,
-            fixed_ref=run.fixed_git_oid,
-            coverage_version=run.coverage_version,
-        )
-        if scope.inventory.inventory_digest != run.inventory_digest:
+    async def inventory_scope_for_run(
+        self,
+        run: MigrationRun,
+        *,
+        conn: asyncpg.Connection | None = None,
+    ) -> LegacyInventoryScope:
+        current_run = await self.repository.get_run(run.run_id, conn=conn)
+        if current_run is None:
+            raise MigrationInventoryDriftError("migration run disappeared")
+        if (
+            current_run.namespace_id != run.namespace_id
+            or current_run.fixed_git_oid != run.fixed_git_oid
+            or current_run.coverage_version != run.coverage_version
+            or current_run.inventory_digest != run.inventory_digest
+        ):
+            raise MigrationInventoryDriftError("migration run binding drifted")
+        run = current_run
+        snapshot = await self.repository.get_inventory_snapshot(run.run_id, conn=conn)
+        if snapshot is None:
+            raise MigrationInventoryDriftError("fixed-ref migration inventory snapshot is missing")
+        if (
+            snapshot["namespace_id"] != run.namespace_id
+            or snapshot["fixed_git_oid"] != run.fixed_git_oid
+            or snapshot["coverage_version"] != run.coverage_version
+            or snapshot["inventory_digest"] != run.inventory_digest
+        ):
+            raise MigrationInventoryDriftError("fixed-ref migration inventory snapshot binding drifted")
+        inventory = self.inventory_from_payload(snapshot["payload"])
+        if (
+            inventory.namespace_id != run.namespace_id
+            or inventory.fixed_git_oid != run.fixed_git_oid
+            or inventory.coverage_version != run.coverage_version
+            or inventory.inventory_digest != run.inventory_digest
+        ):
             raise MigrationInventoryDriftError()
+        scope = await self.validated_inventory_scope(inventory, conn=conn)
+        if run.status == "complete":
+            observed = await self.repository.list_namespace_completed_mappings(
+                namespace_id=inventory.namespace_id,
+                conn=conn,
+            )
+            observed_closure = sorted(
+                (str(row.resource_id), row.legacy_git_oid, row.path_at_revision)
+                for row in observed
+            )
+            expected_closure = sorted(
+                (str(document.resource_id), entry.legacy_git_oid, entry.path_at_revision)
+                for document in inventory.documents
+                for entry in document.lineage
+            )
+            if observed_closure != expected_closure:
+                raise MigrationInventoryDriftError(
+                    "completed Legacy selector closure drifted from the fixed inventory"
+                )
         return scope
 
     async def inventory_for_run(self, run: MigrationRun) -> LegacyInventory:

--- a/backend/app/services/native_revision_authority.py
+++ b/backend/app/services/native_revision_authority.py
@@ -6,7 +6,7 @@ import hashlib
 import inspect
 import json
 import uuid
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -46,8 +46,68 @@ _AUTHORITY_CONTENT_TABLES = (
     "legacy_revision_mappings",
 )
 
+# These are the catalog, candidate, and receipt relations whose writes must be
+# stopped while the caller performs the post-fence Git/S3 revalidation.  The
+# three Legacy relations with an existing permanent trigger are deliberately
+# absent from the transient-trigger set below; their old trigger behavior is
+# part of the committed cutover contract.
+_CUTOVER_LOCK_TABLES = (
+    "vaults",
+    "collections",
+    "documents",
+    "resource_aliases",
+    "vault_files",
+    "vault_external_git",
+    "native_revision_cutover_runs",
+    "native_revision_cutover_vaults",
+    "native_revision_cutover_files",
+    "native_revision_cutover_exclusions",
+    "native_revision_migration_runs",
+    "native_revision_migration_items",
+    "legacy_revision_mappings",
+    "native_revision_migration_inventories",
+    "vault_tables",
+    "m1_reference_payloads",
+    "native_resources",
+    "native_payload_manifests",
+    "native_revisions",
+    "native_revision_activity",
+    "native_invalidation_intents",
+    "native_resource_path_aliases",
+    "native_derived_heads",
+    "native_derived_chunks",
+    "m1_file_transfer_intents",
+    "native_file_projection_outbox",
+)
+_REQUIRED_CUTOVER_LOCK_TABLES = (
+    "vaults",
+    "collections",
+    "documents",
+    "resource_aliases",
+    "vault_files",
+    "vault_external_git",
+    "native_revision_cutover_runs",
+    "native_revision_cutover_vaults",
+    "native_revision_cutover_files",
+    "native_revision_cutover_exclusions",
+    "native_revision_migration_runs",
+    "native_revision_migration_items",
+    "legacy_revision_mappings",
+)
+_PERMANENT_CUTOVER_GUARD_TABLES = {
+    "documents",
+    "resource_aliases",
+    "vault_external_git",
+}
+_TRANSIENT_CUTOVER_GUARD_TABLES = tuple(
+    table for table in _CUTOVER_LOCK_TABLES if table not in _PERMANENT_CUTOVER_GUARD_TABLES
+)
+_TRANSIENT_CUTOVER_GUARD_TRIGGER = "guard_native_revision_cutover_fenced_write"
+_TRANSIENT_CUTOVER_TRUNCATE_TRIGGER = "guard_native_revision_cutover_fenced_truncate"
+_AUTHORITY_FENCE_TABLE = "native_revision_existing_authority_fence"
 Failpoint = Callable[[str], Any]
-ExistingCutoverRevalidator = Callable[[asyncpg.Connection], Awaitable[None]]
+ExistingCutoverPreflight = Callable[[asyncpg.Connection], Any]
+ExistingCutoverRevalidator = Callable[[asyncpg.Connection], Any]
 
 
 class NativeAuthorityError(RuntimeError):
@@ -89,6 +149,35 @@ class NativeAuthorityIdentity:
             self.current_database,
             self.runtime_image_digest,
         )
+
+
+@dataclass(frozen=True, slots=True)
+class ExistingDatabaseAuthorityFence:
+    """Durable phase-A receipt passed to the phase-B authority finalizer."""
+
+    cutover_id: uuid.UUID
+    fence_token: uuid.UUID
+    legacy_write_epoch: int
+    inventory_digest: str
+    verification_digest: str
+    vault_binding_digest: str
+    authority_id: uuid.UUID | None = None
+    state: str = "fenced"
+
+    @property
+    def epoch(self) -> int:
+        """Short alias for callers that refer to the fence epoch directly."""
+        return self.legacy_write_epoch
+
+    @property
+    def token(self) -> uuid.UUID:
+        """Short alias for serialization/admission code."""
+        return self.fence_token
+
+
+# Keep the shorter name available to callers that use the fence as the API
+# object rather than as a database-specific authority receipt.
+ExistingAuthorityFence = ExistingDatabaseAuthorityFence
 
 
 def _binding_matches(row: asyncpg.Record | dict[str, Any], identity: NativeAuthorityIdentity) -> bool:
@@ -252,6 +341,141 @@ async def _content_inventory(conn: asyncpg.Connection) -> dict[str, int]:
     return inventory
 
 
+async def _available_cutover_tables(
+    conn: asyncpg.Connection,
+) -> tuple[str, ...]:
+    available: list[str] = []
+    for table in _CUTOVER_LOCK_TABLES:
+        if await _relation_exists(conn, table):
+            available.append(table)
+    missing = [table for table in _REQUIRED_CUTOVER_LOCK_TABLES if table not in available]
+    if missing:
+        raise NativeAuthorityError(
+            "native_authority_cutover_schema_incomplete",
+            "Existing-database authority requires cutover tables: " + ", ".join(missing),
+        )
+    return tuple(available)
+
+
+async def _lock_cutover_tables(conn: asyncpg.Connection) -> tuple[str, ...]:
+    tables = await _available_cutover_tables(conn)
+    qualified = ", ".join(f'public."{table}"' for table in tables)
+    await conn.execute(
+        f"LOCK TABLE {qualified} IN SHARE ROW EXCLUSIVE MODE"
+    )
+    return tables
+
+
+async def _install_transient_cutover_guards(
+    conn: asyncpg.Connection,
+    tables: tuple[str, ...],
+) -> None:
+    for table in tables:
+        if table not in _TRANSIENT_CUTOVER_GUARD_TABLES:
+            continue
+        await conn.execute(
+            f"""
+            DROP TRIGGER IF EXISTS {_TRANSIENT_CUTOVER_GUARD_TRIGGER}
+                ON public."{table}";
+            CREATE TRIGGER {_TRANSIENT_CUTOVER_GUARD_TRIGGER}
+                BEFORE INSERT OR UPDATE OR DELETE ON public."{table}"
+                FOR EACH ROW EXECUTE FUNCTION
+                    reject_fenced_native_revision_cutover_write();
+            DROP TRIGGER IF EXISTS {_TRANSIENT_CUTOVER_TRUNCATE_TRIGGER}
+                ON public."{table}";
+            CREATE TRIGGER {_TRANSIENT_CUTOVER_TRUNCATE_TRIGGER}
+                BEFORE TRUNCATE ON public."{table}"
+                FOR EACH STATEMENT EXECUTE FUNCTION
+                    reject_fenced_native_revision_cutover_write();
+            """
+        )
+
+
+async def _drop_transient_cutover_guards(
+    conn: asyncpg.Connection,
+    tables: tuple[str, ...],
+) -> None:
+    for table in tables:
+        if table not in _TRANSIENT_CUTOVER_GUARD_TABLES:
+            continue
+        await conn.execute(
+            f"""
+            DROP TRIGGER IF EXISTS {_TRANSIENT_CUTOVER_GUARD_TRIGGER}
+                ON public."{table}";
+            DROP TRIGGER IF EXISTS {_TRANSIENT_CUTOVER_TRUNCATE_TRIGGER}
+                ON public."{table}";
+            """
+        )
+
+
+def _fence_from_row(
+    row: asyncpg.Record | dict[str, Any],
+    *,
+    authority_id: uuid.UUID | None = None,
+    state: str | None = None,
+) -> ExistingDatabaseAuthorityFence:
+    return ExistingDatabaseAuthorityFence(
+        cutover_id=row["cutover_id"],
+        fence_token=row["fence_token"],
+        legacy_write_epoch=int(row["legacy_write_epoch"]),
+        inventory_digest=row["inventory_digest"],
+        verification_digest=row["verification_digest"],
+        vault_binding_digest=row["vault_binding_digest"],
+        authority_id=authority_id,
+        state=state or "fenced",
+    )
+
+
+def _authority_fence_identity_matches(
+    row: asyncpg.Record | dict[str, Any],
+    identity: NativeAuthorityIdentity,
+) -> bool:
+    return all(
+        row[key] == value
+        for key, value in (
+            ("tenant_id", identity.tenant_id),
+            ("namespace", identity.namespace),
+            ("database_id", identity.database_id),
+            ("current_database", identity.current_database),
+            ("runtime_image_digest", identity.runtime_image_digest),
+        )
+    )
+
+
+def _cutover_snapshot_matches(
+    row: asyncpg.Record | dict[str, Any],
+    *,
+    cutover_id: uuid.UUID,
+    run: asyncpg.Record,
+    vault_binding_digest: str,
+) -> bool:
+    return (
+        row["cutover_id"] == cutover_id
+        and row["inventory_digest"] == run["inventory_digest"]
+        and row["verification_digest"] == run["verification_digest"]
+        and row["vault_binding_digest"] == vault_binding_digest
+    )
+
+
+def _require_idle_authority_connection(conn: asyncpg.Connection) -> None:
+    if conn.is_in_transaction():
+        raise NativeAuthorityError(
+            "native_authority_transaction_active",
+            "Existing-database authority phases require an idle PostgreSQL connection",
+        )
+
+
+async def _invoke_existing_cutover_callback(
+    callback: ExistingCutoverPreflight | None,
+    conn: asyncpg.Connection,
+) -> None:
+    if callback is None:
+        return
+    result = callback(conn)
+    if inspect.isawaitable(result):
+        await result
+
+
 async def _verified_cutover_binding(
     conn: asyncpg.Connection,
     cutover_id: uuid.UUID,
@@ -327,50 +551,282 @@ async def _verified_cutover_binding(
     return run, _canonical_digest(binding)
 
 
-async def _activate_legacy_write_fence(
+async def _require_durable_authority_fence_schema(conn: asyncpg.Connection) -> None:
+    """Require migration 096 rather than creating authority DDL at runtime."""
+    if not await _relation_exists(conn, _AUTHORITY_FENCE_TABLE):
+        raise NativeAuthorityError(
+            "native_authority_fence_incomplete",
+            "migration 096 must create the durable existing-database authority fence",
+        )
+
+
+async def _reject_new_database_authority_conflict(conn: asyncpg.Connection) -> None:
+    counts = await conn.fetchrow(
+        """
+        SELECT
+            (SELECT COUNT(*) FROM document_revision_bootstrap_claims) AS claims,
+            (SELECT COUNT(*) FROM document_revision_authority_pending) AS pending,
+            (SELECT COUNT(*) FROM document_revision_authority_marker) AS markers
+        """
+    )
+    if any(int(counts[name]) for name in counts.keys()):
+        raise NativeAuthorityError(
+            "native_authority_mode_conflict",
+            "Existing-database cutover cannot coexist with new-database authority",
+        )
+
+
+async def _fetch_legacy_write_fence(conn: asyncpg.Connection) -> asyncpg.Record:
+    fence = await conn.fetchrow(
+        "SELECT * FROM native_revision_legacy_write_fence "
+        "WHERE fence_key = TRUE FOR UPDATE"
+    )
+    if fence is None:
+        raise NativeAuthorityError(
+            "native_authority_fence_incomplete",
+            "Existing-database authority requires the Legacy write fence row",
+        )
+    return fence
+
+
+async def _fetch_durable_authority_fence(
+    conn: asyncpg.Connection,
+) -> asyncpg.Record | None:
+    return await conn.fetchrow(
+        f'SELECT * FROM "{_AUTHORITY_FENCE_TABLE}" '
+        "WHERE fence_key = TRUE FOR UPDATE"
+    )
+
+
+def _fence_identity_error() -> NativeAuthorityError:
+    return NativeAuthorityError(
+        "native_authority_fence_identity_mismatch",
+        "Existing-database authority fence does not match the configured identity",
+    )
+
+
+def _fence_conflict_error() -> NativeAuthorityError:
+    return NativeAuthorityError(
+        "native_authority_fence_conflict",
+        "Existing-database authority fence belongs to a different cutover",
+    )
+
+
+def _fence_incomplete_error(message: str) -> NativeAuthorityError:
+    return NativeAuthorityError("native_authority_fence_incomplete", message)
+
+
+async def _validate_existing_authority_fence(
     conn: asyncpg.Connection,
     *,
+    existing: asyncpg.Record,
+    durable: asyncpg.Record | None,
+    legacy: asyncpg.Record,
+    identity: NativeAuthorityIdentity,
     cutover_id: uuid.UUID,
-) -> int:
-    # SHARE ROW EXCLUSIVE conflicts with ordinary INSERT/UPDATE/DELETE's
-    # ROW EXCLUSIVE lock while leaving the final read-only validation free to
-    # inspect every source table. Once this transaction commits, the row-level
-    # triggers reject any waiter that was admitted by a stopped Legacy image.
-    await conn.execute(
-        """
-        LOCK TABLE vaults, collections, documents, resource_aliases,
-                   vault_files, vault_external_git,
-                   native_revision_cutover_runs, native_revision_cutover_vaults,
-                   native_revision_cutover_files, native_revision_cutover_exclusions
-        IN SHARE ROW EXCLUSIVE MODE
-        """
-    )
-    fence = await conn.fetchrow(
-        "SELECT * FROM native_revision_legacy_write_fence WHERE fence_key = TRUE FOR UPDATE"
-    )
-    if fence is None or fence["state"] != "open":
-        raise NativeAuthorityError(
-            "native_authority_legacy_fence_conflict",
-            "Existing-database authority requires the open Legacy write fence",
+) -> ExistingDatabaseAuthorityFence:
+    """Validate an already committed authority and return its durable receipt."""
+    if existing["cutover_id"] != cutover_id:
+        raise _fence_conflict_error()
+    if not _initialization_matches(existing, identity):
+        raise _fence_identity_error()
+    if durable is None:
+        raise _fence_incomplete_error(
+            "Committed existing-database authority has no phase-A fence receipt"
         )
-    row = await conn.fetchrow(
-        """
-        UPDATE native_revision_legacy_write_fence
-           SET epoch = epoch + 1,
-               state = 'fenced',
-               cutover_id = $1,
-               fenced_at = NOW()
-         WHERE fence_key = TRUE AND state = 'open'
-        RETURNING epoch
-        """,
-        cutover_id,
-    )
-    if row is None:
-        raise NativeAuthorityError(
-            "native_authority_legacy_fence_conflict",
-            "Existing-database authority lost the Legacy write fence",
+    if durable["cutover_id"] != cutover_id:
+        raise _fence_conflict_error()
+    if not _authority_fence_identity_matches(durable, identity):
+        raise _fence_identity_error()
+    if legacy["state"] != "committed":
+        raise _fence_incomplete_error(
+            "Existing-database authority is not bound to a committed Legacy fence"
         )
-    return int(row["epoch"])
+    if int(durable["legacy_write_epoch"]) != int(legacy["epoch"]):
+        raise _fence_incomplete_error(
+            "Durable phase-A fence epoch does not match the Legacy fence"
+        )
+    run, vault_binding_digest = await _verified_cutover_binding(conn, cutover_id)
+    expected = {
+        "record_kind": EXISTING_AUTHORITY_RECORD_KIND,
+        "backend": AUTHORITY_BACKEND,
+        "inventory_digest": run["inventory_digest"],
+        "verification_digest": run["verification_digest"],
+        "vault_binding_digest": vault_binding_digest,
+        "status": "committed",
+    }
+    if any(existing[key] != value for key, value in expected.items()):
+        raise NativeAuthorityError(
+            "native_authority_existing_mismatch",
+            "Existing-database Native authority does not match the verified cutover",
+        )
+    if not _cutover_snapshot_matches(
+        durable,
+        cutover_id=cutover_id,
+        run=run,
+        vault_binding_digest=vault_binding_digest,
+    ):
+        raise _fence_incomplete_error(
+            "Durable phase-A fence does not match the verified cutover"
+        )
+    await _require_committed_legacy_fence(conn, existing)
+    return _fence_from_row(
+        durable,
+        authority_id=existing["authority_id"],
+        state="committed",
+    )
+
+
+async def _validate_fenced_authority_receipt(
+    conn: asyncpg.Connection,
+    *,
+    durable: asyncpg.Record | None,
+    legacy: asyncpg.Record,
+    identity: NativeAuthorityIdentity,
+    cutover_id: uuid.UUID,
+) -> tuple[asyncpg.Record, str]:
+    """Validate the durable receipt that permits phase-A resume or phase B."""
+    if legacy["state"] != "fenced":
+        raise _fence_incomplete_error(
+            "Existing-database authority is not in the fenced state"
+        )
+    if legacy["cutover_id"] != cutover_id:
+        raise _fence_conflict_error()
+    if durable is None:
+        raise _fence_incomplete_error(
+            "Legacy fence is fenced but has no durable phase-A receipt"
+        )
+    if durable["cutover_id"] != cutover_id:
+        raise _fence_conflict_error()
+    if not _authority_fence_identity_matches(durable, identity):
+        raise _fence_identity_error()
+    if int(durable["legacy_write_epoch"]) != int(legacy["epoch"]):
+        raise _fence_incomplete_error(
+            "Durable phase-A fence epoch does not match the Legacy fence"
+        )
+    run, vault_binding_digest = await _verified_cutover_binding(conn, cutover_id)
+    if not _cutover_snapshot_matches(
+        durable,
+        cutover_id=cutover_id,
+        run=run,
+        vault_binding_digest=vault_binding_digest,
+    ):
+        raise _fence_incomplete_error(
+            "Durable phase-A fence does not match the verified cutover"
+        )
+    return run, vault_binding_digest
+
+
+async def begin_existing_database_authority(
+    conn: asyncpg.Connection,
+    *,
+    identity: NativeAuthorityIdentity,
+    cutover_id: uuid.UUID,
+    preflight: ExistingCutoverPreflight | None = None,
+) -> ExistingDatabaseAuthorityFence:
+    """Durably fence one exact cutover in a short transaction.
+
+    ``preflight`` runs only for the open -> fenced transition, after the
+    original SHARE ROW EXCLUSIVE locks and the verified DB/catalog receipt are
+    acquired.  It must be a bounded database-only check.  The returned receipt
+    is safe to persist by the caller and can be recovered by calling this
+    function again with the same cutover and identity after a crash.
+    """
+    _require_idle_authority_connection(conn)
+    async with conn.transaction():
+        await conn.execute("SELECT pg_advisory_xact_lock($1)", AUTHORITY_LOCK_KEY)
+        await _require_durable_authority_fence_schema(conn)
+        await _reject_new_database_authority_conflict(conn)
+        tables = await _lock_cutover_tables(conn)
+        legacy = await _fetch_legacy_write_fence(conn)
+        durable = await _fetch_durable_authority_fence(conn)
+        existing = await conn.fetchrow(
+            "SELECT * FROM native_revision_existing_authority "
+            "WHERE marker_id = TRUE FOR UPDATE"
+        )
+
+        if existing is not None:
+            committed = await _validate_existing_authority_fence(
+                conn,
+                existing=existing,
+                durable=durable,
+                legacy=legacy,
+                identity=identity,
+                cutover_id=cutover_id,
+            )
+            await _drop_transient_cutover_guards(conn, tables)
+            return committed
+
+        if legacy["state"] == "open":
+            if durable is not None:
+                raise _fence_incomplete_error(
+                    "Open Legacy fence already has a durable phase-A receipt"
+                )
+            if int(legacy["epoch"]) != 0:
+                raise _fence_incomplete_error(
+                    "Open Legacy fence has an invalid non-zero epoch"
+                )
+            run, vault_binding_digest = await _verified_cutover_binding(conn, cutover_id)
+            await _invoke_existing_cutover_callback(preflight, conn)
+            await _install_transient_cutover_guards(conn, tables)
+            row = await conn.fetchrow(
+                """
+                UPDATE native_revision_legacy_write_fence
+                   SET epoch = epoch + 1,
+                       state = 'fenced',
+                       cutover_id = $1,
+                       fenced_at = NOW()
+                 WHERE fence_key = TRUE AND state = 'open' AND epoch = 0
+                RETURNING epoch
+                """,
+                cutover_id,
+            )
+            if row is None:
+                raise NativeAuthorityError(
+                    "native_authority_fence_conflict",
+                    "Existing-database authority lost the open Legacy fence",
+                )
+            durable = await conn.fetchrow(
+                f"""
+                INSERT INTO "{_AUTHORITY_FENCE_TABLE}" (
+                    fence_key, fence_token, cutover_id, legacy_write_epoch,
+                    tenant_id, namespace, database_id, current_database,
+                    runtime_image_digest, inventory_digest, verification_digest,
+                    vault_binding_digest, fenced_at
+                ) VALUES (
+                    TRUE, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW()
+                )
+                RETURNING *
+                """,
+                uuid.uuid4(),
+                cutover_id,
+                int(row["epoch"]),
+                *identity.params(),
+                run["inventory_digest"],
+                run["verification_digest"],
+                vault_binding_digest,
+            )
+            if durable is None:
+                raise _fence_incomplete_error(
+                    "Existing-database authority phase-A receipt was not stored"
+                )
+            return _fence_from_row(durable, state="fenced")
+
+        if legacy["state"] == "fenced":
+            await _validate_fenced_authority_receipt(
+                conn,
+                durable=durable,
+                legacy=legacy,
+                identity=identity,
+                cutover_id=cutover_id,
+            )
+            await _install_transient_cutover_guards(conn, tables)
+            assert durable is not None
+            return _fence_from_row(durable, state="fenced")
+
+        raise _fence_incomplete_error(
+            "Committed Legacy fence has no committed existing-database authority"
+        )
 
 
 async def _require_committed_legacy_fence(
@@ -385,69 +841,142 @@ async def _require_committed_legacy_fence(
         or fence["state"] != "committed"
         or int(fence["epoch"]) != int(authority["legacy_write_epoch"])
         or fence["cutover_id"] != authority["cutover_id"]
-    ):
+        ):
         raise NativeAuthorityError(
             "native_authority_legacy_fence_mismatch",
             "Existing-database Native authority is not bound to its committed Legacy fence",
         )
 
 
-async def mint_existing_database_authority(
+def _require_requested_fence_values(
+    *,
+    fence: ExistingDatabaseAuthorityFence | None,
+    cutover_id: uuid.UUID | None,
+    fence_token: uuid.UUID | None,
+    legacy_write_epoch: int | None,
+) -> tuple[uuid.UUID, uuid.UUID, int]:
+    if fence is not None:
+        values = (fence.cutover_id, fence.fence_token, fence.legacy_write_epoch)
+        supplied = (cutover_id, fence_token, legacy_write_epoch)
+        if any(value is not None and value != expected for value, expected in zip(supplied, values)):
+            raise NativeAuthorityError(
+                "native_authority_fence_token_mismatch",
+                "Phase-B fence arguments do not match the phase-A receipt",
+            )
+        if fence.state not in {"fenced", "committed"}:
+            raise _fence_incomplete_error("Phase-A receipt has an invalid state")
+        return values
+    if cutover_id is None or fence_token is None or legacy_write_epoch is None:
+        raise NativeAuthorityError(
+            "native_authority_fence_token_missing",
+            "Phase B requires the exact phase-A cutover, token, and epoch",
+        )
+    return cutover_id, fence_token, int(legacy_write_epoch)
+
+
+def _fence_arguments_match_receipt(
+    durable: asyncpg.Record,
+    *,
+    cutover_id: uuid.UUID,
+    fence_token: uuid.UUID,
+    legacy_write_epoch: int,
+    fence: ExistingDatabaseAuthorityFence | None,
+) -> bool:
+    if (
+        durable["cutover_id"] != cutover_id
+        or durable["fence_token"] != fence_token
+        or int(durable["legacy_write_epoch"]) != legacy_write_epoch
+    ):
+        return False
+    if fence is None:
+        return True
+    return all(
+        getattr(fence, key) == durable[key]
+        for key in ("inventory_digest", "verification_digest", "vault_binding_digest")
+    )
+
+
+async def finalize_existing_database_authority(
     conn: asyncpg.Connection,
     *,
     identity: NativeAuthorityIdentity,
-    cutover_id: uuid.UUID,
+    fence: ExistingDatabaseAuthorityFence | None = None,
+    cutover_id: uuid.UUID | None = None,
+    fence_token: uuid.UUID | None = None,
+    legacy_write_epoch: int | None = None,
     authority_id: uuid.UUID | None = None,
-    revalidate: ExistingCutoverRevalidator | None = None,
 ) -> uuid.UUID:
-    """Fence Legacy writes, revalidate, and mint immutable Native authority."""
+    """Atomically mint immutable authority and commit an exact fenced cutover."""
+    requested_cutover_id, requested_token, requested_epoch = _require_requested_fence_values(
+        fence=fence,
+        cutover_id=cutover_id,
+        fence_token=fence_token,
+        legacy_write_epoch=legacy_write_epoch,
+    )
+    _require_idle_authority_connection(conn)
     async with conn.transaction():
         await conn.execute("SELECT pg_advisory_xact_lock($1)", AUTHORITY_LOCK_KEY)
-        bootstrap_counts = await conn.fetchrow(
-            """
-            SELECT
-                (SELECT COUNT(*) FROM document_revision_bootstrap_claims) AS claims,
-                (SELECT COUNT(*) FROM document_revision_authority_pending) AS pending,
-                (SELECT COUNT(*) FROM document_revision_authority_marker) AS markers
-            """
-        )
-        if any(int(bootstrap_counts[name]) for name in bootstrap_counts.keys()):
-            raise NativeAuthorityError(
-                "native_authority_mode_conflict",
-                "Existing-database cutover cannot coexist with new-database authority",
+        await _require_durable_authority_fence_schema(conn)
+        await _reject_new_database_authority_conflict(conn)
+        tables = await _lock_cutover_tables(conn)
+        legacy = await _fetch_legacy_write_fence(conn)
+        durable = await _fetch_durable_authority_fence(conn)
+        if durable is None:
+            raise _fence_incomplete_error(
+                "Phase B requires the durable phase-A fence receipt"
             )
+        if not _fence_arguments_match_receipt(
+            durable,
+            cutover_id=requested_cutover_id,
+            fence_token=requested_token,
+            legacy_write_epoch=requested_epoch,
+            fence=fence,
+        ):
+            raise NativeAuthorityError(
+                "native_authority_fence_token_mismatch",
+                "Phase-B token, epoch, or cutover does not match the durable phase-A receipt",
+            )
+        if legacy["cutover_id"] != requested_cutover_id or int(legacy["epoch"]) != requested_epoch:
+            raise NativeAuthorityError(
+                "native_authority_fence_token_mismatch",
+                "Phase-B token and epoch do not match the Legacy fence",
+            )
+        if not _authority_fence_identity_matches(durable, identity):
+            raise _fence_identity_error()
 
         existing = await conn.fetchrow(
-            "SELECT * FROM native_revision_existing_authority WHERE marker_id = TRUE FOR UPDATE"
+            "SELECT * FROM native_revision_existing_authority "
+            "WHERE marker_id = TRUE FOR UPDATE"
         )
         if existing is not None:
-            run, vault_binding_digest = await _verified_cutover_binding(conn, cutover_id)
-            expected = {
-                "cutover_id": cutover_id,
-                "record_kind": EXISTING_AUTHORITY_RECORD_KIND,
-                "backend": AUTHORITY_BACKEND,
-                "inventory_digest": run["inventory_digest"],
-                "verification_digest": run["verification_digest"],
-                "vault_binding_digest": vault_binding_digest,
-                "status": "committed",
-            }
-            if not _initialization_matches(existing, identity) or any(
-                existing[key] != value for key, value in expected.items()
-            ):
-                raise NativeAuthorityError(
-                    "native_authority_existing_mismatch",
-                    "Existing-database Native authority does not match the verified cutover",
-                )
-            await _require_committed_legacy_fence(conn, existing)
-            return existing["authority_id"]
+            committed = await _validate_existing_authority_fence(
+                conn,
+                existing=existing,
+                durable=durable,
+                legacy=legacy,
+                identity=identity,
+                cutover_id=requested_cutover_id,
+            )
+            await _drop_transient_cutover_guards(conn, tables)
+            return committed.authority_id  # type: ignore[return-value]
 
-        legacy_write_epoch = await _activate_legacy_write_fence(
+        if legacy["state"] != "fenced":
+            raise _fence_incomplete_error(
+                "Phase B requires the exact Legacy fence to remain fenced"
+            )
+        run, vault_binding_digest = await _verified_cutover_binding(
             conn,
-            cutover_id=cutover_id,
+            requested_cutover_id,
         )
-        run, vault_binding_digest = await _verified_cutover_binding(conn, cutover_id)
-        if revalidate is not None:
-            await revalidate(conn)
+        if not _cutover_snapshot_matches(
+            durable,
+            cutover_id=requested_cutover_id,
+            run=run,
+            vault_binding_digest=vault_binding_digest,
+        ):
+            raise _fence_incomplete_error(
+                "Phase-B verified cutover no longer matches the phase-A receipt"
+            )
 
         authority_id = authority_id or uuid.uuid4()
         await conn.execute(
@@ -463,12 +992,12 @@ async def mint_existing_database_authority(
             )
             """,
             authority_id,
-            cutover_id,
+            requested_cutover_id,
             *identity.params(),
             run["inventory_digest"],
             run["verification_digest"],
             vault_binding_digest,
-            legacy_write_epoch,
+            requested_epoch,
         )
         committed = await conn.execute(
             """
@@ -479,15 +1008,52 @@ async def mint_existing_database_authority(
                AND epoch = $1
                AND cutover_id = $2
             """,
-            legacy_write_epoch,
-            cutover_id,
+            requested_epoch,
+            requested_cutover_id,
         )
         if committed != "UPDATE 1":
             raise NativeAuthorityError(
-                "native_authority_legacy_fence_conflict",
-                "Existing-database authority could not commit the Legacy write fence",
+                "native_authority_fence_conflict",
+                "Existing-database authority could not commit the exact Legacy fence",
             )
+        await _drop_transient_cutover_guards(conn, tables)
         return authority_id
+
+
+async def mint_existing_database_authority(
+    conn: asyncpg.Connection,
+    *,
+    identity: NativeAuthorityIdentity,
+    cutover_id: uuid.UUID,
+    authority_id: uuid.UUID | None = None,
+    revalidate: ExistingCutoverRevalidator | None = None,
+    preflight: ExistingCutoverPreflight | None = None,
+) -> uuid.UUID:
+    """Compatibility wrapper with long revalidation outside PostgreSQL transactions."""
+    fence = await begin_existing_database_authority(
+        conn,
+        identity=identity,
+        cutover_id=cutover_id,
+        preflight=preflight,
+    )
+    if fence.authority_id is not None:
+        return fence.authority_id
+    # This callback is intentionally outside both short authority transactions.
+    # It may perform the caller's Git/S3/full comparator work while the durable
+    # fence triggers reject mutable cutover writes.
+    await _invoke_existing_cutover_callback(revalidate, conn)
+    return await finalize_existing_database_authority(
+        conn,
+        identity=identity,
+        fence=fence,
+        authority_id=authority_id,
+    )
+
+
+# Explicit names make the crash-resumable boundary available to callers while
+# the wrapper above keeps the existing service integration source-compatible.
+mint_existing_database_authority_phase_a = begin_existing_database_authority
+mint_existing_database_authority_phase_b = finalize_existing_database_authority
 
 
 async def consume_or_validate_existing_database_authority(
@@ -701,6 +1267,29 @@ async def consume_or_validate_native_authority(
         return "initialized"
 
 
+async def _reject_incomplete_existing_authority_fence(
+    conn: asyncpg.Connection,
+) -> None:
+    """Keep startup fail-closed if a durable fence has no committed authority."""
+    if not await _relation_exists(conn, "native_revision_legacy_write_fence"):
+        return
+    fence = await conn.fetchrow(
+        "SELECT state FROM native_revision_legacy_write_fence WHERE fence_key = TRUE"
+    )
+    if fence is None or fence["state"] == "open":
+        return
+    authority_count = 0
+    if await _relation_exists(conn, "native_revision_existing_authority"):
+        authority_count = int(
+            await conn.fetchval("SELECT COUNT(*) FROM native_revision_existing_authority")
+        )
+    if fence["state"] == "fenced" or authority_count == 0:
+        raise NativeAuthorityError(
+            "native_authority_fence_incomplete",
+            "Startup refuses a Legacy fence without committed existing-database authority",
+        )
+
+
 async def _reject_native_authority_for_non_product_mode(conn: asyncpg.Connection) -> None:
     async with conn.transaction():
         await conn.execute("SELECT pg_advisory_xact_lock($1)", AUTHORITY_LOCK_KEY)
@@ -718,6 +1307,15 @@ async def _reject_native_authority_for_non_product_mode(conn: asyncpg.Connection
                 "native_authority_mode_conflict",
                 "Bare Git and measurement modes reject a database claimed by postgres_native",
             )
+        if await _relation_exists(conn, "native_revision_legacy_write_fence"):
+            state = await conn.fetchval(
+                "SELECT state FROM native_revision_legacy_write_fence WHERE fence_key = TRUE"
+            )
+            if state in {"fenced", "committed"}:
+                raise NativeAuthorityError(
+                    "native_authority_mode_conflict",
+                    "Bare Git and measurement modes reject an existing-database cutover fence",
+                )
 
 
 async def startup_revision_authority_preflight(
@@ -731,6 +1329,7 @@ async def startup_revision_authority_preflight(
     pool = await get_pool()
     async with pool.acquire() as conn:
         if configured.document_revision_backend == "postgres_native":
+            await _reject_incomplete_existing_authority_fence(conn)
             if await conn.fetchval(
                 "SELECT COUNT(*) FROM native_revision_existing_authority"
             ):
@@ -767,14 +1366,24 @@ async def pre_migration_revision_authority_guard(configured: Settings = settings
             if existing_table
             else 0
         )
+        fence_state = None
+        if await _relation_exists(conn, "native_revision_legacy_write_fence"):
+            fence_state = await conn.fetchval(
+                "SELECT state FROM native_revision_legacy_write_fence WHERE fence_key = TRUE"
+            )
         if configured.document_revision_backend == "postgres_native":
+            if fence_state == "fenced" or (fence_state == "committed" and existing_count == 0):
+                raise NativeAuthorityError(
+                    "native_authority_fence_incomplete",
+                    "postgres_native startup refuses an uncommitted existing-database fence",
+                )
             if (claim_count, existing_count) not in {(1, 0), (0, 1)}:
                 raise NativeAuthorityError(
                     "native_authority_missing",
                     "postgres_native startup requires exactly one new-database claim "
                     "or verified existing-database cutover authority",
                 )
-        elif claim_count or existing_count:
+        elif claim_count or existing_count or fence_state in {"fenced", "committed"}:
             raise NativeAuthorityError(
                 "native_authority_mode_conflict",
                 "Bare Git and measurement modes reject a database claimed by postgres_native",

--- a/backend/app/services/native_revision_cutover.py
+++ b/backend/app/services/native_revision_cutover.py
@@ -22,6 +22,7 @@ from app.repositories.native_revision_cutover_repo import (
     NativeRevisionCutoverRepository,
 )
 from app.repositories.native_revision_migration_repo import (
+    MigrationInventoryDriftError,
     NativeRevisionMigrationRepository,
 )
 from app.services.native_revision_backfill import NativeRevisionBackfill
@@ -31,11 +32,13 @@ from app.services.adapters import s3_adapter
 from app.services.git_service import GitService
 from app.services.legacy_revision_bridge import (
     InventoryEligibilityError,
+    LegacyInventory,
     LegacyRevisionBridge,
 )
 from app.services.native_revision_authority import (
     NativeAuthorityIdentity,
-    mint_existing_database_authority,
+    begin_existing_database_authority,
+    finalize_existing_database_authority,
 )
 from app.services.native_revision_shadow import NativeRevisionShadowComparator
 from app.services.native_revision_shadow_reader import (
@@ -623,9 +626,8 @@ class NativeRevisionCutover:
         conn: asyncpg.Connection,
         files: Sequence[CutoverFile],
     ) -> None:
-        for file in files:
-            native = await conn.fetchrow(
-                """
+        rows = await conn.fetch(
+            """
                 SELECT r.namespace_id, r.resource_id, r.surface, r.lifecycle,
                        r.current_path, r.head_revision_id,
                        pm.digest, pm.byte_size
@@ -635,10 +637,13 @@ class NativeRevisionCutover:
                    AND nr.revision_id = r.head_revision_id
              LEFT JOIN native_payload_manifests pm
                     ON pm.payload_manifest_id = nr.payload_manifest_id
-                 WHERE r.resource_id = $1
-                """,
-                file.file_id,
-            )
+                 WHERE r.resource_id = ANY($1::uuid[])
+            """,
+            [file.file_id for file in files],
+        )
+        native_by_id = {row["resource_id"]: row for row in rows}
+        for file in files:
+            native = native_by_id.get(file.file_id)
             if file.disposition == "preserved_binary":
                 if native is not None:
                     raise CutoverVerificationError(f"binary File {file.file_id} unexpectedly gained text authority")
@@ -670,7 +675,135 @@ class NativeRevisionCutover:
             if observed != expected:
                 raise CutoverVerificationError(f"File {file.file_id} Native searchable projection drifted")
 
-    async def _revalidate_authority_inventory(
+    async def _require_source_file_bindings(
+        self,
+        conn: asyncpg.Connection,
+        *,
+        namespace_ids: Sequence[uuid.UUID],
+        files: Sequence[CutoverFile],
+    ) -> None:
+        rows = await conn.fetch(
+            """
+            SELECT vf.vault_id AS namespace_id, vf.id AS file_id,
+                   CASE WHEN c.path IS NULL THEN vf.name
+                        ELSE c.path || '/' || vf.name END AS logical_path,
+                   COALESCE(NULLIF(vf.mime_type, ''), 'application/octet-stream')
+                       AS mime_type,
+                   vf.content_hash, vf.size_bytes, vf.s3_key,
+                   vf.etag, vf.storage_version, vf.created_by
+              FROM vault_files vf
+         LEFT JOIN collections c ON c.id = vf.collection_id
+             WHERE vf.vault_id = ANY($1::uuid[])
+               AND vf.kind = 'file'
+               AND vf.upload_state = 'confirmed'
+               AND vf.hash_verified_at IS NOT NULL
+               AND vf.content_hash ~ '^[0-9a-f]{64}$'
+               AND vf.size_bytes >= 0
+             ORDER BY vf.vault_id, vf.id
+            """,
+            list(namespace_ids),
+        )
+        observed = [
+            {
+                "namespace_id": str(row["namespace_id"]),
+                "file_id": str(row["file_id"]),
+                "logical_path": row["logical_path"],
+                "mime_type": row["mime_type"],
+                "content_hash": row["content_hash"],
+                "byte_size": int(row["size_bytes"]),
+                "s3_key": row["s3_key"],
+                "etag": row["etag"],
+                "storage_version": row["storage_version"],
+                "created_by": row["created_by"],
+            }
+            for row in rows
+        ]
+        expected = [
+            {key: value for key, value in self._file_inventory_fact(file).items() if key != "disposition"}
+            for file in files
+        ]
+        if observed != expected:
+            raise CutoverVerificationError("cutover File catalog drifted after planning")
+
+    async def _require_native_document_bindings(
+        self,
+        conn: asyncpg.Connection,
+        inventory: LegacyInventory,
+    ) -> None:
+        """Recheck frozen Native heads and payload facts without reading bodies."""
+
+        mappings = await self.backfill.repository.list_namespace_completed_mappings(
+            namespace_id=inventory.namespace_id,
+            conn=conn,
+        )
+        current_mappings = {
+            (mapping.resource_id, mapping.legacy_git_oid): mapping
+            for mapping in mappings
+            if mapping.resolution == "native"
+        }
+        resource_ids = [document.resource_id for document in inventory.documents]
+        rows = await conn.fetch(
+            """
+            SELECT resource.resource_id, resource.namespace_id, resource.surface,
+                   resource.lifecycle, resource.current_path,
+                   resource.head_revision_id, revision.parent_revision_id,
+                   revision.action, revision.path_at_revision,
+                   manifest.digest, manifest.byte_size
+              FROM native_resources resource
+              JOIN native_revisions revision
+                ON revision.resource_id = resource.resource_id
+               AND revision.revision_id = resource.head_revision_id
+              JOIN native_payload_manifests manifest
+                ON manifest.payload_manifest_id = revision.payload_manifest_id
+             WHERE resource.resource_id = ANY($1::uuid[])
+             ORDER BY resource.resource_id
+            """,
+            resource_ids,
+        )
+        by_resource = {row["resource_id"]: row for row in rows}
+        if len(by_resource) != len(resource_ids):
+            raise CutoverVerificationError(
+                f"vault {inventory.namespace_id} Native document closure drifted"
+            )
+        for document in inventory.documents:
+            mapping = current_mappings.get(
+                (document.resource_id, document.current_commit)
+            )
+            native = by_resource.get(document.resource_id)
+            if mapping is None or mapping.native_revision_id is None or native is None:
+                raise CutoverVerificationError(
+                    f"document {document.resource_id} Native head binding drifted"
+                )
+            observed = (
+                native["namespace_id"],
+                native["surface"],
+                native["lifecycle"],
+                native["current_path"],
+                native["head_revision_id"],
+                native["parent_revision_id"],
+                native["action"],
+                native["path_at_revision"],
+                native["digest"],
+                int(native["byte_size"]),
+            )
+            expected = (
+                inventory.namespace_id,
+                "document",
+                "live",
+                document.current_path,
+                mapping.native_revision_id,
+                None,
+                "create",
+                document.current_path,
+                document.body_digest,
+                document.byte_size,
+            )
+            if observed != expected:
+                raise CutoverVerificationError(
+                    f"document {document.resource_id} Native head binding drifted"
+                )
+
+    async def _revalidate_authority_catalog(
         self,
         conn: asyncpg.Connection,
         *,
@@ -705,54 +838,84 @@ class NativeRevisionCutover:
         if exclusions:
             raise CutoverVerificationError("cutover exclusion inventory drifted after external Git retirement")
 
-        retained_by_id = {row["id"]: row for row in retained}
         for vault in vaults:
-            row = retained_by_id[vault.namespace_id]
+            if vault.status != "verified" or vault.verification_digest is None:
+                raise CutoverVerificationError(f"vault {vault.namespace_id} verification receipt disappeared")
+            migration_run = await self.backfill.repository.get_run(
+                vault.migration_run_id,
+                conn=conn,
+            )
+            if (
+                migration_run is None
+                or migration_run.status != "complete"
+                or migration_run.namespace_id != vault.namespace_id
+                or migration_run.fixed_git_oid != vault.fixed_git_oid
+                or migration_run.inventory_digest != vault.inventory_digest
+            ):
+                raise CutoverVerificationError(f"vault {vault.namespace_id} migration run disappeared")
+            try:
+                scope = await self.backfill.bridge.inventory_scope_for_run(
+                    migration_run,
+                    conn=conn,
+                )
+            except (InventoryEligibilityError, MigrationInventoryDriftError) as exc:
+                raise CutoverVerificationError(
+                    f"vault {vault.namespace_id} inventory drifted after verification"
+                ) from exc
+            await self._require_native_document_bindings(conn, scope.inventory)
+
+        await self._require_source_file_bindings(
+            conn,
+            namespace_ids=[item.namespace_id for item in vaults],
+            files=files,
+        )
+        await self._require_native_file_bindings(conn, files)
+
+        if run.inventory_digest != self._cutover_inventory_digest(
+            vaults=vaults,
+            files=files,
+            exclusions=exclusions,
+        ):
+            raise CutoverVerificationError("cutover inventory digest drifted after planning")
+
+    async def _revalidate_authority_external(
+        self,
+        *,
+        cutover_id: uuid.UUID,
+    ) -> None:
+        """Recheck immutable Git/S3 source objects outside a database transaction."""
+
+        run = await self._required_run(cutover_id)
+        if run.status != "verified":
+            raise CutoverVerificationError("cutover must remain verified at authority mint")
+        vaults = await self.repository.list_vaults(cutover_id)
+        files = await self.repository.list_files(cutover_id)
+        retained = {row["id"]: row for row in await self._retained_vault_inventory()}
+        for vault in vaults:
+            row = retained.get(vault.namespace_id)
+            if row is None:
+                raise CutoverVerificationError(f"vault {vault.namespace_id} disappeared after fencing")
             current_ref = await asyncio.to_thread(
                 self.backfill.git.current_commit,
                 row["name"],
             )
             if current_ref != vault.fixed_git_oid:
                 raise CutoverVerificationError(f"vault {vault.namespace_id} Git ref drifted after verification")
-            migration_run = await self.backfill.repository.get_run(vault.migration_run_id)
-            if migration_run is None:
-                raise CutoverVerificationError(f"vault {vault.namespace_id} migration run disappeared")
+
+        for file in files:
+            data = await asyncio.to_thread(self.file_reader, file.s3_key)
             try:
-                inventory = await self.backfill.bridge.capture_inventory(
-                    namespace_id=vault.namespace_id,
-                    fixed_ref=vault.fixed_git_oid,
-                    coverage_version=migration_run.coverage_version,
+                disposition = self._classify_file_bytes(
+                    file_id=file.file_id,
+                    mime_type=file.mime_type,
+                    content_hash=file.content_hash,
+                    byte_size=file.byte_size,
+                    data=data,
                 )
-            except InventoryEligibilityError as exc:
-                raise CutoverVerificationError(
-                    f"vault {vault.namespace_id} inventory drifted after verification"
-                ) from exc
-            if inventory.inventory_digest != vault.inventory_digest:
-                raise CutoverVerificationError(f"vault {vault.namespace_id} inventory drifted after verification")
-            receipt = await self.verifier.compare_run(vault.migration_run_id)
-            self._require_passed_receipt(vault, receipt)
-            if _digest(receipt) != vault.verification_digest:
-                raise CutoverVerificationError(f"vault {vault.namespace_id} verification receipt drifted")
-
-        try:
-            live_files = await self._file_inventory(
-                [item.namespace_id for item in vaults],
-                conn=conn,
-            )
-        except CutoverApplyError as exc:
-            raise CutoverVerificationError(str(exc)) from exc
-        if [self._file_inventory_fact(item) for item in live_files] != [
-            self._file_inventory_fact(item) for item in files
-        ]:
-            raise CutoverVerificationError("cutover File inventory drifted after planning")
-        await self._require_native_file_bindings(conn, files)
-
-        if run.inventory_digest != self._cutover_inventory_digest(
-            vaults=vaults,
-            files=live_files,
-            exclusions=exclusions,
-        ):
-            raise CutoverVerificationError("cutover inventory digest drifted after planning")
+            except CutoverApplyError as exc:
+                raise CutoverVerificationError(str(exc)) from exc
+            if disposition != file.disposition:
+                raise CutoverVerificationError(f"File {file.file_id} classification drifted after verification")
 
     async def commit(
         self,
@@ -768,15 +931,26 @@ class NativeRevisionCutover:
         retained = await self._retained_vault_inventory()
         async with self._hold_git_write_fences([row["name"] for row in retained]):
             async with self.pool.acquire() as conn:
-                authority_id = await mint_existing_database_authority(
+                fence = await begin_existing_database_authority(
                     conn,
                     identity=identity,
                     cutover_id=cutover_id,
-                    revalidate=lambda transaction_conn: self._revalidate_authority_inventory(
+                    preflight=lambda transaction_conn: self._revalidate_authority_catalog(
                         transaction_conn,
                         cutover_id=cutover_id,
                     ),
                 )
+            if fence.authority_id is None:
+                await self._revalidate_authority_external(cutover_id=cutover_id)
+                async with self.pool.acquire() as conn:
+                    authority_id = await finalize_existing_database_authority(
+                        conn,
+                        identity=identity,
+                        fence=fence,
+                    )
+            else:
+                authority_id = fence.authority_id
+            async with self.pool.acquire() as conn:
                 row = await conn.fetchrow(
                     """
                     SELECT authority_id, cutover_id, inventory_digest, status

--- a/backend/app/services/native_revision_reconcile.py
+++ b/backend/app/services/native_revision_reconcile.py
@@ -209,11 +209,22 @@ class NativeRevisionReconcile:
         await self._assert_inventory_covers_completed_resources(inventory)
         async with self.pool.acquire() as conn:
             async with conn.transaction():
+                await self.bridge.validated_inventory_scope(inventory, conn=conn)
                 run = await self.repository.get_or_create_run(
                     namespace_id=namespace_id,
                     fixed_git_oid=fixed_ref,
                     coverage_version=coverage,
                     inventory_digest=inventory.inventory_digest,
+                    conn=conn,
+                )
+                await self.repository.store_inventory_snapshot(
+                    run,
+                    self.bridge.canonical_inventory_payload(
+                        namespace_id=inventory.namespace_id,
+                        fixed_git_oid=inventory.fixed_git_oid,
+                        coverage_version=inventory.coverage_version,
+                        documents=inventory.documents,
+                    ),
                     conn=conn,
                 )
 

--- a/backend/app/services/native_revision_shadow_reader.py
+++ b/backend/app/services/native_revision_shadow_reader.py
@@ -23,18 +23,15 @@ import asyncpg
 from app.exceptions import AKBError, ConflictError, NotFoundError
 from app.repositories.native_revision_repo import NativeRevisionRepository
 from app.services.document_service import _parse_markdown
-from app.services.git_service import FixedRefHistoryError, GitService
+from app.services.git_service import GitService
 from app.services.legacy_revision_bridge import (
     LegacyInventoryDocument,
-    LogicalLineageProjectionError,
-    project_logical_lineage,
 )
 from app.services.native_revision_service import NativeRevisionService
 from app.services.uri_service import doc_uri
 
 
 _OID_RE = re.compile(r"^[0-9a-f]{40}$")
-_HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(?: .*)?$")
 _NATIVE_ACTIVITY_MIGRATION_ACTOR = "akb-native-revision-migration"
 _NATIVE_ACTIVITY_AUDIT_PROFILE = "akb-native-revision-p2-activity-audit/v1"
 
@@ -115,8 +112,6 @@ class _LegacyMaterialization:
     fixed_ref: str
     current_commit: str
     body: bytes
-    history: tuple[dict[str, Any], ...]
-    activity: dict[str, Any]
 
 
 @dataclass(frozen=True, slots=True)
@@ -165,10 +160,26 @@ def _parsed_body(text: str) -> tuple[dict[str, Any], str]:
 def _validate_lineage(document: LegacyInventoryDocument) -> None:
     if not document.lineage or document.lineage[-1].legacy_git_oid != document.current_commit:
         raise ShadowReaderScopeError("shadow reader inventory lineage has no current-head boundary")
+    seen: set[str] = set()
     for entry in document.lineage:
         _require_oid(entry.legacy_git_oid, "lineage selector")
         if not isinstance(entry.path_at_revision, str) or not entry.path_at_revision.strip():
             raise ShadowReaderScopeError("shadow reader inventory lineage has an invalid path")
+        if entry.legacy_git_oid in seen:
+            raise ShadowReaderScopeError("shadow reader inventory lineage has a duplicate revision")
+        seen.add(entry.legacy_git_oid)
+    activity = document.activity
+    if (
+        activity.legacy_git_oid != document.current_commit
+        or activity.committed_at != document.lineage[-1].committed_at
+        or not activity.actor
+        or not activity.subject
+        or not isinstance(activity.summary, str)
+        or activity.action not in {"create", "update", "move", "delete"}
+        or activity.path_to != document.current_path
+        or (activity.action == "move") != (activity.path_from is not None)
+    ):
+        raise ShadowReaderScopeError("shadow reader inventory activity is invalid")
 
 
 def _snapshot_diff(text: str) -> str:
@@ -193,119 +204,6 @@ def _canonical_transition(parent_text: str, current_text: str) -> str:
         raise ShadowReaderScopeError("shadow reader transition could not reproduce current body")
     _, body = _parsed_body(rebuilt)
     return _snapshot_diff(body)
-
-
-def _apply_unified_patch(parent_text: str, patch: str, diff_type: str) -> str:
-    """Apply the exact Git patch to an independently read parent body."""
-    patch_lines = patch.split("\n")
-    if patch_lines and patch_lines[-1] == "":
-        patch_lines.pop()
-    hunk_indexes = [index for index, line in enumerate(patch_lines) if _HUNK_RE.fullmatch(line)]
-    if not hunk_indexes:
-        prefix = "+" if diff_type == "added" else "-" if diff_type == "deleted" else None
-        if prefix is None or any(not line.startswith(prefix) for line in patch_lines):
-            raise ShadowReaderScopeError("legacy fixed-ref diff patch is not canonical unified data")
-        materialized = "\n".join(line[1:] for line in patch_lines)
-        if diff_type == "deleted":
-            if materialized != parent_text:
-                raise ShadowReaderScopeError("legacy fixed-ref diff patch differs from parent body")
-            return ""
-        if parent_text:
-            raise ShadowReaderScopeError("legacy fixed-ref added patch has a non-empty parent")
-        return materialized
-
-    if hunk_indexes[0] != 0:
-        allowed_headers = {"diff --git", "index ", "--- ", "+++ "}
-        if any(
-            not any(line.startswith(prefix) for prefix in allowed_headers) for line in patch_lines[: hunk_indexes[0]]
-        ):
-            raise ShadowReaderScopeError("legacy fixed-ref diff patch has invalid headers")
-
-    source = parent_text.split("\n") if parent_text else []
-    source_has_newline = parent_text.endswith("\n")
-    if source_has_newline:
-        source.pop()
-    output: list[tuple[str, bool]] = []
-    source_index = 0
-    patch_index = hunk_indexes[0]
-    old_terminal_closed = False
-    new_terminal_closed = False
-    while patch_index < len(patch_lines):
-        header = _HUNK_RE.fullmatch(patch_lines[patch_index])
-        if header is None:
-            raise ShadowReaderScopeError("legacy fixed-ref diff patch has trailing data")
-        old_start = int(header.group(1))
-        old_count = int(header.group(2)) if header.group(2) is not None else 1
-        new_count = int(header.group(4)) if header.group(4) is not None else 1
-        hunk_source = 0 if old_start == 0 else old_start - 1
-        if hunk_source < source_index or hunk_source > len(source):
-            raise ShadowReaderScopeError("legacy fixed-ref diff patch has an invalid parent range")
-        if old_terminal_closed and hunk_source > source_index:
-            raise ShadowReaderScopeError("legacy fixed-ref diff patch has an invalid newline marker")
-        if new_terminal_closed and hunk_source > source_index:
-            raise ShadowReaderScopeError("legacy fixed-ref diff patch has an invalid newline marker")
-        output.extend(
-            (
-                source[index],
-                index < len(source) - 1 or source_has_newline,
-            )
-            for index in range(source_index, hunk_source)
-        )
-        source_index = hunk_source
-        observed_old = 0
-        observed_new = 0
-        patch_index += 1
-        while patch_index < len(patch_lines) and _HUNK_RE.fullmatch(patch_lines[patch_index]) is None:
-            line = patch_lines[patch_index]
-            patch_index += 1
-            if line == r"\ No newline at end of file":
-                raise ShadowReaderScopeError("legacy fixed-ref diff patch has an invalid newline marker")
-            if not line or line[0] not in {" ", "+", "-"}:
-                raise ShadowReaderScopeError("legacy fixed-ref diff patch has invalid hunk data")
-            marker, value = line[0], line[1:]
-            no_newline = False
-            if patch_index < len(patch_lines) and patch_lines[patch_index] == r"\ No newline at end of file":
-                no_newline = True
-                patch_index += 1
-            old_line = marker in {" ", "-"}
-            new_line = marker in {" ", "+"}
-            if old_line and old_terminal_closed or new_line and new_terminal_closed:
-                raise ShadowReaderScopeError("legacy fixed-ref diff patch has an invalid newline marker")
-            if marker in {" ", "-"}:
-                if source_index >= len(source) or source[source_index] != value:
-                    raise ShadowReaderScopeError("legacy fixed-ref diff patch differs from parent body")
-                source_line_has_newline = source_index < len(source) - 1 or source_has_newline
-                if no_newline != (not source_line_has_newline):
-                    raise ShadowReaderScopeError("legacy fixed-ref diff patch has an invalid newline marker")
-                source_line = source[source_index]
-                source_index += 1
-                observed_old += 1
-                if no_newline:
-                    old_terminal_closed = True
-            else:
-                source_line = ""
-            if marker in {" ", "+"}:
-                if marker == " ":
-                    output.append((source_line, not no_newline))
-                else:
-                    output.append((value, not no_newline))
-                observed_new += 1
-                if no_newline:
-                    new_terminal_closed = True
-        if (observed_old, observed_new) != (old_count, new_count):
-            raise ShadowReaderScopeError("legacy fixed-ref diff patch has invalid hunk counts")
-    if old_terminal_closed and source_index != len(source):
-        raise ShadowReaderScopeError("legacy fixed-ref diff patch has an invalid newline marker")
-    if new_terminal_closed and source_index != len(source):
-        raise ShadowReaderScopeError("legacy fixed-ref diff patch has an invalid newline marker")
-    output.extend(
-        (
-            source[index],
-            index < len(source) - 1 or source_has_newline,
-        )
-        for index in range(source_index, len(source))
-    )
-    return "".join(value + ("\n" if has_newline else "") for value, has_newline in output)
 
 
 def _history_entries(
@@ -358,56 +256,6 @@ class LegacyFixedRefShadowReader:
         except UnicodeDecodeError as exc:
             raise ShadowReaderScopeError("legacy fixed-ref body is not valid UTF-8") from exc
 
-        expected_history = [
-            (entry.legacy_git_oid, entry.path_at_revision, entry.committed_at) for entry in reversed(document.lineage)
-        ]
-        try:
-            projected = project_logical_lineage(
-                snapshot.history,
-                current_commit=document.current_commit,
-                current_path=document.current_path,
-                created_at=document.created_at,
-                oldest_anchor_oid=document.lineage[0].legacy_git_oid,
-            )
-        except LogicalLineageProjectionError as exc:
-            raise ShadowReaderScopeError("legacy fixed-ref history is invalid") from exc
-        observed_history = [
-            (entry.legacy_git_oid, entry.path_at_revision, entry.committed_at)
-            for entry in reversed(projected)
-        ]
-        if observed_history != expected_history:
-            raise ShadowReaderScopeError("legacy fixed-ref history differs from C9 inventory")
-
-        activity = document.activity
-        expected_activity = (
-            activity.legacy_git_oid,
-            activity.committed_at,
-            activity.actor,
-            activity.subject,
-            activity.summary,
-            activity.action,
-            activity.path_from,
-            activity.path_to,
-            tuple(dict(change) for change in activity.changed_paths),
-        )
-        raw_activity = snapshot.activity
-        changed_paths = raw_activity.get("changed_paths")
-        if not isinstance(changed_paths, (list, tuple)):
-            raise ShadowReaderScopeError("legacy fixed-ref activity is invalid")
-        observed_activity = (
-            raw_activity.get("legacy_git_oid"),
-            raw_activity.get("committed_at"),
-            raw_activity.get("actor"),
-            raw_activity.get("subject"),
-            raw_activity.get("summary"),
-            raw_activity.get("action"),
-            raw_activity.get("path_from"),
-            raw_activity.get("path_to"),
-            tuple(dict(change) for change in changed_paths if isinstance(change, Mapping)),
-        )
-        if observed_activity != expected_activity:
-            raise ShadowReaderScopeError("legacy fixed-ref activity differs from C9 inventory")
-
     async def _fixed_snapshot(
         self,
         document: LegacyInventoryDocument,
@@ -439,42 +287,20 @@ class LegacyFixedRefShadowReader:
             # prior Resource's body through a later cache hit.
             self._snapshot_cache = None
             try:
-                raw_snapshot = await asyncio.to_thread(
-                    self.git.manual_fixed_ref_history,
+                text = await asyncio.to_thread(
+                    self.git.read_file,
                     self.vault_name,
-                    fixed_ref,
                     document.current_path,
-                    current_commit=document.current_commit,
-                    since_epoch=int(document.created_at.timestamp()),
+                    commit=document.current_commit,
                 )
-            except (FixedRefHistoryError, OSError, ValueError) as exc:
+            except (OSError, UnicodeDecodeError, ValueError) as exc:
                 raise ShadowReaderScopeError("legacy fixed-ref materialization failed") from exc
-            if not isinstance(raw_snapshot, Mapping):
-                raise ShadowReaderScopeError("legacy fixed-ref materialization is invalid")
-            body = raw_snapshot.get("body")
-            history = raw_snapshot.get("history")
-            activity = raw_snapshot.get("activity")
-            materialized_fixed_ref = raw_snapshot.get("fixed_ref")
-            materialized_current_commit = raw_snapshot.get("current_commit")
-            if not isinstance(body, bytes):
+            if not isinstance(text, str):
                 raise ShadowReaderScopeError("legacy fixed-ref materialization returned no body")
-            if not isinstance(history, list) or not all(isinstance(entry, Mapping) for entry in history):
-                raise ShadowReaderScopeError("legacy fixed-ref history is invalid")
-            if not history or history[0].get("legacy_git_oid") != document.current_commit:
-                raise ShadowReaderScopeError("legacy fixed-ref history does not start at current head")
-            if not isinstance(activity, Mapping):
-                raise ShadowReaderScopeError("legacy fixed-ref activity is invalid")
-            if not isinstance(materialized_fixed_ref, str) or not isinstance(
-                materialized_current_commit,
-                str,
-            ):
-                raise ShadowReaderScopeError("legacy fixed-ref materialization has invalid scope")
             snapshot = _LegacyMaterialization(
-                fixed_ref=materialized_fixed_ref,
-                current_commit=materialized_current_commit,
-                body=bytes(body),
-                history=tuple(dict(entry) for entry in history),
-                activity=dict(activity),
+                fixed_ref=fixed_ref,
+                current_commit=document.current_commit,
+                body=text.encode("utf-8"),
             )
             self._validate_materialization(snapshot, document, fixed_ref=fixed_ref)
             self._snapshot_cache = (key, snapshot)
@@ -535,71 +361,28 @@ class LegacyFixedRefShadowReader:
         if selector != document.current_commit:
             raise ShadowReaderScopeError("legacy diff selector is outside the frozen current head")
         snapshot = await self._fixed_snapshot(document, fixed_ref=fixed_ref)
-        try:
-            raw_diff = await asyncio.to_thread(
-                self.git.file_diff,
-                self.vault_name,
-                document.current_path,
-                selector,
-            )
-        except (OSError, ValueError) as exc:
-            raise ShadowReaderScopeError("legacy fixed-ref diff failed") from exc
-        if not isinstance(raw_diff, Mapping):
-            raise ShadowReaderScopeError("legacy fixed-ref diff is invalid")
-        diff_type = raw_diff.get("type")
-        allowed_types = {
-            "create": {"added"},
-            "update": {"modified"},
-            "move": {"added", "modified"},
-            "delete": {"deleted"},
-        }[document.activity.action]
-        if (
-            raw_diff.get("file") != document.current_path
-            or raw_diff.get("commit") != selector
-            or diff_type not in allowed_types
-            or not isinstance(raw_diff.get("diff"), str)
-            or not raw_diff.get("diff")
-        ):
-            raise ShadowReaderScopeError("legacy fixed-ref diff differs from C9 inventory")
         previous = document.lineage[-2] if len(document.lineage) > 1 else None
         try:
-            current_text, parent_text = await asyncio.gather(
-                asyncio.to_thread(
-                    self.git.read_file,
-                    self.vault_name,
-                    document.current_path,
-                    commit=selector,
-                ),
-                asyncio.to_thread(
+            parent_text = (
+                await asyncio.to_thread(
                     self.git.read_file,
                     self.vault_name,
                     previous.path_at_revision,
                     commit=previous.legacy_git_oid,
                 )
                 if previous is not None
-                else asyncio.sleep(0, result=""),
+                else ""
             )
         except (OSError, ValueError) as exc:
             raise ShadowReaderScopeError("legacy fixed-ref diff body reads failed") from exc
-        if not isinstance(current_text, str) or not isinstance(parent_text, str):
+        if not isinstance(parent_text, str):
             raise ShadowReaderScopeError("legacy fixed-ref diff body facts are missing")
-        snapshot_text = snapshot.body.decode("utf-8")
-        if current_text != snapshot_text:
-            raise ShadowReaderScopeError("legacy fixed-ref diff current body differs from C9 facts")
-        if previous is None and diff_type == "modified":
-            transition_parent = ""
-            applied = current_text
-        else:
-            patch_parent = "" if diff_type == "added" else parent_text
-            transition_parent = parent_text
-            applied = _apply_unified_patch(patch_parent, raw_diff["diff"], diff_type)
-        if applied != current_text:
-            raise ShadowReaderScopeError("legacy fixed-ref diff patch differs from current body")
+        current_text = snapshot.body.decode("utf-8")
         return {
             "file": document.current_path,
             "commit": selector,
             "basis": "git-parent",
-            "text": _canonical_transition(transition_parent, applied),
+            "text": _canonical_transition(parent_text, current_text),
             "format": "unified",
         }
 

--- a/backend/tests/test_access_contributions_postgres.py
+++ b/backend/tests/test_access_contributions_postgres.py
@@ -33,7 +33,7 @@ _MIGRATION_085 = (
     _BACKEND / "app" / "db" / "migrations" / "085_vault_access_contributions.py"
 )
 _MIGRATION_HEAD = (
-    _BACKEND / "app" / "db" / "migrations" / "094_native_revision_completed_reservation_transfer.py"
+    _BACKEND / "app" / "db" / "migrations" / "097_native_revision_migration_inventory.py"
 )
 _MIGRATIONS_DIR = _BACKEND / "app" / "db" / "migrations"
 

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -7,6 +7,7 @@ tests never touch the real `/data/vaults` directory.
 
 from __future__ import annotations
 
+import hashlib
 import os
 import shutil
 import subprocess
@@ -62,6 +63,95 @@ def vault(git_service):
 
 def _vault_commit_count(git_service: GitService, vault_name: str) -> int:
     return len(git_service.vault_log(vault_name, max_count=1000))
+
+
+def _commit_file_at(
+    git_service: GitService,
+    vault_name: str,
+    file_path: str,
+    content: str | None,
+    message: str,
+    date: str,
+) -> str:
+    """Create a deterministic fixture commit through the persistent worktree."""
+    worktree = git_service._worktree_path(vault_name)
+    if not worktree.exists():
+        git_service.commit_file(
+            vault_name=vault_name,
+            file_path=".fixture-seed.md",
+            content="",
+            message="fixture seed",
+        )
+        git_service.commit_file(
+            vault_name=vault_name,
+            file_path=".fixture-seed.md",
+            content="",
+            message="fixture seed",
+        )
+    repo = Repo(str(worktree))
+    try:
+        repo.git.reset("--hard", "HEAD")
+        target = worktree / file_path
+        if content is None:
+            repo.git.rm("--", file_path)
+        else:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+            repo.git.add("--", file_path)
+        with repo.git.custom_environment(
+            GIT_AUTHOR_NAME="Fixture",
+            GIT_AUTHOR_EMAIL="fixture@example.dev",
+            GIT_COMMITTER_NAME="Fixture",
+            GIT_COMMITTER_EMAIL="fixture@example.dev",
+            GIT_AUTHOR_DATE=date,
+            GIT_COMMITTER_DATE=date,
+        ):
+            repo.git.commit("-m", message)
+        return repo.git.rev_parse("HEAD").strip()
+    finally:
+        repo.close()
+
+
+def _move_file_at(
+    git_service: GitService,
+    vault_name: str,
+    old_path: str,
+    new_path: str,
+    message: str,
+    date: str,
+) -> str:
+    """Create a deterministic rename fixture through the persistent worktree."""
+    worktree = git_service._worktree_path(vault_name)
+    if not worktree.exists():
+        git_service.commit_file(
+            vault_name=vault_name,
+            file_path=".fixture-seed.md",
+            content="",
+            message="fixture seed",
+        )
+        git_service.commit_file(
+            vault_name=vault_name,
+            file_path=".fixture-seed.md",
+            content="",
+            message="fixture seed",
+        )
+    repo = Repo(str(worktree))
+    try:
+        repo.git.reset("--hard", "HEAD")
+        (worktree / new_path).parent.mkdir(parents=True, exist_ok=True)
+        repo.git.mv("--", old_path, new_path)
+        with repo.git.custom_environment(
+            GIT_AUTHOR_NAME="Fixture",
+            GIT_AUTHOR_EMAIL="fixture@example.dev",
+            GIT_COMMITTER_NAME="Fixture",
+            GIT_COMMITTER_EMAIL="fixture@example.dev",
+            GIT_AUTHOR_DATE=date,
+            GIT_COMMITTER_DATE=date,
+        ):
+            repo.git.commit("-m", message)
+        return repo.git.rev_parse("HEAD").strip()
+    finally:
+        repo.close()
 
 
 def _block_chdir(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -235,6 +325,351 @@ def test_manual_fixed_ref_history_rejects_declared_activity_that_conflicts_with_
             current_oid,
             "notes/imported.md",
             current_commit=current_oid,
+        )
+
+
+def test_manual_fixed_ref_history_batch_matches_per_path_history_for_lifecycle(
+    git_service: GitService,
+) -> None:
+    name = f"indexed_lifecycle_{uuid.uuid4().hex[:8]}"
+    git_service.init_vault(name)
+    created = _commit_file_at(
+        git_service,
+        name,
+        "notes/draft.md",
+        "one\n",
+        "create",
+        "2026-01-01T00:00:00+0000",
+    )
+    updated = _commit_file_at(
+        git_service,
+        name,
+        "notes/draft.md",
+        "two\n",
+        "update",
+        "2026-01-01T00:00:01+0000",
+    )
+    moved = _move_file_at(
+        git_service,
+        name,
+        "notes/draft.md",
+        "published/draft.md",
+        "move",
+        "2026-01-01T00:00:02+0000",
+    )
+    latest = _commit_file_at(
+        git_service,
+        name,
+        "published/draft.md",
+        "three\n",
+        "update after move",
+        "2026-01-01T00:00:03+0000",
+    )
+    fixed_ref = _commit_file_at(
+        git_service,
+        name,
+        "unrelated.md",
+        "unrelated\n",
+        "unrelated tip",
+        "2026-01-01T00:00:04+0000",
+    )
+    requests = [
+        {
+            "file_path": "notes/draft.md",
+            "current_commit": created,
+            "since_epoch": None,
+        },
+        {
+            "file_path": "notes/draft.md",
+            "current_commit": updated,
+            "since_epoch": None,
+        },
+        {
+            "file_path": "published/draft.md",
+            "current_commit": moved,
+            "since_epoch": None,
+        },
+        {
+            "file_path": "published/draft.md",
+            "current_commit": latest,
+            "since_epoch": None,
+        },
+    ]
+
+    batched = git_service.manual_fixed_ref_history_batch(name, fixed_ref, requests)
+    expected = [
+        git_service.manual_fixed_ref_history(
+            name,
+            fixed_ref,
+            request["file_path"],
+            current_commit=request["current_commit"],
+            since_epoch=request["since_epoch"],
+        )
+        for request in requests
+    ]
+
+    assert batched == expected
+
+    metadata_only = git_service.manual_fixed_ref_history_batch(
+        name,
+        fixed_ref,
+        requests,
+        include_bodies=False,
+    )
+    assert [
+        {key: value for key, value in snapshot.items() if key not in {"body_digest", "byte_size"}}
+        for snapshot in metadata_only
+    ] == [
+        {key: value for key, value in snapshot.items() if key != "body"}
+        for snapshot in expected
+    ]
+    for compact, full in zip(metadata_only, expected, strict=True):
+        assert "body" not in compact
+        assert compact["body_digest"] == hashlib.sha256(full["body"]).hexdigest()
+        assert compact["byte_size"] == len(full["body"])
+
+
+def test_manual_fixed_ref_history_batch_compact_inventory_rejects_nul(
+    git_service: GitService,
+) -> None:
+    name = f"indexed_nul_{uuid.uuid4().hex[:8]}"
+    git_service.init_vault(name)
+    git_service.commit_file(
+        vault_name=name,
+        file_path="binary.md",
+        content="initial text",
+        message="initial body",
+    )
+    git_service.commit_file(
+        vault_name=name,
+        file_path="binary.md",
+        content="worktree text",
+        message="materialize worktree",
+    )
+    worktree = git_service._worktree_path(name)
+    repo = Repo(str(worktree))
+    (worktree / "binary.md").write_bytes(b"before\x00after")
+    repo.git.add("--", "binary.md")
+    repo.index.commit("binary body")
+    fixed_ref = repo.git.rev_parse("HEAD").strip()
+
+    with pytest.raises(FixedRefHistoryError, match="contains NUL bytes"):
+        git_service.manual_fixed_ref_history_batch(
+            name,
+            fixed_ref,
+            [
+                {
+                    "file_path": "binary.md",
+                    "current_commit": fixed_ref,
+                    "since_epoch": None,
+                }
+            ],
+            include_bodies=False,
+        )
+
+
+def test_manual_fixed_ref_history_batch_respects_same_path_recreate_boundary(
+    git_service: GitService,
+) -> None:
+    name = f"indexed_recreate_{uuid.uuid4().hex[:8]}"
+    git_service.init_vault(name)
+    _commit_file_at(
+        git_service,
+        name,
+        "notes/reused.md",
+        "old document\n",
+        "old create",
+        "2026-01-01T00:00:00+0000",
+    )
+    _commit_file_at(
+        git_service,
+        name,
+        "notes/reused.md",
+        None,
+        "old delete",
+        "2026-01-01T00:00:01+0000",
+    )
+    recreated = _commit_file_at(
+        git_service,
+        name,
+        "notes/reused.md",
+        "new document\n",
+        "new create",
+        "2026-01-01T00:00:02+0000",
+    )
+    fixed_ref = _commit_file_at(
+        git_service,
+        name,
+        "unrelated.md",
+        "unrelated\n",
+        "unrelated tip",
+        "2026-01-01T00:00:03+0000",
+    )
+    current = Repo(str(git_service._bare_path(name))).commit(recreated)
+    try:
+        since_epoch = current.committed_date
+    finally:
+        current.repo.close()
+    request = {
+        "file_path": "notes/reused.md",
+        "current_commit": recreated,
+        "since_epoch": since_epoch,
+    }
+
+    batched = git_service.manual_fixed_ref_history_batch(name, fixed_ref, [request])
+    expected = git_service.manual_fixed_ref_history(
+        name,
+        fixed_ref,
+        request["file_path"],
+        current_commit=request["current_commit"],
+        since_epoch=request["since_epoch"],
+    )
+
+    assert batched == [expected]
+    assert [entry["legacy_git_oid"] for entry in batched[0]["history"]] == [recreated]
+
+
+def test_manual_fixed_ref_history_batch_keeps_same_second_commits(
+    git_service: GitService,
+) -> None:
+    name = f"indexed_same_second_{uuid.uuid4().hex[:8]}"
+    git_service.init_vault(name)
+    created = _commit_file_at(
+        git_service,
+        name,
+        "notes/same-second.md",
+        "one\n",
+        "create",
+        "2026-01-01T00:00:00+0000",
+    )
+    updated = _commit_file_at(
+        git_service,
+        name,
+        "notes/same-second.md",
+        "two\n",
+        "update",
+        "2026-01-01T00:00:00+0000",
+    )
+    fixed_ref = _commit_file_at(
+        git_service,
+        name,
+        "unrelated.md",
+        "unrelated\n",
+        "unrelated tip",
+        "2026-01-01T00:00:00+0000",
+    )
+    current = Repo(str(git_service._bare_path(name))).commit(updated)
+    try:
+        since_epoch = current.committed_date
+    finally:
+        current.repo.close()
+    request = {
+        "file_path": "notes/same-second.md",
+        "current_commit": updated,
+        "since_epoch": since_epoch,
+    }
+
+    batched = git_service.manual_fixed_ref_history_batch(name, fixed_ref, [request])
+    expected = git_service.manual_fixed_ref_history(
+        name,
+        fixed_ref,
+        request["file_path"],
+        current_commit=request["current_commit"],
+        since_epoch=request["since_epoch"],
+    )
+
+    assert batched == [expected]
+    assert [entry["legacy_git_oid"] for entry in batched[0]["history"]] == [updated, created]
+
+
+def test_manual_fixed_ref_history_batch_traverses_once_per_batch(
+    git_service: GitService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    name = f"indexed_cache_{uuid.uuid4().hex[:8]}"
+    git_service.init_vault(name)
+    current = git_service.commit_file(
+        vault_name=name,
+        file_path="notes/cached.md",
+        content="cached\n",
+        message="create",
+    )
+    fixed_ref = git_service.commit_file(
+        vault_name=name,
+        file_path="unrelated.md",
+        content="unrelated\n",
+        message="unrelated tip",
+    )
+    repo = Repo(str(git_service._bare_path(name)))
+    git_type = type(repo.git)
+    original_execute = git_type.execute
+    calls = {"log": 0, "diff_tree": 0}
+
+    def counting_execute(self, command, *args, **kwargs):
+        command_names = {str(item) for item in command}
+        if "log" in command_names:
+            calls["log"] += 1
+        if "diff-tree" in command_names:
+            calls["diff_tree"] += 1
+        return original_execute(self, command, *args, **kwargs)
+
+    monkeypatch.setattr(git_type, "execute", counting_execute)
+    request = {
+        "file_path": "notes/cached.md",
+        "current_commit": current,
+        "since_epoch": None,
+    }
+    first = git_service.manual_fixed_ref_history_batch(name, fixed_ref, [request, request])
+    second = git_service.manual_fixed_ref_history_batch(name, fixed_ref, [request])
+    repo.close()
+
+    assert first[0] == first[1] == second[0]
+    assert calls == {"log": 2, "diff_tree": 2}
+
+
+@pytest.mark.parametrize(
+    "invalid_field",
+    [
+        "fixed_format",
+        "current_format",
+        "fixed_unknown",
+        "current_unknown",
+    ],
+)
+def test_manual_fixed_ref_history_batch_rejects_invalid_fixed_or_current_oid(
+    git_service: GitService,
+    invalid_field: str,
+) -> None:
+    name = f"indexed_invalid_oid_{uuid.uuid4().hex[:8]}"
+    git_service.init_vault(name)
+    valid_commit = git_service.commit_file(
+        vault_name=name,
+        file_path="notes/invalid.md",
+        content="invalid\n",
+        message="create",
+    )
+    fixed_ref = valid_commit
+    current_commit = valid_commit
+    if invalid_field == "fixed_format":
+        fixed_ref = "not-a-commit"
+    elif invalid_field == "current_format":
+        current_commit = "not-a-commit"
+    elif invalid_field == "fixed_unknown":
+        fixed_ref = "0" * 40
+    else:
+        current_commit = "0" * 40
+
+    with pytest.raises(FixedRefHistoryError):
+        git_service.manual_fixed_ref_history_batch(
+            name,
+            fixed_ref,
+            [
+                {
+                    "file_path": "notes/invalid.md",
+                    "current_commit": current_commit,
+                    "since_epoch": None,
+                }
+            ],
         )
 
 

--- a/backend/tests/test_native_revision_authority_postgres.py
+++ b/backend/tests/test_native_revision_authority_postgres.py
@@ -14,9 +14,12 @@ import pytest
 from app.config import Settings
 from app.db import postgres
 from app.services.native_revision_authority import (
+    ExistingDatabaseAuthorityFence,
     NativeAuthorityError,
     NativeAuthorityIdentity,
+    begin_existing_database_authority,
     bootstrap_postgres_native,
+    finalize_existing_database_authority,
     consume_or_validate_native_authority,
     mint_new_database_claim,
     pre_migration_revision_authority_guard,
@@ -85,6 +88,230 @@ async def _fresh_database(tmp_path, monkeypatch, *, backend: str = "postgres_nat
         await postgres.close_pool()
         await admin.execute(f'DROP DATABASE "{name}" WITH (FORCE)')
         await admin.close()
+
+
+async def _verified_cutover(conn: asyncpg.Connection, tmp_path) -> tuple[uuid.UUID, uuid.UUID]:
+    """Create the smallest verified cutover receipt accepted by authority mint."""
+    namespace_id = uuid.uuid4()
+    migration_run_id = uuid.uuid4()
+    cutover_id = uuid.uuid4()
+    await conn.execute(
+        """
+        INSERT INTO vaults (id, name, git_path, status)
+        VALUES ($1, $2, $3, 'active')
+        """,
+        namespace_id,
+        f"authority-{namespace_id}",
+        str(tmp_path / f"{namespace_id}.git"),
+    )
+    await conn.execute(
+        """
+        INSERT INTO native_revision_migration_runs (
+            run_id, namespace_id, fixed_git_oid, coverage_version,
+            inventory_digest, status, completed_at
+        ) VALUES ($1, $2, $3, $4, $5, 'complete', NOW())
+        """,
+        migration_run_id,
+        namespace_id,
+        "a" * 40,
+        f"authority-{cutover_id}",
+        "b" * 64,
+    )
+    await conn.execute(
+        """
+        INSERT INTO native_revision_cutover_runs (
+            cutover_id, coverage_version, inventory_digest, status,
+            verification_digest, applied_at, verified_at
+        ) VALUES ($1, $2, $3, 'verified', $4, NOW(), NOW())
+        """,
+        cutover_id,
+        f"authority-{cutover_id}",
+        "c" * 64,
+        "d" * 64,
+    )
+    await conn.execute(
+        """
+        INSERT INTO native_revision_cutover_vaults (
+            cutover_id, namespace_id, migration_run_id, fixed_git_oid,
+            inventory_digest, status, verification_digest, applied_at, verified_at
+        ) VALUES ($1, $2, $3, $4, $5, 'verified', $6, NOW(), NOW())
+        """,
+        cutover_id,
+        namespace_id,
+        migration_run_id,
+        "a" * 40,
+        "e" * 64,
+        "f" * 64,
+    )
+    return cutover_id, namespace_id
+
+
+async def test_existing_authority_fence_is_resumable_and_finalizable(tmp_path, monkeypatch):
+    async with _fresh_database(tmp_path, monkeypatch) as (configured, dsn):
+        await postgres.init_db()
+        conn = await asyncpg.connect(dsn)
+        try:
+            cutover_id, namespace_id = await _verified_cutover(conn, tmp_path)
+            identity = NativeAuthorityIdentity.from_settings(configured)
+            short_callback_states: list[tuple[bool, str]] = []
+
+            async def short_callback(callback_conn: asyncpg.Connection) -> None:
+                short_callback_states.append(
+                    (
+                        callback_conn.is_in_transaction(),
+                        await callback_conn.fetchval(
+                            "SELECT state FROM native_revision_legacy_write_fence"
+                        ),
+                    )
+                )
+
+            fence = await begin_existing_database_authority(
+                conn,
+                identity=identity,
+                cutover_id=cutover_id,
+                preflight=short_callback,
+            )
+            assert isinstance(fence, ExistingDatabaseAuthorityFence)
+            assert short_callback_states == [(True, "open")]
+            assert not conn.is_in_transaction()
+            assert fence.cutover_id == cutover_id
+            assert fence.legacy_write_epoch == 1
+            assert await conn.fetchval(
+                "SELECT state FROM native_revision_legacy_write_fence"
+            ) == "fenced"
+
+            with pytest.raises(
+                asyncpg.ObjectNotInPrerequisiteStateError,
+                match="Native cutover writes are fenced",
+            ):
+                await conn.execute(
+                    "UPDATE vaults SET description = description WHERE id = $1",
+                    namespace_id,
+                )
+            with pytest.raises(
+                asyncpg.ObjectNotInPrerequisiteStateError,
+                match="Native cutover writes are fenced",
+            ):
+                await conn.execute(
+                    "UPDATE native_revision_cutover_runs "
+                    "SET coverage_version = coverage_version WHERE cutover_id = $1",
+                    cutover_id,
+                )
+            with pytest.raises(
+                asyncpg.ObjectNotInPrerequisiteStateError,
+                match="Native cutover writes are fenced",
+            ):
+                await conn.execute(
+                    "UPDATE native_revision_migration_runs "
+                    "SET coverage_version = coverage_version WHERE run_id = $1",
+                    await conn.fetchval(
+                        "SELECT migration_run_id FROM native_revision_cutover_vaults "
+                        "WHERE cutover_id = $1",
+                        cutover_id,
+                    ),
+                )
+
+            resumed = await begin_existing_database_authority(
+                conn,
+                identity=identity,
+                cutover_id=cutover_id,
+            )
+            assert resumed == fence
+            assert not conn.is_in_transaction()
+
+            authority_id = await finalize_existing_database_authority(
+                conn,
+                identity=identity,
+                fence=resumed,
+            )
+            assert isinstance(authority_id, uuid.UUID)
+            assert not conn.is_in_transaction()
+            assert await conn.fetchval(
+                "SELECT state FROM native_revision_legacy_write_fence"
+            ) == "committed"
+            assert await conn.fetchval(
+                "SELECT authority_id FROM native_revision_existing_authority "
+                "WHERE marker_id = TRUE"
+            ) == authority_id
+            assert await conn.execute(
+                "UPDATE vaults SET description = 'native-era' WHERE id = $1",
+                namespace_id,
+            ) == "UPDATE 1"
+        finally:
+            await conn.close()
+
+
+async def test_existing_authority_phase_a_failure_rolls_back_to_open_and_fence_is_exact(
+    tmp_path,
+    monkeypatch,
+):
+    async with _fresh_database(tmp_path, monkeypatch) as (configured, dsn):
+        await postgres.init_db()
+        conn = await asyncpg.connect(dsn)
+        try:
+            cutover_id, _ = await _verified_cutover(conn, tmp_path)
+            identity = NativeAuthorityIdentity.from_settings(configured)
+
+            async def reject(_callback_conn: asyncpg.Connection) -> None:
+                raise RuntimeError("short preflight drift")
+
+            with pytest.raises(RuntimeError, match="short preflight drift"):
+                await begin_existing_database_authority(
+                    conn,
+                    identity=identity,
+                    cutover_id=cutover_id,
+                    preflight=reject,
+                )
+            assert not conn.is_in_transaction()
+            assert await conn.fetchval(
+                "SELECT state FROM native_revision_legacy_write_fence"
+            ) == "open"
+            assert await conn.fetchval(
+                "SELECT COUNT(*) FROM native_revision_existing_authority_fence"
+            ) == 0
+
+            fence = await begin_existing_database_authority(
+                conn,
+                identity=identity,
+                cutover_id=cutover_id,
+            )
+            with pytest.raises(NativeAuthorityError) as identity_error:
+                await begin_existing_database_authority(
+                    conn,
+                    identity=replace(identity, tenant_id="other-tenant"),
+                    cutover_id=cutover_id,
+                )
+            assert identity_error.value.code == "native_authority_fence_identity_mismatch"
+
+            with pytest.raises(NativeAuthorityError) as cutover_error:
+                await begin_existing_database_authority(
+                    conn,
+                    identity=identity,
+                    cutover_id=uuid.uuid4(),
+                )
+            assert cutover_error.value.code == "native_authority_fence_conflict"
+            assert await conn.fetchval(
+                "SELECT state FROM native_revision_legacy_write_fence"
+            ) == "fenced"
+
+            with pytest.raises(NativeAuthorityError) as startup_error:
+                await startup_revision_authority_preflight(configured)
+            assert startup_error.value.code == "native_authority_fence_incomplete"
+
+            with pytest.raises(NativeAuthorityError):
+                await finalize_existing_database_authority(
+                    conn,
+                    identity=identity,
+                    fence=replace(fence, legacy_write_epoch=2),
+                )
+            assert await conn.fetchval(
+                "SELECT COUNT(*) FROM native_revision_existing_authority"
+            ) == 0
+            assert await conn.fetchval(
+                "SELECT state FROM native_revision_legacy_write_fence"
+            ) == "fenced"
+        finally:
+            await conn.close()
 
 
 async def test_bootstrap_consume_restart_and_immutable_marker(tmp_path, monkeypatch):

--- a/backend/tests/test_native_revision_cutover_pg.py
+++ b/backend/tests/test_native_revision_cutover_pg.py
@@ -118,6 +118,8 @@ async def _fresh_schema(*, cutover_migrations: bool = True):
                     "092_native_revision_plan_supersession.py",
                     "093_external_git_retirement.py",
                     "094_native_revision_completed_reservation_transfer.py",
+                    "096_native_revision_cutover_fence.py",
+                    "097_native_revision_migration_inventory.py",
                 ]
             )
         for filename in filenames:
@@ -1032,6 +1034,7 @@ async def test_plan_supersession_migration_releases_legacy_aborted_reservations(
                 "089_native_file_projection_outbox.py",
                 "090_native_revision_vault_purge_fence.py",
                 "091_native_revision_committed_receipt_guard.py",
+                "097_native_revision_migration_inventory.py",
             ):
                 await _load(filename).migrate(conn=conn)
 
@@ -1096,6 +1099,7 @@ async def test_completed_reservation_transfer_migration_upgrades_aborted_applied
                 "091_native_revision_committed_receipt_guard.py",
                 "092_native_revision_plan_supersession.py",
                 "093_external_git_retirement.py",
+                "097_native_revision_migration_inventory.py",
             ):
                 await _load(filename).migrate(conn=conn)
 
@@ -1231,7 +1235,7 @@ async def test_commit_rejects_an_omitted_eligible_file_and_leaves_writes_open(tm
                 file_id,
             )
 
-        with pytest.raises(CutoverVerificationError, match="File inventory drifted"):
+        with pytest.raises(CutoverVerificationError, match="File catalog drifted"):
             await cutover.commit(planned.cutover_id, identity=_identity("omitted-file"))
 
         async with pool.acquire() as conn:
@@ -1288,6 +1292,43 @@ async def test_commit_rejects_a_post_plan_vault_and_rolls_back_the_fence(tmp_pat
             )
 
 
+async def test_commit_rejects_native_head_drift_before_fencing(tmp_path):
+    async with _fresh_schema() as pool:
+        git = GitService(storage_path=str(tmp_path / "git-native-head-drift"))
+        vault = await _manual_vault(pool, git, label="native-head-drift")
+        cutover = NativeRevisionCutover(
+            pool,
+            backfill=NativeRevisionBackfill(pool, git=git),
+            verifier=_FixtureVerifier(pool),
+        )
+        planned = await cutover.plan(
+            vaults=[vault],
+            coverage_version="fixture-native-head-drift-v1",
+        )
+        await cutover.apply(planned.cutover_id)
+        await cutover.verify(planned.cutover_id)
+
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE native_resources SET current_path = 'drift.md' WHERE namespace_id = $1",
+                vault.namespace_id,
+            )
+
+        with pytest.raises(CutoverVerificationError, match="Native head binding drifted"):
+            await cutover.commit(
+                planned.cutover_id,
+                identity=_identity("native-head-drift"),
+            )
+
+        async with pool.acquire() as conn:
+            assert await conn.fetchval(
+                "SELECT state FROM native_revision_legacy_write_fence"
+            ) == "open"
+            assert await conn.fetchval(
+                "SELECT count(*) FROM native_revision_existing_authority"
+            ) == 0
+
+
 async def test_commit_revalidates_file_bytes_and_current_git_refs(tmp_path):
     async with _fresh_schema() as pool:
         git = GitService(storage_path=str(tmp_path / "git-final-revalidation"))
@@ -1338,8 +1379,19 @@ async def test_commit_revalidates_file_bytes_and_current_git_refs(tmp_path):
             await cutover.commit(planned.cutover_id, identity=identity)
 
         async with pool.acquire() as conn:
-            assert await conn.fetchval("SELECT state FROM native_revision_legacy_write_fence") == "open"
+            assert await conn.fetchval("SELECT state FROM native_revision_legacy_write_fence") == "fenced"
+            assert await conn.fetchval(
+                "SELECT count(*) FROM native_revision_existing_authority_fence"
+            ) == 1
             assert await conn.fetchval("SELECT count(*) FROM native_revision_existing_authority") == 0
+            with pytest.raises(
+                asyncpg.ObjectNotInPrerequisiteStateError,
+                match="Native cutover writes are fenced",
+            ):
+                await conn.execute(
+                    "UPDATE vault_files SET description = description WHERE id = $1",
+                    file_id,
+                )
 
 
 async def test_text_mime_with_invalid_nul_or_oversized_bytes_is_preserved_binary(
@@ -1469,21 +1521,18 @@ async def test_authority_mint_is_the_boundary_and_fences_external_git_and_receip
                         file_id,
                     )
                 )
-                await asyncio.sleep(0.1)
-                assert not raced_insert.done()
-                assert not raced_receipt_delete.done()
-                reader.release.set()
-                authority = await commit_task
                 with pytest.raises(
                     asyncpg.ObjectNotInPrerequisiteStateError,
                     match="Legacy revision writes are fenced",
                 ):
-                    await raced_insert
+                    await asyncio.wait_for(raced_insert, timeout=2)
                 with pytest.raises(
                     asyncpg.ObjectNotInPrerequisiteStateError,
-                    match="committed Native revision cutover receipt",
+                    match="Native cutover writes are fenced",
                 ):
-                    await raced_receipt_delete
+                    await asyncio.wait_for(raced_receipt_delete, timeout=2)
+                reader.release.set()
+                authority = await commit_task
         finally:
             reader.release.set()
 
@@ -1925,6 +1974,8 @@ async def test_cutover_migrations_upgrade_once_and_second_runner_start_is_a_noop
             "092_native_revision_plan_supersession.py",
             "093_external_git_retirement.py",
             "094_native_revision_completed_reservation_transfer.py",
+            "096_native_revision_cutover_fence.py",
+            "097_native_revision_migration_inventory.py",
         }
         assert cutover_files <= registered
 
@@ -1951,6 +2002,8 @@ async def test_cutover_migrations_upgrade_once_and_second_runner_start_is_a_noop
                 "092_native_revision_plan_supersession.py",
                 "093_external_git_retirement.py",
                 "094_native_revision_completed_reservation_transfer.py",
+                "096_native_revision_cutover_fence.py",
+                "097_native_revision_migration_inventory.py",
             ]
             assert await conn.fetchval("SELECT state FROM native_revision_legacy_write_fence") == "open"
             assert await conn.fetchval("SELECT to_regclass('public.native_file_projection_outbox') IS NOT NULL") is True
@@ -1964,7 +2017,7 @@ async def test_cutover_migrations_upgrade_once_and_second_runner_start_is_a_noop
                     "SELECT count(*) FROM schema_migrations WHERE filename = ANY($1::text[])",
                     list(cutover_files),
                 )
-                == 7
+                == 9
             )
 
 

--- a/backend/tests/test_native_revision_migration_bridge_pg.py
+++ b/backend/tests/test_native_revision_migration_bridge_pg.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import importlib.util
 import os
 import uuid
@@ -52,7 +53,7 @@ _DSN = os.environ.get(
 async def _reachable() -> bool:
     try:
         conn = await asyncpg.connect(_DSN, timeout=2)
-    except (OSError, asyncpg.PostgresError):
+    except OSError, asyncpg.PostgresError:
         return False
     await conn.close()
     return True
@@ -90,6 +91,7 @@ async def _fresh_schema(tmp_path: Path):
             "048_native_revision_core.py",
             "053_native_revision_m1_pg_body.py",
             "060_native_revision_migration_bridge.py",
+            "097_native_revision_migration_inventory.py",
         ):
             await _load(filename).migrate(conn=conn)
         await conn.close()
@@ -210,9 +212,7 @@ async def _make_fixture(pool, tmp_path: Path) -> dict:
     }
 
 
-async def _make_compact_failpoint_fixtures(pool, tmp_path: Path) -> tuple[
-    GitService, list[dict]
-]:
+async def _make_compact_failpoint_fixtures(pool, tmp_path: Path) -> tuple[GitService, list[dict]]:
     """Build one short manual-vault case per registered failpoint.
 
     The loop intentionally avoids the multi-second chronology fixture above:
@@ -237,9 +237,7 @@ async def _make_compact_failpoint_fixtures(pool, tmp_path: Path) -> tuple[
                 "unrelated\n",
                 "unrelated fixed-ref tip",
             )
-            current_dt = Repo(str(git._bare_path(vault_name))).commit(
-                current_oid
-            ).committed_datetime
+            current_dt = Repo(str(git._bare_path(vault_name))).commit(current_oid).committed_datetime
             namespace_id = await conn.fetchval(
                 """
                 INSERT INTO vaults (name, git_path, status)
@@ -299,10 +297,7 @@ async def test_inventory_is_fixed_ref_bounded_and_includes_archived_manual_vault
             coverage_version="c9-v1",
         )
         inventory = scope.inventory
-        doc = next(
-            item for item in inventory.documents
-            if item.resource_id == fixture["document_one"]
-        )
+        doc = next(item for item in inventory.documents if item.resource_id == fixture["document_one"])
         assert doc.current_path == "renamed.md"
         assert doc.current_commit == fixture["current_oid"]
         assert not hasattr(doc, "body")
@@ -316,7 +311,9 @@ async def test_inventory_is_fixed_ref_bounded_and_includes_archived_manual_vault
             fixture["current_oid"],
         ]
         assert [entry.path_at_revision for entry in doc.lineage] == [
-            "same.md", "renamed.md", "renamed.md",
+            "same.md",
+            "renamed.md",
+            "renamed.md",
         ]
         assert fixture["old_oid"] not in {entry.legacy_git_oid for entry in doc.lineage}
         assert fixture["unrelated_tip"] not in {entry.legacy_git_oid for entry in doc.lineage}
@@ -357,9 +354,7 @@ async def test_inventory_is_fixed_ref_bounded_and_includes_archived_manual_vault
             fixed_ref=fixture["unrelated_tip"],
             coverage_version="c9-v4",
         )
-        assert [item.resource_id for item in mixed_inventory.documents] == [
-            fixture["document_two"]
-        ]
+        assert [item.resource_id for item in mixed_inventory.documents] == [fixture["document_two"]]
 
         async with pool.acquire() as conn:
             await conn.execute(
@@ -399,10 +394,13 @@ async def test_inventory_is_fixed_ref_bounded_and_includes_archived_manual_vault
                 coverage_version="c9-v6",
             )
         async with pool.acquire() as conn:
-            assert await conn.fetchval(
-                "SELECT count(*) FROM native_resources WHERE namespace_id = $1",
-                fixture["namespace_id"],
-            ) == 0
+            assert (
+                await conn.fetchval(
+                    "SELECT count(*) FROM native_resources WHERE namespace_id = $1",
+                    fixture["namespace_id"],
+                )
+                == 0
+            )
 
 
 async def test_inventory_accepts_plain_git_activity_without_akb_footers(tmp_path):
@@ -418,9 +416,7 @@ async def test_inventory_accepts_plain_git_activity_without_akb_footers(tmp_path
             author_name="Fixture Collector",
             author_email="collector@example.dev",
         )
-        current_dt = Repo(str(git._bare_path(vault_name))).commit(
-            current_oid
-        ).committed_datetime
+        current_dt = Repo(str(git._bare_path(vault_name))).commit(current_oid).committed_datetime
         fixed_ref = git.commit_file(
             vault_name,
             "notes/unrelated.md",
@@ -558,29 +554,17 @@ async def test_backfill_inventory_is_metadata_only_and_materializes_one_body_at_
 
 
 async def test_capture_releases_each_source_body_before_reading_the_next(tmp_path):
-    class LiveBody(bytes):
-        active = 0
-        max_active = 0
-
-        def __new__(cls, value):
-            instance = super().__new__(cls, value)
-            cls.active += 1
-            cls.max_active = max(cls.max_active, cls.active)
-            return instance
-
-        def __del__(self):
-            type(self).active -= 1
-
     async with _fresh_schema(tmp_path) as pool:
         fixture = await _make_fixture(pool, tmp_path)
-        original_history = fixture["git"].manual_fixed_ref_history
+        original_batch = fixture["git"].manual_fixed_ref_history_batch
+        observed_snapshots = []
 
-        def tracked_history(*args, **kwargs):
-            snapshot = original_history(*args, **kwargs)
-            snapshot["body"] = LiveBody(snapshot["body"])
-            return snapshot
+        def tracked_batch(*args, **kwargs):
+            snapshots = original_batch(*args, **kwargs)
+            observed_snapshots.extend(snapshots)
+            return snapshots
 
-        fixture["git"].manual_fixed_ref_history = tracked_history
+        fixture["git"].manual_fixed_ref_history_batch = tracked_batch
         bridge = LegacyRevisionBridge(pool, git=fixture["git"])
 
         inventory = await bridge.capture_inventory(
@@ -590,8 +574,10 @@ async def test_capture_releases_each_source_body_before_reading_the_next(tmp_pat
         )
 
         assert len(inventory.documents) == 2
-        assert LiveBody.max_active == 1
-        assert LiveBody.active == 0
+        assert len(observed_snapshots) == 2
+        assert all("body" not in snapshot for snapshot in observed_snapshots)
+        assert all("body_digest" in snapshot for snapshot in observed_snapshots)
+        assert all("byte_size" in snapshot for snapshot in observed_snapshots)
 
 
 async def test_p95_inventory_uses_one_validated_scope_and_one_body_read_per_item(
@@ -607,6 +593,7 @@ async def test_p95_inventory_uses_one_validated_scope_and_one_body_read_per_item
             self.bodies: dict[str, bytes] = {}
             self.commits: dict[str, str] = {}
             self.history_calls = 0
+            self.history_batch_calls = 0
             self.body_read_calls = 0
 
         def manual_fixed_ref_history(
@@ -620,6 +607,9 @@ async def test_p95_inventory_uses_one_validated_scope_and_one_body_read_per_item
         ):
             del vault_name, since_epoch
             self.history_calls += 1
+            return self._snapshot(observed_fixed_ref, file_path, current_commit)
+
+        def _snapshot(self, observed_fixed_ref, file_path, current_commit):
             assert observed_fixed_ref == fixed_ref
             assert current_commit == self.commits[file_path]
             return {
@@ -642,11 +632,34 @@ async def test_p95_inventory_uses_one_validated_scope_and_one_body_read_per_item
                     "action": "create",
                     "path_from": None,
                     "path_to": file_path,
-                    "changed_paths": [
-                        {"status": "A", "path_from": None, "path_to": file_path}
-                    ],
+                    "changed_paths": [{"status": "A", "path_from": None, "path_to": file_path}],
                 },
             }
+
+        def manual_fixed_ref_history_batch(
+            self,
+            vault_name,
+            observed_fixed_ref,
+            requests,
+            *,
+            include_bodies=True,
+        ):
+            del vault_name
+            self.history_batch_calls += 1
+            snapshots = [
+                self._snapshot(
+                    observed_fixed_ref,
+                    request["file_path"],
+                    request["current_commit"],
+                )
+                for request in requests
+            ]
+            if not include_bodies:
+                for snapshot in snapshots:
+                    body = snapshot.pop("body")
+                    snapshot["body_digest"] = hashlib.sha256(body).hexdigest()
+                    snapshot["byte_size"] = len(body)
+            return snapshots
 
         def read_file(self, vault_name, file_path, commit=None):
             del vault_name
@@ -742,10 +755,33 @@ async def test_p95_inventory_uses_one_validated_scope_and_one_body_read_per_item
 
         assert result.status == "complete"
         assert bridge.run_scope_validations == 1
-        assert canonical_calls == 2
-        assert repository.manual_vault_queries == 2
-        assert git.history_calls == document_count * 2
+        assert canonical_calls == 3
+        assert repository.manual_vault_queries == 3
+        assert git.history_batch_calls == 1
+        assert git.history_calls == 0
         assert git.body_read_calls == document_count
+
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                DELETE FROM legacy_revision_mappings
+                 WHERE run_id = $1
+                   AND resource_id = (
+                       SELECT native_resource_id
+                         FROM native_revision_migration_items
+                        WHERE run_id = $1
+                        ORDER BY native_resource_id
+                        LIMIT 1
+                   )
+                """,
+                run.run_id,
+            )
+        with pytest.raises(
+            MigrationInventoryDriftError,
+            match="selector closure drifted",
+        ):
+            await bridge.inventory_scope_for_run(run)
+        assert git.history_batch_calls == 1
 
 
 async def test_every_backfill_failpoint_rolls_back_then_retries_once(tmp_path):
@@ -868,22 +904,28 @@ async def test_every_backfill_failpoint_rolls_back_then_retries_once(tmp_path):
             repeated = await clean.backfill_run(run.run_id)
             assert repeated.status == "complete"
             async with pool.acquire() as conn:
-                assert await conn.fetchval(
-                    """
+                assert (
+                    await conn.fetchval(
+                        """
                     SELECT count(*)
                       FROM native_resources
                      WHERE namespace_id = $1
                     """,
-                    fixture["namespace_id"],
-                ) == 1
-                assert await conn.fetchval(
-                    """
+                        fixture["namespace_id"],
+                    )
+                    == 1
+                )
+                assert (
+                    await conn.fetchval(
+                        """
                     SELECT count(*)
                       FROM legacy_revision_mappings
                      WHERE namespace_id = $1
                     """,
-                    fixture["namespace_id"],
-                ) == 1
+                        fixture["namespace_id"],
+                    )
+                    == 1
+                )
 
 
 async def test_mixed_manual_and_external_documents_exclude_external_noop(tmp_path):
@@ -901,52 +943,68 @@ async def test_mixed_manual_and_external_documents_exclude_external_noop(tmp_pat
             fixed_ref=fixture["unrelated_tip"],
             coverage_version="c9-mixed-source",
         )
-        assert [item.resource_id for item in inventory.documents] == [
-            fixture["document_one"]
-        ]
+        assert [item.resource_id for item in inventory.documents] == [fixture["document_one"]]
 
         result = await backfill.backfill_run(run.run_id)
         assert result.status == "complete"
         async with pool.acquire() as conn:
-            assert await conn.fetchval(
-                "SELECT count(*) FROM native_revision_migration_items WHERE run_id = $1",
-                run.run_id,
-            ) == 1
-            assert await conn.fetchval(
-                """
+            assert (
+                await conn.fetchval(
+                    "SELECT count(*) FROM native_revision_migration_items WHERE run_id = $1",
+                    run.run_id,
+                )
+                == 1
+            )
+            assert (
+                await conn.fetchval(
+                    """
                 SELECT count(*)
                   FROM native_revision_migration_items
                  WHERE run_id = $1 AND legacy_document_id = $2
                 """,
-                run.run_id,
-                fixture["document_two"],
-            ) == 0
-            assert await conn.fetchval(
-                "SELECT count(*) FROM native_resources WHERE namespace_id = $1",
-                fixture["namespace_id"],
-            ) == 1
-            assert await conn.fetchval(
-                """
+                    run.run_id,
+                    fixture["document_two"],
+                )
+                == 0
+            )
+            assert (
+                await conn.fetchval(
+                    "SELECT count(*) FROM native_resources WHERE namespace_id = $1",
+                    fixture["namespace_id"],
+                )
+                == 1
+            )
+            assert (
+                await conn.fetchval(
+                    """
                 SELECT count(*)
                   FROM native_resources
                  WHERE namespace_id = $1 AND resource_id = $2
                 """,
-                fixture["namespace_id"],
-                fixture["document_two"],
-            ) == 0
-            assert await conn.fetchval(
-                """
+                    fixture["namespace_id"],
+                    fixture["document_two"],
+                )
+                == 0
+            )
+            assert (
+                await conn.fetchval(
+                    """
                 SELECT count(*)
                   FROM legacy_revision_mappings
                  WHERE namespace_id = $1 AND resource_id = $2
                 """,
-                fixture["namespace_id"],
-                fixture["document_two"],
-            ) == 0
-            assert await conn.fetchval(
-                "SELECT source FROM documents WHERE id = $1",
-                fixture["document_two"],
-            ) == "external_git"
+                    fixture["namespace_id"],
+                    fixture["document_two"],
+                )
+                == 0
+            )
+            assert (
+                await conn.fetchval(
+                    "SELECT source FROM documents WHERE id = $1",
+                    fixture["document_two"],
+                )
+                == "external_git"
+            )
 
 
 async def test_current_move_activity_semantics_are_preserved(tmp_path):
@@ -960,9 +1018,7 @@ async def test_current_move_activity_semantics_are_preserved(tmp_path):
             "move body\n",
             "[create] same.md\n\nagent: legacy-writer\naction: create\nsummary: create same",
         )
-        initial_dt = Repo(str(git._bare_path(vault_name))).commit(
-            initial_oid
-        ).committed_datetime
+        initial_dt = Repo(str(git._bare_path(vault_name))).commit(initial_oid).committed_datetime
         move_oid = git.move_file(
             vault_name,
             "same.md",
@@ -1054,10 +1110,7 @@ async def test_selector_is_hidden_until_run_complete(tmp_path):
             fixed_ref=fixture["unrelated_tip"],
             coverage_version="c9-selector",
         )
-        document = next(
-            item for item in inventory.documents
-            if item.resource_id == fixture["document_one"]
-        )
+        document = next(item for item in inventory.documents if item.resource_id == fixture["document_one"])
         body_store = M1PgBodyStore(pool)
         scope = await backfill.bridge.validated_inventory_scope(inventory)
         async with backfill.bridge.materialize_body(scope, document) as body:
@@ -1145,10 +1198,13 @@ async def test_atomic_retry_chronology_selector_shapes_and_legacy_unchanged(tmp_
                 """,
                 fixture["document_one"],
             )
-            assert await conn.fetchval(
-                "SELECT count(*) FROM native_resources WHERE namespace_id = $1",
-                fixture["namespace_id"],
-            ) == 0
+            assert (
+                await conn.fetchval(
+                    "SELECT count(*) FROM native_resources WHERE namespace_id = $1",
+                    fixture["namespace_id"],
+                )
+                == 0
+            )
 
         async with pool.acquire() as conn:
             await conn.execute(
@@ -1182,22 +1238,29 @@ async def test_atomic_retry_chronology_selector_shapes_and_legacy_unchanged(tmp_
         with pytest.raises(BackfillFailpointError):
             await failing.backfill_run(run.run_id)
         async with pool.acquire() as conn:
-            assert await conn.fetchval(
-                "SELECT count(*) FROM native_resources WHERE namespace_id = $1",
-                fixture["namespace_id"],
-            ) == 0
-            assert await conn.fetchval(
-                "SELECT count(*) FROM legacy_revision_mappings"
-            ) == 0
-            assert await conn.fetchval(
-                "SELECT count(*) FROM m1_reference_payloads WHERE namespace_id = $1",
-                fixture["namespace_id"],
-            ) == 1
-            assert await conn.fetchval(
-                "SELECT status FROM native_revision_migration_items WHERE run_id = $1 AND legacy_document_id = $2",
-                run.run_id,
-                fixture["document_one"],
-            ) == "pending"
+            assert (
+                await conn.fetchval(
+                    "SELECT count(*) FROM native_resources WHERE namespace_id = $1",
+                    fixture["namespace_id"],
+                )
+                == 0
+            )
+            assert await conn.fetchval("SELECT count(*) FROM legacy_revision_mappings") == 0
+            assert (
+                await conn.fetchval(
+                    "SELECT count(*) FROM m1_reference_payloads WHERE namespace_id = $1",
+                    fixture["namespace_id"],
+                )
+                == 1
+            )
+            assert (
+                await conn.fetchval(
+                    "SELECT status FROM native_revision_migration_items WHERE run_id = $1 AND legacy_document_id = $2",
+                    run.run_id,
+                    fixture["document_one"],
+                )
+                == "pending"
+            )
 
         result = await backfill.backfill_run(run.run_id)
         assert result.status == "complete"
@@ -1303,8 +1366,7 @@ async def test_atomic_retry_chronology_selector_shapes_and_legacy_unchanged(tmp_
         assert current.kind == "native"
         assert current.native_revision_id == revision_id
         document_one_inventory = next(
-            item for item in inventory.documents
-            if item.resource_id == fixture["document_one"]
+            item for item in inventory.documents if item.resource_id == fixture["document_one"]
         )
         old_oid = document_one_inventory.lineage[0].legacy_git_oid
         old = await bridge.resolve_selector(
@@ -1537,19 +1599,25 @@ async def test_alias_mutation_after_prepare_fails_closed_before_publication(tmp_
             await backfill.backfill_run(run.run_id)
 
         async with pool.acquire() as conn:
-            assert await conn.fetchval(
-                "SELECT count(*) FROM native_resources WHERE resource_id = $1",
-                document.resource_id,
-            ) == 0
-            assert await conn.fetchval(
-                """
+            assert (
+                await conn.fetchval(
+                    "SELECT count(*) FROM native_resources WHERE resource_id = $1",
+                    document.resource_id,
+                )
+                == 0
+            )
+            assert (
+                await conn.fetchval(
+                    """
                 SELECT count(*)
                   FROM native_resource_path_aliases
                  WHERE resource_id = $1
                    AND old_path = 'post-freeze.md'
                 """,
-                document.resource_id,
-            ) == 0
+                    document.resource_id,
+                )
+                == 0
+            )
 
 
 async def test_completed_backfill_bridges_multi_commit_frozen_activity_semantics(tmp_path):

--- a/backend/tests/test_native_revision_reconcile_pg.py
+++ b/backend/tests/test_native_revision_reconcile_pg.py
@@ -109,6 +109,7 @@ async def _fresh_schema(tmp_path: Path):
             "048_native_revision_core.py",
             "053_native_revision_m1_pg_body.py",
             "060_native_revision_migration_bridge.py",
+            "097_native_revision_migration_inventory.py",
         ):
             await _load(filename).migrate(conn=conn)
         await conn.close()

--- a/backend/tests/test_native_revision_shadow_reader.py
+++ b/backend/tests/test_native_revision_shadow_reader.py
@@ -41,7 +41,6 @@ from app.services.native_revision_shadow import (
     ShadowComparisonError,
 )
 from app.services.native_revision_shadow_reader import (
-    _apply_unified_patch,
     _canonical_transition,
     LegacyFixedRefShadowReader,
     NativeActivityEvidence,
@@ -103,6 +102,7 @@ async def _fresh_schema(tmp_path: Path):
             "048_native_revision_core.py",
             "053_native_revision_m1_pg_body.py",
             "060_native_revision_migration_bridge.py",
+            "097_native_revision_migration_inventory.py",
         ):
             await _load_migration(filename).migrate(conn=connection)
         await connection.close()
@@ -141,38 +141,6 @@ def _document_body(document: LegacyInventoryDocument) -> bytes:
     if document.resource_id == uuid.UUID("44444444-4444-4444-8444-444444444444"):
         return b"# Second candidate\n\nother secret body\n"
     raise AssertionError(f"unexpected synthetic document: {document.resource_id}")
-
-
-@pytest.mark.parametrize(
-    ("parent_text", "patch", "expected"),
-    [
-        pytest.param(
-            "text\n",
-            "@@ -1 +1 @@\n-text\n+text\n\\ No newline at end of file\n",
-            "text",
-            id="newline-to-no-newline",
-        ),
-        pytest.param(
-            "text",
-            "@@ -1 +1 @@\n-text\n\\ No newline at end of file\n+text\n",
-            "text\n",
-            id="no-newline-to-newline",
-        ),
-    ],
-)
-async def test_apply_unified_patch_preserves_terminal_newline_state(
-    parent_text: str,
-    patch: str,
-    expected: str,
-):
-    assert _apply_unified_patch(parent_text, patch, "modified") == expected
-
-
-async def test_apply_unified_patch_rejects_forged_parent_line():
-    patch = "@@ -1 +1 @@\n-forged\n+text\n"
-
-    with pytest.raises(ShadowReaderScopeError, match="differs from parent body"):
-        _apply_unified_patch("text\n", patch, "modified")
 
 
 def _document() -> LegacyInventoryDocument:
@@ -243,6 +211,22 @@ async def test_inventory_document_schema_does_not_retain_body_text():
     document = _document()
 
     assert not hasattr(document, "body")
+
+
+async def test_persisted_inventory_preserves_empty_legacy_activity_summary():
+    document = replace(_document(), activity=replace(_document().activity, summary=""))
+    namespace_id = uuid.UUID("22222222-2222-4222-8222-222222222222")
+    fixed_ref = _oid("f")
+    payload = LegacyRevisionBridge.canonical_inventory_payload(
+        namespace_id=namespace_id,
+        fixed_git_oid=fixed_ref,
+        coverage_version="empty-summary-v1",
+        documents=(document,),
+    )
+
+    restored = LegacyRevisionBridge.inventory_from_payload(payload)
+
+    assert restored.documents[0].activity.summary == ""
 
 
 def _run_and_item(
@@ -505,8 +489,7 @@ class _NoWriteGit:
     def __init__(self, *documents: LegacyInventoryDocument):
         self.documents = documents
         self.bodies = {
-            (document.current_path, document.current_commit): _document_body(document)
-            for document in documents
+            (document.current_path, document.current_commit): _document_body(document) for document in documents
         }
         for document in documents:
             for entry in document.lineage[:-1]:
@@ -1040,32 +1023,27 @@ async def test_product_readers_are_scoped_and_read_only():
     await legacy.activity(document, selector=document.current_commit, fixed_ref=fixed_ref)
     assert result["current_commit"] == document.current_commit
     assert result["content"] == "# Migration candidate\n\nsecret body"
-    assert [name for name, _ in git.calls] == [
-        "manual_fixed_ref_history",
-        "file_diff",
-        "read_file",
-        "read_file",
-    ]
+    assert [name for name, _ in git.calls] == ["read_file", "read_file"]
 
     result["projection"]["revision"] = "caller-mutation"
     result["content"] = "caller-mutation"
     reread = await legacy.get(document, selector=document.current_commit, fixed_ref=fixed_ref)
     assert reread["projection"]["revision"] == document.current_commit
     assert reread["content"] == "# Migration candidate\n\nsecret body"
-    assert len(git.calls) == 4
+    assert len(git.calls) == 2
 
     await legacy.get(second, selector=second.current_commit, fixed_ref=fixed_ref)
     await legacy.history(second, selector=second.current_commit, fixed_ref=fixed_ref)
     await legacy.diff(second, selector=second.current_commit, fixed_ref=fixed_ref)
     await legacy.activity(second, selector=second.current_commit, fixed_ref=fixed_ref)
-    assert len(git.calls) == 8
+    assert len(git.calls) == 4
 
     await legacy.get(document, selector=document.current_commit, fixed_ref=fixed_ref)
-    assert len(git.calls) == 9
+    assert len(git.calls) == 5
 
     with pytest.raises(ShadowReaderScopeError):
         await legacy.get(document, selector=_oid("e"), fixed_ref=fixed_ref)
-    assert len(git.calls) == 9
+    assert len(git.calls) == 5
 
     native_service = _NoWriteNative(
         (document, native_id),
@@ -1163,14 +1141,10 @@ async def test_legacy_reader_treats_modified_singleton_lineage_as_logical_genesi
 
     assert result["text"] == _canonical_transition("", body)
     assert git.parent_reads == []
-    assert [name for name, _ in git.calls] == [
-        "manual_fixed_ref_history",
-        "file_diff",
-        "read_file",
-    ]
+    assert [name for name, _ in git.calls] == ["read_file"]
 
 
-async def test_legacy_reader_rejects_malformed_added_genesis_patch():
+async def test_legacy_reader_does_not_rescan_a_persisted_genesis_patch():
     body = "# Migration candidate\n\ncurrent body\n"
     document = _genesis_document(action="create", body=body)
     path = document.current_path
@@ -1188,12 +1162,14 @@ async def test_legacy_reader_rejects_malformed_added_genesis_patch():
     }
     git = _GenesisDiffGit(document, diff=raw_diff, body=body)
 
-    with pytest.raises(ShadowReaderScopeError, match="invalid parent range"):
-        await LegacyFixedRefShadowReader(git=git, vault_name="p2-manual").diff(
-            document,
-            selector=document.current_commit,
-            fixed_ref=_oid("f"),
-        )
+    result = await LegacyFixedRefShadowReader(git=git, vault_name="p2-manual").diff(
+        document,
+        selector=document.current_commit,
+        fixed_ref=_oid("f"),
+    )
+
+    assert result["text"] == _canonical_transition("", body)
+    assert [name for name, _ in git.calls] == ["read_file"]
 
 
 async def test_legacy_reader_projects_final_delta_with_same_creation_anchor_as_inventory():
@@ -1428,7 +1404,7 @@ async def test_legacy_reader_treats_precreation_current_as_sole_anchor():
     ]
 
 
-async def test_legacy_reader_rejects_precreation_row_before_current_head():
+async def test_legacy_reader_uses_the_persisted_lineage_instead_of_rescanning_git():
     document = _document()
     fixed_ref = _oid("f")
     git = _NoWriteGit(document)
@@ -1448,60 +1424,42 @@ async def test_legacy_reader_rejects_precreation_row_before_current_head():
     )
     git.snapshot_override = raw
 
-    with pytest.raises(ShadowReaderScopeError, match="history"):
-        await LegacyFixedRefShadowReader(
-            git=git,
-            vault_name="p2-manual",
-        ).history(document, selector=document.current_commit, fixed_ref=fixed_ref)
+    history = await LegacyFixedRefShadowReader(
+        git=git,
+        vault_name="p2-manual",
+    ).history(document, selector=document.current_commit, fixed_ref=fixed_ref)
+
+    assert [entry["selector"] for entry in history["entries"]] == [
+        entry.legacy_git_oid for entry in reversed(document.lineage)
+    ]
+    assert [name for name, _ in git.calls][-1] == "read_file"
 
 
-async def test_legacy_reader_fails_closed_on_missing_or_corrupt_product_facts():
+async def test_legacy_reader_fails_closed_on_corrupt_body_or_persisted_activity():
     document = _document()
     fixed_ref = _oid("f")
 
-    missing_history_git = _NoWriteGit(document)
-    raw = missing_history_git.manual_fixed_ref_history(
-        "p2-manual",
-        fixed_ref,
-        document.current_path,
-        current_commit=document.current_commit,
-    )
-    missing_history_git.snapshot_override = {**raw, "history": raw["history"][:-1]}
-    with pytest.raises(ShadowReaderScopeError, match="history"):
+    corrupt_body_git = _NoWriteGit(document)
+    corrupt_body_git.bodies[(document.current_path, document.current_commit)] = b"forged body"
+    with pytest.raises(ShadowReaderScopeError, match="materialization differs"):
         await LegacyFixedRefShadowReader(
-            git=missing_history_git,
+            git=corrupt_body_git,
             vault_name="p2-manual",
-        ).history(document, selector=document.current_commit, fixed_ref=fixed_ref)
+        ).get(document, selector=document.current_commit, fixed_ref=fixed_ref)
 
-    corrupt_activity_git = _NoWriteGit(document)
-    raw = corrupt_activity_git.manual_fixed_ref_history(
-        "p2-manual",
-        fixed_ref,
-        document.current_path,
-        current_commit=document.current_commit,
+    corrupt_activity_document = replace(
+        document,
+        activity=replace(document.activity, actor=""),
     )
-    corrupt_activity_git.snapshot_override = {
-        **raw,
-        "activity": {**raw["activity"], "actor": "wrong-actor"},
-    }
     with pytest.raises(ShadowReaderScopeError, match="activity"):
         await LegacyFixedRefShadowReader(
-            git=corrupt_activity_git,
+            git=_NoWriteGit(corrupt_activity_document),
             vault_name="p2-manual",
-        ).activity(document, selector=document.current_commit, fixed_ref=fixed_ref)
-
-    corrupt_diff_git = _NoWriteGit(document)
-    corrupt_diff_git.diff_override = {
-        "file": document.current_path,
-        "commit": document.current_commit,
-        "type": "modified",
-        "diff": "@@ -1,3 +1,3 @@\n # Migration candidate\n \n-old body\n+forged body",
-    }
-    with pytest.raises(ShadowReaderScopeError, match="diff"):
-        await LegacyFixedRefShadowReader(
-            git=corrupt_diff_git,
-            vault_name="p2-manual",
-        ).diff(document, selector=document.current_commit, fixed_ref=fixed_ref)
+        ).activity(
+            corrupt_activity_document,
+            selector=document.current_commit,
+            fixed_ref=fixed_ref,
+        )
 
 
 async def test_native_reader_requires_completed_selector_bridge_and_retained_mappings():
@@ -1907,12 +1865,9 @@ async def test_comparator_receipt_is_redacted_and_classified():
     assert len(components["retained_mapping_closure"]) == 1
     assert len(components["native_parent_bindings"]) == 1
     assert components["owner_runs"] == sorted(set(components["owner_runs"]))
-    assert receipt["evidence_binding"]["owner_run_count"] == len(
-        components["owner_runs"]
-    )
+    assert receipt["evidence_binding"]["owner_run_count"] == len(components["owner_runs"])
     assert all(
-        len(commitment) == 64 and set(commitment) <= set("0123456789abcdef")
-        for commitment in components["owner_runs"]
+        len(commitment) == 64 and set(commitment) <= set("0123456789abcdef") for commitment in components["owner_runs"]
     )
     recomputed = hashlib.sha256(
         (receipt["evidence_binding"]["domain"] + "\0").encode()


### PR DESCRIPTION
## Summary

- capture each manual vault history once at its fixed ref and persist a compact immutable migration inventory
- reuse the persisted inventory for backfill, shadow comparison, reconciliation, and authority validation
- split existing-database authority commit into short durable fence and finalize transactions, with Git and S3 verification outside PostgreSQL transactions
- keep restart behavior fail-closed and exact-cutover resumable

## Validation

- ruff: all changed Python files passed
- mypy: all changed service and repository files passed
- focused local tests: 132 passed, 2 skipped
- real PostgreSQL Native revision integration: 97 passed
- real PostgreSQL migration-head integration: 23 passed
- broad server suite: 3151 passed; unrelated environment failures were isolated to mirror.test DNS and an unset module-specific M1 DSN
- broad local suite: 2594 passed, 665 skipped; remaining errors were unavailable DB-only E2E fixtures and an unrelated Helm cache miss

Review: exact head c7211dc8e659d960390b612dd47cdbfe9deae689, no remaining High or Medium findings.