### PR TITLE
refactor(mcp): keep Inspector command smoke-only

### DIFF
--- a/backend/scripts/ci/README.md
+++ b/backend/scripts/ci/README.md
@@ -174,16 +174,13 @@ client's existing npm workflow:
 (cd packages/akb-mcp-client && npm ci)
 ```
 
-The same package entrypoint provides a machine-readable smoke and an
-interactive Web diagnostic. It consumes the ready descriptor printed by the
-repository runtime and never needs a global Inspector install:
+The package entrypoint provides the machine-readable consumer smoke. It
+consumes the ready descriptor printed by the repository runtime and never
+needs a global Inspector install:
 
 ```bash
 npm --prefix packages/akb-mcp-client run --silent inspect -- \
-  --intent smoke --target both --descriptor /path/to/descriptor.json
-
-npm --prefix packages/akb-mcp-client run --silent inspect -- \
-  --intent interactive --config /path/to/mcp-config.json
+  --target both --descriptor /path/to/descriptor.json
 ```
 
 The smoke uses Node.js `>=22.19.0` and the exact-pinned
@@ -201,12 +198,6 @@ directory's 0600 temporary Inspector config, which is deleted in `finally`
 cleanup. The PAT is not placed in argv, logs, command output, reports, or
 uploaded artifacts. The focused package regression exercises the same public
 entrypoint with a synthetic marker and verifies config removal and redaction.
-
-For an interactive session, pass a user-owned Inspector config file. The
-entrypoint binds the Web server to `127.0.0.1` and keeps Inspector's normal
-session authentication; it does not create a user PAT file or alter the
-user's credential boundary. The existing `transport-proxy` runtime profile
-can be used when the interactive config includes stdio.
 
 For a direct local gate, use the uv-managed Python environment to generate
 per-run values and export them without placing a credential value in the

--- a/backend/scripts/ci/e2e_runtime.py
+++ b/backend/scripts/ci/e2e_runtime.py
@@ -3484,8 +3484,6 @@ class E2ERuntime:
                         "--silent",
                         "inspect",
                         "--",
-                        "--intent",
-                        "smoke",
                         "--target",
                         "both",
                         "--descriptor",

--- a/packages/akb-mcp-client/scripts/mcp-inspector-smoke.mjs
+++ b/packages/akb-mcp-client/scripts/mcp-inspector-smoke.mjs
@@ -63,10 +63,8 @@ export function parseArguments(argv) {
     ({ values } = parseArgs({
       args: argv,
       options: {
-        intent: { type: "string" },
         target: { type: "string" },
         descriptor: { type: "string" },
-        config: { type: "string" },
         help: { type: "boolean", short: "h" },
       },
       strict: true,
@@ -76,24 +74,14 @@ export function parseArguments(argv) {
     error("invalid command options");
   }
   const result = {
-    intent: values.intent ?? null,
     target: values.target ?? null,
     descriptor: values.descriptor ?? null,
-    config: values.config ?? null,
     help: values.help === true,
   };
   if (result.help) return result;
-  if (result.intent === "smoke") {
-    if (!["http", "stdio", "both"].includes(result.target)) error("smoke target must be http, stdio, or both");
-    if (!result.descriptor) error("smoke descriptor is required");
-    return result;
-  }
-  if (result.intent === "interactive") {
-    if (!result.config) error("interactive Inspector config is required");
-    if (result.target || result.descriptor) error("interactive accepts --config only");
-    return result;
-  }
-  error("intent must be smoke or interactive");
+  if (!["http", "stdio", "both"].includes(result.target)) error("smoke target must be http, stdio, or both");
+  if (!result.descriptor) error("smoke descriptor is required");
+  return result;
 }
 
 export async function inspectInstallation({ packageRoot = PACKAGE_ROOT, nodeVersion = process.versions.node } = {}) {
@@ -430,20 +418,8 @@ export async function runSmoke({ info, descriptor, target, fetchImpl = globalThi
   }
 }
 
-export async function runInteractive(info, configPath, spawnProcess = nodeSpawn) {
-  const path = resolve(configPath);
-  if (!(await stat(path).then((value) => value.isFile()).catch(() => false))) error("interactive Inspector config file is missing");
-  const env = { ...process.env, HOST: "127.0.0.1" };
-  delete env.DANGEROUSLY_OMIT_AUTH;
-  const child = spawnProcess(process.execPath, [info.entry, "--web", "--config", path], { cwd: REPOSITORY_ROOT, env, stdio: ["ignore", "inherit", "inherit"] });
-  return await new Promise((resolveClose) => {
-    child.once("error", () => resolveClose(1));
-    child.once("close", (value) => resolveClose(value ?? 1));
-  });
-}
-
 function usage() {
-  return "Usage: npm run inspect -- --intent smoke --target <http|stdio|both> --descriptor <path|->\n       npm run inspect -- --intent interactive --config <mcp-config.json>\n";
+  return "Usage: npm run inspect -- --target <http|stdio|both> --descriptor <path|->\n";
 }
 
 export async function main(argv = process.argv.slice(2)) {
@@ -455,13 +431,12 @@ export async function main(argv = process.argv.slice(2)) {
       return 0;
     }
     const info = await inspectInstallation();
-    if (args.intent === "interactive") return await runInteractive(info, args.config);
     const descriptor = await loadDescriptor(args.descriptor);
     const output = await runSmoke({ info, descriptor, target: args.target });
     process.stdout.write(`${JSON.stringify(output)}\n`);
     return output.status === "passed" ? 0 : 1;
   } catch (value) {
-    process.stdout.write(`${JSON.stringify({ status: "failed", intent: args?.intent ?? null, target: args?.target ?? null, error: messageOf(value) })}\n`);
+    process.stdout.write(`${JSON.stringify({ status: "failed", target: args?.target ?? null, error: messageOf(value) })}\n`);
     return 1;
   }
 }

--- a/packages/akb-mcp-client/test/mcp-inspector-smoke.test.mjs
+++ b/packages/akb-mcp-client/test/mcp-inspector-smoke.test.mjs
@@ -9,7 +9,6 @@ import {
   PACKAGE_ROOT,
   inspectInstallation,
   parseArguments,
-  runInteractive,
   runSmoke,
 } from "../scripts/mcp-inspector-smoke.mjs";
 
@@ -56,41 +55,13 @@ async function consumerRoot() {
   return root;
 }
 
-test("parses the small smoke and interactive interfaces", () => {
-  assert.deepEqual(parseArguments(["--intent", "smoke", "--target", "both", "--descriptor", "-"]), {
-    intent: "smoke", target: "both", descriptor: "-", config: null, help: false,
+test("parses the smoke interface and rejects removed mode options", () => {
+  assert.deepEqual(parseArguments(["--target", "both", "--descriptor", "-"]), {
+    target: "both", descriptor: "-", help: false,
   });
-  assert.deepEqual(parseArguments(["--intent", "interactive", "--config", "config.json"]), {
-    intent: "interactive", target: null, descriptor: null, config: "config.json", help: false,
-  });
-  assert.throws(() => parseArguments(["--intent", "interactive", "--config", "x", "--target", "http"]));
-});
-
-test("interactive launch keeps loopback binding and Inspector session auth", async () => {
-  const directory = await mkdtemp(join(tmpdir(), "akb-inspector-interactive-test-"));
-  const configPath = join(directory, "config.json");
-  await writeFile(configPath, '{"mcpServers":{}}\n', { mode: 0o600 });
-  const captured = {};
-  const spawnProcess = (_command, args, options) => {
-    captured.args = args;
-    captured.options = options;
-    const child = new EventEmitter();
-    queueMicrotask(() => child.emit("close", 0));
-    return child;
-  };
-  const oldOmitAuth = process.env.DANGEROUSLY_OMIT_AUTH;
-  process.env.DANGEROUSLY_OMIT_AUTH = "true";
-  try {
-    const code = await runInteractive(await inspectInstallation(), configPath, spawnProcess);
-    assert.equal(code, 0);
-    assert.deepEqual(captured.args.slice(1), ["--web", "--config", configPath]);
-    assert.equal(captured.options.env.HOST, "127.0.0.1");
-    assert.equal(captured.options.env.DANGEROUSLY_OMIT_AUTH, undefined);
-    await stat(configPath);
-  } finally {
-    if (oldOmitAuth === undefined) delete process.env.DANGEROUSLY_OMIT_AUTH; else process.env.DANGEROUSLY_OMIT_AUTH = oldOmitAuth;
-    await rm(directory, { recursive: true, force: true });
-  }
+  assert.throws(() => parseArguments(["--intent", "smoke", "--target", "both", "--descriptor", "-"]));
+  assert.throws(() => parseArguments(["--config", "config.json"]));
+  assert.throws(() => parseArguments(["--intent", "interactive", "--config", "config.json"]));
 });
 
 test("preflights the exact installed public Inspector", async () => {


### PR DESCRIPTION
The Inspector command previously exposed both consumer smoke tests and interactive Web diagnostics. This change removes the Web entrypoint and the public `--intent` and `--config` options. Smoke tests now run directly with `--target <http|stdio|both> --descriptor <path|->`; removed options fail explicitly. The runtime invocation and documentation use the same interface.

The pinned Inspector development dependency, HTTP and clean-installed stdio checks, protocol/server validation, strict tool catalog validation, representative read-only call, and transport comparison remain intact. Credential redaction, temporary configuration cleanup, and published package boundaries are preserved. The documentation distinguishes repository consumer smoke tests from the orchestrator's source-blind validation responsibilities.

Validation:

- Public CLI help and rejection of removed options verified.
- All 5 focused Inspector tests, the full proxy package suite, and 34 runtime unit tests passed.
- `bash scripts/check.sh` passed.
- Correctness/security and complexity reviews completed with no P0/P1 findings.
- All four candidate-bound CI checks passed: [static analysis](https://github.com/dnotitia/akb/actions/runs/33829146604), [backend unit tests and live PostgreSQL E2E](https://github.com/dnotitia/akb/actions/runs/33829146630), and [repository-owned transport-proxy E2E](https://github.com/dnotitia/akb/actions/runs/33829146745).
- The hosted runtime completed the real Inspector HTTP/stdio smoke, the MCP pytest scenario, and 831 shell assertions with no failures.

Per the accepted AKB-254 verification contract, this change reuses public CLI checks and hosted E2E with the real Inspector.
