### PR TITLE
fix: allow large external Git retirement manifests

### DIFF
--- a/backend/app/services/external_git_retirement.py
+++ b/backend/app/services/external_git_retirement.py
@@ -58,7 +58,10 @@ _DOCUMENT_KEYS = frozenset(
     }
 )
 _MANAGED_METADATA_KEYS = frozenset({"managed", "title", "type", "tags", "summary", "domain"})
-_MAX_MANIFEST_BYTES = 8 * 1024 * 1024
+# Large repositories can legitimately need tens of thousands of body-free
+# document facts. Keep the operator input bounded while leaving enough room
+# for that inventory and its canonical metadata.
+_MAX_MANIFEST_BYTES = 32 * 1024 * 1024
 
 
 class ExternalGitRetirementError(RuntimeError):

--- a/backend/tests/test_external_git_retirement_unit.py
+++ b/backend/tests/test_external_git_retirement_unit.py
@@ -8,11 +8,16 @@ import pytest
 
 from app.services.external_git_retirement import (
     ExternalGitRetirementError,
+    _MAX_MANIFEST_BYTES,
     parse_adoption_manifest,
 )
 
 
 _REF = "a" * 40
+
+
+def test_operator_manifest_limit_covers_large_body_free_inventories() -> None:
+    assert _MAX_MANIFEST_BYTES == 32 * 1024 * 1024
 
 
 def _manifest() -> dict:


### PR DESCRIPTION
## Summary
- raise the bounded operator-only external-Git adoption manifest limit from 8 MiB to 32 MiB
- retain strict body-free schema parsing and an explicit upper bound

## Production finding
A valid body-free manifest for 22,096 documents was 21.7 MB and was refused before any database mutation. Splitting the manifest would break its complete fixed-snapshot proof.

## Validation
- RED-first capacity regression
- external-Git retirement and CLI unit tests: 10 passed
- Ruff clean
- git diff check clean
- host-model review: no High/Medium findings