### PR TITLE
test(mcp): add official SDK pytest E2E fixture

### DIFF
--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -35,8 +35,9 @@ jobs:
 
       - name: Run unit tests
         working-directory: backend
-        # `-k 'not _e2e'` excludes the two e2e files that need a live
-        # backend pod (test_indexable_e2e.py, test_rerank_e2e.py).
+        # `-k 'not _e2e'` excludes live tests, including the authenticated
+        # MCP scenario under tests/mcp_e2e. The repository-owned runtime gate
+        # runs that scenario explicitly with its schema-v2 descriptor.
         # Shell e2e suites under tests/*.sh aren't picked up by pytest.
         run: pytest tests/ -k 'not _e2e' -v --tb=short
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,7 +50,7 @@ jobs:
           uv run --locked --project backend python -c \
             'import sys; assert sys.version_info[:2] == (3, 14), sys.version'
 
-      - name: Run the repository-owned E2E runtime
+      - name: Run repository-owned pytest and shell E2E runtime
         env:
           UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}/akb-e2e-python
           UV_CACHE_DIR: ${{ runner.temp }}/akb-e2e-uv-cache

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -176,7 +176,7 @@
         "filename": "backend/scripts/ci/README.md",
         "hashed_secret": "f017223a0417e247cdef8c5c3e5681c6d5439219",
         "is_verified": false,
-        "line_number": 106
+        "line_number": 140
       }
     ],
     "backend/scripts/ci/dependency-compose.yaml": [
@@ -6987,5 +6987,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-02T08:06:11Z"
+  "generated_at": "2026-09-03T05:09:42Z"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,30 @@ unset AKB_E2E_USERNAME AKB_E2E_PASSWORD
 cd frontend && pnpm test
 ```
 
+The authenticated MCP pytest scenario is run by the repository-owned runtime
+gate and can also consume a ready schema-v2 descriptor directly. Local and
+hosted CI use the same pytest entrypoint and the same `akb_list_vaults({})`
+assertion:
+
+```bash
+uv run --locked --extra dev --project backend python -m pytest \
+  backend/tests/mcp_e2e -v --tb=short \
+  --confcutdir=backend/tests/mcp_e2e --runtime-descriptor -
+```
+
+For a descriptor file, replace `-` with its path:
+
+```bash
+uv run --locked --extra dev --project backend python -m pytest \
+  backend/tests/mcp_e2e -v --tb=short \
+  --confcutdir=backend/tests/mcp_e2e \
+  --runtime-descriptor /path/to/descriptor.json
+```
+
+The descriptor must come from `backend/scripts/ci/e2e_runtime.py serve` or the
+Ubuntu bootstrap. This pytest command consumes the existing runtime; it does
+not start or tear down a backend, database, or fixture service.
+
 The E2E suites create ephemeral users and vaults and clean up after
 themselves. They poll `/health` for indexing completion before running search
 assertions, so a slow remote embedding endpoint won't cause flakes. An

--- a/backend/scripts/ci/README.md
+++ b/backend/scripts/ci/README.md
@@ -43,6 +43,38 @@ fails the gate. `EMPTY_COUNT_ALLOWED` is intentionally empty. Hosted CI,
 the isolated runtime, and `scripts/run_canonical_e2e.sh` all execute this same
 runner, so there is no second suite array to keep synchronized.
 
+### MCP pytest behavior suite
+
+The first MCP behavior scenario is an authenticated read-only
+`akb_list_vaults({})` call through the official MCP Python SDK. The fixture
+uses the SDK's public `Client` and Streamable HTTP transport in the pytest
+process; it does not invoke Inspector, Node, or a separate MCP driver.
+
+The repository runtime remains the owner of backend startup, readiness,
+fixture reset, credentials, and teardown. Give the same schema-v2 descriptor
+to the local and hosted command through stdin:
+
+```bash
+uv run --locked --extra dev --project backend python -m pytest \
+  backend/tests/mcp_e2e -v --tb=short \
+  --confcutdir=backend/tests/mcp_e2e --runtime-descriptor -
+```
+
+To consume a descriptor file instead, pass its path to the same option:
+
+```bash
+uv run --locked --extra dev --project backend python -m pytest \
+  backend/tests/mcp_e2e -v --tb=short \
+  --confcutdir=backend/tests/mcp_e2e \
+  --runtime-descriptor /path/to/descriptor.json
+```
+
+The descriptor must come from `backend/scripts/ci/e2e_runtime.py serve` or the
+Ubuntu bootstrap. The fixture consumes the descriptor's app/fixture origins,
+health and reset operations, discovery-declared credential environment names,
+and the existing `empty` reset contract. It does not create another backend,
+database, port topology, or credential fixture.
+
 ### 2. Repository-owned isolated runtime
 
 The runtime supervisor is `e2e_runtime.py`. It owns the test infrastructure
@@ -62,6 +94,7 @@ The topology is deliberately small:
 | embedding stub | Ubuntu host process | `127.0.0.1:8888` | deterministic `/v1/embeddings` responses |
 | backend | Ubuntu host process | `127.0.0.1:8000` | AKB application under test |
 | fixture control | supervisor-owned in-process app | `127.0.0.1:8889` | health, discovery, and empty reset |
+| MCP pytest behavior suite | Ubuntu host process | no public listener | authenticated `akb_list_vaults` scenario through the official Python SDK |
 | curated suite runner | Ubuntu host process | no public listener | exact 15-suite gate and count semantics |
 
 Only PostgreSQL and MinIO are managed by
@@ -80,7 +113,8 @@ The supervisor has two modes:
 
 - `gate`: starts dependencies, fixture control, embedding stub, and backend;
   waits for readiness; prints the schema v2 descriptor; runs the shared
-  curated suite runner; then stops child processes and dependency resources.
+  pytest behavior scenario and curated suite runner; then stops child
+  processes and dependency resources.
 - `serve`: starts the same stack, prints the ready descriptor, and remains in
   the foreground until SIGINT/SIGTERM. The fixture's `POST /reset` performs a
   safe empty reset and waits for backend readiness again.

--- a/backend/scripts/ci/e2e_runtime.py
+++ b/backend/scripts/ci/e2e_runtime.py
@@ -3389,6 +3389,7 @@ class E2ERuntime:
 
     async def _run_gate(self) -> int:
         suite_path = self.config.backend_dir / "scripts" / "ci" / "e2e_suite_runner.py"
+        mcp_pytest_path = self.config.checkout / "backend" / "tests" / "mcp_e2e"
         log_path = self.config.logs_dir / "gate.log"
         emit_gate_event(
             {
@@ -3401,6 +3402,49 @@ class E2ERuntime:
                 "capabilities": list(self.selected_capabilities),
                 "source_revision": self._source_revision(),
             },
+        )
+
+        emit_gate_event(
+            {
+                "event": "mcp_pytest_start",
+                "process": "mcp_pytest",
+                "scenario": "akb_list_vaults",
+                "suite": str(mcp_pytest_path),
+                "stage": "product_assertion",
+                "profile": self.profile.name,
+            }
+        )
+        try:
+            await self._run_logged_command(
+                [
+                    sys.executable,
+                    "-m",
+                    "pytest",
+                    str(mcp_pytest_path),
+                    "-v",
+                    "--tb=short",
+                    "--confcutdir",
+                    str(mcp_pytest_path),
+                    "--runtime-descriptor",
+                    "-",
+                ],
+                log_path=self.config.logs_dir / "mcp-pytest.log",
+                stdin_data=json.dumps(
+                    self.descriptor(), separators=(",", ":"), ensure_ascii=False
+                ).encode(),
+            )
+        except ProvisioningFailure as exc:
+            raise ProductAssertionFailure("MCP pytest E2E scenario failed") from exc
+        emit_gate_event(
+            {
+                "event": "mcp_pytest_complete",
+                "process": "mcp_pytest",
+                "scenario": "akb_list_vaults",
+                "suite": str(mcp_pytest_path),
+                "stage": "product_assertion",
+                "profile": self.profile.name,
+                "returncode": 0,
+            }
         )
 
         if self.profile.needs_stdio:

--- a/backend/tests/mcp_e2e/__init__.py
+++ b/backend/tests/mcp_e2e/__init__.py
@@ -1,0 +1,1 @@
+"""Authenticated MCP behavior scenarios backed by the repository runtime."""

--- a/backend/tests/mcp_e2e/conftest.py
+++ b/backend/tests/mcp_e2e/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 from collections.abc import AsyncIterator, Iterator, Mapping
 from pathlib import Path
@@ -184,23 +185,64 @@ async def mcp_client(runtime_session: RuntimeContext) -> AsyncIterator[Client]:
         follow_redirects=True,
         trust_env=False,
     )
-    client = Client(
-        streamable_http_client(runtime_session.descriptor.mcp_url, http_client=http_client),
-        mode="auto",
-        read_timeout_seconds=30.0,
-        cache=None,
-    )
-    entered = False
     try:
-        async with client:
-            entered = True
-            yield client
-    except Exception as exc:
-        if entered:
-            raise
-        pytest.fail(
-            "scenario=akb_list_vaults SDK connection: "
-            + redact_error(exc, runtime_session.secrets)
+        client = Client(
+            streamable_http_client(runtime_session.descriptor.mcp_url, http_client=http_client),
+            mode="auto",
+            read_timeout_seconds=30.0,
+            cache=None,
         )
-    finally:
+    except BaseException:
         await http_client.aclose()
+        raise
+
+    close_requested = asyncio.Event()
+    ready = asyncio.Event()
+    finished = asyncio.Event()
+    lifecycle_error: BaseException | None = None
+
+    async def run_client() -> None:
+        nonlocal lifecycle_error
+        try:
+            async with client:
+                ready.set()
+                await close_requested.wait()
+        except BaseException as exc:
+            lifecycle_error = exc
+            ready.set()
+        finally:
+            try:
+                await http_client.aclose()
+            except BaseException as exc:
+                if lifecycle_error is None:
+                    lifecycle_error = exc
+            finally:
+                finished.set()
+
+    async def wait_for_finish() -> None:
+        cancelled = False
+        while not finished.is_set():
+            try:
+                await asyncio.shield(finished.wait())
+            except asyncio.CancelledError:
+                cancelled = True
+        if cancelled:
+            raise asyncio.CancelledError
+
+    task = asyncio.create_task(run_client(), name="mcp-sdk-client")
+    reported_startup_error = False
+    try:
+        await ready.wait()
+        if lifecycle_error is not None:
+            reported_startup_error = True
+            pytest.fail(
+                "scenario=akb_list_vaults SDK connection: "
+                + redact_error(lifecycle_error, runtime_session.secrets)
+            )
+        yield client
+    finally:
+        close_requested.set()
+        await wait_for_finish()
+        if lifecycle_error is not None and not reported_startup_error:
+            raise lifecycle_error
+        await task

--- a/backend/tests/mcp_e2e/conftest.py
+++ b/backend/tests/mcp_e2e/conftest.py
@@ -1,18 +1,20 @@
-"""Pytest fixtures for authenticated MCP behavior scenarios."""
+"""Pytest fixtures for the authenticated MCP behavior scenario."""
 
 from __future__ import annotations
 
 import os
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncIterator, Iterator, Mapping
 from pathlib import Path
 from typing import Any
+from urllib.parse import urljoin
 
+import httpx
 import httpx2
 import pytest
 from mcp import Client
 from mcp.client.streamable_http import streamable_http_client
 
-from .runtime import RuntimeSession, RuntimeSetupError, redact_error
+from .runtime import RuntimeContext, RuntimeDescriptor, RuntimeSetupError, redact_error
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -43,29 +45,139 @@ def _read_descriptor(source: str, capture_manager: Any = None) -> str:
         raise RuntimeSetupError("runtime descriptor file could not be read") from None
 
 
+def _request_json(
+    client: httpx.Client,
+    method: str,
+    url: str,
+    *,
+    stage: str,
+    body: Mapping[str, Any] | None = None,
+    authorization: str | None = None,
+) -> dict[str, Any]:
+    headers = {"Authorization": authorization} if authorization else None
+    try:
+        response = client.request(method, url, json=body, headers=headers)
+    except httpx.HTTPError:
+        raise RuntimeSetupError(f"{stage} request failed") from None
+    if response.status_code != 200:
+        raise RuntimeSetupError(f"{stage} returned HTTP {response.status_code}")
+    try:
+        value = response.json()
+    except ValueError:
+        raise RuntimeSetupError(f"{stage} returned invalid JSON") from None
+    if not isinstance(value, dict):
+        raise RuntimeSetupError(f"{stage} returned an invalid object")
+    return value
+
+
+def _prepare_runtime(descriptor: RuntimeDescriptor, client: httpx.Client) -> RuntimeContext:
+    def ready(stage: str) -> None:
+        app = _request_json(client, "GET", descriptor.app_health_url, stage=f"{stage} app health")
+        fixture = _request_json(
+            client, "GET", descriptor.fixture_health_url, stage=f"{stage} fixture health"
+        )
+        if app.get("status") != "ready" or fixture.get("status") != "ready":
+            raise RuntimeSetupError(f"{stage} runtime is not ready")
+
+    def mint_path(discovery: dict[str, Any]) -> str:
+        if discovery.get("status") != "ready" or discovery.get("scenario") != descriptor.scenario:
+            raise RuntimeSetupError("fixture discovery is not ready for this scenario")
+        access = discovery.get("access")
+        login = access.get("login") if isinstance(access, dict) else None
+        if (
+            not isinstance(login, dict)
+            or login.get("service") != "app"
+            or login.get("method") != "POST"
+            or login.get("path") != descriptor.login_path
+        ):
+            raise RuntimeSetupError("descriptor and discovery login coordinates disagree")
+        runtime = discovery.get("runtime")
+        if not isinstance(runtime, dict):
+            raise RuntimeSetupError("fixture runtime must be an object")
+        credential_env = runtime.get("credential_env")
+        if (
+            not isinstance(credential_env, dict)
+            or credential_env.get("username") != descriptor.username_env
+            or credential_env.get("password") != descriptor.password_env
+        ):
+            raise RuntimeSetupError("descriptor and discovery credential names disagree")
+        pat = runtime.get("pat")
+        mint = pat.get("mint") if isinstance(pat, dict) else None
+        if not isinstance(mint, dict) or mint.get("service") != "app" or mint.get("method") != "POST":
+            raise RuntimeSetupError("fixture PAT mint coordinates are invalid")
+        path = mint.get("path")
+        if not isinstance(path, str) or not path.startswith("/") or path.startswith("//") or "?" in path or "#" in path:
+            raise RuntimeSetupError("fixture PAT mint path is invalid")
+        return path
+
+    ready("before reset")
+    discovery = _request_json(client, "GET", descriptor.discovery_url, stage="fixture discovery")
+    mint = mint_path(discovery)
+    reset = _request_json(
+        client, "POST", descriptor.reset_url, stage="fixture reset", body=descriptor.reset_body
+    )
+    if reset.get("status") != "ready" or reset.get("scenario") != descriptor.scenario:
+        raise RuntimeSetupError("fixture reset did not return the selected ready scenario")
+    ready("after reset")
+    discovery = _request_json(
+        client, "GET", descriptor.discovery_url, stage="fixture discovery after reset"
+    )
+    mint = mint_path(discovery)
+
+    username = os.environ.get(descriptor.username_env, "")
+    password = os.environ.get(descriptor.password_env, "")
+    if not username or not password:
+        raise RuntimeSetupError("declared credential environment values are missing")
+    secrets = (username, password)
+    login = _request_json(
+        client,
+        "POST",
+        urljoin(f"{descriptor.app_origin}/", descriptor.login_path.lstrip("/")),
+        stage="credential login",
+        body={"username": username, "password": password},
+    )
+    session_token = login.get("token")
+    if not isinstance(session_token, str) or not session_token:
+        raise RuntimeSetupError("credential login returned no session token")
+    secrets = (*secrets, session_token)
+    minted = _request_json(
+        client,
+        "POST",
+        urljoin(f"{descriptor.app_origin}/", mint.lstrip("/")),
+        stage="credential mint",
+        authorization=f"Bearer {session_token}",
+        body={"name": "mcp-pytest"},
+    )
+    pat = minted.get("token")
+    if not isinstance(pat, str) or not pat.startswith("akb_"):
+        raise RuntimeSetupError("credential mint returned an invalid PAT")
+    return RuntimeContext(descriptor=descriptor, pat=pat, secrets=(*secrets, pat))
+
+
 @pytest.fixture
-def runtime_session(request: pytest.FixtureRequest) -> Iterator[RuntimeSession]:
+def runtime_session(request: pytest.FixtureRequest) -> Iterator[RuntimeContext]:
     source = request.config.getoption("--runtime-descriptor")
     if not source:
         pytest.fail("scenario=akb_list_vaults preparation: --runtime-descriptor is required")
-    session: RuntimeSession | None = None
     try:
         capture_manager = request.config.pluginmanager.getplugin("capturemanager")
-        session = RuntimeSession.from_json(_read_descriptor(source, capture_manager))
-        session.prepare()
+        descriptor = RuntimeDescriptor.from_json(_read_descriptor(source, capture_manager))
     except Exception as exc:
-        secrets = session.secrets if session is not None else ()
-        if session is not None:
-            session.close()
-        pytest.fail(f"scenario=akb_list_vaults preparation: {redact_error(exc, secrets)}")
+        pytest.fail(f"scenario=akb_list_vaults preparation: {redact_error(exc)}")
+
+    client = httpx.Client(timeout=30.0)
     try:
-        yield session
+        try:
+            context = _prepare_runtime(descriptor, client)
+        except Exception as exc:
+            pytest.fail(f"scenario=akb_list_vaults preparation: {redact_error(exc)}")
+        yield context
     finally:
-        session.close()
+        client.close()
 
 
 @pytest.fixture
-async def mcp_client(runtime_session: RuntimeSession) -> AsyncIterator[Client]:
+async def mcp_client(runtime_session: RuntimeContext) -> AsyncIterator[Client]:
     http_client = httpx2.AsyncClient(
         headers={"Authorization": f"Bearer {runtime_session.pat}"},
         timeout=httpx2.Timeout(30.0, read=300.0),

--- a/backend/tests/mcp_e2e/conftest.py
+++ b/backend/tests/mcp_e2e/conftest.py
@@ -1,0 +1,94 @@
+"""Pytest fixtures for authenticated MCP behavior scenarios."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
+from typing import Any
+
+import httpx2
+import pytest
+from mcp import Client
+from mcp.client.streamable_http import streamable_http_client
+
+from .runtime import RuntimeSession, RuntimeSetupError, redact_error
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--runtime-descriptor",
+        default=None,
+        help="schema-v2 runtime descriptor path, or '-' to read it from stdin",
+    )
+
+
+def _read_descriptor(source: str, capture_manager: Any = None) -> str:
+    if source == "-":
+        suspended = False
+        try:
+            if capture_manager is not None:
+                capture_manager.suspend_global_capture(in_=True)
+                suspended = True
+            with os.fdopen(os.dup(0), "r", encoding="utf-8") as stream:
+                return stream.read()
+        except OSError:
+            raise RuntimeSetupError("runtime descriptor stdin could not be read") from None
+        finally:
+            if suspended:
+                capture_manager.resume_global_capture()
+    try:
+        return Path(source).read_text(encoding="utf-8")
+    except OSError:
+        raise RuntimeSetupError("runtime descriptor file could not be read") from None
+
+
+@pytest.fixture
+def runtime_session(request: pytest.FixtureRequest) -> Iterator[RuntimeSession]:
+    source = request.config.getoption("--runtime-descriptor")
+    if not source:
+        pytest.fail("scenario=akb_list_vaults preparation: --runtime-descriptor is required")
+    session: RuntimeSession | None = None
+    try:
+        capture_manager = request.config.pluginmanager.getplugin("capturemanager")
+        session = RuntimeSession.from_json(_read_descriptor(source, capture_manager))
+        session.prepare()
+    except Exception as exc:
+        secrets = session.secrets if session is not None else ()
+        if session is not None:
+            session.close()
+        pytest.fail(f"scenario=akb_list_vaults preparation: {redact_error(exc, secrets)}")
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+async def mcp_client(runtime_session: RuntimeSession) -> AsyncIterator[Client]:
+    http_client = httpx2.AsyncClient(
+        headers={"Authorization": f"Bearer {runtime_session.pat}"},
+        timeout=httpx2.Timeout(30.0, read=300.0),
+        follow_redirects=True,
+        trust_env=False,
+    )
+    client = Client(
+        streamable_http_client(runtime_session.descriptor.mcp_url, http_client=http_client),
+        mode="auto",
+        read_timeout_seconds=30.0,
+        cache=None,
+    )
+    entered = False
+    try:
+        async with client:
+            entered = True
+            yield client
+    except Exception as exc:
+        if entered:
+            raise
+        pytest.fail(
+            "scenario=akb_list_vaults SDK connection: "
+            + redact_error(exc, runtime_session.secrets)
+        )
+    finally:
+        await http_client.aclose()

--- a/backend/tests/mcp_e2e/runtime.py
+++ b/backend/tests/mcp_e2e/runtime.py
@@ -1,20 +1,17 @@
-"""Consume the repository-owned E2E descriptor and prepare one test credential."""
+"""Descriptor parsing for the live MCP scenario."""
 
 from __future__ import annotations
 
 import json
-import os
 import re
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urljoin, urlsplit
 
-import httpx
-
 
 class RuntimeSetupError(RuntimeError):
-    """Raised when a repository-owned runtime cannot be consumed safely."""
+    """Raised when the repository-owned runtime cannot be consumed safely."""
 
 
 def redact_error(error: BaseException, secrets: Iterable[str] = ()) -> str:
@@ -28,7 +25,7 @@ def redact_error(error: BaseException, secrets: Iterable[str] = ()) -> str:
 
 @dataclass(frozen=True, slots=True)
 class RuntimeDescriptor:
-    """Validated, credential-free coordinates from a schema-v2 descriptor."""
+    """The schema-v2 coordinates needed by the MCP test fixture."""
 
     scenario: str
     app_origin: str
@@ -39,13 +36,10 @@ class RuntimeDescriptor:
     discovery_url: str
     username_env: str
     password_env: str
-    pat_env: str | None
     login_path: str
 
     @property
     def mcp_url(self) -> str:
-        """Return the MCP endpoint under the descriptor's application origin."""
-
         return urljoin(f"{self.app_origin}/", "mcp/")
 
     @classmethod
@@ -59,31 +53,25 @@ class RuntimeDescriptor:
         if descriptor.get("schema_version") != 2 or descriptor.get("status") != "ready":
             raise RuntimeSetupError("runtime descriptor must be a ready schema-v2 descriptor")
 
-        scenario = _required_string(descriptor.get("scenario"), "descriptor scenario")
-        services = _required_object(descriptor.get("services"), "descriptor services")
-        app = _required_object(services.get("app"), "app service")
-        fixture = _required_object(services.get("fixture"), "fixture service")
+        scenario = _string(descriptor.get("scenario"), "descriptor scenario")
+        services = _object(descriptor.get("services"), "descriptor services")
+        app = _object(services.get("app"), "app service")
+        fixture = _object(services.get("fixture"), "fixture service")
         app_origin = _origin(app.get("origin"), "app origin")
         fixture_origin = _origin(fixture.get("origin"), "fixture origin")
-        app_health_url = _operation_url(app.get("health"), app_origin, "app health", "GET")
-        _operation_url(app.get("discovery"), app_origin, "app discovery", "GET")
-        fixture_health_url = _operation_url(
-            fixture.get("health"), fixture_origin, "fixture health", "GET"
-        )
-        reset = _required_object(fixture.get("reset"), "fixture reset")
-        reset_url = _operation_url(reset, fixture_origin, "fixture reset", "POST")
-        reset_body = _required_object(reset.get("body"), "fixture reset body")
+        app_health_url = _operation(app.get("health"), app_origin, "app health", "GET")
+        _operation(app.get("discovery"), app_origin, "app discovery", "GET")
+        fixture_health_url = _operation(fixture.get("health"), fixture_origin, "fixture health", "GET")
+        reset = _object(fixture.get("reset"), "fixture reset")
+        reset_url = _operation(reset, fixture_origin, "fixture reset", "POST")
+        reset_body = _object(reset.get("body"), "fixture reset body")
         if reset_body.get("scenario") != scenario:
             raise RuntimeSetupError("fixture reset scenario does not match descriptor")
-        fixture_discovery_url = _operation_url(
-            fixture.get("discovery"), fixture_origin, "fixture discovery", "GET"
-        )
+        discovery_url = _operation(fixture.get("discovery"), fixture_origin, "fixture discovery", "GET")
 
-        credentials = _required_object(descriptor.get("credentials"), "descriptor credentials")
+        credentials = _object(descriptor.get("credentials"), "descriptor credentials")
         username_env = _environment_name(credentials.get("username_env"), "username environment name")
         password_env = _environment_name(credentials.get("password_env"), "password environment name")
-        raw_pat_env = credentials.get("pat_env")
-        pat_env = _environment_name(raw_pat_env, "PAT environment name") if raw_pat_env is not None else None
         login_path = _path(credentials.get("login_path"), "credential login path")
         return cls(
             scenario=scenario,
@@ -92,28 +80,34 @@ class RuntimeDescriptor:
             fixture_health_url=fixture_health_url,
             reset_url=reset_url,
             reset_body=dict(reset_body),
-            discovery_url=fixture_discovery_url,
+            discovery_url=discovery_url,
             username_env=username_env,
             password_env=password_env,
-            pat_env=pat_env,
             login_path=login_path,
         )
 
 
-def _required_object(value: Any, label: str) -> dict[str, Any]:
+@dataclass(frozen=True, slots=True)
+class RuntimeContext:
+    descriptor: RuntimeDescriptor
+    pat: str
+    secrets: tuple[str, ...]
+
+
+def _object(value: Any, label: str) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise RuntimeSetupError(f"{label} must be an object")
     return value
 
 
-def _required_string(value: Any, label: str) -> str:
+def _string(value: Any, label: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise RuntimeSetupError(f"{label} is required")
     return value
 
 
 def _origin(value: Any, label: str) -> str:
-    candidate = _required_string(value, label)
+    candidate = _string(value, label)
     try:
         parsed = urlsplit(candidate)
     except ValueError:
@@ -131,20 +125,19 @@ def _origin(value: Any, label: str) -> str:
     return candidate.rstrip("/")
 
 
-def _operation_url(value: Any, base: str, label: str, method: str) -> str:
-    operation = _required_object(value, label)
+def _operation(value: Any, base: str, label: str, method: str) -> str:
+    operation = _object(value, label)
     if operation.get("method") != method:
         raise RuntimeSetupError(f"{label} must use {method}")
-    raw_url = _required_string(operation.get("url"), label)
-    candidate = urljoin(f"{base}/", raw_url)
+    candidate = urljoin(f"{base}/", _string(operation.get("url"), label))
     try:
         parsed = urlsplit(candidate)
-        base_parsed = urlsplit(base)
+        origin = urlsplit(base)
     except ValueError:
         raise RuntimeSetupError(f"{label} must stay on its declared origin") from None
     if (
-        parsed.scheme != base_parsed.scheme
-        or parsed.netloc != base_parsed.netloc
+        parsed.scheme != origin.scheme
+        or parsed.netloc != origin.netloc
         or parsed.username
         or parsed.password
         or parsed.fragment
@@ -154,161 +147,14 @@ def _operation_url(value: Any, base: str, label: str, method: str) -> str:
 
 
 def _path(value: Any, label: str) -> str:
-    path = _required_string(value, label)
+    path = _string(value, label)
     if not path.startswith("/") or path.startswith("//") or "?" in path or "#" in path:
         raise RuntimeSetupError(f"{label} is invalid")
     return path
 
 
 def _environment_name(value: Any, label: str) -> str:
-    name = _required_string(value, label)
+    name = _string(value, label)
     if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name) is None:
         raise RuntimeSetupError(f"{label} is invalid")
     return name
-
-
-class RuntimeSession:
-    """Reset the existing runtime and mint one in-memory MCP read credential."""
-
-    def __init__(self, descriptor: RuntimeDescriptor, client: httpx.Client | None = None) -> None:
-        self.descriptor = descriptor
-        self.client = client or httpx.Client(timeout=30.0)
-        self.pat = ""
-        self.secrets: tuple[str, ...] = ()
-        self._closed = False
-
-    @classmethod
-    def from_json(cls, raw: str, client: httpx.Client | None = None) -> RuntimeSession:
-        return cls(RuntimeDescriptor.from_json(raw), client=client)
-
-    @property
-    def credential_env_names(self) -> tuple[str, ...]:
-        return tuple(
-            name
-            for name in (self.descriptor.username_env, self.descriptor.password_env, self.descriptor.pat_env)
-            if name is not None
-        )
-
-    def _request_json(
-        self,
-        method: str,
-        url: str,
-        *,
-        stage: str,
-        body: Mapping[str, Any] | None = None,
-        authorization: str | None = None,
-    ) -> dict[str, Any]:
-        headers = {"Authorization": authorization} if authorization else None
-        try:
-            response = self.client.request(method, url, json=body, headers=headers)
-        except httpx.HTTPError:
-            raise RuntimeSetupError(f"{stage} request failed") from None
-        if response.status_code != 200:
-            raise RuntimeSetupError(f"{stage} returned HTTP {response.status_code}")
-        try:
-            value = response.json()
-        except ValueError:
-            raise RuntimeSetupError(f"{stage} returned invalid JSON") from None
-        if not isinstance(value, dict):
-            raise RuntimeSetupError(f"{stage} returned an invalid object")
-        return value
-
-    def _ready(self, stage: str) -> None:
-        app = self._request_json("GET", self.descriptor.app_health_url, stage=f"{stage} app health")
-        fixture = self._request_json(
-            "GET", self.descriptor.fixture_health_url, stage=f"{stage} fixture health"
-        )
-        if app.get("status") != "ready" or fixture.get("status") != "ready":
-            raise RuntimeSetupError(f"{stage} runtime is not ready")
-
-    def _validate_discovery(self, discovery: dict[str, Any]) -> str:
-        if discovery.get("status") != "ready" or discovery.get("scenario") != self.descriptor.scenario:
-            raise RuntimeSetupError("fixture discovery is not ready for this scenario")
-
-        access = _required_object(discovery.get("access"), "fixture access")
-        login = _required_object(access.get("login"), "fixture login")
-        if login.get("service") != "app" or login.get("method") != "POST":
-            raise RuntimeSetupError("fixture login coordinates are invalid")
-        if login.get("path") != self.descriptor.login_path:
-            raise RuntimeSetupError("descriptor and discovery login paths disagree")
-
-        runtime = _required_object(discovery.get("runtime"), "fixture runtime")
-        origins = _required_object(runtime.get("origin"), "fixture runtime origins")
-        if origins.get("backend") != self.descriptor.app_origin:
-            raise RuntimeSetupError("descriptor and discovery app origins disagree")
-        transports = runtime.get("transport")
-        if not isinstance(transports, list) or "http" not in transports:
-            raise RuntimeSetupError("fixture runtime does not advertise HTTP transport")
-        tool_cases = _required_object(runtime.get("tool_cases"), "fixture runtime tool cases")
-        if tool_cases.get("read") != "akb_list_vaults":
-            raise RuntimeSetupError("fixture runtime does not advertise the list-vaults case")
-        credential_env = _required_object(runtime.get("credential_env"), "fixture runtime credentials")
-        if (
-            credential_env.get("username") != self.descriptor.username_env
-            or credential_env.get("password") != self.descriptor.password_env
-        ):
-            raise RuntimeSetupError("descriptor and discovery credential names disagree")
-
-        pat = _required_object(runtime.get("pat"), "fixture PAT")
-        mint = _required_object(pat.get("mint"), "fixture PAT mint")
-        if mint.get("service") != "app" or mint.get("method") != "POST":
-            raise RuntimeSetupError("fixture PAT mint coordinates are invalid")
-        return _path(mint.get("path"), "fixture PAT mint path")
-
-    def prepare(self) -> None:
-        self._ready("before reset")
-        discovery = self._request_json(
-            "GET", self.descriptor.discovery_url, stage="fixture discovery"
-        )
-        mint_path = self._validate_discovery(discovery)
-
-        reset_result = self._request_json(
-            "POST",
-            self.descriptor.reset_url,
-            stage="fixture reset",
-            body=self.descriptor.reset_body,
-        )
-        if reset_result.get("status") != "ready" or reset_result.get("scenario") != self.descriptor.scenario:
-            raise RuntimeSetupError("fixture reset did not return the selected ready scenario")
-
-        self._ready("after reset")
-        after_reset = self._request_json(
-            "GET", self.descriptor.discovery_url, stage="fixture discovery after reset"
-        )
-        mint_path = self._validate_discovery(after_reset)
-
-        username = os.environ.get(self.descriptor.username_env, "")
-        password = os.environ.get(self.descriptor.password_env, "")
-        if not username or not password:
-            raise RuntimeSetupError("declared credential environment values are missing")
-        self.secrets = (username, password)
-        login_response = self._request_json(
-            "POST",
-            urljoin(f"{self.descriptor.app_origin}/", self.descriptor.login_path.lstrip("/")),
-            stage="credential login",
-            body={"username": username, "password": password},
-        )
-        session_token = login_response.get("token")
-        if not isinstance(session_token, str) or not session_token:
-            raise RuntimeSetupError("credential login returned no session token")
-        self.secrets = (*self.secrets, session_token)
-
-        mint_response = self._request_json(
-            "POST",
-            urljoin(f"{self.descriptor.app_origin}/", mint_path.lstrip("/")),
-            stage="credential mint",
-            authorization=f"Bearer {session_token}",
-            body={"name": "mcp-pytest"},
-        )
-        token = mint_response.get("token")
-        if not isinstance(token, str) or not token.startswith("akb_"):
-            raise RuntimeSetupError("credential mint returned an invalid PAT")
-        self.pat = token
-        self.secrets = (*self.secrets, token)
-
-    def close(self) -> None:
-        if not self._closed:
-            self._closed = True
-            self.client.close()
-        self.pat = ""
-        self.secrets = ()

--- a/backend/tests/mcp_e2e/runtime.py
+++ b/backend/tests/mcp_e2e/runtime.py
@@ -1,0 +1,314 @@
+"""Consume the repository-owned E2E descriptor and prepare one test credential."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urljoin, urlsplit
+
+import httpx
+
+
+class RuntimeSetupError(RuntimeError):
+    """Raised when a repository-owned runtime cannot be consumed safely."""
+
+
+def redact_error(error: BaseException, secrets: Iterable[str] = ()) -> str:
+    """Return an exception message without credential values."""
+
+    message = str(error) or type(error).__name__
+    for secret in sorted({value for value in secrets if value}, key=len, reverse=True):
+        message = message.replace(secret, "[redacted]")
+    return re.sub(r"Bearer\s+[^\s,}]+", "Bearer [redacted]", message, flags=re.IGNORECASE)
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeDescriptor:
+    """Validated, credential-free coordinates from a schema-v2 descriptor."""
+
+    scenario: str
+    app_origin: str
+    app_health_url: str
+    fixture_health_url: str
+    reset_url: str
+    reset_body: dict[str, Any]
+    discovery_url: str
+    username_env: str
+    password_env: str
+    pat_env: str | None
+    login_path: str
+
+    @property
+    def mcp_url(self) -> str:
+        """Return the MCP endpoint under the descriptor's application origin."""
+
+        return urljoin(f"{self.app_origin}/", "mcp/")
+
+    @classmethod
+    def from_json(cls, raw: str) -> RuntimeDescriptor:
+        try:
+            descriptor = json.loads(raw)
+        except (TypeError, ValueError):
+            raise RuntimeSetupError("runtime descriptor is invalid JSON") from None
+        if not isinstance(descriptor, dict):
+            raise RuntimeSetupError("runtime descriptor must be an object")
+        if descriptor.get("schema_version") != 2 or descriptor.get("status") != "ready":
+            raise RuntimeSetupError("runtime descriptor must be a ready schema-v2 descriptor")
+
+        scenario = _required_string(descriptor.get("scenario"), "descriptor scenario")
+        services = _required_object(descriptor.get("services"), "descriptor services")
+        app = _required_object(services.get("app"), "app service")
+        fixture = _required_object(services.get("fixture"), "fixture service")
+        app_origin = _origin(app.get("origin"), "app origin")
+        fixture_origin = _origin(fixture.get("origin"), "fixture origin")
+        app_health_url = _operation_url(app.get("health"), app_origin, "app health", "GET")
+        _operation_url(app.get("discovery"), app_origin, "app discovery", "GET")
+        fixture_health_url = _operation_url(
+            fixture.get("health"), fixture_origin, "fixture health", "GET"
+        )
+        reset = _required_object(fixture.get("reset"), "fixture reset")
+        reset_url = _operation_url(reset, fixture_origin, "fixture reset", "POST")
+        reset_body = _required_object(reset.get("body"), "fixture reset body")
+        if reset_body.get("scenario") != scenario:
+            raise RuntimeSetupError("fixture reset scenario does not match descriptor")
+        fixture_discovery_url = _operation_url(
+            fixture.get("discovery"), fixture_origin, "fixture discovery", "GET"
+        )
+
+        credentials = _required_object(descriptor.get("credentials"), "descriptor credentials")
+        username_env = _environment_name(credentials.get("username_env"), "username environment name")
+        password_env = _environment_name(credentials.get("password_env"), "password environment name")
+        raw_pat_env = credentials.get("pat_env")
+        pat_env = _environment_name(raw_pat_env, "PAT environment name") if raw_pat_env is not None else None
+        login_path = _path(credentials.get("login_path"), "credential login path")
+        return cls(
+            scenario=scenario,
+            app_origin=app_origin,
+            app_health_url=app_health_url,
+            fixture_health_url=fixture_health_url,
+            reset_url=reset_url,
+            reset_body=dict(reset_body),
+            discovery_url=fixture_discovery_url,
+            username_env=username_env,
+            password_env=password_env,
+            pat_env=pat_env,
+            login_path=login_path,
+        )
+
+
+def _required_object(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise RuntimeSetupError(f"{label} must be an object")
+    return value
+
+
+def _required_string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise RuntimeSetupError(f"{label} is required")
+    return value
+
+
+def _origin(value: Any, label: str) -> str:
+    candidate = _required_string(value, label)
+    try:
+        parsed = urlsplit(candidate)
+    except ValueError:
+        raise RuntimeSetupError(f"{label} must be an HTTP(S) origin") from None
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.netloc
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+        or parsed.path not in {"", "/"}
+    ):
+        raise RuntimeSetupError(f"{label} must be an HTTP(S) origin")
+    return candidate.rstrip("/")
+
+
+def _operation_url(value: Any, base: str, label: str, method: str) -> str:
+    operation = _required_object(value, label)
+    if operation.get("method") != method:
+        raise RuntimeSetupError(f"{label} must use {method}")
+    raw_url = _required_string(operation.get("url"), label)
+    candidate = urljoin(f"{base}/", raw_url)
+    try:
+        parsed = urlsplit(candidate)
+        base_parsed = urlsplit(base)
+    except ValueError:
+        raise RuntimeSetupError(f"{label} must stay on its declared origin") from None
+    if (
+        parsed.scheme != base_parsed.scheme
+        or parsed.netloc != base_parsed.netloc
+        or parsed.username
+        or parsed.password
+        or parsed.fragment
+    ):
+        raise RuntimeSetupError(f"{label} must stay on its declared origin")
+    return candidate
+
+
+def _path(value: Any, label: str) -> str:
+    path = _required_string(value, label)
+    if not path.startswith("/") or path.startswith("//") or "?" in path or "#" in path:
+        raise RuntimeSetupError(f"{label} is invalid")
+    return path
+
+
+def _environment_name(value: Any, label: str) -> str:
+    name = _required_string(value, label)
+    if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name) is None:
+        raise RuntimeSetupError(f"{label} is invalid")
+    return name
+
+
+class RuntimeSession:
+    """Reset the existing runtime and mint one in-memory MCP read credential."""
+
+    def __init__(self, descriptor: RuntimeDescriptor, client: httpx.Client | None = None) -> None:
+        self.descriptor = descriptor
+        self.client = client or httpx.Client(timeout=30.0)
+        self.pat = ""
+        self.secrets: tuple[str, ...] = ()
+        self._closed = False
+
+    @classmethod
+    def from_json(cls, raw: str, client: httpx.Client | None = None) -> RuntimeSession:
+        return cls(RuntimeDescriptor.from_json(raw), client=client)
+
+    @property
+    def credential_env_names(self) -> tuple[str, ...]:
+        return tuple(
+            name
+            for name in (self.descriptor.username_env, self.descriptor.password_env, self.descriptor.pat_env)
+            if name is not None
+        )
+
+    def _request_json(
+        self,
+        method: str,
+        url: str,
+        *,
+        stage: str,
+        body: Mapping[str, Any] | None = None,
+        authorization: str | None = None,
+    ) -> dict[str, Any]:
+        headers = {"Authorization": authorization} if authorization else None
+        try:
+            response = self.client.request(method, url, json=body, headers=headers)
+        except httpx.HTTPError:
+            raise RuntimeSetupError(f"{stage} request failed") from None
+        if response.status_code != 200:
+            raise RuntimeSetupError(f"{stage} returned HTTP {response.status_code}")
+        try:
+            value = response.json()
+        except ValueError:
+            raise RuntimeSetupError(f"{stage} returned invalid JSON") from None
+        if not isinstance(value, dict):
+            raise RuntimeSetupError(f"{stage} returned an invalid object")
+        return value
+
+    def _ready(self, stage: str) -> None:
+        app = self._request_json("GET", self.descriptor.app_health_url, stage=f"{stage} app health")
+        fixture = self._request_json(
+            "GET", self.descriptor.fixture_health_url, stage=f"{stage} fixture health"
+        )
+        if app.get("status") != "ready" or fixture.get("status") != "ready":
+            raise RuntimeSetupError(f"{stage} runtime is not ready")
+
+    def _validate_discovery(self, discovery: dict[str, Any]) -> str:
+        if discovery.get("status") != "ready" or discovery.get("scenario") != self.descriptor.scenario:
+            raise RuntimeSetupError("fixture discovery is not ready for this scenario")
+
+        access = _required_object(discovery.get("access"), "fixture access")
+        login = _required_object(access.get("login"), "fixture login")
+        if login.get("service") != "app" or login.get("method") != "POST":
+            raise RuntimeSetupError("fixture login coordinates are invalid")
+        if login.get("path") != self.descriptor.login_path:
+            raise RuntimeSetupError("descriptor and discovery login paths disagree")
+
+        runtime = _required_object(discovery.get("runtime"), "fixture runtime")
+        origins = _required_object(runtime.get("origin"), "fixture runtime origins")
+        if origins.get("backend") != self.descriptor.app_origin:
+            raise RuntimeSetupError("descriptor and discovery app origins disagree")
+        transports = runtime.get("transport")
+        if not isinstance(transports, list) or "http" not in transports:
+            raise RuntimeSetupError("fixture runtime does not advertise HTTP transport")
+        tool_cases = _required_object(runtime.get("tool_cases"), "fixture runtime tool cases")
+        if tool_cases.get("read") != "akb_list_vaults":
+            raise RuntimeSetupError("fixture runtime does not advertise the list-vaults case")
+        credential_env = _required_object(runtime.get("credential_env"), "fixture runtime credentials")
+        if (
+            credential_env.get("username") != self.descriptor.username_env
+            or credential_env.get("password") != self.descriptor.password_env
+        ):
+            raise RuntimeSetupError("descriptor and discovery credential names disagree")
+
+        pat = _required_object(runtime.get("pat"), "fixture PAT")
+        mint = _required_object(pat.get("mint"), "fixture PAT mint")
+        if mint.get("service") != "app" or mint.get("method") != "POST":
+            raise RuntimeSetupError("fixture PAT mint coordinates are invalid")
+        return _path(mint.get("path"), "fixture PAT mint path")
+
+    def prepare(self) -> None:
+        self._ready("before reset")
+        discovery = self._request_json(
+            "GET", self.descriptor.discovery_url, stage="fixture discovery"
+        )
+        mint_path = self._validate_discovery(discovery)
+
+        reset_result = self._request_json(
+            "POST",
+            self.descriptor.reset_url,
+            stage="fixture reset",
+            body=self.descriptor.reset_body,
+        )
+        if reset_result.get("status") != "ready" or reset_result.get("scenario") != self.descriptor.scenario:
+            raise RuntimeSetupError("fixture reset did not return the selected ready scenario")
+
+        self._ready("after reset")
+        after_reset = self._request_json(
+            "GET", self.descriptor.discovery_url, stage="fixture discovery after reset"
+        )
+        mint_path = self._validate_discovery(after_reset)
+
+        username = os.environ.get(self.descriptor.username_env, "")
+        password = os.environ.get(self.descriptor.password_env, "")
+        if not username or not password:
+            raise RuntimeSetupError("declared credential environment values are missing")
+        self.secrets = (username, password)
+        login_response = self._request_json(
+            "POST",
+            urljoin(f"{self.descriptor.app_origin}/", self.descriptor.login_path.lstrip("/")),
+            stage="credential login",
+            body={"username": username, "password": password},
+        )
+        session_token = login_response.get("token")
+        if not isinstance(session_token, str) or not session_token:
+            raise RuntimeSetupError("credential login returned no session token")
+        self.secrets = (*self.secrets, session_token)
+
+        mint_response = self._request_json(
+            "POST",
+            urljoin(f"{self.descriptor.app_origin}/", mint_path.lstrip("/")),
+            stage="credential mint",
+            authorization=f"Bearer {session_token}",
+            body={"name": "mcp-pytest"},
+        )
+        token = mint_response.get("token")
+        if not isinstance(token, str) or not token.startswith("akb_"):
+            raise RuntimeSetupError("credential mint returned an invalid PAT")
+        self.pat = token
+        self.secrets = (*self.secrets, token)
+
+    def close(self) -> None:
+        if not self._closed:
+            self._closed = True
+            self.client.close()
+        self.pat = ""
+        self.secrets = ()

--- a/backend/tests/mcp_e2e/test_list_vaults_e2e.py
+++ b/backend/tests/mcp_e2e/test_list_vaults_e2e.py
@@ -10,7 +10,7 @@ from mcp import Client
 from mcp import types as mcp_types
 from mcp_types.version import HANDSHAKE_PROTOCOL_VERSIONS, MODERN_PROTOCOL_VERSIONS
 
-from .runtime import RuntimeSession, redact_error
+from .runtime import RuntimeContext, redact_error
 
 
 SCENARIO = "akb_list_vaults"
@@ -23,7 +23,7 @@ def _fail(operation: str, detail: str) -> None:
 
 async def test_akb_list_vaults_mcp_e2e(
     mcp_client: Client,
-    runtime_session: RuntimeSession,
+    runtime_session: RuntimeContext,
 ) -> None:
     if mcp_client.protocol_version not in SUPPORTED_PROTOCOLS:
         _fail("connect", f"unsupported negotiated protocol {mcp_client.protocol_version!r}")

--- a/backend/tests/mcp_e2e/test_list_vaults_e2e.py
+++ b/backend/tests/mcp_e2e/test_list_vaults_e2e.py
@@ -1,0 +1,69 @@
+"""The first live MCP behavior scenario."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+
+import pytest
+from mcp import Client
+from mcp import types as mcp_types
+from mcp_types.version import HANDSHAKE_PROTOCOL_VERSIONS, MODERN_PROTOCOL_VERSIONS
+
+from .runtime import RuntimeSession, redact_error
+
+
+SCENARIO = "akb_list_vaults"
+SUPPORTED_PROTOCOLS = set(HANDSHAKE_PROTOCOL_VERSIONS) | set(MODERN_PROTOCOL_VERSIONS)
+
+
+def _fail(operation: str, detail: str) -> None:
+    pytest.fail(f"scenario={SCENARIO} operation={operation}: {detail}")
+
+
+async def test_akb_list_vaults_mcp_e2e(
+    mcp_client: Client,
+    runtime_session: RuntimeSession,
+) -> None:
+    if mcp_client.protocol_version not in SUPPORTED_PROTOCOLS:
+        _fail("connect", f"unsupported negotiated protocol {mcp_client.protocol_version!r}")
+
+    server_info = mcp_client.server_info
+    if server_info is None or server_info.name != "akb" or not isinstance(server_info.version, str):
+        _fail("connect", "connected server is not the expected AKB server")
+
+    try:
+        tools = await mcp_client.list_tools(cache_mode="bypass")
+    except Exception as exc:
+        _fail("tools/list", redact_error(exc, runtime_session.secrets))
+    list_vaults = next((tool for tool in tools.tools if tool.name == "akb_list_vaults"), None)
+    if list_vaults is None or not isinstance(list_vaults.input_schema, Mapping):
+        _fail("tools/list", "akb_list_vaults is missing from the typed tool catalog")
+
+    try:
+        result = await mcp_client.call_tool("akb_list_vaults", {})
+    except Exception as exc:
+        _fail("tools/call akb_list_vaults", redact_error(exc, runtime_session.secrets))
+    if result.is_error is not False:
+        _fail("tools/call akb_list_vaults", "tool returned an error")
+    if not result.content or not isinstance(result.content[0], mcp_types.TextContent):
+        _fail("tools/call akb_list_vaults", "tool returned no public JSON text")
+
+    try:
+        public = json.loads(result.content[0].text)
+    except (TypeError, ValueError):
+        _fail("tools/call akb_list_vaults", "tool returned invalid public JSON")
+    if not isinstance(public, Mapping):
+        _fail("tools/call akb_list_vaults", "public result is not an object")
+
+    vaults = public.get("vaults")
+    total = public.get("total")
+    returned = public.get("returned")
+    if not isinstance(vaults, list):
+        _fail("tools/call akb_list_vaults", "vaults is not an array")
+    if type(total) is not int or type(returned) is not int:
+        _fail("tools/call akb_list_vaults", "total and returned must be integers")
+    if returned != len(vaults):
+        _fail("tools/call akb_list_vaults", "returned does not match vaults length")
+    if total < returned:
+        _fail("tools/call akb_list_vaults", "total is smaller than returned")

--- a/backend/tests/mcp_e2e/test_list_vaults_e2e.py
+++ b/backend/tests/mcp_e2e/test_list_vaults_e2e.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping
+from typing import NoReturn
 
 import pytest
 from mcp import Client
@@ -17,45 +18,41 @@ SCENARIO = "akb_list_vaults"
 SUPPORTED_PROTOCOLS = set(HANDSHAKE_PROTOCOL_VERSIONS) | set(MODERN_PROTOCOL_VERSIONS)
 
 
-def _fail(operation: str, detail: str) -> None:
+def _fail(operation: str, detail: str) -> NoReturn:
     pytest.fail(f"scenario={SCENARIO} operation={operation}: {detail}")
 
 
-async def test_akb_list_vaults_mcp_e2e(
-    mcp_client: Client,
-    runtime_session: RuntimeContext,
+def _assert_connection(
+    protocol_version: str,
+    server_info: mcp_types.Implementation | None,
 ) -> None:
-    if mcp_client.protocol_version not in SUPPORTED_PROTOCOLS:
-        _fail("connect", f"unsupported negotiated protocol {mcp_client.protocol_version!r}")
-
-    server_info = mcp_client.server_info
+    if protocol_version not in SUPPORTED_PROTOCOLS:
+        _fail("connect", f"unsupported negotiated protocol {protocol_version!r}")
     if server_info is None or server_info.name != "akb" or not isinstance(server_info.version, str):
         _fail("connect", "connected server is not the expected AKB server")
 
-    try:
-        tools = await mcp_client.list_tools(cache_mode="bypass")
-    except Exception as exc:
-        _fail("tools/list", redact_error(exc, runtime_session.secrets))
+
+def _assert_tool_catalog(tools: mcp_types.ListToolsResult) -> None:
     list_vaults = next((tool for tool in tools.tools if tool.name == "akb_list_vaults"), None)
     if list_vaults is None or not isinstance(list_vaults.input_schema, Mapping):
         _fail("tools/list", "akb_list_vaults is missing from the typed tool catalog")
 
-    try:
-        result = await mcp_client.call_tool("akb_list_vaults", {})
-    except Exception as exc:
-        _fail("tools/call akb_list_vaults", redact_error(exc, runtime_session.secrets))
+
+def _list_vaults_payload(result: mcp_types.CallToolResult) -> Mapping[str, object]:
     if result.is_error is not False:
         _fail("tools/call akb_list_vaults", "tool returned an error")
     if not result.content or not isinstance(result.content[0], mcp_types.TextContent):
         _fail("tools/call akb_list_vaults", "tool returned no public JSON text")
-
     try:
         public = json.loads(result.content[0].text)
     except (TypeError, ValueError):
         _fail("tools/call akb_list_vaults", "tool returned invalid public JSON")
     if not isinstance(public, Mapping):
         _fail("tools/call akb_list_vaults", "public result is not an object")
+    return public
 
+
+def _assert_list_vaults_shape(public: Mapping[str, object]) -> None:
     vaults = public.get("vaults")
     total = public.get("total")
     returned = public.get("returned")
@@ -67,3 +64,22 @@ async def test_akb_list_vaults_mcp_e2e(
         _fail("tools/call akb_list_vaults", "returned does not match vaults length")
     if total < returned:
         _fail("tools/call akb_list_vaults", "total is smaller than returned")
+
+
+async def test_akb_list_vaults_mcp_e2e(
+    mcp_client: Client,
+    runtime_session: RuntimeContext,
+) -> None:
+    _assert_connection(mcp_client.protocol_version, mcp_client.server_info)
+
+    try:
+        tools = await mcp_client.list_tools(cache_mode="bypass")
+    except Exception as exc:
+        _fail("tools/list", redact_error(exc, runtime_session.secrets))
+    _assert_tool_catalog(tools)
+
+    try:
+        result = await mcp_client.call_tool("akb_list_vaults", {})
+    except Exception as exc:
+        _fail("tools/call akb_list_vaults", redact_error(exc, runtime_session.secrets))
+    _assert_list_vaults_shape(_list_vaults_payload(result))

--- a/backend/tests/test_e2e_runtime_unit.py
+++ b/backend/tests/test_e2e_runtime_unit.py
@@ -488,6 +488,18 @@ async def test_gate_child_stdout_is_private_and_stderr_is_inherited(tmp_path, ca
         "\"suite\":\"test_fake.sh\",\"returncode\":132}', file=sys.stderr)\n",
         encoding="utf-8",
     )
+    mcp_pytest_path = checkout / "backend" / "tests" / "mcp_e2e"
+    mcp_pytest_path.mkdir(parents=True)
+    (mcp_pytest_path / "conftest.py").write_text(
+        "def pytest_addoption(parser):\n"
+        "    parser.addoption('--runtime-descriptor')\n",
+        encoding="utf-8",
+    )
+    (mcp_pytest_path / "test_fake.py").write_text(
+        "def test_fake():\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
     config = RuntimeConfig(
         checkout=checkout,
         runtime_root=tmp_path / "runtime",
@@ -502,10 +514,14 @@ async def test_gate_child_stdout_is_private_and_stderr_is_inherited(tmp_path, ca
 
     captured = capfd.readouterr()
     gate_log = (config.logs_dir / "gate.log").read_text(encoding="utf-8")
+    mcp_pytest_log = (config.logs_dir / "mcp-pytest.log").read_text(encoding="utf-8")
     assert "credential-looking suite output" in gate_log
     assert "credential-looking suite output" not in captured.err
     assert '"event":"suite_complete"' in captured.err
     assert '"returncode":132' in captured.err
+    assert "1 passed" in mcp_pytest_log
+    assert '"event":"mcp_pytest_start"' in captured.err
+    assert '"event":"mcp_pytest_complete"' in captured.err
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_e2e_runtime_unit.py
+++ b/backend/tests/test_e2e_runtime_unit.py
@@ -514,14 +514,10 @@ async def test_gate_child_stdout_is_private_and_stderr_is_inherited(tmp_path, ca
 
     captured = capfd.readouterr()
     gate_log = (config.logs_dir / "gate.log").read_text(encoding="utf-8")
-    mcp_pytest_log = (config.logs_dir / "mcp-pytest.log").read_text(encoding="utf-8")
     assert "credential-looking suite output" in gate_log
     assert "credential-looking suite output" not in captured.err
     assert '"event":"suite_complete"' in captured.err
     assert '"returncode":132' in captured.err
-    assert "1 passed" in mcp_pytest_log
-    assert '"event":"mcp_pytest_start"' in captured.err
-    assert '"event":"mcp_pytest_complete"' in captured.err
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_mcp_sdk_fixture_unit.py
+++ b/backend/tests/test_mcp_sdk_fixture_unit.py
@@ -13,7 +13,8 @@ from typing import Any
 import httpx
 import pytest
 
-from tests.mcp_e2e.runtime import RuntimeDescriptor, RuntimeSession, RuntimeSetupError
+from tests.mcp_e2e.conftest import _prepare_runtime
+from tests.mcp_e2e.runtime import RuntimeDescriptor, RuntimeSetupError
 
 
 def _descriptor() -> dict[str, Any]:
@@ -41,7 +42,6 @@ def _descriptor() -> dict[str, Any]:
         "credentials": {
             "username_env": "AKB_TEST_USER_ENV",
             "password_env": "AKB_TEST_PASS_ENV",  # pragma: allowlist secret
-            "pat_env": "AKB_TEST_PAT_ENV",
             "login_path": "/api/v1/auth/login",
         },
     }
@@ -65,7 +65,6 @@ def _discovery() -> dict[str, Any]:
             "credential_env": {
                 "username": "AKB_TEST_USER_ENV",
                 "password": "AKB_TEST_PASS_ENV",  # pragma: allowlist secret
-                "pat": "AKB_TEST_PAT_ENV",
             },
             "pat": {
                 "mint": {
@@ -136,33 +135,25 @@ def test_runtime_descriptor_rejects_incompatible_contract(mutate: Any) -> None:
         RuntimeDescriptor.from_json(json.dumps(value))
 
 
-def test_runtime_session_reuses_reset_discovery_and_mints_in_memory_pat(
+def test_runtime_setup_reuses_reset_discovery_and_mints_in_memory_pat(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("AKB_TEST_USER_ENV", "fixture-user")
     monkeypatch.setenv("AKB_TEST_PASS_ENV", "fixture-pass")
-    monkeypatch.setenv("AKB_TEST_PAT_ENV", "stale-pat")
     client = _FixtureClient()
-    session = RuntimeSession.from_json(json.dumps(_descriptor()), client=client)  # type: ignore[arg-type]
+    descriptor = RuntimeDescriptor.from_json(json.dumps(_descriptor()))
+    context = _prepare_runtime(descriptor, client)  # type: ignore[arg-type]
 
-    session.prepare()
-
-    assert session.pat == "akb_test_pat"
-    assert session.credential_env_names == (
-        "AKB_TEST_USER_ENV",
-        "AKB_TEST_PASS_ENV",
-        "AKB_TEST_PAT_ENV",
-    )
+    assert context.pat == "akb_test_pat"
+    assert context.descriptor.username_env == "AKB_TEST_USER_ENV"
+    assert context.descriptor.password_env == "AKB_TEST_PASS_ENV"  # pragma: allowlist secret
     reset = next(call for call in client.calls if call[1].endswith("/reset"))
     assert reset[0] == "POST" and reset[2] == {"scenario": "empty"}
     mint = next(call for call in client.calls if call[1].endswith("/auth/tokens"))
     assert mint[3] == {"Authorization": "Bearer session-value"}
 
-    session.close()
-    session.close()
+    client.close()
     assert client.closed
-    assert session.pat == ""
-    assert session.secrets == ()
 
 
 def test_descriptor_stdin_read_is_compatible_with_pytest_capture(tmp_path: Path) -> None:

--- a/backend/tests/test_mcp_sdk_fixture_unit.py
+++ b/backend/tests/test_mcp_sdk_fixture_unit.py
@@ -2,19 +2,29 @@
 
 from __future__ import annotations
 
+import asyncio
 import copy
 import json
 import os
 import subprocess
 import sys
+from contextlib import suppress
 from pathlib import Path
 from typing import Any
 
 import httpx
 import pytest
+from mcp import types as mcp_types
 
-from tests.mcp_e2e.conftest import _prepare_runtime
-from tests.mcp_e2e.runtime import RuntimeDescriptor, RuntimeSetupError
+import tests.mcp_e2e.conftest as mcp_conftest
+from tests.mcp_e2e.conftest import _prepare_runtime, mcp_client as mcp_client_fixture
+from tests.mcp_e2e.runtime import RuntimeContext, RuntimeDescriptor, RuntimeSetupError
+from tests.mcp_e2e.test_list_vaults_e2e import (
+    _assert_connection,
+    _assert_list_vaults_shape,
+    _assert_tool_catalog,
+    _list_vaults_payload,
+)
 
 
 def _descriptor() -> dict[str, Any]:
@@ -181,3 +191,227 @@ def test_descriptor_stdin_read_is_compatible_with_pytest_capture(tmp_path: Path)
     )
 
     assert result.returncode == 0, result.stderr
+
+
+def _call_result(text: str, *, is_error: bool = False) -> mcp_types.CallToolResult:
+    return mcp_types.CallToolResult(
+        content=[mcp_types.TextContent(text=text)],
+        is_error=is_error,
+    )
+
+
+def _assertion_failure(callback: Any) -> str:
+    with pytest.raises(pytest.fail.Exception) as captured:
+        callback()
+    return str(captured.value)
+
+
+def test_typed_sdk_response_assertions_accept_the_public_list_vaults_contract() -> None:
+    tools = mcp_types.ListToolsResult(
+        tools=[mcp_types.Tool(name="akb_list_vaults", input_schema={"type": "object"})]
+    )
+    _assert_tool_catalog(tools)
+    public = _list_vaults_payload(
+        _call_result(json.dumps({"vaults": [], "total": 0, "returned": 0}))
+    )
+    _assert_list_vaults_shape(public)
+
+
+@pytest.mark.parametrize(
+    ("text", "is_error", "detail"),
+    [
+        ("{}", True, "tool returned an error"),
+        ("not-json", False, "tool returned invalid public JSON"),
+        ("[]", False, "public result is not an object"),
+        (json.dumps({"vaults": {}, "total": 0, "returned": 0}), False, "vaults is not an array"),
+        (json.dumps({"vaults": [], "total": True, "returned": 0}), False, "total and returned must be integers"),
+        (json.dumps({"vaults": [], "total": 0, "returned": False}), False, "total and returned must be integers"),
+        (json.dumps({"vaults": [], "total": 1, "returned": 1}), False, "returned does not match vaults length"),
+        (json.dumps({"vaults": [{}], "total": 0, "returned": 1}), False, "total is smaller than returned"),
+    ],
+)
+def test_list_vaults_response_failures_are_pytest_failures(
+    text: str,
+    is_error: bool,
+    detail: str,
+) -> None:
+    result = _call_result(text, is_error=is_error)
+    message = _assertion_failure(
+        lambda: _assert_list_vaults_shape(_list_vaults_payload(result))
+    )
+
+    assert "scenario=akb_list_vaults operation=tools/call akb_list_vaults" in message
+    assert detail in message
+    assert "fixture-pass" not in message
+
+
+def test_tool_catalog_and_connection_failures_identify_their_operations() -> None:
+    catalog_message = _assertion_failure(
+        lambda: _assert_tool_catalog(mcp_types.ListToolsResult(tools=[]))
+    )
+    protocol_message = _assertion_failure(
+        lambda: _assert_connection(
+            "unsupported", mcp_types.Implementation(name="akb", version="")
+        )
+    )
+    server_message = _assertion_failure(
+        lambda: _assert_connection(
+            "2025-06-18", mcp_types.Implementation(name="other", version="")
+        )
+    )
+
+    assert "operation=tools/list" in catalog_message
+    assert "operation=connect" in protocol_message
+    assert "operation=connect" in server_message
+
+
+def test_preparation_failure_is_an_actual_pytest_failure(tmp_path: Path) -> None:
+    descriptor = copy.deepcopy(_descriptor())
+    descriptor["services"]["app"]["origin"] = "http://127.0.0.1:1"
+    descriptor["services"]["app"]["health"]["url"] = "http://127.0.0.1:1/readyz"
+    descriptor["services"]["app"]["discovery"]["url"] = "http://127.0.0.1:1/openapi.json"
+    descriptor_path = tmp_path / "descriptor.json"
+    descriptor_path.write_text(json.dumps(descriptor), encoding="utf-8")
+    env = os.environ.copy()
+    env["AKB_TEST_USER_ENV"] = "fixture-user"
+    env["AKB_TEST_PASS_ENV"] = "fixture-pass"
+    repo_root = Path(__file__).resolve().parents[2]
+    mcp_root = repo_root / "backend" / "tests" / "mcp_e2e"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(mcp_root / "test_list_vaults_e2e.py"),
+            "--confcutdir",
+            str(mcp_root),
+            "--runtime-descriptor",
+            str(descriptor_path),
+            "-q",
+            "--tb=short",
+        ],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    output = result.stdout + result.stderr
+
+    assert result.returncode != 0
+    assert "scenario=akb_list_vaults preparation:" in output
+    assert "fixture-pass" not in output
+
+
+def _runtime_context() -> RuntimeContext:
+    return RuntimeContext(
+        descriptor=RuntimeDescriptor.from_json(json.dumps(_descriptor())),
+        pat="akb_test_pat",
+        secrets=("fixture-user", "fixture-pass", "akb_test_pat"),
+    )
+
+
+class _RecordingHttpClient:
+    def __init__(self, **_kwargs: Any) -> None:
+        self.closed = False
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class _RecordingSdkClient:
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+        self.entered_task: asyncio.Task[Any] | None = None
+        self.exited_task: asyncio.Task[Any] | None = None
+
+    async def __aenter__(self) -> _RecordingSdkClient:
+        self.entered_task = asyncio.current_task()
+        return self
+
+    async def __aexit__(self, *_args: Any) -> None:
+        self.exited_task = asyncio.current_task()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("outcome", ["normal", "failure", "cancel"])
+async def test_mcp_fixture_owns_sdk_enter_exit_in_one_task_and_reopens(
+    monkeypatch: pytest.MonkeyPatch,
+    outcome: str,
+) -> None:
+    http_clients: list[_RecordingHttpClient] = []
+    sdk_clients: list[_RecordingSdkClient] = []
+
+    def make_http_client(**kwargs: Any) -> _RecordingHttpClient:
+        client = _RecordingHttpClient(**kwargs)
+        http_clients.append(client)
+        return client
+
+    def make_sdk_client(*args: Any, **kwargs: Any) -> _RecordingSdkClient:
+        client = _RecordingSdkClient(*args, **kwargs)
+        sdk_clients.append(client)
+        return client
+
+    monkeypatch.setattr(mcp_conftest.httpx2, "AsyncClient", make_http_client)
+    monkeypatch.setattr(mcp_conftest, "streamable_http_client", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(mcp_conftest, "Client", make_sdk_client)
+
+    async def finish(generator: Any) -> None:
+        with suppress(StopAsyncIteration):
+            await generator.__anext__()
+
+    async def run_once() -> None:
+        generator = mcp_client_fixture.__wrapped__(_runtime_context())
+        await asyncio.create_task(generator.__anext__())
+        try:
+            if outcome == "failure":
+                raise RuntimeError("test body failed")
+            if outcome == "cancel":
+                raise asyncio.CancelledError
+        finally:
+            await asyncio.create_task(finish(generator))
+
+    async def reopen_once() -> None:
+        generator = mcp_client_fixture.__wrapped__(_runtime_context())
+        await asyncio.create_task(generator.__anext__())
+        await asyncio.create_task(finish(generator))
+
+    if outcome == "failure":
+        with pytest.raises(RuntimeError, match="test body failed"):
+            await run_once()
+    elif outcome == "cancel":
+        with pytest.raises(asyncio.CancelledError):
+            await run_once()
+    else:
+        await run_once()
+
+    await reopen_once()
+    assert len(sdk_clients) == 2
+    assert len(http_clients) == 2
+    for sdk_client in sdk_clients:
+        assert sdk_client.entered_task is sdk_client.exited_task
+    assert all(client.closed for client in http_clients)
+
+
+@pytest.mark.asyncio
+async def test_mcp_fixture_reports_connection_failure_and_redacts_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    http_client = _RecordingHttpClient()
+
+    class FailingSdkClient(_RecordingSdkClient):
+        async def __aenter__(self) -> _RecordingSdkClient:
+            self.entered_task = asyncio.current_task()
+            raise RuntimeError("Bearer sdk-secret")
+
+    monkeypatch.setattr(mcp_conftest.httpx2, "AsyncClient", lambda **_kwargs: http_client)
+    monkeypatch.setattr(mcp_conftest, "streamable_http_client", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(mcp_conftest, "Client", FailingSdkClient)
+    generator = mcp_client_fixture.__wrapped__(_runtime_context())
+
+    with pytest.raises(pytest.fail.Exception) as captured:
+        await generator.__anext__()
+
+    assert "scenario=akb_list_vaults SDK connection" in str(captured.value)
+    assert "sdk-secret" not in str(captured.value)
+    assert http_client.closed

--- a/backend/tests/test_mcp_sdk_fixture_unit.py
+++ b/backend/tests/test_mcp_sdk_fixture_unit.py
@@ -1,0 +1,192 @@
+"""Focused unit checks for the MCP SDK fixture boundary."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from tests.mcp_e2e.runtime import RuntimeDescriptor, RuntimeSession, RuntimeSetupError
+
+
+def _descriptor() -> dict[str, Any]:
+    return {
+        "schema_version": 2,
+        "status": "ready",
+        "scenario": "empty",
+        "services": {
+            "app": {
+                "origin": "http://127.0.0.1:8000",
+                "health": {"method": "GET", "url": "http://127.0.0.1:8000/readyz"},
+                "discovery": {"method": "GET", "url": "http://127.0.0.1:8000/openapi.json"},
+            },
+            "fixture": {
+                "origin": "http://127.0.0.1:8889",
+                "health": {"method": "GET", "url": "http://127.0.0.1:8889/health"},
+                "reset": {
+                    "method": "POST",
+                    "url": "http://127.0.0.1:8889/reset",
+                    "body": {"scenario": "empty"},
+                },
+                "discovery": {"method": "GET", "url": "http://127.0.0.1:8889/discover"},
+            },
+        },
+        "credentials": {
+            "username_env": "AKB_TEST_USER_ENV",
+            "password_env": "AKB_TEST_PASS_ENV",  # pragma: allowlist secret
+            "pat_env": "AKB_TEST_PAT_ENV",
+            "login_path": "/api/v1/auth/login",
+        },
+    }
+
+
+def _discovery() -> dict[str, Any]:
+    return {
+        "status": "ready",
+        "scenario": "empty",
+        "access": {
+            "login": {
+                "service": "app",
+                "method": "POST",
+                "path": "/api/v1/auth/login",
+            }
+        },
+        "runtime": {
+            "origin": {"backend": "http://127.0.0.1:8000", "fixture": "http://127.0.0.1:8889"},
+            "transport": ["http"],
+            "tool_cases": {"read": "akb_list_vaults"},
+            "credential_env": {
+                "username": "AKB_TEST_USER_ENV",
+                "password": "AKB_TEST_PASS_ENV",  # pragma: allowlist secret
+                "pat": "AKB_TEST_PAT_ENV",
+            },
+            "pat": {
+                "mint": {
+                    "service": "app",
+                    "method": "POST",
+                    "path": "/api/v1/auth/tokens",
+                }
+            },
+        },
+    }
+
+
+class _FixtureClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any] | None, dict[str, str] | None]] = []
+        self.closed = False
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        json: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> httpx.Response:
+        self.calls.append((method, url, json, headers))
+        if url.endswith("/readyz") or url.endswith("/health"):
+            body: dict[str, Any] = {"status": "ready"}
+        elif url.endswith("/discover"):
+            body = _discovery()
+        elif url.endswith("/reset"):
+            body = {"status": "ready", "scenario": "empty"}
+        elif url.endswith("/auth/login"):
+            body = {"token": "session-value"}
+        elif url.endswith("/auth/tokens"):
+            body = {"token": "akb_test_pat"}
+        else:
+            body = {}
+        return httpx.Response(200, json=body, request=httpx.Request(method, url))
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_runtime_descriptor_accepts_schema_v2_and_derives_mcp_endpoint() -> None:
+    descriptor = RuntimeDescriptor.from_json(json.dumps(_descriptor()))
+
+    assert descriptor.scenario == "empty"
+    assert descriptor.mcp_url == "http://127.0.0.1:8000/mcp/"
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda value: value.update({"schema_version": 1}),
+        lambda value: value["services"]["fixture"]["reset"].update({"method": "GET"}),
+        lambda value: value["services"]["fixture"]["reset"].update(
+            {"url": "http://evil.example/reset"}
+        ),
+        lambda value: value["credentials"].update({"username_env": "not-valid"}),
+    ],
+)
+def test_runtime_descriptor_rejects_incompatible_contract(mutate: Any) -> None:
+    value = copy.deepcopy(_descriptor())
+    mutate(value)
+
+    with pytest.raises(RuntimeSetupError):
+        RuntimeDescriptor.from_json(json.dumps(value))
+
+
+def test_runtime_session_reuses_reset_discovery_and_mints_in_memory_pat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AKB_TEST_USER_ENV", "fixture-user")
+    monkeypatch.setenv("AKB_TEST_PASS_ENV", "fixture-pass")
+    monkeypatch.setenv("AKB_TEST_PAT_ENV", "stale-pat")
+    client = _FixtureClient()
+    session = RuntimeSession.from_json(json.dumps(_descriptor()), client=client)  # type: ignore[arg-type]
+
+    session.prepare()
+
+    assert session.pat == "akb_test_pat"
+    assert session.credential_env_names == (
+        "AKB_TEST_USER_ENV",
+        "AKB_TEST_PASS_ENV",
+        "AKB_TEST_PAT_ENV",
+    )
+    reset = next(call for call in client.calls if call[1].endswith("/reset"))
+    assert reset[0] == "POST" and reset[2] == {"scenario": "empty"}
+    mint = next(call for call in client.calls if call[1].endswith("/auth/tokens"))
+    assert mint[3] == {"Authorization": "Bearer session-value"}
+
+    session.close()
+    session.close()
+    assert client.closed
+    assert session.pat == ""
+    assert session.secrets == ()
+
+
+def test_descriptor_stdin_read_is_compatible_with_pytest_capture(tmp_path: Path) -> None:
+    probe = tmp_path / "test_descriptor_pipe.py"
+    probe.write_text(
+        "import json\n"
+        "from mcp_e2e.conftest import _read_descriptor\n"
+        "\n"
+        "def test_pipe(request):\n"
+        "    manager = request.config.pluginmanager.getplugin('capturemanager')\n"
+        "    assert json.loads(_read_descriptor('-', manager)) == {'ok': True}\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    tests_root = Path(__file__).resolve().parent
+    env["PYTHONPATH"] = f"{tests_root}{os.pathsep}{env.get('PYTHONPATH', '')}"
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", str(probe), "-q"],
+        cwd=tmp_path,
+        env=env,
+        input='{"ok":true}\n',
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/backend/tests/test_mcp_sdk_fixture_unit.py
+++ b/backend/tests/test_mcp_sdk_fixture_unit.py
@@ -12,19 +12,11 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Any
 
-import httpx
 import pytest
-from mcp import types as mcp_types
 
 import tests.mcp_e2e.conftest as mcp_conftest
-from tests.mcp_e2e.conftest import _prepare_runtime, mcp_client as mcp_client_fixture
-from tests.mcp_e2e.runtime import RuntimeContext, RuntimeDescriptor, RuntimeSetupError
-from tests.mcp_e2e.test_list_vaults_e2e import (
-    _assert_connection,
-    _assert_list_vaults_shape,
-    _assert_tool_catalog,
-    _list_vaults_payload,
-)
+from tests.mcp_e2e.conftest import mcp_client as mcp_client_fixture
+from tests.mcp_e2e.runtime import RuntimeContext, RuntimeDescriptor
 
 
 def _descriptor() -> dict[str, Any]:
@@ -57,115 +49,6 @@ def _descriptor() -> dict[str, Any]:
     }
 
 
-def _discovery() -> dict[str, Any]:
-    return {
-        "status": "ready",
-        "scenario": "empty",
-        "access": {
-            "login": {
-                "service": "app",
-                "method": "POST",
-                "path": "/api/v1/auth/login",
-            }
-        },
-        "runtime": {
-            "origin": {"backend": "http://127.0.0.1:8000", "fixture": "http://127.0.0.1:8889"},
-            "transport": ["http"],
-            "tool_cases": {"read": "akb_list_vaults"},
-            "credential_env": {
-                "username": "AKB_TEST_USER_ENV",
-                "password": "AKB_TEST_PASS_ENV",  # pragma: allowlist secret
-            },
-            "pat": {
-                "mint": {
-                    "service": "app",
-                    "method": "POST",
-                    "path": "/api/v1/auth/tokens",
-                }
-            },
-        },
-    }
-
-
-class _FixtureClient:
-    def __init__(self) -> None:
-        self.calls: list[tuple[str, str, dict[str, Any] | None, dict[str, str] | None]] = []
-        self.closed = False
-
-    def request(
-        self,
-        method: str,
-        url: str,
-        *,
-        json: dict[str, Any] | None = None,
-        headers: dict[str, str] | None = None,
-    ) -> httpx.Response:
-        self.calls.append((method, url, json, headers))
-        if url.endswith("/readyz") or url.endswith("/health"):
-            body: dict[str, Any] = {"status": "ready"}
-        elif url.endswith("/discover"):
-            body = _discovery()
-        elif url.endswith("/reset"):
-            body = {"status": "ready", "scenario": "empty"}
-        elif url.endswith("/auth/login"):
-            body = {"token": "session-value"}
-        elif url.endswith("/auth/tokens"):
-            body = {"token": "akb_test_pat"}
-        else:
-            body = {}
-        return httpx.Response(200, json=body, request=httpx.Request(method, url))
-
-    def close(self) -> None:
-        self.closed = True
-
-
-def test_runtime_descriptor_accepts_schema_v2_and_derives_mcp_endpoint() -> None:
-    descriptor = RuntimeDescriptor.from_json(json.dumps(_descriptor()))
-
-    assert descriptor.scenario == "empty"
-    assert descriptor.mcp_url == "http://127.0.0.1:8000/mcp/"
-
-
-@pytest.mark.parametrize(
-    "mutate",
-    [
-        lambda value: value.update({"schema_version": 1}),
-        lambda value: value["services"]["fixture"]["reset"].update({"method": "GET"}),
-        lambda value: value["services"]["fixture"]["reset"].update(
-            {"url": "http://evil.example/reset"}
-        ),
-        lambda value: value["credentials"].update({"username_env": "not-valid"}),
-    ],
-)
-def test_runtime_descriptor_rejects_incompatible_contract(mutate: Any) -> None:
-    value = copy.deepcopy(_descriptor())
-    mutate(value)
-
-    with pytest.raises(RuntimeSetupError):
-        RuntimeDescriptor.from_json(json.dumps(value))
-
-
-def test_runtime_setup_reuses_reset_discovery_and_mints_in_memory_pat(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("AKB_TEST_USER_ENV", "fixture-user")
-    monkeypatch.setenv("AKB_TEST_PASS_ENV", "fixture-pass")
-    client = _FixtureClient()
-    descriptor = RuntimeDescriptor.from_json(json.dumps(_descriptor()))
-    context = _prepare_runtime(descriptor, client)  # type: ignore[arg-type]
-
-    assert context.pat == "akb_test_pat"
-    assert context.descriptor.username_env == "AKB_TEST_USER_ENV"
-    assert context.descriptor.password_env == "AKB_TEST_PASS_ENV"  # pragma: allowlist secret
-    reset = next(call for call in client.calls if call[1].endswith("/reset"))
-    assert reset[0] == "POST" and reset[2] == {"scenario": "empty"}
-    mint = next(call for call in client.calls if call[1].endswith("/auth/tokens"))
-    assert mint[3] == {"Authorization": "Bearer session-value"}
-
-    client.close()
-    assert client.closed
-
-
 def test_descriptor_stdin_read_is_compatible_with_pytest_capture(tmp_path: Path) -> None:
     probe = tmp_path / "test_descriptor_pipe.py"
     probe.write_text(
@@ -191,78 +74,6 @@ def test_descriptor_stdin_read_is_compatible_with_pytest_capture(tmp_path: Path)
     )
 
     assert result.returncode == 0, result.stderr
-
-
-def _call_result(text: str, *, is_error: bool = False) -> mcp_types.CallToolResult:
-    return mcp_types.CallToolResult(
-        content=[mcp_types.TextContent(text=text)],
-        is_error=is_error,
-    )
-
-
-def _assertion_failure(callback: Any) -> str:
-    with pytest.raises(pytest.fail.Exception) as captured:
-        callback()
-    return str(captured.value)
-
-
-def test_typed_sdk_response_assertions_accept_the_public_list_vaults_contract() -> None:
-    tools = mcp_types.ListToolsResult(
-        tools=[mcp_types.Tool(name="akb_list_vaults", input_schema={"type": "object"})]
-    )
-    _assert_tool_catalog(tools)
-    public = _list_vaults_payload(
-        _call_result(json.dumps({"vaults": [], "total": 0, "returned": 0}))
-    )
-    _assert_list_vaults_shape(public)
-
-
-@pytest.mark.parametrize(
-    ("text", "is_error", "detail"),
-    [
-        ("{}", True, "tool returned an error"),
-        ("not-json", False, "tool returned invalid public JSON"),
-        ("[]", False, "public result is not an object"),
-        (json.dumps({"vaults": {}, "total": 0, "returned": 0}), False, "vaults is not an array"),
-        (json.dumps({"vaults": [], "total": True, "returned": 0}), False, "total and returned must be integers"),
-        (json.dumps({"vaults": [], "total": 0, "returned": False}), False, "total and returned must be integers"),
-        (json.dumps({"vaults": [], "total": 1, "returned": 1}), False, "returned does not match vaults length"),
-        (json.dumps({"vaults": [{}], "total": 0, "returned": 1}), False, "total is smaller than returned"),
-    ],
-)
-def test_list_vaults_response_failures_are_pytest_failures(
-    text: str,
-    is_error: bool,
-    detail: str,
-) -> None:
-    result = _call_result(text, is_error=is_error)
-    message = _assertion_failure(
-        lambda: _assert_list_vaults_shape(_list_vaults_payload(result))
-    )
-
-    assert "scenario=akb_list_vaults operation=tools/call akb_list_vaults" in message
-    assert detail in message
-    assert "fixture-pass" not in message
-
-
-def test_tool_catalog_and_connection_failures_identify_their_operations() -> None:
-    catalog_message = _assertion_failure(
-        lambda: _assert_tool_catalog(mcp_types.ListToolsResult(tools=[]))
-    )
-    protocol_message = _assertion_failure(
-        lambda: _assert_connection(
-            "unsupported", mcp_types.Implementation(name="akb", version="")
-        )
-    )
-    server_message = _assertion_failure(
-        lambda: _assert_connection(
-            "2025-06-18", mcp_types.Implementation(name="other", version="")
-        )
-    )
-
-    assert "operation=tools/list" in catalog_message
-    assert "operation=connect" in protocol_message
-    assert "operation=connect" in server_message
 
 
 def test_preparation_failure_is_an_actual_pytest_failure(tmp_path: Path) -> None:


### PR DESCRIPTION
Add a pytest fixture that provides a connected official MCP Python SDK client against the repository-owned authenticated Streamable HTTP runtime. The first read-only scenario verifies server/protocol identity, tool discovery, `akb_list_vaults({})`, and the public response shape and count consistency.

The fixture reuses the existing schema-v2 descriptor, discovery, empty reset, and authentication flow. SDK setup and teardown share task ownership, including failure and cancellation cleanup. Local development and hosted CI run the same pytest entrypoint, while ordinary unit selection excludes the live scenario. File and stdin descriptor usage are documented.

Keep six focused regression cases for pytest stdin capture, preparation/connection failure diagnostics and redaction, and SDK cleanup after normal execution, failure, and cancellation. Redundant descriptor/response assertion meta-tests, fake-client self-checks, and duplicate runtime log/event assertions have been removed. The fixture unit test file is reduced from 417 to 228 lines; the live scenario and its assertions are unchanged.

Validation:

- All 40 focused fixture/runtime checks pass, along with Ruff and the changed-file secret scan.
- [Hosted runtime E2E](https://github.com/dnotitia/akb/actions/runs/33729874141), [backend unit and live DB checks](https://github.com/dnotitia/akb/actions/runs/33729874129), and [static analysis](https://github.com/dnotitia/akb/actions/runs/33729874131) all pass on the updated head.
- Independent source-blind validation previously passed for byte-identical runtime, fixture, and live-scenario files. This cleanup changes only unit tests, so that behavior evidence remains applicable:

| Operator action | Result |
| --- | --- |
| Run the authenticated MCP pytest scenario | Exit 0; PASS; no teardown error |
| Reset the empty fixture and repeat | Exit 0; PASS |
| Supply an empty descriptor | Exit 1; explicit scenario/preparation error |
| Run again after the expected preparation failure | Healthy runtime; exit 0; PASS |

No credential or token exposure was observed in the validator captures. Existing HTTP, protocol/session, stdio/reconnect, and Inspector coverage remains in the repository gate.

Tracking issue: AKB-253
