### PR TITLE
fix(vaults): make global name conflicts non-disclosing

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3683
+        "line_number": 3693
       }
     ],
     "backend/mcp_server/help.py": [
@@ -166,7 +166,7 @@
         "filename": "backend/mcp_server/help.py",
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_verified": false,
-        "line_number": 1191,
+        "line_number": 1195,
         "is_secret": false
       }
     ],
@@ -6987,5 +6987,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-03T05:09:42Z"
+  "generated_at": "2026-09-07T03:53:01Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -7,6 +7,16 @@ specifically; the proxy has its own log in
 
 ## Unreleased
 
+### Made globally reserved Vault-name conflicts non-disclosing
+
+Vault creation now returns the same `vault_name_unavailable` conflict for an
+existing name and for concurrent database or Git creation races. The response
+does not expose the conflicting Vault's name, owner, visibility, or state, and
+the contract is shared by REST, MCP, standard, native-ledger, and external-git
+creation paths. The create UI documents installation-wide uniqueness and only
+offers to open an existing Vault when that Vault is already present in the
+caller's access-filtered list.
+
 ### Added the strict App Release Manifest v2 contract
 
 App release registration now requires a v2-only manifest with immutable app

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -43,6 +43,12 @@ doc_service = get_document_service()
 
 @router.post("/vaults", summary="Create a new vault")
 async def create_vault(name: str, description: str = "", template: str | None = None, public_access: str = "none", user: AuthenticatedUser = Depends(get_current_user)):
+    """Create a Vault whose name is unique across this AKB installation.
+
+    Any unavailable name returns HTTP 409 with the stable
+    ``vault_name_unavailable`` code.  The response intentionally does not say
+    whether the conflicting Vault is visible to the caller.
+    """
     if template is not None and template not in template_registry.list_names():
         raise HTTPException(
             status.HTTP_400_BAD_REQUEST,

--- a/backend/app/exceptions.py
+++ b/backend/app/exceptions.py
@@ -71,6 +71,25 @@ class ConflictError(AKBError):
         )
 
 
+VAULT_NAME_UNAVAILABLE = "vault_name_unavailable"
+
+
+class VaultNameUnavailableError(ConflictError):
+    """A globally reserved Vault name cannot be assigned to the caller.
+
+    The message deliberately carries no Vault, owner, visibility, or lifecycle
+    data.  Callers that cannot see an existing private Vault must receive the
+    same response as callers colliding with one they can see, including when
+    the database UNIQUE constraint resolves a concurrent create race.
+    """
+
+    def __init__(self):
+        super().__init__(
+            "Vault name is unavailable. Choose a different name.",
+            code=VAULT_NAME_UNAVAILABLE,
+        )
+
+
 DOCUMENT_TITLE_CONFLICT = "document_title_conflict"
 
 

--- a/backend/app/repositories/vault_repo.py
+++ b/backend/app/repositories/vault_repo.py
@@ -6,6 +6,8 @@ import uuid
 
 import asyncpg
 
+from app.exceptions import VaultNameUnavailableError
+
 
 async def lock_vault_for_child_write(conn, vault_id: uuid.UUID) -> bool:
     """Hold the parent vault before locking or writing child resources.
@@ -61,9 +63,19 @@ class VaultRepository:
         vault_id = uuid.uuid4()
         sql = "INSERT INTO vaults (id, name, description, git_path, owner_id, public_access) VALUES ($1, $2, $3, $4, $5, $6)"
         args = (vault_id, name, description, git_path, owner_id, public_access)
-        if conn is not None:
-            await conn.execute(sql, *args)
-        else:
-            async with self.pool.acquire() as acq:
-                await acq.execute(sql, *args)
+        try:
+            if conn is not None:
+                await conn.execute(sql, *args)
+            else:
+                async with self.pool.acquire() as acq:
+                    await acq.execute(sql, *args)
+        except asyncpg.UniqueViolationError as exc:
+            # The database is the final authority for globally unique Vault
+            # names.  Mapping here keeps standard, native, external-git, REST,
+            # and MCP create paths identical when concurrent requests both
+            # pass an advisory pre-check.  Other UNIQUE constraints remain
+            # programming/data errors and must not be mislabeled.
+            if exc.constraint_name == "vaults_name_key":
+                raise VaultNameUnavailableError() from exc
+            raise
         return vault_id

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -118,6 +118,7 @@ from app.exceptions import (
     DocumentTitleConflictError,
     NotFoundError,
     ValidationError,
+    VaultNameUnavailableError,
     WriteBusyError,
 )
 from app.models.document import (
@@ -2165,7 +2166,7 @@ class DocumentService:
         public_access = validate_public_access(public_access)
 
         if await vault_repo.get_by_name(name):
-            raise ConflictError(f"Vault already exists: {name}")
+            raise VaultNameUnavailableError()
 
         uid = uuid.UUID(owner_id) if owner_id else None
 
@@ -2263,8 +2264,20 @@ class DocumentService:
         existed_before = await asyncio.to_thread(self.git.vault_exists, name)
         git_path: str | None = None
         created_vault_id: uuid.UUID | None = None
+        collided_before_disk_create = False
         try:
-            git_path = await run_git_write(self.git.init_vault, name)
+            try:
+                git_path = await run_git_write(self.git.init_vault, name)
+            except FileExistsError as exc:
+                # Another process can win after the advisory DB pre-check but
+                # before this request obtains the storage-backed create lock.
+                # Keep that race on the same non-disclosing 409 contract as a
+                # database UNIQUE collision; the outer handler still performs
+                # ownership-aware compensation for failures that happen after
+                # this request creates storage.  This request created nothing,
+                # so its outer handler must not remove the winner's directory.
+                collided_before_disk_create = True
+                raise VaultNameUnavailableError() from exc
             vault_yaml = f"name: {name}\ndescription: {description}\n"
             if template:
                 vault_yaml += f"template: {template}\n"
@@ -2311,6 +2324,8 @@ class DocumentService:
                     skill_internal=True,
                 )
         except BaseException:
+            if collided_before_disk_create:
+                raise
             # run_compensation: the whole rollback runs to COMPLETION even
             # if the cancellation that may be unwinding us keeps firing;
             # the cancel is re-delivered afterwards. Any rollback-internal

--- a/backend/app/services/external_git_service.py
+++ b/backend/app/services/external_git_service.py
@@ -165,9 +165,20 @@ class ExternalGitService:
         """
         host = _host_only(remote_url)
         if not self.git.vault_exists(vault_name):
-            logger.info("Bootstrap clone: vault=%s host=%s", vault_name, host)
-            sha = self.git.clone_mirror(vault_name, remote_url, branch, auth_token)
-            return ("cloned", sha)
+            # Join standard Vault creation's cross-process lock before
+            # materialising an absent bare path. Without this, a standard
+            # create that already observed "absent" can mistake this poller's
+            # mirror for its own failed-create artefact and remove it during
+            # compensation. Re-check after the wait because the standard
+            # winner may have created and then rolled back the same path.
+            creation_fd = self.git.acquire_vault_creation_lock(vault_name)
+            try:
+                if not self.git.vault_exists(vault_name):
+                    logger.info("Bootstrap clone: vault=%s host=%s", vault_name, host)
+                    sha = self.git.clone_mirror(vault_name, remote_url, branch, auth_token)
+                    return ("cloned", sha)
+            finally:
+                self.git.release_vault_creation_lock(creation_fd)
         # A normal marker is written only by a fresh clone or the
         # DB-authoritative startup backfill. Do NOT recreate it from this stale
         # poller snapshot: after a completed retirement the retained bare is a

--- a/backend/app/services/native_document_service.py
+++ b/backend/app/services/native_document_service.py
@@ -26,6 +26,7 @@ from app.exceptions import (
     DocumentTitleConflictError,
     NotFoundError,
     ValidationError,
+    VaultNameUnavailableError,
 )
 from app.models.document import (
     DOC_STATUSES,
@@ -1382,7 +1383,7 @@ class NativeDocumentService(DocumentService):
         pool = await self._pool()
         vault_repo = VaultRepository(pool)
         if await vault_repo.get_by_name(name):
-            raise ConflictError(f"Vault already exists: {name}")
+            raise VaultNameUnavailableError()
         uid = uuid.UUID(owner_id) if owner_id else None
         vault_id: uuid.UUID | None = None
         # These strict same-connection hooks observe the uncommitted catalog
@@ -1412,7 +1413,7 @@ class NativeDocumentService(DocumentService):
                     )
         except asyncpg.UniqueViolationError as exc:
             if exc.constraint_name == "vaults_name_key":
-                raise ConflictError(f"Vault already exists: {name}") from exc
+                raise VaultNameUnavailableError() from exc
             raise
         assert vault_id is not None
         # POST-COMMIT (the transaction above has exited). Drops any negative

--- a/backend/app/util/errors.py
+++ b/backend/app/util/errors.py
@@ -38,6 +38,7 @@ from app.exceptions import (
     ForbiddenError,
     InvalidColumnTypeError,
     NotFoundError,
+    VAULT_NAME_UNAVAILABLE,
     ValidationError,
     WriteBusyError,
 )
@@ -173,6 +174,8 @@ def exception_envelope(e: Exception) -> dict:
     if isinstance(e, NotFoundError):
         return err(str(e), code=NOT_FOUND)
     if isinstance(e, ConflictError):
+        if e.code == VAULT_NAME_UNAVAILABLE:
+            return err(str(e), code=VAULT_NAME_UNAVAILABLE)
         if e.code == DOCUMENT_TITLE_CONFLICT:
             return err(
                 str(e),

--- a/backend/mcp_server/help.py
+++ b/backend/mcp_server/help.py
@@ -1050,7 +1050,7 @@ akb_list_vaults()
 ## Parameters
 | Param | Required | Description |
 |-------|----------|-------------|
-| name | ✓ | Lowercase, hyphens allowed |
+| name | ✓ | Unique across this AKB installation; lowercase letters and digits with single hyphens between words. Becomes part of the canonical `akb://` URI |
 | description | | What this vault is for |
 | template | | Pre-populate with collections |
 
@@ -1060,7 +1060,11 @@ akb_list_vaults()
 ## Example
 ```
 akb_create_vault(name="project-x", description="Project X docs", template="engineering")
-```""",
+```
+
+If the name cannot be assigned, the tool returns the stable
+`vault_name_unavailable` conflict without revealing another Vault's owner,
+visibility, or state.""",
 
     "akb_create_collection": """# akb_create_collection — Create an Empty Collection
 

--- a/backend/mcp_server/tools.py
+++ b/backend/mcp_server/tools.py
@@ -74,13 +74,20 @@ TOOLS = [
         name="akb_create_vault",
         description=(
             "Create a new knowledge base vault (a separate, access-controlled repository for documents). "
+            "Its name is unique across the AKB installation and becomes part of the canonical akb:// URI. "
             "Pass `external_git` to instead create a read-only mirror of an upstream git repo — the vault "
             "tracks the remote on a polling schedule and rejects user writes."
         ),
         input_schema={
             "type": "object",
             "properties": {
-                "name": {"type": "string", "description": "Vault name (lowercase, hyphens allowed)"},
+                "name": {
+                    "type": "string",
+                    "description": (
+                        "Globally unique Vault name: lowercase letters and digits, "
+                        "with single hyphens between words"
+                    ),
+                },
                 "description": {"type": "string", "description": "What this vault is for"},
                 "template": {
                     "type": "string",

--- a/backend/scripts/ci/e2e_suite_runner.py
+++ b/backend/scripts/ci/e2e_suite_runner.py
@@ -28,6 +28,7 @@ CURATED_SUITES: tuple[str, ...] = (
     "test_mcp_e2e.sh",
     "test_edit_e2e.sh",
     "test_security_edge_e2e.sh",
+    "test_vault_name_conflict_e2e.sh",
     "test_pg_rbac_e2e.sh",
     "test_vault_scope_e2e.sh",
     "test_vault_scope_sql_e2e.sh",

--- a/backend/tests/concurrency/test_native_ledger_b_core.py
+++ b/backend/tests/concurrency/test_native_ledger_b_core.py
@@ -19,7 +19,7 @@ import asyncpg
 import frontmatter
 import pytest
 
-from app.exceptions import ConflictError, NotFoundError, ValidationError
+from app.exceptions import ConflictError, NotFoundError, ValidationError, VaultNameUnavailableError
 from app.models.document import DocumentPutRequest, DocumentUpdateRequest
 from app.repositories.native_revision_repo import NativeRevisionRepository
 from app.services.document_service import VAULT_SKILL_SEED_TEMPLATE
@@ -938,7 +938,10 @@ async def test_native_vault_create_concurrent_same_name_returns_one_conflict(mon
         )
 
         assert len([result for result in outcomes if isinstance(result, str)]) == 1
-        assert len([result for result in outcomes if isinstance(result, ConflictError)]) == 1
+        conflicts = [result for result in outcomes if isinstance(result, VaultNameUnavailableError)]
+        assert len(conflicts) == 1
+        assert conflicts[0].code == "vault_name_unavailable"
+        assert str(conflicts[0]) == "Vault name is unavailable. Choose a different name."
         async with pool.acquire() as conn:
             winner = await conn.fetchrow("SELECT id FROM vaults WHERE name = $1", vault_name)
             assert winner is not None

--- a/backend/tests/test_mcp_error_envelope_unit.py
+++ b/backend/tests/test_mcp_error_envelope_unit.py
@@ -15,6 +15,7 @@ from app.exceptions import (
     ForbiddenError,
     NotFoundError,
     ValidationError,
+    VaultNameUnavailableError,
 )
 from app.util.errors import (
     exception_envelope,
@@ -23,6 +24,7 @@ from app.util.errors import (
     INVALID_ARGUMENT,
     NOT_FOUND,
     PERMISSION_DENIED,
+    VAULT_NAME_UNAVAILABLE,
 )
 
 
@@ -42,6 +44,14 @@ def test_notfound_maps_to_not_found():
 
 def test_conflict_maps_to_conflict():
     assert exception_envelope(ConflictError("Table already exists: t"))["code"] == CONFLICT
+
+
+def test_vault_name_conflict_keeps_specific_non_disclosing_code():
+    env = exception_envelope(VaultNameUnavailableError())
+    assert env == {
+        "error": "Vault name is unavailable. Choose a different name.",
+        "code": VAULT_NAME_UNAVAILABLE,
+    }
 
 
 def test_validation_maps_to_invalid_argument():

--- a/backend/tests/test_vault_name_conflict_e2e.sh
+++ b/backend/tests/test_vault_name_conflict_e2e.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+#
+# Vault-name confidentiality and create-race contract.
+# Runs in the repository-owned HTTP E2E runtime and uses only ephemeral data.
+
+set -uo pipefail
+
+BASE_URL="${AKB_URL:-http://localhost:8000}"
+SUFFIX=$(python3 -c 'import uuid; print(uuid.uuid4().hex[:12])')
+PASSWORD=$(python3 -c 'import secrets; print(secrets.token_urlsafe(18))')
+ALICE="vault-name-a-$SUFFIX"
+BOB="vault-name-b-$SUFFIX"
+HIDDEN_VAULT="hidden-vault-$SUFFIX"
+RACE_VAULT="race-vault-$SUFFIX"
+PASS=0
+FAIL=0
+ERRORS=()
+TMP=$(mktemp -d)
+
+cleanup() {
+  rm -r "$TMP"
+}
+trap cleanup EXIT
+
+pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL+1)); ERRORS+=("$1: $2"); echo "  ✗ $1 — $2"; }
+
+register_and_pat() {
+  local username=$1
+  local jwt
+  curl -sk -X POST "$BASE_URL/api/v1/auth/register" \
+    -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$username\",\"email\":\"$username@test.invalid\",\"password\":\"$PASSWORD\"}" \
+    >/dev/null
+  jwt=$(curl -sk -X POST "$BASE_URL/api/v1/auth/login" \
+    -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$username\",\"password\":\"$PASSWORD\"}" \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin).get("token", ""))' 2>/dev/null)
+  curl -sk -X POST "$BASE_URL/api/v1/auth/tokens" \
+    -H "Authorization: Bearer $jwt" \
+    -H 'Content-Type: application/json' \
+    -d '{"name":"vault-name-contract"}' \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin).get("token", ""))' 2>/dev/null
+}
+
+rest_conflict_is_safe() {
+  local body_file=$1
+  local attempted_name=$2
+  python3 -c '
+import json, sys
+body = json.load(open(sys.argv[1]))
+attempted = sys.argv[2]
+fixed = "Vault name is unavailable. Choose a different name."
+expected = {
+    "message": fixed,
+    "error": fixed,
+    "code": "vault_name_unavailable",
+    "detail": {
+        "message": fixed,
+        "code": "vault_name_unavailable",
+    },
+}
+ok = body == expected and attempted not in json.dumps(body)
+raise SystemExit(0 if ok else 1)
+' "$body_file" "$attempted_name"
+}
+
+mcp_call() {
+  local pat=$1 sid=$2 id=$3 tool=$4 args=$5
+  curl -sk -X POST "$BASE_URL/mcp/" \
+    -H "Authorization: Bearer $pat" \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json, text/event-stream' \
+    -H "mcp-session-id: $sid" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}"
+}
+
+echo "▸ Setup isolated users"
+ALICE_PAT=$(register_and_pat "$ALICE")
+BOB_PAT=$(register_and_pat "$BOB")
+if [ -n "$ALICE_PAT" ] && [ -n "$BOB_PAT" ]; then
+  pass "two users received independent PATs"
+else
+  fail "setup" "PAT creation failed"
+  exit 1
+fi
+
+ALICE_AUTH="Authorization: Bearer $ALICE_PAT"
+BOB_AUTH="Authorization: Bearer $BOB_PAT"
+
+echo ""
+echo "▸ Hidden Vault collision"
+CREATE_STATUS=$(curl -sk -o "$TMP/hidden-create" -w '%{http_code}' -X POST \
+  "$BASE_URL/api/v1/vaults?name=$HIDDEN_VAULT" -H "$ALICE_AUTH")
+[ "$CREATE_STATUS" = "200" ] && pass "Alice created a private Vault" \
+  || fail "private Vault create" "expected 200, got $CREATE_STATUS"
+
+BOB_SEES_HIDDEN=$(curl -sk -H "$BOB_AUTH" "$BASE_URL/api/v1/my/vaults" \
+  | python3 -c "import json,sys; print(any(v['name']=='$HIDDEN_VAULT' for v in json.load(sys.stdin)['vaults']))" \
+  2>/dev/null)
+[ "$BOB_SEES_HIDDEN" = "False" ] && pass "private Vault is absent from Bob's list" \
+  || fail "private Vault listing" "hidden Vault appeared in Bob's list"
+
+REST_STATUS=$(curl -sk -o "$TMP/rest-hidden-conflict" -w '%{http_code}' -X POST \
+  "$BASE_URL/api/v1/vaults?name=$HIDDEN_VAULT" -H "$BOB_AUTH")
+if [ "$REST_STATUS" = "409" ] && rest_conflict_is_safe "$TMP/rest-hidden-conflict" "$HIDDEN_VAULT"; then
+  pass "REST returns the fixed non-disclosing conflict"
+else
+  fail "REST hidden conflict" "status=$REST_STATUS body=$(head -c 180 "$TMP/rest-hidden-conflict")"
+fi
+
+MCP_INIT=$(curl -sk -i -X POST "$BASE_URL/mcp/" \
+  -H "$BOB_AUTH" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"vault-name-contract","version":"1"}}}')
+MCP_SID=$(echo "$MCP_INIT" | grep -i 'mcp-session-id' | tr -d '\r' | awk '{print $2}')
+curl -sk -X POST "$BASE_URL/mcp/" \
+  -H "$BOB_AUTH" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -H "mcp-session-id: $MCP_SID" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null
+MCP_RESPONSE=$(mcp_call "$BOB_PAT" "$MCP_SID" 2 akb_create_vault "{\"name\":\"$HIDDEN_VAULT\"}")
+MCP_SAFE=$(echo "$MCP_RESPONSE" | python3 -c '
+import json, sys
+outer = json.load(sys.stdin)
+expected = {
+    "error": "Vault name is unavailable. Choose a different name.",
+    "code": "vault_name_unavailable",
+}
+result = outer.get("result", {})
+content = result.get("content", [])
+safe = (
+    set(outer) == {"jsonrpc", "id", "result"}
+    and outer.get("jsonrpc") == "2.0"
+    and outer.get("id") == 2
+    and set(result) <= {"content", "isError"}
+    and len(content) == 1
+    and set(content[0]) == {"type", "text"}
+    and content[0].get("type") == "text"
+    and json.loads(content[0].get("text", "")) == expected
+)
+print(safe)
+' 2>/dev/null)
+[ "$MCP_SAFE" = "True" ] && pass "MCP returns exactly error + stable code" \
+  || fail "MCP hidden conflict" "unexpected envelope"
+
+echo ""
+echo "▸ Concurrent create and storage rollback"
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  (
+    curl -sk -o "$TMP/race-body-$i" -w '%{http_code}' -X POST \
+      "$BASE_URL/api/v1/vaults?name=$RACE_VAULT" -H "$BOB_AUTH" \
+      > "$TMP/race-status-$i"
+  ) &
+done
+wait
+
+WINNERS=0
+CONFLICTS=0
+BAD=0
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  STATUS=$(cat "$TMP/race-status-$i")
+  if [ "$STATUS" = "200" ]; then
+    WINNERS=$((WINNERS+1))
+  elif [ "$STATUS" = "409" ] \
+    && rest_conflict_is_safe "$TMP/race-body-$i" "$RACE_VAULT"; then
+    CONFLICTS=$((CONFLICTS+1))
+  else
+    BAD=$((BAD+1))
+  fi
+done
+if [ "$WINNERS" = "1" ] && [ "$CONFLICTS" = "9" ] && [ "$BAD" = "0" ]; then
+  pass "ten concurrent creates produce one winner and nine stable 409s"
+else
+  fail "concurrent create" "winner=$WINNERS conflicts=$CONFLICTS bad=$BAD"
+fi
+
+DOC_STATUS=$(curl -sk -o "$TMP/race-doc" -w '%{http_code}' -X POST \
+  "$BASE_URL/api/v1/documents" \
+  -H "$BOB_AUTH" -H 'Content-Type: application/json' \
+  -d "{\"vault\":\"$RACE_VAULT\",\"collection\":\"checks\",\"title\":\"Winner remains usable\",\"content\":\"The winning repository survived every losing rollback.\",\"type\":\"note\"}")
+if [ "$DOC_STATUS" = "200" ] && grep -q '"commit_hash"' "$TMP/race-doc"; then
+  pass "the winning Vault remains writable after losing rollbacks"
+else
+  fail "winner usability" "status=$DOC_STATUS body=$(head -c 180 "$TMP/race-doc")"
+fi
+
+DELETE_STATUS=$(curl -sk -o "$TMP/race-delete" -w '%{http_code}' -X DELETE \
+  "$BASE_URL/api/v1/vaults/$RACE_VAULT" -H "$BOB_AUTH")
+RECREATE_STATUS=$(curl -sk -o "$TMP/race-recreate" -w '%{http_code}' -X POST \
+  "$BASE_URL/api/v1/vaults?name=$RACE_VAULT" -H "$BOB_AUTH")
+if [ "$DELETE_STATUS" = "200" ] && [ "$RECREATE_STATUS" = "200" ]; then
+  pass "delete then recreate succeeds without a stale Git orphan"
+else
+  fail "orphan cleanup" "delete=$DELETE_STATUS recreate=$RECREATE_STATUS"
+fi
+
+curl -sk -X DELETE "$BASE_URL/mcp/" -H "$BOB_AUTH" -H "mcp-session-id: $MCP_SID" >/dev/null
+curl -sk -X DELETE "$BASE_URL/api/v1/vaults/$HIDDEN_VAULT" -H "$ALICE_AUTH" >/dev/null
+curl -sk -X DELETE "$BASE_URL/api/v1/vaults/$RACE_VAULT" -H "$BOB_AUTH" >/dev/null
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  for error in "${ERRORS[@]}"; do echo "  ✗ $error"; done
+  exit 1
+fi

--- a/backend/tests/test_vault_name_unavailable_unit.py
+++ b/backend/tests/test_vault_name_unavailable_unit.py
@@ -1,0 +1,212 @@
+"""Vault-name conflicts share one non-disclosing contract across create paths."""
+
+from __future__ import annotations
+
+import json
+
+import asyncpg
+import pytest
+
+from app.exceptions import VaultNameUnavailableError
+from app.repositories import vault_repo as vault_repo_module
+from app.repositories.vault_repo import VaultRepository
+from app.services import document_service as document_service_module
+from app.services.document_service import DocumentService
+from app.services.external_git_service import ExternalGitService
+
+
+class _AsyncContext:
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+class _Pool:
+    def __init__(self, connection):
+        self.connection = connection
+
+    def acquire(self):
+        return _AsyncContext(self.connection)
+
+
+@pytest.mark.asyncio
+async def test_repository_maps_only_vault_name_unique_constraint(monkeypatch):
+    class _FakeUniqueViolation(Exception):
+        def __init__(self, constraint_name: str):
+            self.constraint_name = constraint_name
+
+    class _Connection:
+        async def execute(self, sql, *args):
+            raise _FakeUniqueViolation("vaults_name_key")
+
+    monkeypatch.setattr(
+        vault_repo_module.asyncpg,
+        "UniqueViolationError",
+        _FakeUniqueViolation,
+    )
+
+    with pytest.raises(VaultNameUnavailableError) as caught:
+        await VaultRepository(_Pool(_Connection())).create(
+            "reserved", "", "/tmp/reserved.git"
+        )
+
+    assert caught.value.code == "vault_name_unavailable"
+    assert caught.value.details is None
+    assert "reserved" not in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_repository_does_not_mask_an_unrelated_unique_constraint(monkeypatch):
+    class _FakeUniqueViolation(Exception):
+        def __init__(self, constraint_name: str):
+            self.constraint_name = constraint_name
+
+    class _Connection:
+        async def execute(self, sql, *args):
+            raise _FakeUniqueViolation("some_other_key")
+
+    monkeypatch.setattr(
+        vault_repo_module.asyncpg,
+        "UniqueViolationError",
+        _FakeUniqueViolation,
+    )
+
+    with pytest.raises(_FakeUniqueViolation):
+        await VaultRepository(_Pool(_Connection())).create(
+            "candidate", "", "/tmp/candidate.git"
+        )
+
+
+@pytest.mark.asyncio
+async def test_standard_git_race_rolls_back_and_returns_stable_conflict(monkeypatch):
+    class _Git:
+        @staticmethod
+        def vault_exists(name: str) -> bool:
+            return False
+
+        @staticmethod
+        def init_vault(name: str) -> str:
+            raise FileExistsError("storage path exists")
+
+    async def _direct_git_write(fn, /, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+    monkeypatch.setattr(document_service_module, "run_git_write", _direct_git_write)
+    service = DocumentService(git=_Git())
+    rollback_calls: list[dict] = []
+
+    async def _record_rollback(**kwargs):
+        rollback_calls.append(kwargs)
+
+    monkeypatch.setattr(service, "_rollback_vault_create", _record_rollback)
+
+    with pytest.raises(VaultNameUnavailableError) as caught:
+        await service._create_vault_standard(
+            name="raced-name",
+            description="",
+            template=None,
+            public_access="none",
+            owner_id=None,
+            uid=None,
+            external_git=None,
+            vault_repo=object(),
+            coll_repo=object(),
+        )
+
+    assert caught.value.code == "vault_name_unavailable"
+    assert "raced-name" not in str(caught.value)
+    # FileExists means this request created no directory. Even when its earlier
+    # probe saw "absent", an external mirror or another out-of-band writer may
+    # have materialised the path, so deleting it would destroy the winner.
+    assert rollback_calls == []
+
+
+def test_external_git_bootstrap_joins_creation_lock_and_rechecks_absence():
+    calls: list[object] = []
+
+    class _Git:
+        def __init__(self):
+            self.exists_calls = 0
+
+        def vault_exists(self, name: str) -> bool:
+            self.exists_calls += 1
+            calls.append(("exists", self.exists_calls, name))
+            return self.exists_calls >= 2
+
+        @staticmethod
+        def acquire_vault_creation_lock(name: str) -> int:
+            calls.append(("acquire", name))
+            return 73
+
+        @staticmethod
+        def release_vault_creation_lock(fd: int) -> None:
+            calls.append(("release", fd))
+
+        @staticmethod
+        def clone_mirror(*args):
+            raise AssertionError("the path appeared while waiting; do not clone over it")
+
+        @staticmethod
+        def _is_mirror(name: str) -> bool:
+            return True
+
+        @staticmethod
+        def inspect_mirror_structure(name: str, remote_url: str, branch: str) -> list:
+            return []
+
+        @staticmethod
+        def is_healthy_repo(name: str) -> bool:
+            return True
+
+        @staticmethod
+        def materialized_sha(name: str, branch: str) -> str:
+            return "abc123"
+
+    result = ExternalGitService(git=_Git()).ensure_local_bare(
+        "raced-name",
+        "abc123",
+        "abc123",
+        "https://git.example.test/team/repo.git",
+        "main",
+        None,
+    )
+
+    assert result == ("unchanged", "abc123")
+    assert calls[:4] == [
+        ("exists", 1, "raced-name"),
+        ("acquire", "raced-name"),
+        ("exists", 2, "raced-name"),
+        ("release", 73),
+    ]
+
+
+def test_real_asyncpg_type_remains_available_after_monkeypatch_cleanup():
+    """The test double above must not leak into later integration tests."""
+    assert issubclass(asyncpg.UniqueViolationError, asyncpg.PostgresError)
+
+
+@pytest.mark.asyncio
+async def test_rest_handler_preserves_the_stable_409_without_resource_metadata(
+    monkeypatch, tmp_path
+):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "git_storage_path", str(tmp_path / "vaults"))
+    from app.main import akb_error_handler
+
+    response = await akb_error_handler(None, VaultNameUnavailableError())
+    body = json.loads(response.body)
+
+    assert response.status_code == 409
+    assert body["code"] == "vault_name_unavailable"
+    assert body["message"] == "Vault name is unavailable. Choose a different name."
+    assert not ({"owner", "visibility", "public_access", "archived"} & set(body))
+    assert body["detail"] == {
+        "message": "Vault name is unavailable. Choose a different name.",
+        "code": "vault_name_unavailable",
+    }

--- a/frontend/src/components/__tests__/vault-create-dialog.test.tsx
+++ b/frontend/src/components/__tests__/vault-create-dialog.test.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from "react";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
@@ -7,10 +7,11 @@ import { VaultCreateDialog } from "@/components/vault-create-dialog";
 
 vi.mock("@/lib/api", () => ({
   listVaultTemplates: vi.fn(),
+  listVaults: vi.fn(),
   createVault: vi.fn(),
 }));
 
-import { createVault, listVaultTemplates } from "@/lib/api";
+import { createVault, listVaults, listVaultTemplates } from "@/lib/api";
 
 function DialogHarness() {
   const [open, setOpen] = useState(false);
@@ -34,6 +35,10 @@ function DialogHarness() {
           setCreated(name);
           setOpen(false);
         }}
+        onOpenExisting={(name) => {
+          setCreated(name);
+          setOpen(false);
+        }}
         returnFocusRef={triggerRef}
       />
       {created && <output>{created}</output>}
@@ -45,6 +50,7 @@ describe("VaultCreateDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(listVaultTemplates).mockResolvedValue([]);
+    vi.mocked(listVaults).mockResolvedValue({ vaults: [] });
     vi.mocked(createVault).mockResolvedValue({ vault_id: "v1", name: "engineering" } as any);
   });
 
@@ -78,5 +84,91 @@ describe("VaultCreateDialog", () => {
     );
     await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
     expect(screen.getByText("engineering")).toBeInTheDocument();
+  });
+
+  it("explains installation-wide uniqueness and enforces the backend name grammar", async () => {
+    const user = userEvent.setup();
+    render(<DialogHarness />);
+
+    await user.click(screen.getByRole("button", { name: "New vault" }));
+    expect(screen.getByText(/unique across this AKB installation/i)).toBeInTheDocument();
+
+    const name = await screen.findByLabelText(/^name/i);
+    await user.type(name, "two--words");
+    expect(screen.getByRole("button", { name: "Create vault" })).toBeDisabled();
+  });
+
+  it("keeps a hidden-name conflict generic and offers no inaccessible target", async () => {
+    const user = userEvent.setup();
+    vi.mocked(createVault).mockRejectedValue({
+      message: "legacy text that must not be trusted",
+      detail: { code: "vault_name_unavailable" },
+    });
+    vi.mocked(listVaults).mockResolvedValue({ vaults: [{ name: "visible-vault" }] });
+    render(<DialogHarness />);
+
+    await user.click(screen.getByRole("button", { name: "New vault" }));
+    await user.type(await screen.findByLabelText(/^name/i), "hidden-vault");
+    await user.click(screen.getByRole("button", { name: "Create vault" }));
+
+    expect(
+      await screen.findByText("Vault name is unavailable. Choose a different name."),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Open existing vault" })).not.toBeInTheDocument();
+    expect(screen.queryByText(/legacy text/i)).not.toBeInTheDocument();
+  });
+
+  it("offers recovery only when the conflicting vault is already accessible", async () => {
+    const user = userEvent.setup();
+    vi.mocked(createVault).mockRejectedValue({
+      detail: { code: "vault_name_unavailable" },
+    });
+    vi.mocked(listVaults).mockResolvedValue({ vaults: [{ name: "engineering" }] });
+    render(<DialogHarness />);
+
+    await user.click(screen.getByRole("button", { name: "New vault" }));
+    await user.type(await screen.findByLabelText(/^name/i), "engineering");
+    await user.click(screen.getByRole("button", { name: "Create vault" }));
+    expect(
+      await screen.findByRole("status", { name: "" }),
+    ).toHaveTextContent("An accessible vault with this name can be opened.");
+    await user.click(await screen.findByRole("button", { name: "Open existing vault" }));
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(screen.getByText("engineering")).toBeInTheDocument();
+  });
+
+  it("unlocks immediately after conflict and ignores a stale accessibility lookup", async () => {
+    const user = userEvent.setup();
+    let resolveVaults: ((value: { vaults: Array<{ name: string }> }) => void) | undefined;
+    vi.mocked(createVault).mockRejectedValue({
+      detail: { code: "vault_name_unavailable" },
+    });
+    vi.mocked(listVaults).mockReturnValue(
+      new Promise((resolve) => {
+        resolveVaults = resolve;
+      }),
+    );
+    render(<DialogHarness />);
+
+    await user.click(screen.getByRole("button", { name: "New vault" }));
+    const name = await screen.findByLabelText(/^name/i);
+    await user.type(name, "engineering");
+    await user.click(screen.getByRole("button", { name: "Create vault" }));
+
+    expect(
+      await screen.findByText("Vault name is unavailable. Choose a different name."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Create vault" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeEnabled();
+
+    await user.clear(name);
+    await user.type(name, "another-vault");
+    await act(async () => {
+      resolveVaults?.({ vaults: [{ name: "engineering" }] });
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByRole("button", { name: "Open existing vault" })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/vault-create-dialog.tsx
+++ b/frontend/src/components/vault-create-dialog.tsx
@@ -12,11 +12,13 @@ export function VaultCreateDialog({
   open,
   onOpenChange,
   onCreated,
+  onOpenExisting,
   returnFocusRef,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onCreated: (name: string) => void;
+  onOpenExisting: (name: string) => void;
   returnFocusRef?: RefObject<HTMLElement | null>;
 }) {
   const [busy, setBusy] = useState(false);
@@ -54,6 +56,7 @@ export function VaultCreateDialog({
         </DialogHeader>
         <VaultCreateForm
           onCreated={onCreated}
+          onOpenExisting={onOpenExisting}
           onCancel={() => handleOpenChange(false)}
           onBusyChange={setBusy}
           className="p-6"

--- a/frontend/src/components/vault-create-form.tsx
+++ b/frontend/src/components/vault-create-form.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { ArrowRight, GitBranch } from "lucide-react";
-import { createVault, listVaultTemplates, type VaultTemplateSummary } from "@/lib/api";
+import {
+  createVault,
+  listVaults,
+  listVaultTemplates,
+  type VaultTemplateSummary,
+} from "@/lib/api";
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -10,11 +15,13 @@ import { cn } from "@/lib/utils";
 
 export function VaultCreateForm({
   onCreated,
+  onOpenExisting,
   onCancel,
   onBusyChange,
   className,
 }: {
   onCreated: (name: string) => void;
+  onOpenExisting?: (name: string) => void;
   onCancel?: () => void;
   onBusyChange?: (busy: boolean) => void;
   className?: string;
@@ -28,11 +35,13 @@ export function VaultCreateForm({
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [error, setError] = useState("");
+  const [accessibleConflict, setAccessibleConflict] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
   const [templates, setTemplates] = useState<VaultTemplateSummary[]>([]);
   const [selectedTemplate, setSelectedTemplate] = useState("");
   const nameRef = useRef<HTMLInputElement>(null);
-  const nameValid = /^[a-z0-9-]+$/.test(name.trim());
+  const conflictCheckGeneration = useRef(0);
+  const nameValid = /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name.trim());
 
   useEffect(() => {
     listVaultTemplates()
@@ -42,6 +51,13 @@ export function VaultCreateForm({
         setTemplates([]);
       });
   }, []);
+
+  useEffect(
+    () => () => {
+      conflictCheckGeneration.current += 1;
+    },
+    [],
+  );
 
   const selectedSummary = useMemo(
     () => templates.find((template) => template.name === selectedTemplate) || null,
@@ -56,13 +72,15 @@ export function VaultCreateForm({
       nameRef.current?.focus();
       return;
     }
-    if (!/^[a-z0-9-]+$/.test(trimmed)) {
-      setError("Use lowercase letters, digits, and hyphens only.");
+    if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(trimmed)) {
+      setError("Use lowercase letters and digits, with single hyphens between words.");
       nameRef.current?.focus();
       return;
     }
 
     setError("");
+    setAccessibleConflict(null);
+    conflictCheckGeneration.current += 1;
     setCreating(true);
     onBusyChange?.(true);
     try {
@@ -72,8 +90,40 @@ export function VaultCreateForm({
         selectedTemplate || undefined,
       );
       onCreated(trimmed);
-    } catch (cause: any) {
-      setError(cause?.message || "Failed to create vault");
+    } catch (cause: unknown) {
+      const detail =
+        typeof cause === "object" && cause !== null && "detail" in cause
+          ? (cause as { detail?: unknown }).detail
+          : null;
+      const code =
+        typeof detail === "object" && detail !== null && "code" in detail
+          ? (detail as { code?: unknown }).code
+          : null;
+
+      if (code === "vault_name_unavailable") {
+        setError("Vault name is unavailable. Choose a different name.");
+        if (onOpenExisting) {
+          const generation = ++conflictCheckGeneration.current;
+          void listVaults()
+            .then((result) => {
+              if (conflictCheckGeneration.current !== generation) return;
+              const isAccessible = result.vaults.some(
+                (vault) =>
+                  typeof vault === "object" &&
+                  vault !== null &&
+                  "name" in vault &&
+                  vault.name === trimmed,
+              );
+              if (isAccessible) setAccessibleConflict(trimmed);
+            })
+            .catch(() => {
+              // The recovery action is optional. Keep the original conflict
+              // visible if the access-filtered list cannot be refreshed.
+            });
+        }
+      } else {
+        setError(cause instanceof Error ? cause.message : "Failed to create vault");
+      }
       setCreating(false);
       onBusyChange?.(false);
     }
@@ -91,7 +141,9 @@ export function VaultCreateForm({
           value={name}
           onChange={(event) => {
             setName(event.target.value);
+            conflictCheckGeneration.current += 1;
             if (error) setError("");
+            if (accessibleConflict) setAccessibleConflict(null);
           }}
           placeholder="e.g. engineering"
           required
@@ -103,7 +155,7 @@ export function VaultCreateForm({
           aria-describedby={error ? `${errorId} ${nameHintId}` : nameHintId}
         />
         <div id={nameHintId} className="coord">
-          Lowercase letters, digits, hyphens · becomes /vault/&lt;name&gt;
+          Lowercase letters, digits, single hyphens · unique across this AKB installation · becomes akb://&lt;name&gt;
         </div>
       </div>
 
@@ -163,8 +215,24 @@ export function VaultCreateForm({
 
       {error && (
         <Alert variant="destructive" id={errorId}>
-          {error}
+          <p>{error}</p>
         </Alert>
+      )}
+      {accessibleConflict && onOpenExisting && (
+        <>
+          <p role="status" className="sr-only">
+            An accessible vault with this name can be opened.
+          </p>
+          <div className="flex justify-end">
+            <Button
+              type="button"
+              variant="link"
+              onClick={() => onOpenExisting(accessibleConflict)}
+            >
+              Open existing vault
+            </Button>
+          </div>
+        </>
       )}
 
       <div className="flex flex-col-reverse gap-2 pt-2 sm:flex-row sm:justify-end">

--- a/frontend/src/components/vault-shell.tsx
+++ b/frontend/src/components/vault-shell.tsx
@@ -469,6 +469,7 @@ export function VaultShell() {
           open={createVaultOpen}
           onOpenChange={setCreateVaultOpen}
           onCreated={handleVaultCreated}
+          onOpenExisting={handleVaultCreated}
           returnFocusRef={createVaultTriggerRef}
         />
         {name && (

--- a/frontend/src/pages/__tests__/vault-new-cancel.test.tsx
+++ b/frontend/src/pages/__tests__/vault-new-cancel.test.tsx
@@ -5,6 +5,7 @@ import VaultNewPage from "../vault-new";
 
 vi.mock("@/lib/api", () => ({
   createVault: vi.fn(),
+  listVaults: vi.fn().mockResolvedValue({ vaults: [] }),
   listVaultTemplates: vi.fn().mockResolvedValue([]),
 }));
 

--- a/frontend/src/pages/__tests__/vault-new.test.tsx
+++ b/frontend/src/pages/__tests__/vault-new.test.tsx
@@ -7,6 +7,7 @@ import * as api from "@/lib/api";
 
 vi.mock("@/lib/api", () => ({
   listVaultTemplates: vi.fn(),
+  listVaults: vi.fn(),
   createVault: vi.fn(),
 }));
 
@@ -48,6 +49,7 @@ async function openTemplateMenu() {
 describe("VaultNewPage template selection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    (api.listVaults as any).mockResolvedValue({ vaults: [] });
     (api.createVault as any).mockResolvedValue({ vault_id: "v1", name: "x" });
   });
 

--- a/frontend/src/pages/vault-new.tsx
+++ b/frontend/src/pages/vault-new.tsx
@@ -38,7 +38,7 @@ export default function VaultNewPage() {
           </nav>
           <PageHeader
             title="Create a vault"
-            subtitle="A vault is a Git-backed knowledge root. Documents, tables, and files live inside it. Pick a short, lowercase name — it becomes the URL path and the repo identifier."
+            subtitle="A vault is a Git-backed knowledge root. Documents, tables, and files live inside it. Pick a short, lowercase name that is unique across this AKB installation — it becomes part of the canonical akb:// URI and the repo identifier."
             className="mb-6"
           />
         </>
@@ -47,6 +47,7 @@ export default function VaultNewPage() {
     >
       <VaultCreateForm
         onCreated={(name) => navigate(`/vault/${name}`)}
+        onOpenExisting={(name) => navigate(`/vault/${name}`)}
         onCancel={handleCancel}
         onBusyChange={setCreating}
         className="rounded-[var(--radius-lg)] border border-border bg-surface p-8 shadow-sm"

--- a/frontend/src/stories/pages-vaults.stories.tsx
+++ b/frontend/src/stories/pages-vaults.stories.tsx
@@ -123,10 +123,22 @@ export const NewVaultNameConflict: Story = {
     router: { initialEntries: ["/vault/new"] },
     msw: {
       handlers: [
+        http.get(`${API}/my/vaults`, () => HttpResponse.json({ vaults: [] })),
         ...appLayoutHandlers,
         http.get(`${API}/vaults/templates`, () => HttpResponse.json(templates)),
         http.post(`${API}/vaults`, () =>
-          HttpResponse.json({ detail: "Vault already exists." }, { status: 409 }),
+          HttpResponse.json(
+            {
+              message: "Vault name is unavailable. Choose a different name.",
+              error: "Vault name is unavailable. Choose a different name.",
+              code: "vault_name_unavailable",
+              detail: {
+                message: "Vault name is unavailable. Choose a different name.",
+                code: "vault_name_unavailable",
+              },
+            },
+            { status: 409 },
+          ),
         ),
       ],
     },
@@ -136,7 +148,10 @@ export const NewVaultNameConflict: Story = {
     const canvas = within(canvasElement);
     await userEvent.type(await canvas.findByLabelText(/Name/i), "akb");
     await userEvent.click(canvas.getByRole("button", { name: /Create vault/i }));
-    await expect(await canvas.findByText("Vault already exists.")).toBeInTheDocument();
+    await expect(
+      await canvas.findByText("Vault name is unavailable. Choose a different name."),
+    ).toBeInTheDocument();
+    await expect(canvas.queryByRole("button", { name: "Open existing vault" })).not.toBeInTheDocument();
     await expect(canvas.queryByRole("navigation", { name: "Vaults" })).not.toBeInTheDocument();
   },
 };


### PR DESCRIPTION
## Summary

- return one stable, non-disclosing conflict contract when an installation-wide Vault name is unavailable
- make the database uniqueness constraint authoritative across standard, native, and external-Git creation paths
- prevent losing create attempts from deleting a winning repository during cross-process storage races
- align the create UI with the backend name grammar and only offer an existing-Vault recovery action when that Vault is already visible to the caller
- document the global namespace behavior in the REST/MCP surfaces and changelog

## Why

Vault names are intentionally unique across an AKB installation because they form canonical `akb://` identifiers and Git storage roots. The previous error included the attempted name and differed across creation paths. Concurrent standard and external-Git creation could also cross between the advisory lookup and storage/DB writes, creating a rollback window where a losing request could remove storage it did not own.

This change preserves the global namespace while reducing the conflict response to a fixed message and stable `vault_name_unavailable` code. It does not expose the existing Vault's owner, visibility, lifecycle state, or other metadata. Availability itself remains observable, which is inherent to a globally unique user-selected namespace.

## Implementation notes

- `VaultRepository.create()` maps only the `vaults_name_key` unique violation to the public conflict; unrelated unique violations remain visible as internal data/programming errors.
- Standard creation maps a storage `FileExistsError` to the same contract and skips compensation when that request created no storage.
- External-Git bootstrap joins the same cross-process creation lock and rechecks storage after waiting.
- REST and MCP emit deterministic envelopes suitable for clients to branch on without parsing prose.
- The frontend performs optional recovery through the access-filtered Vault list. It never probes an inaccessible Vault for details.
- Name validation now matches the backend's single-hyphen segment grammar.

## Verification

- `bash scripts/check.sh` using Node.js 24.19.0
  - Ruff, mypy, Bandit
  - frontend ESLint/typecheck and 736 unit tests
  - `@akb/client` build, typecheck, 55 tests, generated-type and packed-consumer checks
  - stdio proxy and MCP Inspector contracts
  - tracked-file secret scan
- focused backend unit and PostgreSQL native-concurrency tests
- isolated HTTP E2E covering:
  - hidden private Vault collision through REST and MCP
  - exact response envelopes with no additional metadata
  - ten concurrent creates producing one winner and nine stable conflicts
  - winner write after losing-request rollback
  - delete/recreate without a stale Git orphan
- production frontend and Storybook builds
- focused Vault-name conflict Storybook interaction test

No production or Kubernetes environment was modified.
