### PR TITLE
Support cutover create on reused Git path

### DIFF
--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -146,6 +146,11 @@ def _canonical_legacy_activity_action(action: str) -> str:
     return _LEGACY_ACTIVITY_ACTION_ALIASES.get(action, action)
 
 
+def _legacy_activity_matches_git_change(declared: str, inferred: str | None) -> bool:
+    """Accept Legacy resource creation when an orphan already owns the path."""
+    return not declared or declared == inferred or (declared == "create" and inferred == "update")
+
+
 def _marker_state(marker: Path) -> str:
     """Classify the on-disk ``_MIRROR_MARKER`` entry, fail-CLOSED.
 
@@ -1993,7 +1998,7 @@ class GitService:
         selected_change = selected_changes[0]
         inferred_action = selected_change["change"]
         action = declared_action or inferred_action
-        if action != inferred_action:
+        if not _legacy_activity_matches_git_change(declared_action, inferred_action):
             raise FixedRefHistoryError(
                 "fixed-ref current commit activity does not match the file action"
             )
@@ -2420,7 +2425,7 @@ class GitService:
         selected_change = changes[0]
         inferred_action = selected_change["change"]
         action = declared_action or inferred_action
-        if action != inferred_action:
+        if not _legacy_activity_matches_git_change(declared_action, inferred_action):
             raise FixedRefHistoryError(
                 "fixed-ref current commit activity does not match the file action"
             )

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -409,6 +409,55 @@ def test_manual_fixed_ref_history_rejects_declared_activity_that_conflicts_with_
         )
 
 
+def test_manual_fixed_ref_history_accepts_create_on_reused_git_path(
+    git_service: GitService,
+) -> None:
+    """A new DB resource may reuse a path that still exists in Legacy Git."""
+    name = f"reused_create_{uuid.uuid4().hex[:8]}"
+    git_service.init_vault(name)
+    git_service.commit_file(
+        vault_name=name,
+        file_path="notes/reused.md",
+        content="orphaned prior body\n",
+        message="orphaned prior write",
+    )
+    current_oid = git_service.commit_file(
+        vault_name=name,
+        file_path="notes/reused.md",
+        content="new resource body\n",
+        message=(
+            "Create replacement resource\n\n"
+            "agent: fixture-user\n"
+            "action: create\n"
+            "summary: create on reused path"
+        ),
+    )
+
+    single = git_service.manual_fixed_ref_history(
+        name,
+        current_oid,
+        "notes/reused.md",
+        current_commit=current_oid,
+    )
+    batched = git_service.manual_fixed_ref_history_batch(
+        name,
+        current_oid,
+        [
+            {
+                "file_path": "notes/reused.md",
+                "current_commit": current_oid,
+                "since_epoch": None,
+            }
+        ],
+    )[0]
+
+    assert single["activity"]["action"] == "create"
+    assert single["activity"]["changed_paths"] == [
+        {"change": "update", "path_from": None, "path_to": "notes/reused.md"}
+    ]
+    assert batched == single
+
+
 def test_manual_fixed_ref_history_batch_matches_per_path_history_for_lifecycle(
     git_service: GitService,
 ) -> None:


### PR DESCRIPTION
## Summary\n- preserve Legacy resource-level create semantics when a new DB document reuses an existing Git path\n- keep the underlying Git changed-path fact as update\n- continue rejecting incompatible update-on-new-path metadata\n\n## Validation\n- 16 focused fixed-ref history tests\n- ruff on changed files\n- mypy on git_service.py\n\nThis is the minimal compatibility fix for the production mhlee-knowledge document observed during the read-only v6 plan.