### PR TITLE
fix(auth): keep 0.14 rollback config compatible

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -658,6 +658,11 @@ class Settings(BaseModel):
     keycloak_realm: str = "akb"
     keycloak_client_id: str = "akb-web"
     keycloak_client_secret: str = ""       # secret.yaml — blank for public (PKCE) clients
+    # Accepted for configuration compatibility with the newer product-admin
+    # client.  The 0.14.x hybrid runtime does not use this credential itself;
+    # retaining it here lets a shared secret.yaml be mounted without weakening
+    # strict rejection of every other unknown setting.
+    keycloak_admin_client_secret: str = ""
     keycloak_public_client: bool = False   # true → PKCE (no client_secret); false → confidential
     keycloak_verify_ssl: bool = True       # set false only for local self-signed Keycloak
     # Exact identity is issuer/subject and does not require email. During the

--- a/backend/tests/test_legacy_hybrid_config_compat_unit.py
+++ b/backend/tests/test_legacy_hybrid_config_compat_unit.py
@@ -1,0 +1,17 @@
+"""Compatibility coverage for the bounded 0.14.x rollback runtime."""
+
+from app.config import Settings
+
+
+def test_hybrid_runtime_accepts_newer_admin_client_secret_field() -> None:
+    configured = Settings(
+        keycloak_enabled=True,
+        keycloak_sso_only=False,
+        local_auth_enabled=True,
+        keycloak_admin_client_secret="test-admin-client-secret",  # pragma: allowlist secret
+    )
+
+    assert configured.keycloak_enabled is True
+    assert configured.keycloak_sso_only is False
+    assert configured.local_auth_enabled is True
+    assert configured.keycloak_admin_client_secret == "test-admin-client-secret"

--- a/backend/tests/test_legacy_hybrid_config_compat_unit.py
+++ b/backend/tests/test_legacy_hybrid_config_compat_unit.py
@@ -2,16 +2,18 @@
 
 from app.config import Settings
 
+_ADMIN_SECRET = "test-admin-client-secret"  # pragma: allowlist secret
+
 
 def test_hybrid_runtime_accepts_newer_admin_client_secret_field() -> None:
     configured = Settings(
         keycloak_enabled=True,
         keycloak_sso_only=False,
         local_auth_enabled=True,
-        keycloak_admin_client_secret="test-admin-client-secret",  # pragma: allowlist secret
+        keycloak_admin_client_secret=_ADMIN_SECRET,
     )
 
     assert configured.keycloak_enabled is True
     assert configured.keycloak_sso_only is False
     assert configured.local_auth_enabled is True
-    assert configured.keycloak_admin_client_secret == "test-admin-client-secret"
+    assert configured.keycloak_admin_client_secret == _ADMIN_SECRET


### PR DESCRIPTION
## Summary
- accept the newer product-admin client secret key in the bounded 0.14.x runtime
- preserve existing hybrid local + Keycloak behavior
- retain strict rejection for every other unknown configuration key

## Validation
- `uv run pytest -q tests/test_legacy_hybrid_config_compat_unit.py tests/test_auth_config_shape_unit.py` (7 passed)
- `uv run ruff check app/config.py tests/test_legacy_hybrid_config_compat_unit.py`

This is a maintenance-only rollback compatibility patch; it does not change current main authentication policy.