### PR TITLE
fix: stream native cutover lineage revisions

### DIFF
--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -35,6 +35,7 @@ import selectors
 import shutil
 import stat
 import subprocess
+import tempfile
 import threading
 import time
 import uuid
@@ -1855,6 +1856,64 @@ class GitService:
             raise FixedRefHistoryError("fixed-ref history could not be read") from exc
         return _FixedRefHistoryIndex(commits)
 
+    @staticmethod
+    def _independent_commit_oids(
+        repo: Repo,
+        current_oids: Iterable[str],
+    ) -> tuple[str, ...]:
+        """Resolve independent lineage tips without placing OIDs in argv.
+
+        ``git merge-base --independent`` accepts revisions only as command-line
+        arguments and exceeds ``ARG_MAX`` for large imported vaults. Feed the
+        revisions to one topological ``rev-list --stdin`` walk instead. A
+        current commit first encountered outside the ancestry already covered
+        by another current commit is an independent lineage tip.
+        """
+        current_set = set(current_oids)
+        if not current_set:
+            return ()
+        try:
+            with tempfile.TemporaryFile(mode="w+b") as revisions:
+                revisions.write(
+                    "".join(f"{oid}\n" for oid in sorted(current_set)).encode("ascii")
+                )
+                revisions.seek(0)
+                output = repo.git.rev_list(
+                    "--stdin",
+                    "--topo-order",
+                    "--parents",
+                    istream=revisions,
+                )
+        except (GitError, OSError, ValueError) as exc:
+            raise FixedRefHistoryError(
+                "fixed-ref history could not resolve current lineages"
+            ) from exc
+
+        covered: set[str] = set()
+        seen_current: set[str] = set()
+        lineage_tips: list[str] = []
+        for line in str(output).splitlines():
+            fields = line.split()
+            if not fields:
+                continue
+            oid, *parents = fields
+            is_covered = oid in covered
+            covered.discard(oid)
+            is_current = oid in current_set
+            if is_current:
+                seen_current.add(oid)
+            is_tip = is_current and not is_covered
+            if is_tip:
+                lineage_tips.append(oid)
+            if is_covered or is_tip:
+                covered.update(parents)
+
+        if seen_current != current_set or not lineage_tips:
+            raise FixedRefHistoryError(
+                "fixed-ref history could not resolve current lineages"
+            )
+        return tuple(sorted(lineage_tips))
+
     def _indexed_commit_metadata(
         self,
         repo: Repo,
@@ -2218,22 +2277,7 @@ class GitService:
                     validated_current[current_commit] = current
 
                 current_oids = sorted(validated_current)
-                try:
-                    lineage_tips = tuple(
-                        oid
-                        for oid in str(
-                            repo.git.merge_base("--independent", *current_oids)
-                        ).splitlines()
-                        if oid
-                    )
-                except GitError as exc:
-                    raise FixedRefHistoryError(
-                        "fixed-ref history could not resolve current lineages"
-                    ) from exc
-                if not lineage_tips:
-                    raise FixedRefHistoryError(
-                        "fixed-ref history could not resolve current lineages"
-                    )
+                lineage_tips = self._independent_commit_oids(repo, current_oids)
 
                 positions_by_current: dict[str, list[int]] = {}
                 for position, (

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -846,6 +846,55 @@ def test_manual_fixed_ref_history_batches_independent_imported_lineages(
     ]
 
 
+def test_independent_commit_oids_streams_large_revision_sets(
+    git_service: GitService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lineage discovery must not expand the revision set into process argv."""
+    name = f"indexed_streamed_{uuid.uuid4().hex[:8]}"
+    git_service.init_vault(name)
+    parent = git_service.commit_file(
+        vault_name=name,
+        file_path="seed.md",
+        content="seed\n",
+        message="seed",
+    )
+    repo = Repo(str(git_service._bare_path(name)))
+    tree = repo.git.rev_parse(f"{parent}^{{tree}}")
+    current_oids: list[str] = []
+    with repo.git.custom_environment(
+        GIT_AUTHOR_NAME="Fixture",
+        GIT_AUTHOR_EMAIL="fixture@example.dev",
+        GIT_COMMITTER_NAME="Fixture",
+        GIT_COMMITTER_EMAIL="fixture@example.dev",
+    ):
+        for index in range(128):
+            parent = repo.git.commit_tree(
+                tree,
+                "-p",
+                parent,
+                "-m",
+                f"streamed lineage {index}",
+            ).strip()
+            current_oids.append(parent)
+
+    git_type = type(repo.git)
+    original_execute = git_type.execute
+
+    def reject_large_argv(self, command, *args, **kwargs):
+        if len(command) > 16:
+            raise OSError("simulated ARG_MAX overflow")
+        return original_execute(self, command, *args, **kwargs)
+
+    monkeypatch.setattr(git_type, "execute", reject_large_argv)
+    try:
+        tips = git_service._independent_commit_oids(repo, current_oids)
+    finally:
+        repo.close()
+
+    assert tips == (current_oids[-1],)
+
+
 def test_manual_fixed_ref_history_batch_keeps_same_second_commits(
     git_service: GitService,
 ) -> None:


### PR DESCRIPTION
Summary:
- stream large current-commit sets through git rev-list stdin
- preserve independent-lineage grouping without expanding OIDs into process argv
- add an ARG_MAX regression covering 128 distinct commits

Validation:
- 18 focused fixed-ref/history tests passed
- Ruff check passed on changed files
- mypy passed on git_service.py

Production boundary: v8 plan failed before apply with E2BIG while passing 5,611 OIDs to git merge-base independent; this change removes only that argv-size dependency.