### PR TITLE
fix: preserve NUL in native document bodies

### DIFF
--- a/backend/app/services/git_service.py
+++ b/backend/app/services/git_service.py
@@ -2186,10 +2186,6 @@ class GitService:
         if include_bodies:
             snapshot["body"] = body
         else:
-            if b"\x00" in body:
-                raise FixedRefHistoryError(
-                    "fixed-ref body contains NUL bytes"
-                )
             snapshot["body_digest"] = hashlib.sha256(body).hexdigest()
             snapshot["byte_size"] = len(body)
         return snapshot

--- a/backend/app/services/legacy_revision_bridge.py
+++ b/backend/app/services/legacy_revision_bridge.py
@@ -548,8 +548,6 @@ class LegacyRevisionBridge:
         if not isinstance(history, list) or not isinstance(raw_activity, Mapping):
             raise InventoryEligibilityError(f"document {resource_id} returned invalid fixed-ref metadata")
         if isinstance(body, bytes):
-            if b"\x00" in body:
-                raise InventoryEligibilityError(f"document {resource_id} body contains NUL bytes")
             try:
                 body.decode("utf-8", errors="strict")
             except UnicodeDecodeError as exc:
@@ -917,8 +915,6 @@ class LegacyRevisionBridge:
         del text
         if len(body) != document.byte_size or hashlib.sha256(body).hexdigest() != document.body_digest:
             raise InventoryEligibilityError(f"document {document.resource_id} body differs from the frozen inventory")
-        if b"\x00" in body:
-            raise InventoryEligibilityError(f"document {document.resource_id} body contains NUL bytes")
         try:
             body.decode("utf-8", errors="strict")
         except UnicodeDecodeError as exc:

--- a/backend/app/services/m1_pg_body_store.py
+++ b/backend/app/services/m1_pg_body_store.py
@@ -84,9 +84,9 @@ class M1PgBodyStore:
             canonical.decode("utf-8", errors="strict")
         except UnicodeDecodeError as exc:
             raise ValidationError("PostgreSQL text body must be valid UTF-8") from exc
-        if b"\x00" in canonical:
-            raise ValidationError("PostgreSQL text body must not contain NUL bytes")
-
+        # ``canonical_bytes`` is BYTEA, not PostgreSQL TEXT.  Preserve U+0000
+        # because the legacy document API accepts it as valid UTF-8 and native
+        # cutover must remain byte-compatible with those existing Documents.
         digest = hashlib.sha256(canonical).hexdigest()
         if expected_digest is not None and expected_digest != digest:
             raise ValidationError("PostgreSQL body digest does not match expected digest")
@@ -218,8 +218,6 @@ class M1PgBodyStore:
             canonical.decode("utf-8", errors="strict")
         except UnicodeDecodeError as exc:
             raise PgBodyIntegrityError("PostgreSQL body is not valid UTF-8") from exc
-        if b"\x00" in canonical:
-            raise PgBodyIntegrityError("PostgreSQL body contains NUL bytes")
         if row["selected_placement"] != cls.selected_placement:
             raise PgBodyIntegrityError("PostgreSQL body placement mismatch")
         if row["verification_profile"] != cls.verification_profile:

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -602,7 +602,7 @@ def test_manual_fixed_ref_history_batch_matches_per_path_history_for_lifecycle(
         assert compact["byte_size"] == len(full["body"])
 
 
-def test_manual_fixed_ref_history_batch_compact_inventory_rejects_nul(
+def test_manual_fixed_ref_history_batch_compact_inventory_preserves_nul(
     git_service: GitService,
 ) -> None:
     name = f"indexed_nul_{uuid.uuid4().hex[:8]}"
@@ -626,19 +626,21 @@ def test_manual_fixed_ref_history_batch_compact_inventory_rejects_nul(
     repo.index.commit("binary body")
     fixed_ref = repo.git.rev_parse("HEAD").strip()
 
-    with pytest.raises(FixedRefHistoryError, match="contains NUL bytes"):
-        git_service.manual_fixed_ref_history_batch(
-            name,
-            fixed_ref,
-            [
-                {
-                    "file_path": "binary.md",
-                    "current_commit": fixed_ref,
-                    "since_epoch": None,
-                }
-            ],
-            include_bodies=False,
-        )
+    snapshots = git_service.manual_fixed_ref_history_batch(
+        name,
+        fixed_ref,
+        [
+            {
+                "file_path": "binary.md",
+                "current_commit": fixed_ref,
+                "since_epoch": None,
+            }
+        ],
+        include_bodies=False,
+    )
+
+    assert snapshots[0]["body_digest"] == hashlib.sha256(b"before\x00after").hexdigest()
+    assert snapshots[0]["byte_size"] == len(b"before\x00after")
 
 
 def test_manual_fixed_ref_history_batch_respects_same_path_recreate_boundary(

--- a/backend/tests/test_m1_pg_body_grep_unit.py
+++ b/backend/tests/test_m1_pg_body_grep_unit.py
@@ -38,10 +38,20 @@ def test_pg_body_candidate_verifies_one_canonical_utf8_representation():
     )
 
 
-@pytest.mark.parametrize("payload", [b"bad\x00text", b"\xff"])
+@pytest.mark.parametrize("payload", [b"\xff"])
 def test_pg_body_candidate_rejects_non_searchable_bytes(payload: bytes):
     with pytest.raises(ValidationError):
         M1PgBodyStore._verified_bytes(payload)
+
+
+def test_pg_body_candidate_preserves_utf8_nul_bytes():
+    payload = b"before\x00after"
+
+    canonical, digest = M1PgBodyStore._verified_bytes(payload)
+
+    assert canonical == payload
+    assert digest == hashlib.sha256(payload).hexdigest()
+    assert M1PgBodyStore._verify_row(_row(payload)) == payload
 
 
 def test_pg_body_candidate_rejects_oversize_before_text_scan(monkeypatch):

--- a/backend/tests/test_native_revision_migration_bridge_pg.py
+++ b/backend/tests/test_native_revision_migration_bridge_pg.py
@@ -405,6 +405,46 @@ async def test_inventory_is_fixed_ref_bounded_and_includes_archived_manual_vault
             )
 
 
+async def test_inventory_and_pg_body_store_preserve_utf8_nul_bytes(tmp_path):
+    async with _fresh_schema(tmp_path) as pool:
+        fixture = await _make_fixture(pool, tmp_path)
+        text = "before\x00after\n"
+        current_oid = fixture["git"].commit_file(
+            fixture["vault_name"],
+            "renamed.md",
+            text,
+            "[update] renamed.md\n\nagent: legacy-writer\naction: update\nsummary: preserve NUL text",
+        )
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE documents SET current_commit = $2 WHERE id = $1",
+                fixture["document_one"],
+                current_oid,
+            )
+
+        bridge = LegacyRevisionBridge(pool, git=fixture["git"])
+        scope = await bridge.capture_inventory_scope(
+            namespace_id=fixture["namespace_id"],
+            fixed_ref=current_oid,
+            coverage_version="c9-nul-compat",
+        )
+        document = scope.documents_by_id[fixture["document_one"]]
+        expected = text.encode("utf-8")
+
+        assert document.body_digest == hashlib.sha256(expected).hexdigest()
+        assert document.byte_size == len(expected)
+        async with bridge.materialize_body(scope, document) as body:
+            assert body == expected
+            prepared = await M1PgBodyStore(pool).prepare_text(
+                namespace_id=fixture["namespace_id"],
+                payload=body,
+                expected_digest=document.body_digest,
+                expected_size=document.byte_size,
+            )
+
+        assert await M1PgBodyStore(pool).open_verified(prepared.payload_id) == expected
+
+
 async def test_inventory_accepts_plain_git_activity_without_akb_footers(tmp_path):
     async with _fresh_schema(tmp_path) as pool:
         git = GitService(storage_path=str(tmp_path / "plain-import-git"))


### PR DESCRIPTION
## Summary
- preserve valid UTF-8 document bodies containing U+0000 across fixed-ref inventory capture
- store and verify those exact bytes in the PostgreSQL BYTEA body store
- add Git inventory, body-store, and migration regression coverage

## Production finding
The fenced production inventory contains exactly three manual Markdown Documents with valid UTF-8 bodies containing NUL bytes. The legacy document path accepts these bytes, while the native cutover rejected them before apply. This change removes that compatibility-only rejection without relaxing UTF-8, digest, size, or 10 MiB validation.

## Validation
- 17 fixed-ref Git history tests passed
- 33 PostgreSQL body/grep unit tests passed
- focused NUL compatibility tests: 3 passed; PostgreSQL integration test skipped locally because disposable PostgreSQL was unavailable
- Ruff passed on affected files
- mypy passed on affected services