### PR TITLE
fix: bridge migrated commit token on first native write

### DIFF
--- a/backend/app/services/native_document_service.py
+++ b/backend/app/services/native_document_service.py
@@ -250,6 +250,33 @@ class NativeDocumentService(DocumentService):
         )
         return vault_id, snapshot
 
+    async def _expected_commit_matches_current(
+        self,
+        *,
+        namespace_id: uuid.UUID,
+        resource_id: uuid.UUID,
+        expected_commit: str,
+        current_revision_id: str,
+    ) -> bool:
+        """Accept a migrated Legacy head token only while it names this Head.
+
+        Existing clients retain the public ``current_commit`` returned before
+        an in-place Native cutover. The completed migration mapping is the
+        authority that binds that Legacy Git OID to the replacement Native
+        Revision. Once a Native write advances Head, the mapping no longer
+        points at current and the old token becomes stale again.
+        """
+        if expected_commit == current_revision_id:
+            return True
+        mapping = await NativeRevisionMigrationRepository(
+            await self._pool()
+        ).mapping_for_native_revision(
+            namespace_id=namespace_id,
+            resource_id=resource_id,
+            native_revision_id=current_revision_id,
+        )
+        return mapping is not None and mapping.legacy_git_oid == expected_commit
+
     async def _path_is_owned(self, vault_id: uuid.UUID, path: str) -> bool:
         repository = NativeRevisionRepository(await self._pool())
         return (
@@ -674,7 +701,12 @@ class NativeDocumentService(DocumentService):
         native = await self._native()
         race_count = 0
         while True:
-            if req.expected_commit and req.expected_commit != current.revision_id:
+            if req.expected_commit and not await self._expected_commit_matches_current(
+                namespace_id=vault_id,
+                resource_id=resource_id,
+                expected_commit=req.expected_commit,
+                current_revision_id=current.revision_id,
+            ):
                 raise ConflictError(
                     f"current_commit moved: expected {req.expected_commit}, actual {current.revision_id}"
                 )
@@ -900,7 +932,12 @@ class NativeDocumentService(DocumentService):
         native = await self._native()
         race_count = 0
         while True:
-            if base_commit and base_commit != current.revision_id:
+            if base_commit and not await self._expected_commit_matches_current(
+                namespace_id=vault_id,
+                resource_id=resource_id,
+                expected_commit=base_commit,
+                current_revision_id=current.revision_id,
+            ):
                 raise ConflictError(f"current_commit moved: expected {base_commit}, actual {current.revision_id}")
             _, body = _parse_markdown(current.text)
             occurrences = body.count(old_string)

--- a/backend/app/services/native_document_service.py
+++ b/backend/app/services/native_document_service.py
@@ -268,13 +268,19 @@ class NativeDocumentService(DocumentService):
         """
         if expected_commit == current_revision_id:
             return True
-        mapping = await NativeRevisionMigrationRepository(
-            await self._pool()
-        ).mapping_for_native_revision(
-            namespace_id=namespace_id,
-            resource_id=resource_id,
-            native_revision_id=current_revision_id,
-        )
+        try:
+            mapping = await NativeRevisionMigrationRepository(
+                await self._pool()
+            ).mapping_for_native_revision(
+                namespace_id=namespace_id,
+                resource_id=resource_id,
+                native_revision_id=current_revision_id,
+            )
+        except asyncpg.UndefinedTableError:
+            # Native-only test/install schemas can intentionally omit the
+            # optional migration bridge. Preserve their historical mismatch
+            # behavior instead of turning a stale token into a server error.
+            return False
         return mapping is not None and mapping.legacy_git_oid == expected_commit
 
     async def _path_is_owned(self, vault_id: uuid.UUID, path: str) -> bool:

--- a/backend/tests/test_native_revision_migration_bridge_pg.py
+++ b/backend/tests/test_native_revision_migration_bridge_pg.py
@@ -15,6 +15,8 @@ import asyncpg
 import pytest
 from git import Repo
 
+from app.exceptions import ConflictError
+from app.models.document import DocumentUpdateRequest
 from app.repositories.native_revision_migration_repo import (
     MigrationInventoryDriftError,
     NativeRevisionMigrationRepository,
@@ -1690,6 +1692,78 @@ async def test_completed_backfill_preserves_pg_only_public_document_metadata(tmp
         assert current.domain == "migration"
         assert current.tags == ["fixture", "replacement"]
         assert current.content == "new v2"
+
+
+async def test_completed_backfill_accepts_only_the_mapped_legacy_head_for_first_native_update(
+    tmp_path,
+):
+    async with _fresh_schema(tmp_path) as pool:
+        fixture = await _make_fixture(pool, tmp_path)
+        backfill = NativeRevisionBackfill(pool, git=fixture["git"])
+        run, _ = await backfill.prepare_run(
+            namespace_id=fixture["namespace_id"],
+            fixed_ref=fixture["unrelated_tip"],
+            coverage_version="c9-first-native-write-legacy-token",
+        )
+        assert (await backfill.backfill_run(run.run_id)).status == "complete"
+
+        documents = NativeDocumentService(pool=pool, legacy_git=fixture["git"])
+        migrated = await documents.get(fixture["vault_name"], "renamed.md")
+        assert migrated.current_commit != fixture["current_oid"]
+
+        with pytest.raises(ConflictError, match="current_commit moved"):
+            await documents.update(
+                fixture["vault_name"],
+                "renamed.md",
+                DocumentUpdateRequest(
+                    content="must stay rejected",
+                    expected_commit=fixture["move_oid"],
+                ),
+                agent_id="collector",
+            )
+
+        migrated_other = await documents.get(fixture["vault_name"], "other.md")
+        edited = await documents.edit(
+            fixture["vault_name"],
+            "other.md",
+            "other",
+            "first post-cutover edit",
+            base_commit=fixture["other_oid"],
+            agent_id="existing-client",
+        )
+        assert edited.previous_commit == migrated_other.current_commit
+        with pytest.raises(ConflictError, match="current_commit moved"):
+            await documents.edit(
+                fixture["vault_name"],
+                "other.md",
+                "first post-cutover edit",
+                "stale token must not work twice",
+                base_commit=fixture["other_oid"],
+                agent_id="existing-client",
+            )
+
+        updated = await documents.update(
+            fixture["vault_name"],
+            "renamed.md",
+            DocumentUpdateRequest(
+                content="first post-cutover write",
+                expected_commit=fixture["current_oid"],
+            ),
+            agent_id="collector",
+        )
+        assert updated.previous_commit == migrated.current_commit
+        assert updated.current_commit != migrated.current_commit
+
+        with pytest.raises(ConflictError, match="current_commit moved"):
+            await documents.update(
+                fixture["vault_name"],
+                "renamed.md",
+                DocumentUpdateRequest(
+                    content="stale token must not work twice",
+                    expected_commit=fixture["current_oid"],
+                ),
+                agent_id="collector",
+            )
 
 
 async def test_native_move_keeps_completed_legacy_paths_for_historical_reads(tmp_path):

--- a/backend/tests/test_native_revision_public_compat_unit.py
+++ b/backend/tests/test_native_revision_public_compat_unit.py
@@ -144,3 +144,46 @@ async def test_native_history_annotates_mapped_and_native_authors(monkeypatch):
         ["owner", "11111111-1111-1111-1111-111111111111", "external-committer"],
         pool=pool,
     )
+
+
+@pytest.mark.asyncio
+async def test_expected_commit_accepts_only_completed_mapping_to_current_native_head(monkeypatch):
+    pool, _ = _pool()
+    service = NativeDocumentService(pool=pool)
+    namespace_id = uuid.uuid4()
+    resource_id = uuid.uuid4()
+    legacy_head = "1" * 40
+    native_head = "2" * 40
+    lookup = AsyncMock(return_value=SimpleNamespace(legacy_git_oid=legacy_head))
+    monkeypatch.setattr(
+        "app.repositories.native_revision_migration_repo."
+        "NativeRevisionMigrationRepository.mapping_for_native_revision",
+        lookup,
+    )
+
+    assert await service._expected_commit_matches_current(
+        namespace_id=namespace_id,
+        resource_id=resource_id,
+        expected_commit=native_head,
+        current_revision_id=native_head,
+    )
+    lookup.assert_not_awaited()
+
+    assert await service._expected_commit_matches_current(
+        namespace_id=namespace_id,
+        resource_id=resource_id,
+        expected_commit=legacy_head,
+        current_revision_id=native_head,
+    )
+    lookup.assert_awaited_once_with(
+        namespace_id=namespace_id,
+        resource_id=resource_id,
+        native_revision_id=native_head,
+    )
+
+    assert not await service._expected_commit_matches_current(
+        namespace_id=namespace_id,
+        resource_id=resource_id,
+        expected_commit="3" * 40,
+        current_revision_id=native_head,
+    )

--- a/backend/tests/test_native_revision_public_compat_unit.py
+++ b/backend/tests/test_native_revision_public_compat_unit.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 import uuid
 
+import asyncpg
 import pytest
 
 from app.services.native_document_service import NativeDocumentService
@@ -186,4 +187,23 @@ async def test_expected_commit_accepts_only_completed_mapping_to_current_native_
         resource_id=resource_id,
         expected_commit="3" * 40,
         current_revision_id=native_head,
+    )
+
+
+@pytest.mark.asyncio
+async def test_expected_commit_without_migration_schema_remains_a_normal_mismatch(monkeypatch):
+    pool, _ = _pool()
+    service = NativeDocumentService(pool=pool)
+    lookup = AsyncMock(side_effect=asyncpg.UndefinedTableError("missing migration bridge"))
+    monkeypatch.setattr(
+        "app.repositories.native_revision_migration_repo."
+        "NativeRevisionMigrationRepository.mapping_for_native_revision",
+        lookup,
+    )
+
+    assert not await service._expected_commit_matches_current(
+        namespace_id=uuid.uuid4(),
+        resource_id=uuid.uuid4(),
+        expected_commit="1" * 40,
+        current_revision_id="2" * 40,
     )


### PR DESCRIPTION
## Summary
- accept a pre-cutover Legacy `current_commit` only when the completed migration mapping binds it to the current Native head
- retain Native OCC by writing against the actual current Native revision
- make the Legacy token stale immediately after the first Native head advance
- cover both document update and edit compatibility

## Why
An independent A-to-B replacement rehearsal restored all PostgreSQL, Legacy Git, S3 and security state, completed Native cutover, and preserved public reads. The first real post-cutover Collector update then failed because its source-resource ledger correctly retained the Legacy Git token returned before cutover while Native exposed the mapped revision token.

## Validation
- RED-first unit regression confirmed the compatibility helper was absent
- public compatibility unit suite: 6 passed
- local backend non-E2E suite at the initial PR head: 2549 passed, 659 skipped, 59 deselected
- Ruff: passed
- mypy on changed service: passed
- Linux disposable PostgreSQL focused migration/write regression: passed
- Linux disposable PostgreSQL full migration bridge suite: 19 passed
- exact reproduction of the first GitHub live-PG failure plus the migration/write regression after the follow-up: 2 passed

## Safety boundary
No blind rebase is added. Older Legacy commits remain conflicts. The accepted Legacy token must map to the exact current Native revision in a completed migration, and the same token is rejected after that head advances. Native-only schemas that intentionally omit the optional migration table retain the pre-change stale-token conflict instead of raising a server error.