### PR TITLE
Fix orphaned Native cutover plan reservations

### DIFF
--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -77,6 +77,7 @@ STANDALONE_SSO_BOOTSTRAP_USAGE = (
 MIGRATE_REVISION_BACKEND_USAGE = (
     "Usage: python -m app.cli migrate-revision-backend "
     "{plan --coverage-version VERSION|apply|verify|commit|abort --cutover-id UUID|"
+    "supersede-orphan --migration-run-id UUID|"
     "retire-external-git --vault-id UUID --manifest-file PATH --idempotency-key UUID "
     "--requested-by ID --confirm-planned-downtime RETIRE-EXTERNAL-GIT:UUID}"
 )
@@ -652,6 +653,8 @@ def _native_revision_cutover_parser() -> argparse.ArgumentParser:
     for phase in ("apply", "verify", "commit", "abort"):
         command = phases.add_parser(phase, add_help=False)
         command.add_argument("--cutover-id", required=True)
+    orphan = phases.add_parser("supersede-orphan", add_help=False)
+    orphan.add_argument("--migration-run-id", required=True)
     retire = phases.add_parser("retire-external-git", add_help=False)
     retire.add_argument("--vault-id", required=True)
     retire.add_argument("--manifest-file", required=True)
@@ -718,6 +721,7 @@ async def _execute_native_revision_cutover(
     *,
     coverage_version: str | None,
     cutover_id: str | None,
+    migration_run_id: str | None = None,
 ) -> dict[str, object]:
     """Run one thin operator phase over the product cutover services."""
     from app.db.postgres import close_pool, get_pool, init_db
@@ -759,6 +763,9 @@ async def _execute_native_revision_cutover(
                 vaults=vaults,
                 coverage_version=coverage_version,
             )
+        elif phase == "supersede-orphan":
+            assert migration_run_id is not None
+            result = await cutover.supersede_orphan_plan(uuid.UUID(migration_run_id))
         else:
             assert cutover_id is not None
             parsed_id = uuid.UUID(cutover_id)
@@ -801,11 +808,19 @@ async def _migrate_revision_backend(args: list[str]) -> int:
                 planned_downtime_confirmation=parsed.confirm_planned_downtime,
             )
         else:
-            report = await _execute_native_revision_cutover(
-                parsed.phase,
-                coverage_version=getattr(parsed, "coverage_version", None),
-                cutover_id=getattr(parsed, "cutover_id", None),
-            )
+            if parsed.phase == "supersede-orphan":
+                report = await _execute_native_revision_cutover(
+                    parsed.phase,
+                    coverage_version=None,
+                    cutover_id=None,
+                    migration_run_id=parsed.migration_run_id,
+                )
+            else:
+                report = await _execute_native_revision_cutover(
+                    parsed.phase,
+                    coverage_version=getattr(parsed, "coverage_version", None),
+                    cutover_id=getattr(parsed, "cutover_id", None),
+                )
     except (ValueError, RuntimeError) as exc:
         prefix = (
             "revision_backend_retirement_failed"

--- a/backend/app/repositories/native_revision_cutover_repo.py
+++ b/backend/app/repositories/native_revision_cutover_repo.py
@@ -281,6 +281,28 @@ class NativeRevisionCutoverRepository:
                     inventory_digest,
                 )
                 if row is None:
+                    migration_rows = await conn.fetch(
+                        """
+                        SELECT run_id, namespace_id, fixed_git_oid,
+                               inventory_digest, status
+                          FROM native_revision_migration_runs
+                         WHERE run_id = ANY($1::uuid[])
+                         ORDER BY run_id
+                         FOR UPDATE
+                        """,
+                        [item[1] for item in expected],
+                    )
+                    observed_runs = sorted(
+                        (
+                            item["namespace_id"],
+                            item["run_id"],
+                            item["fixed_git_oid"],
+                            item["inventory_digest"],
+                        )
+                        for item in migration_rows
+                    )
+                    if observed_runs != expected or any(item["status"] != "planned" for item in migration_rows):
+                        raise CutoverIntegrityError("cutover migration runs are not exact pending plans")
                     row = await conn.fetchrow(
                         """
                         INSERT INTO native_revision_cutover_runs

--- a/backend/app/repositories/native_revision_migration_repo.py
+++ b/backend/app/repositories/native_revision_migration_repo.py
@@ -542,6 +542,81 @@ class NativeRevisionMigrationRepository:
         )
         return True
 
+    async def supersede_unlinked_pending_runs(
+        self,
+        run_ids: Iterable[uuid.UUID],
+    ) -> tuple[uuid.UUID, ...]:
+        """Compensate only all-pending runs not yet linked to a cutover."""
+
+        ordered = sorted(set(run_ids), key=str)
+        superseded: list[uuid.UUID] = []
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                for run_id in ordered:
+                    run = await conn.fetchrow(
+                        """
+                        SELECT run_id, status
+                          FROM native_revision_migration_runs
+                         WHERE run_id = $1
+                         FOR UPDATE
+                        """,
+                        run_id,
+                    )
+                    if run is None or run["status"] != "planned":
+                        continue
+                    if await conn.fetchval(
+                        """
+                        SELECT EXISTS (
+                            SELECT 1
+                              FROM native_revision_cutover_vaults
+                             WHERE migration_run_id = $1
+                        )
+                        """,
+                        run_id,
+                    ):
+                        continue
+                    items = await conn.fetch(
+                        """
+                        SELECT status, reservation_active
+                          FROM native_revision_migration_items
+                         WHERE run_id = $1
+                         FOR UPDATE
+                        """,
+                        run_id,
+                    )
+                    if any(item["status"] != "pending" or not item["reservation_active"] for item in items):
+                        continue
+                    await conn.execute(
+                        """
+                        UPDATE native_revision_migration_items
+                           SET reservation_active = FALSE,
+                               updated_at = NOW()
+                         WHERE run_id = $1
+                           AND status = 'pending'
+                           AND reservation_active
+                        """,
+                        run_id,
+                    )
+                    changed = await conn.fetchval(
+                        """
+                        UPDATE native_revision_migration_runs
+                           SET status = 'superseded'
+                         WHERE run_id = $1
+                           AND status = 'planned'
+                           AND NOT EXISTS (
+                               SELECT 1
+                                 FROM native_revision_cutover_vaults
+                                WHERE migration_run_id = $1
+                           )
+                        RETURNING run_id
+                        """,
+                        run_id,
+                    )
+                    if changed is None:
+                        raise MigrationIntegrityError("orphan migration run became linked during compensation")
+                    superseded.append(run_id)
+        return tuple(superseded)
+
     async def ensure_pending_items(
         self,
         run: MigrationRun,

--- a/backend/app/services/native_revision_cutover.py
+++ b/backend/app/services/native_revision_cutover.py
@@ -23,6 +23,7 @@ from app.repositories.native_revision_cutover_repo import (
 )
 from app.repositories.native_revision_migration_repo import (
     MigrationInventoryDriftError,
+    MigrationRun,
     NativeRevisionMigrationRepository,
 )
 from app.services.native_revision_backfill import NativeRevisionBackfill
@@ -404,39 +405,60 @@ class NativeRevisionCutover:
             raise ValueError("cutover requires at least one eligible manual vault")
 
         prepared: list[CutoverVault] = []
-        for item in eligible:
-            migration_run, _ = await self.backfill.prepare_run(
-                namespace_id=item.namespace_id,
-                fixed_ref=item.fixed_ref,
-                coverage_version=coverage_version,
-            )
-            prepared.append(
-                CutoverVault(
-                    cutover_id=uuid.UUID(int=0),
-                    namespace_id=migration_run.namespace_id,
-                    migration_run_id=migration_run.run_id,
-                    fixed_git_oid=migration_run.fixed_git_oid,
-                    inventory_digest=migration_run.inventory_digest,
-                    status="planned",
-                    verification_digest=None,
-                    applied_at=None,
-                    verified_at=None,
+        try:
+            for item in eligible:
+                migration_run, _ = await self.backfill.prepare_run(
+                    namespace_id=item.namespace_id,
+                    fixed_ref=item.fixed_ref,
+                    coverage_version=coverage_version,
                 )
+                prepared.append(
+                    CutoverVault(
+                        cutover_id=uuid.UUID(int=0),
+                        namespace_id=migration_run.namespace_id,
+                        migration_run_id=migration_run.run_id,
+                        fixed_git_oid=migration_run.fixed_git_oid,
+                        inventory_digest=migration_run.inventory_digest,
+                        status="planned",
+                        verification_digest=None,
+                        applied_at=None,
+                        verified_at=None,
+                    )
+                )
+            files = await self._file_inventory([item.namespace_id for item in eligible])
+            inventory_digest = self._cutover_inventory_digest(
+                vaults=prepared,
+                files=files,
+                exclusions=exclusions,
             )
-        files = await self._file_inventory([item.namespace_id for item in eligible])
-        inventory_digest = self._cutover_inventory_digest(
-            vaults=prepared,
-            files=files,
-            exclusions=exclusions,
-        )
-        run = await self.repository.get_or_create_run(
-            coverage_version=coverage_version,
-            inventory_digest=inventory_digest,
-            vaults=prepared,
-            files=files,
-            exclusions=exclusions,
-        )
+            run = await self.repository.get_or_create_run(
+                coverage_version=coverage_version,
+                inventory_digest=inventory_digest,
+                vaults=prepared,
+                files=files,
+                exclusions=exclusions,
+            )
+        except Exception as exc:
+            try:
+                if prepared:
+                    await self.backfill.repository.supersede_unlinked_pending_runs(
+                        item.migration_run_id for item in prepared
+                    )
+            except Exception as cleanup_exc:
+                exc.add_note(f"failed to compensate unlinked migration plans: {cleanup_exc}")
+            raise
         return await self._state(run)
+
+    async def supersede_orphan_plan(self, migration_run_id: uuid.UUID) -> MigrationRun:
+        """Release one exact never-applied run that has no outer cutover."""
+
+        superseded = await self.backfill.repository.supersede_unlinked_pending_runs([migration_run_id])
+        if superseded != (migration_run_id,):
+            raise CutoverIntegrityError("migration run is not an unlinked all-pending plan")
+        run = await self.backfill.repository.get_run(migration_run_id)
+        if run is None or run.status != "superseded":
+            raise CutoverIntegrityError("orphan migration run supersession was not durable")
+        return run
 
     @staticmethod
     def _validate_text_file(file: CutoverFile, data: bytes) -> str:

--- a/backend/tests/test_cli_native_revision_cutover_unit.py
+++ b/backend/tests/test_cli_native_revision_cutover_unit.py
@@ -120,6 +120,39 @@ def test_native_revision_cutover_cli_routes_abort(monkeypatch) -> None:
     assert calls == [("abort", {"coverage_version": None, "cutover_id": cutover_id})]
 
 
+def test_native_revision_cutover_cli_routes_exact_orphan_supersession(monkeypatch) -> None:
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    async def fake_execute(phase: str, **kwargs):
+        calls.append((phase, kwargs))
+        return {"status": "superseded"}
+
+    monkeypatch.setattr(cli, "_execute_native_revision_cutover", fake_execute)
+    migration_run_id = "00000000-0000-0000-0000-000000000003"
+
+    assert (
+        cli.main(
+            [
+                "migrate-revision-backend",
+                "supersede-orphan",
+                "--migration-run-id",
+                migration_run_id,
+            ]
+        )
+        == 0
+    )
+    assert calls == [
+        (
+            "supersede-orphan",
+            {
+                "coverage_version": None,
+                "cutover_id": None,
+                "migration_run_id": migration_run_id,
+            },
+        )
+    ]
+
+
 def test_native_revision_cutover_cli_rejects_incomplete_arguments(capsys) -> None:
     assert cli.main(["migrate-revision-backend", "apply"]) == 2
     assert "migrate-revision-backend" in capsys.readouterr().err

--- a/backend/tests/test_native_revision_cutover_pg.py
+++ b/backend/tests/test_native_revision_cutover_pg.py
@@ -23,6 +23,7 @@ from app.db import postgres
 from app.exceptions import ForbiddenError
 from app.models.document import DocumentUpdateRequest
 from app.repositories.native_revision_migration_repo import MigrationIntegrityError
+from app.repositories.native_revision_cutover_repo import CutoverIntegrityError
 from app.services import access_service
 from app.services.document_service import DocumentService
 from app.services.external_git_service import ExternalGitService
@@ -47,6 +48,7 @@ from app.services.native_revision_cutover import (
     NativeRevisionCutover,
     NativeRevisionCutoverVerifier,
 )
+from app.services.legacy_revision_bridge import InventoryEligibilityError
 from app.services.native_revision_backend import NativeRevisionBackend
 from app.services.uri_service import doc_uri, split_uri
 
@@ -532,6 +534,8 @@ async def test_aborting_classification_plan_releases_pending_item_reservations(t
         assert [item.namespace_id for item in classification.vaults] == [manual.namespace_id]
         assert [item.namespace_id for item in classification.exclusions] == [mirror_id]
         classification_run_id = classification.vaults[0].migration_run_id
+        with pytest.raises(CutoverIntegrityError, match="not an unlinked all-pending plan"):
+            await cutover.supersede_orphan_plan(classification_run_id)
         with pytest.raises(
             asyncpg.UniqueViolationError,
             match="native_revision_migration_items_active_resource_head_key",
@@ -593,6 +597,112 @@ async def test_aborting_classification_plan_releases_pending_item_reservations(t
             await cutover.apply(classification.cutover_id)
         with pytest.raises(MigrationIntegrityError, match="superseded"):
             await backfill.backfill_run(classification_run_id)
+
+
+async def test_operator_supersedes_one_exact_unlinked_pending_orphan(tmp_path):
+    """An operator can release a stranded pre-cutover plan by exact run ID."""
+    async with _fresh_schema() as pool:
+        git = GitService(storage_path=str(tmp_path / "git-unlinked-orphan"))
+        vault = await _manual_vault(pool, git, label="unlinked-orphan")
+        backfill = NativeRevisionBackfill(pool, git=git)
+        orphan, _ = await backfill.prepare_run(
+            namespace_id=vault.namespace_id,
+            fixed_ref=vault.fixed_ref,
+            coverage_version="fixture-unlinked-orphan-v1",
+        )
+
+        cutover = NativeRevisionCutover(
+            pool,
+            backfill=backfill,
+            verifier=_FixtureVerifier(pool),
+        )
+        superseded = await cutover.supersede_orphan_plan(orphan.run_id)
+        assert superseded.run_id == orphan.run_id
+        assert superseded.status == "superseded"
+        planned = await cutover.plan(
+            vaults=[vault],
+            coverage_version="fixture-unlinked-orphan-v2",
+        )
+
+        assert planned.vaults[0].migration_run_id != orphan.run_id
+        async with pool.acquire() as conn:
+            assert (
+                await conn.fetchval(
+                    "SELECT status FROM native_revision_migration_runs WHERE run_id = $1",
+                    orphan.run_id,
+                )
+                == "superseded"
+            )
+            assert (
+                await conn.fetchval(
+                    "SELECT reservation_active FROM native_revision_migration_items WHERE run_id = $1",
+                    orphan.run_id,
+                )
+                is False
+            )
+
+
+async def test_plan_failure_compensates_previously_prepared_unlinked_vaults(tmp_path, monkeypatch):
+    """A later vault validation error leaves no active reservation from this plan."""
+    async with _fresh_schema() as pool:
+        git = GitService(storage_path=str(tmp_path / "git-plan-compensation"))
+        vaults = sorted(
+            [
+                await _manual_vault(pool, git, label="plan-compensation-one"),
+                await _manual_vault(pool, git, label="plan-compensation-two"),
+            ],
+            key=lambda item: str(item.namespace_id),
+        )
+        backfill = NativeRevisionBackfill(pool, git=git)
+        prepare_run = backfill.prepare_run
+
+        async def fail_second_prepare(*, namespace_id, fixed_ref, coverage_version):
+            if namespace_id == vaults[1].namespace_id:
+                raise InventoryEligibilityError("fixture second-vault failure")
+            return await prepare_run(
+                namespace_id=namespace_id,
+                fixed_ref=fixed_ref,
+                coverage_version=coverage_version,
+            )
+
+        monkeypatch.setattr(backfill, "prepare_run", fail_second_prepare)
+        cutover = NativeRevisionCutover(
+            pool,
+            backfill=backfill,
+            verifier=_FixtureVerifier(pool),
+        )
+        with pytest.raises(InventoryEligibilityError, match="second-vault failure"):
+            await cutover.plan(
+                vaults=vaults,
+                coverage_version="fixture-plan-compensation-v1",
+            )
+
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT run.run_id, run.status, item.reservation_active
+                  FROM native_revision_migration_runs run
+                  JOIN native_revision_migration_items item ON item.run_id = run.run_id
+                 WHERE run.coverage_version = 'fixture-plan-compensation-v1'
+                """
+            )
+            assert row is not None
+            assert row["status"] == "superseded"
+            assert row["reservation_active"] is False
+            assert (
+                await conn.fetchval(
+                    "SELECT count(*) FROM native_revision_cutover_vaults WHERE migration_run_id = $1",
+                    row["run_id"],
+                )
+                == 0
+            )
+
+        monkeypatch.setattr(backfill, "prepare_run", prepare_run)
+        fresh = await cutover.plan(
+            vaults=vaults,
+            coverage_version="fixture-plan-compensation-v2",
+        )
+        assert len(fresh.vaults) == 2
 
 
 async def test_external_git_retirement_reclassifies_a_collector_adoption_and_requires_a_fresh_plan(tmp_path):


### PR DESCRIPTION
## Summary
- compensate unlinked all-pending migration runs when a multi-vault cutover plan fails before publication
- add an exact-run operator recovery command for older stranded plans
- serialize migration-run linking against orphan supersession

## Validation
- 23 passed — test_native_revision_cutover_pg.py
- 19 passed — test_native_revision_migration_bridge_pg.py
- 7 passed — test_cli_native_revision_cutover_unit.py
- Ruff and mypy passed on affected files

No applied/completed or outer-cutover-linked run can be superseded.