### PR TITLE
Fix cutover history at recorded document head

### DIFF
--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -2110,7 +2110,12 @@ class GitService:
                     )
                     history: list[dict] = []
                     active_path = file_path
+                    reached_recorded_head = False
                     for oid, committed_at, changes in index.commits:
+                        if not reached_recorded_head:
+                            if oid != current_commit:
+                                continue
+                            reached_recorded_head = True
                         if (
                             effective_since is not None
                             and int(committed_at.timestamp()) < effective_since
@@ -2277,7 +2282,11 @@ class GitService:
         # path history. Native AKB writes keep the bounded legacy behavior.
         if since_epoch is not None and current.committed_date >= since_epoch:
             log_args.append(f"--since=@{since_epoch}")
-        log_args.extend(["--format=%H%x00%ct", fixed_ref, "--", file_path])
+        # ``documents.current_commit`` is the Legacy document authority.  A
+        # later orphan write may reuse the same path without updating that DB
+        # row, so history must stop at the recorded document head rather than
+        # absorbing unrelated path activity between it and the vault tip.
+        log_args.extend(["--format=%H%x00%ct", current_commit, "--", file_path])
         try:
             output = repo.git.log(*log_args)
         except (GitError, ValueError) as exc:

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -610,6 +610,55 @@ def test_manual_fixed_ref_history_batch_respects_same_path_recreate_boundary(
     assert [entry["legacy_git_oid"] for entry in batched[0]["history"]] == [recreated]
 
 
+def test_manual_fixed_ref_history_stops_at_recorded_current_commit(
+    git_service: GitService,
+) -> None:
+    """Later writes to a reused path do not belong to an older DB document."""
+    name = f"indexed_recorded_head_{uuid.uuid4().hex[:8]}"
+    git_service.init_vault(name)
+    recorded = _commit_file_at(
+        git_service,
+        name,
+        "notes/reused.md",
+        "recorded document\n",
+        "recorded create",
+        "2026-01-01T00:00:00+0000",
+    )
+    _commit_file_at(
+        git_service,
+        name,
+        "notes/reused.md",
+        "later orphan write\n",
+        "later create",
+        "2026-01-01T00:00:01+0000",
+    )
+    fixed_ref = _commit_file_at(
+        git_service,
+        name,
+        "unrelated.md",
+        "unrelated\n",
+        "unrelated tip",
+        "2026-01-01T00:00:02+0000",
+    )
+    request = {
+        "file_path": "notes/reused.md",
+        "current_commit": recorded,
+        "since_epoch": None,
+    }
+
+    single = git_service.manual_fixed_ref_history(
+        name,
+        fixed_ref,
+        request["file_path"],
+        current_commit=request["current_commit"],
+    )
+    batched = git_service.manual_fixed_ref_history_batch(name, fixed_ref, [request])
+
+    assert single["body"] == b"recorded document\n"
+    assert [entry["legacy_git_oid"] for entry in single["history"]] == [recorded]
+    assert batched == [single]
+
+
 def test_manual_fixed_ref_history_batch_keeps_same_second_commits(
     git_service: GitService,
 ) -> None:


### PR DESCRIPTION
## Summary\n- bound Legacy migration history to the DB-recorded document current_commit\n- ignore later orphan writes that reuse the same Git path\n- add regression coverage for single and batched fixed-ref history\n\n## Validation\n- 15 focused fixed-ref history tests\n- ruff on changed files\n- mypy on git_service.py