### PR TITLE
Fix Unicode paths in native cutover activity scan

### DIFF
--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -1699,6 +1699,39 @@ class GitService:
     @staticmethod
     def _parse_name_status_changes(output: str) -> tuple[dict[str, str | None], ...]:
         """Parse one Git name-status stream into path changes."""
+        if "\x00" in output:
+            fields = output.split("\x00")
+            if fields and fields[-1] == "":
+                fields.pop()
+            nul_changes: list[dict[str, str | None]] = []
+            index = 0
+            while index < len(fields):
+                status = fields[index]
+                index += 1
+                if status.startswith(("R", "C")):
+                    if index + 1 >= len(fields):
+                        raise ValueError("incomplete NUL-delimited rename/copy change")
+                    nul_changes.append(
+                        {
+                            "status": status,
+                            "path_from": fields[index],
+                            "path_to": fields[index + 1],
+                        }
+                    )
+                    index += 2
+                else:
+                    if index >= len(fields):
+                        raise ValueError("incomplete NUL-delimited path change")
+                    nul_changes.append(
+                        {
+                            "status": status,
+                            "path_from": None,
+                            "path_to": fields[index],
+                        }
+                    )
+                    index += 1
+            return tuple(nul_changes)
+
         changes: list[dict[str, str | None]] = []
         for line in str(output).splitlines():
             fields = line.split("\t")
@@ -1854,7 +1887,9 @@ class GitService:
                 output = repo.git.diff_tree(
                     "--root",
                     "-r",
+                    "--no-commit-id",
                     "--name-status",
+                    "-z",
                     "-M",
                     commit_oid,
                 )

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -346,6 +346,40 @@ def test_manual_fixed_ref_history_normalizes_legacy_edit_action(
     assert batched == snapshot
 
 
+def test_manual_fixed_ref_history_batch_preserves_unicode_activity_path(
+    git_service: GitService,
+) -> None:
+    name = f"unicode_activity_{uuid.uuid4().hex[:8]}"
+    git_service.init_vault(name)
+    path = "research/dynamo/전체-아키텍처.md"
+    current_oid = git_service.commit_file(
+        vault_name=name,
+        file_path=path,
+        content="# 전체 아키텍처\n",
+        message=(
+            "Import documentation\n\n"
+            "agent: fixture-collector\n"
+            "action: create\n"
+            "summary: unicode path"
+        ),
+    )
+
+    snapshot = git_service.manual_fixed_ref_history_batch(
+        name,
+        current_oid,
+        [
+            {
+                "file_path": path,
+                "current_commit": current_oid,
+                "since_epoch": None,
+            }
+        ],
+    )[0]
+
+    assert snapshot["activity"]["action"] == "create"
+    assert snapshot["activity"]["path_to"] == path
+
+
 def test_manual_fixed_ref_history_rejects_declared_activity_that_conflicts_with_git(
     git_service: GitService,
 ) -> None:


### PR DESCRIPTION
## Summary
- parse `git diff-tree` activity using NUL-delimited paths
- preserve Unicode document paths during Native cutover planning
- add regression coverage for a production-shaped Korean path

## Verification
- `pytest -q tests/test_git_service.py`
- focused lifecycle/recreate/Unicode tests
- `ruff check app/services/git_service.py tests/test_git_service.py`
- `mypy app/services/git_service.py`

Production v4 exposed this as a read-only plan failure before apply. Intermediate reservations were compensated by the already-merged orphan-plan fix.