### PR TITLE
fix(native): preserve migration public metadata

### DIFF
--- a/backend/app/services/native_document_service.py
+++ b/backend/app/services/native_document_service.py
@@ -128,6 +128,79 @@ class NativeDocumentService(DocumentService):
             raise NotFoundError("Vault", vault)
         return vault_id
 
+    @staticmethod
+    def _has_complete_native_frontmatter(frontmatter: dict) -> bool:
+        """Return whether a native payload carries the public metadata core.
+
+        Normal Native writes always produce these fields.  Existing-database
+        migration may instead preserve an external Git payload byte-for-byte;
+        those payloads can omit metadata that Legacy served from PostgreSQL.
+        """
+
+        return all(
+            key in frontmatter
+            for key in ("title", "type", "status", "created_at", "updated_at", "tags")
+        )
+
+    async def _document_frontmatter(
+        self,
+        vault_id: uuid.UUID,
+        snapshot: NativeRevisionSnapshot,
+    ) -> tuple[dict, str]:
+        """Parse one payload and restore missing frozen Legacy projection data.
+
+        Cutover deliberately retains the old ``documents`` rows while Native
+        owns revision authority.  For a migrated external-Git document, the
+        immutable body may not contain fields such as ``status`` even though
+        Legacy served them from that retained row.  Fill only absent fields;
+        explicit Native frontmatter always wins.  Complete Native payloads do
+        not pay a legacy projection read.
+        """
+
+        frontmatter, body = _parse_markdown(snapshot.text)
+        if self._has_complete_native_frontmatter(frontmatter):
+            return frontmatter, body
+
+        pool = await self._pool()
+        async with pool.acquire() as conn:
+            legacy = await conn.fetchrow(
+                """
+                SELECT title, doc_type, status, summary, domain, created_by,
+                       created_at, updated_at, tags, metadata
+                  FROM documents
+                 WHERE vault_id = $1 AND id = $2
+                """,
+                vault_id,
+                snapshot.resource_id,
+            )
+        if legacy is None:
+            return frontmatter, body
+
+        row = dict(legacy)
+        fallback = {
+            "title": row.get("title"),
+            "type": row.get("doc_type") or "note",
+            "status": row.get("status") or "draft",
+            "summary": row.get("summary"),
+            "domain": row.get("domain"),
+            "created_by": row.get("created_by"),
+            "created_at": (
+                row["created_at"].isoformat()
+                if isinstance(row.get("created_at"), datetime)
+                else row.get("created_at")
+            ),
+            "updated_at": (
+                row["updated_at"].isoformat()
+                if isinstance(row.get("updated_at"), datetime)
+                else row.get("updated_at")
+            ),
+            "tags": list(row.get("tags") or []),
+        }
+        for key, value in fallback.items():
+            if key not in frontmatter and value is not None:
+                frontmatter[key] = value
+        return frontmatter, body
+
     async def _native(self) -> NativeRevisionService:
         """Compose the substrate on the frozen P1 searchable-body placement.
 
@@ -267,7 +340,7 @@ class NativeDocumentService(DocumentService):
                 resource_id=row["resource_id"],
                 revision_id=row["head_revision_id"],
             )
-            frontmatter, _ = _parse_markdown(snapshot.text)
+            frontmatter, _ = await self._document_frontmatter(vault_id, snapshot)
             candidate_title = to_nfc(str(frontmatter.get("title") or "")).strip()
             if candidate_title == expected_title:
                 return snapshot.path, candidate_title
@@ -327,7 +400,7 @@ class NativeDocumentService(DocumentService):
         public_selector: str | None = None,
     ) -> DocumentResponse:
         selected = selected or current
-        current_fm, _ = _parse_markdown(current.text)
+        current_fm, _ = await self._document_frontmatter(vault_id, current)
         _, selected_body = _parse_markdown(selected.text)
         created_by = current_fm.get("created_by")
         # Sequential on purpose. These two reads are independent and a
@@ -605,7 +678,7 @@ class NativeDocumentService(DocumentService):
                 raise ConflictError(
                     f"current_commit moved: expected {req.expected_commit}, actual {current.revision_id}"
                 )
-            frontmatter, current_body = _parse_markdown(current.text)
+            frontmatter, current_body = await self._document_frontmatter(vault_id, current)
             previous_hash = _body_content_hash(current_body)
             if req.expected_content_hash and req.expected_content_hash != previous_hash:
                 raise ConflictError(f"content_hash moved: expected {req.expected_content_hash}, actual {previous_hash}")
@@ -730,7 +803,7 @@ class NativeDocumentService(DocumentService):
             if base_path == current.path:
                 raise ValidationError("move is a no-op: the target path equals the current path")
             if title_conflict_policy == "reject":
-                frontmatter, _ = _parse_markdown(current.text)
+                frontmatter, _ = await self._document_frontmatter(vault_id, current)
                 current_title = str(frontmatter.get("title") or current.path.rsplit("/", 1)[-1])
                 existing = await self._find_native_title_conflict(
                     vault_id,
@@ -1039,7 +1112,7 @@ class NativeDocumentService(DocumentService):
                 resource_id=row["resource_id"],
                 revision_id=row["revision_id"],
             )
-            frontmatter, body = _parse_markdown(snapshot.text)
+            frontmatter, body = await self._document_frontmatter(vault_id, snapshot)
             status = frontmatter.get("status") or "draft"
             if not include_archived and status == "archived":
                 continue

--- a/backend/app/services/native_document_service.py
+++ b/backend/app/services/native_document_service.py
@@ -137,9 +137,9 @@ class NativeDocumentService(DocumentService):
         those payloads can omit metadata that Legacy served from PostgreSQL.
         """
 
-        return all(
-            key in frontmatter
-            for key in ("title", "type", "status", "created_at", "updated_at", "tags")
+        return (
+            all(frontmatter.get(key) for key in ("title", "type", "status", "created_at", "updated_at"))
+            and "tags" in frontmatter
         )
 
     async def _document_frontmatter(
@@ -166,7 +166,7 @@ class NativeDocumentService(DocumentService):
             legacy = await conn.fetchrow(
                 """
                 SELECT title, doc_type, status, summary, domain, created_by,
-                       created_at, updated_at, tags, metadata
+                       created_at, updated_at, tags
                   FROM documents
                  WHERE vault_id = $1 AND id = $2
                 """,
@@ -197,7 +197,7 @@ class NativeDocumentService(DocumentService):
             "tags": list(row.get("tags") or []),
         }
         for key, value in fallback.items():
-            if key not in frontmatter and value is not None:
+            if frontmatter.get(key) is None and value is not None:
                 frontmatter[key] = value
         return frontmatter, body
 

--- a/backend/app/services/native_revision_backend.py
+++ b/backend/app/services/native_revision_backend.py
@@ -28,6 +28,7 @@ from app.services.native_payload_verification import (
     verify_native_head_body,
 )
 from app.services.native_revision_service import NativeRevisionService
+from app.services.user_directory import resolve_display_names
 
 
 class NativeRevisionBackend:
@@ -66,6 +67,25 @@ class NativeRevisionBackend:
         pool = await self._pool()
         async with pool.acquire() as conn:
             return await conn.fetchval("SELECT id FROM vaults WHERE name = $1", vault)
+
+    async def _annotate_history_authors(
+        self, entries: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Apply the same id-or-username display-name contract as Legacy."""
+
+        authors = [entry.get("author") for entry in entries]
+        names = await resolve_display_names(authors, pool=await self._pool())
+        for entry in entries:
+            author = entry.get("author")
+            if isinstance(author, str) and author in names:
+                entry["author_name"] = names[author]
+        return entries
+
+    async def _annotated_history_payload(
+        self, payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        payload["history"] = await self._annotate_history_authors(payload["history"])
+        return payload
 
     @staticmethod
     def _public_action(action: str) -> str:
@@ -584,7 +604,7 @@ class NativeRevisionBackend:
         native = await self.document_service.history(vault, doc_ref, limit=limit)
         resolved = await self._resolve_resource(vault, doc_ref)
         if resolved is None:
-            return native
+            return await self._annotated_history_payload(native)
         vault_id, resource = resolved
         migration = NativeRevisionMigrationRepository(await self._pool())
         try:
@@ -593,15 +613,15 @@ class NativeRevisionBackend:
                 resource_id=resource["resource_id"],
             )
         except asyncpg.UndefinedTableError:
-            return native
+            return await self._annotated_history_payload(native)
         if not mappings:
-            return native
+            return await self._annotated_history_payload(native)
 
         fixed_refs = {mapping.fixed_git_oid for mapping in mappings}
         if len(fixed_refs) != 1:
             # Completed immutable mappings are expected to describe one
             # frozen lineage.  Do not synthesize history across authorities.
-            return native
+            return await self._annotated_history_payload(native)
         frozen_head = mappings[-1]
         try:
             snapshot = await asyncio.to_thread(
@@ -612,17 +632,17 @@ class NativeRevisionBackend:
                 current_commit=frozen_head.legacy_git_oid,
             )
         except FixedRefHistoryError:
-            return native
+            return await self._annotated_history_payload(native)
         rows = snapshot.get("history")
         if not isinstance(rows, list):
-            return native
+            return await self._annotated_history_payload(native)
         by_oid = {
             row.get("legacy_git_oid"): row
             for row in rows
             if isinstance(row, dict) and isinstance(row.get("legacy_git_oid"), str)
         }
         if any(mapping.legacy_git_oid not in by_oid for mapping in mappings):
-            return native
+            return await self._annotated_history_payload(native)
 
         # Native genesis represents the same head as the newest legacy
         # mapping. Replace that internal token with the public Git history,
@@ -649,9 +669,10 @@ class NativeRevisionBackend:
                     "date": committed_at.isoformat(),
                 }
             )
+        combined = (native_only + legacy)[:limit]
         return {
             "uri": native["uri"],
-            "history": (native_only + legacy)[:limit],
+            "history": await self._annotate_history_authors(combined),
         }
 
 

--- a/backend/app/services/user_directory.py
+++ b/backend/app/services/user_directory.py
@@ -16,10 +16,16 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
+import asyncpg
+
 from app.db.postgres import get_pool
 
 
-async def resolve_display_names(tokens: Iterable[str | None]) -> dict[str, str]:
+async def resolve_display_names(
+    tokens: Iterable[str | None],
+    *,
+    pool: asyncpg.Pool | None = None,
+) -> dict[str, str]:
     """Map each actor token (user UUID or username) to a display name.
 
     Returns a dict keyed by **both** the matched ``id`` and ``username`` so a
@@ -29,8 +35,8 @@ async def resolve_display_names(tokens: Iterable[str | None]) -> dict[str, str]:
     keys = [t for t in set(tokens) if t]
     if not keys:
         return {}
-    pool = await get_pool()
-    async with pool.acquire() as conn:
+    selected_pool = pool or await get_pool()
+    async with selected_pool.acquire() as conn:
         rows = await conn.fetch(
             """
             SELECT id::text AS id, username,

--- a/backend/tests/test_native_revision_migration_bridge_pg.py
+++ b/backend/tests/test_native_revision_migration_bridge_pg.py
@@ -1658,6 +1658,40 @@ async def test_completed_backfill_bridges_multi_commit_frozen_activity_semantics
         assert fixture["later_file_tip"][:12] not in {entry["hash"] for entry in activity}
 
 
+async def test_completed_backfill_preserves_pg_only_public_document_metadata(tmp_path):
+    async with _fresh_schema(tmp_path) as pool:
+        fixture = await _make_fixture(pool, tmp_path)
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                UPDATE documents
+                   SET status = 'active', doc_type = 'reference',
+                       summary = 'PG-only summary', domain = 'migration',
+                       tags = ARRAY['fixture', 'replacement']::text[]
+                 WHERE id = $1
+                """,
+                fixture["document_one"],
+            )
+        backfill = NativeRevisionBackfill(pool, git=fixture["git"])
+        run, _ = await backfill.prepare_run(
+            namespace_id=fixture["namespace_id"],
+            fixed_ref=fixture["unrelated_tip"],
+            coverage_version="c9-public-metadata-continuity",
+        )
+        assert (await backfill.backfill_run(run.run_id)).status == "complete"
+
+        documents = NativeDocumentService(pool=pool, legacy_git=fixture["git"])
+        current = await documents.get(fixture["vault_name"], "renamed.md")
+
+        assert current.title == "renamed"
+        assert current.type == "reference"
+        assert current.status == "active"
+        assert current.summary == "PG-only summary"
+        assert current.domain == "migration"
+        assert current.tags == ["fixture", "replacement"]
+        assert current.content == "new v2"
+
+
 async def test_native_move_keeps_completed_legacy_paths_for_historical_reads(tmp_path):
     async with _fresh_schema(tmp_path) as pool:
         fixture = await _make_fixture(pool, tmp_path)

--- a/backend/tests/test_native_revision_public_compat_unit.py
+++ b/backend/tests/test_native_revision_public_compat_unit.py
@@ -84,6 +84,38 @@ async def test_complete_native_frontmatter_never_reads_legacy_document_projectio
 
 
 @pytest.mark.asyncio
+async def test_empty_migrated_status_uses_frozen_legacy_status():
+    pool, conn = _pool(
+        row={
+            "title": "Imported",
+            "doc_type": "reference",
+            "status": "active",
+            "summary": None,
+            "domain": None,
+            "created_by": None,
+            "created_at": None,
+            "updated_at": None,
+            "tags": [],
+        }
+    )
+    service = NativeDocumentService(pool=pool)
+    snapshot = SimpleNamespace(
+        resource_id=uuid.uuid4(),
+        text=(
+            "---\ntitle: Imported\ntype: reference\nstatus:\n"
+            "created_at: '2026-09-03T01:02:03+00:00'\n"
+            "updated_at: '2026-09-03T01:02:03+00:00'\n"
+            "tags: []\n---\nbody\n"
+        ),
+    )
+
+    frontmatter, _ = await service._document_frontmatter(uuid.uuid4(), snapshot)
+
+    assert frontmatter["status"] == "active"
+    conn.fetchrow.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_native_history_annotates_mapped_and_native_authors(monkeypatch):
     pool, _ = _pool()
     backend = NativeRevisionBackend(pool=pool)

--- a/backend/tests/test_native_revision_public_compat_unit.py
+++ b/backend/tests/test_native_revision_public_compat_unit.py
@@ -1,0 +1,114 @@
+"""Focused compatibility regressions for an existing-database Native cutover."""
+
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+import uuid
+
+import pytest
+
+from app.services.native_document_service import NativeDocumentService
+from app.services.native_revision_backend import NativeRevisionBackend
+
+
+def _pool(*, row=None):
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=row)
+
+    @asynccontextmanager
+    async def acquire():
+        yield conn
+
+    pool = MagicMock()
+    pool.acquire = acquire
+    return pool, conn
+
+
+@pytest.mark.asyncio
+async def test_migrated_native_document_fills_missing_public_metadata_from_frozen_legacy_row():
+    created_at = datetime(2026, 9, 3, 1, 2, 3, tzinfo=UTC)
+    updated_at = datetime(2026, 9, 3, 2, 3, 4, tzinfo=UTC)
+    pool, conn = _pool(
+        row={
+            "title": "Collector fixture",
+            "doc_type": "reference",
+            "status": "active",
+            "summary": "A to B source",
+            "domain": "native-revision",
+            "created_by": None,
+            "created_at": created_at,
+            "updated_at": updated_at,
+            "tags": ["fixture", "collector"],
+            "metadata": {},
+        }
+    )
+    service = NativeDocumentService(pool=pool)
+    snapshot = SimpleNamespace(
+        resource_id=uuid.uuid4(),
+        text=(
+            "---\ntitle: Collector fixture\ntype: reference\n"
+            "tags: [fixture, collector]\nsummary: A to B source\n"
+            "domain: native-revision\n---\nbody\n"
+        ),
+    )
+
+    frontmatter, body = await service._document_frontmatter(uuid.uuid4(), snapshot)
+
+    assert body == "body"
+    assert frontmatter["status"] == "active"
+    assert frontmatter["created_at"] == created_at.isoformat()
+    assert frontmatter["updated_at"] == updated_at.isoformat()
+    conn.fetchrow.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_complete_native_frontmatter_never_reads_legacy_document_projection():
+    pool, conn = _pool(row=None)
+    service = NativeDocumentService(pool=pool)
+    snapshot = SimpleNamespace(
+        resource_id=uuid.uuid4(),
+        text=(
+            "---\ntitle: Native\ntype: note\nstatus: active\n"
+            "created_at: '2026-09-03T01:02:03+00:00'\n"
+            "updated_at: '2026-09-03T01:02:03+00:00'\n"
+            "tags: []\n---\nbody\n"
+        ),
+    )
+
+    frontmatter, body = await service._document_frontmatter(uuid.uuid4(), snapshot)
+
+    assert frontmatter["status"] == "active"
+    assert body == "body"
+    conn.fetchrow.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_native_history_annotates_mapped_and_native_authors(monkeypatch):
+    pool, _ = _pool()
+    backend = NativeRevisionBackend(pool=pool)
+    resolver = AsyncMock(
+        return_value={
+            "owner": "Fixture Owner",
+            "11111111-1111-1111-1111-111111111111": "Fixture Reader",
+        }
+    )
+    monkeypatch.setattr(
+        "app.services.native_revision_backend.resolve_display_names",
+        resolver,
+    )
+    entries = [
+        {"hash": "native", "author": "owner"},
+        {"hash": "legacy", "author": "11111111-1111-1111-1111-111111111111"},
+        {"hash": "external", "author": "external-committer"},
+    ]
+
+    annotated = await backend._annotate_history_authors(entries)
+
+    assert annotated[0]["author_name"] == "Fixture Owner"
+    assert annotated[1]["author_name"] == "Fixture Reader"
+    assert "author_name" not in annotated[2]
+    resolver.assert_awaited_once_with(
+        ["owner", "11111111-1111-1111-1111-111111111111", "external-committer"],
+        pool=pool,
+    )


### PR DESCRIPTION
## Summary
- preserve PG-only public metadata for migrated Native documents whose retained Git payload omits or nulls required frontmatter fields
- resolve `author_name` for both bridged Legacy and new Native history entries
- keep complete Native payload reads on the Native-only fast path

## Verification
- exact-head focused unit tests: 15 passed
- exact-head affected unit selection: 55 passed, 2 skipped
- exact-head full backend non-E2E suite: 2548 passed, 658 skipped, 59 deselected
- ruff and mypy on changed services/tests
- Linux disposable-PostgreSQL migration checks: 3 passed (metadata continuity, bridged activity, moved historical reads)