### PR TITLE
fix(search): apply filters before retrieval limits

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3693
+        "line_number": 3703
       }
     ],
     "backend/mcp_server/help.py": [
@@ -6987,5 +6987,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-07T03:53:01Z"
+  "generated_at": "2026-09-07T05:41:15Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -7,6 +7,16 @@ specifically; the proxy has its own log in
 
 ## Unreleased
 
+### Applied search filters before result limits
+
+REST search now supports repeated document types and explicit resource kinds.
+Collection scope is boundary-aware for documents, files and tables, and document
+metadata filters no longer admit unrelated resources. Grep accepts document types,
+tags and explicit archived inclusion, preserves its legacy archive default, and
+reports invalid regex patterns as validation errors. Native and standard search
+paths share metadata semantics. The web Search workspace uses URL-backed server
+filters, regex/case options and distinct incomplete, truncated and empty states.
+
 ### Made globally reserved Vault-name conflicts non-disclosing
 
 Vault creation now returns the same `vault_name_unavailable` conflict for an

--- a/backend/app/api/routes/search.py
+++ b/backend/app/api/routes/search.py
@@ -35,6 +35,8 @@ async def search_documents(
     collection: str | None = Query(None),
     type: str | None = Query(None),
     tags: list[str] | None = Query(None),
+    doc_types: list[str] | None = Query(None, description="Document types (OR); intersects legacy type."),
+    source_type: Literal["document", "file", "table"] | None = Query(None),
     limit: int = Query(10, ge=1, le=100),
     include_archived: bool = Query(False, description="Include archived documents (hidden from search by default)."),
     source_uris: list[str] | None = Query(
@@ -49,6 +51,7 @@ async def search_documents(
         doc_type=type, tags=tags, limit=limit,
         user_id=user.user_id, include_archived=include_archived,
         source_uris=source_uris,
+        doc_types=doc_types, source_type=source_type,
     )
 
 
@@ -88,6 +91,9 @@ async def grep_documents(
     collection: str | None = Query(None),
     regex: bool = Query(False),
     case_sensitive: bool = Query(False),
+    doc_types: list[str] | None = Query(None),
+    tags: list[str] | None = Query(None),
+    include_archived: bool = Query(True, description="Legacy default includes archived documents; the search UI explicitly excludes them."),
     limit: int = Query(20, ge=1, le=100),
     count_only: bool = Query(False, description="grep -c — per-doc counts + total"),
     files_with_matches: bool = Query(False, description="grep -l — URIs with matches"),
@@ -103,6 +109,7 @@ async def grep_documents(
         count_only=count_only, files_with_matches=files_with_matches,
         measurement_include_text_files=measurement_include_text_files,
         user_id=user.user_id,
+        doc_types=doc_types, tags=tags, include_archived=include_archived,
     )
     response.setdefault("regex", regex)
     return {"kind": "grep", **response}

--- a/backend/app/services/m1_native_grep_service.py
+++ b/backend/app/services/m1_native_grep_service.py
@@ -649,6 +649,9 @@ class M1NativeGrepService:
         replace: str | None = None,
         actor: str | None = None,
         include_text_files: bool = False,
+        doc_types: list[str] | None = None,
+        tags: list[str] | None = None,
+        include_archived: bool = True,
     ) -> dict[str, Any]:
         if pattern == "":
             raise ValidationError("grep pattern must not be empty")
@@ -690,6 +693,13 @@ class M1NativeGrepService:
             resource_id=resource_id,
             surfaces=self._selected_surfaces(include_text_files=include_text_files),
         )
+        if doc_types or tags or not include_archived:
+            from app.services.search_filters import metadata_matches
+
+            bodies = [body for body in bodies if (
+                body.surface == "document"
+                and metadata_matches(_parse_markdown(body.text)[0], doc_types, tags, include_archived)
+            ) or (body.surface != "document" and not (doc_types or tags))]
         searched_bytes = sum(body.byte_size for body in bodies)
         if searched_bytes > NATIVE_GREP_MAX_SEARCH_BYTES:
             raise ValidationError(

--- a/backend/app/services/search_filters.py
+++ b/backend/app/services/search_filters.py
@@ -1,0 +1,24 @@
+"""Small shared predicates for search scope; values always remain bound parameters."""
+
+
+def escape_like(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def collection_predicate(column: str, collection: str, params: list) -> str:
+    """Match a collection itself or descendants, never a similarly named sibling.
+
+    ``column`` is a repository-owned SQL expression, never request input.
+    """
+    path = collection.strip("/")
+    params.extend([path, escape_like(path) + "/%"])
+    return f"({column} = ${len(params) - 1} OR {column} LIKE ${len(params)} ESCAPE '\\')"
+
+
+def metadata_matches(metadata: dict, doc_types: list[str] | None,
+                     tags: list[str] | None, include_archived: bool) -> bool:
+    return (
+        (not doc_types or (metadata.get("type") or "note") in doc_types)
+        and (not tags or bool(set(metadata.get("tags") or []).intersection(tags)))
+        and (include_archived or metadata.get("status", "draft") != "archived")
+    )

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -20,6 +20,7 @@ from typing import Literal
 from app.config import settings
 from app.db.postgres import get_pool
 from app.exceptions import ValidationError
+from app.services.search_filters import collection_predicate, escape_like, metadata_matches
 from app.models.document import SearchResponse, SearchResult
 from app.repositories.vault_files_repo import confirmed_file_predicate
 from app.services import sparse_encoder
@@ -237,6 +238,7 @@ class SearchService:
         tags: list[str] | None,
         include_archived: bool,
         source_uris: list[str] | None,
+        doc_types: list[str] | None = None,
     ) -> list[str]:
         conditions = ["r.surface = 'document'", "r.lifecycle = 'live'"]
         params: list = []
@@ -324,10 +326,7 @@ class SearchService:
             metadata = await asyncio.to_thread(_verified_native_metadata, row)
             if doc_type and (metadata.get("type") or "note") != doc_type:
                 continue
-            row_tags = set(metadata.get("tags") or [])
-            if tags and not row_tags.intersection(tags):
-                continue
-            if not include_archived and metadata.get("status", "draft") == "archived":
+            if not metadata_matches(metadata, doc_types, tags, include_archived):
                 continue
             candidates.append(str(row["resource_id"]))
         return candidates
@@ -345,6 +344,8 @@ class SearchService:
         user_id: str | None = None,
         include_archived: bool = False,
         source_uris: list[str] | None = None,
+        doc_types: list[str] | None = None,
+        source_type: Literal["document", "file", "table"] | None = None,
     ) -> SearchResponse:
         """Hybrid search across documents. See module docstring for flow.
 
@@ -417,7 +418,7 @@ class SearchService:
         # pre-upgrade pgvector point carries its vault_id, fall back to the
         # source-id path so a user can't miss their own un-backfilled docs.
         from app.services import vault_backfill
-        use_vault_path = vault_path_eligible(
+        use_vault_path = not (doc_types or source_type or not include_archived) and vault_path_eligible(
             collection=collection, doc_type=doc_type, tags=tags, source_uris=source_uris,
         ) and vault_backfill.is_ready()
 
@@ -483,14 +484,17 @@ class SearchService:
                     conditions.append(f"v.name = ANY(${idx})")
                     params.append(vaults); idx += 1
                 if collection:
-                    conditions.append(f"d.path LIKE ${idx} || '%'")
-                    params.append(collection); idx += 1
+                    conditions.append(collection_predicate("d.path", collection, params))
+                    idx = len(params) + 1
                 if doc_type:
                     conditions.append(f"d.doc_type = ${idx}")
                     params.append(doc_type); idx += 1
                 if tags:
                     conditions.append(f"d.tags && ${idx}")
                     params.append(tags); idx += 1
+                if doc_types:
+                    conditions.append(f"d.doc_type = ANY(${idx}::text[])")
+                    params.append(doc_types); idx += 1
                 acl_sql, acl_params = _vault_acl(idx)
                 if acl_sql:
                     conditions.append(acl_sql)
@@ -507,7 +511,9 @@ class SearchService:
                     conditions.append("d.status != 'archived'")
 
                 where_sql = " AND ".join(conditions) if conditions else "TRUE"
-                if document_source == NATIVE_DOCUMENT_SOURCE:
+                if source_type in {"file", "table"}:
+                    candidate_source_ids = []
+                elif document_source == NATIVE_DOCUMENT_SOURCE:
                     candidate_source_ids = await self._native_document_candidates(
                         conn,
                         user_uuid=user_uuid,
@@ -518,6 +524,7 @@ class SearchService:
                         tags=tags,
                         include_archived=include_archived,
                         source_uris=source_uris,
+                        doc_types=doc_types,
                     )
                 else:
                     rows = await conn.fetch(
@@ -530,10 +537,8 @@ class SearchService:
                     )
                     candidate_source_ids = [str(r["id"]) for r in rows]
 
-                # Tables (skip when doc_type explicitly constrains to a
-                # non-table source). Tags/collection apply to documents
-                # only.
-                if not doc_type or doc_type == "table":
+                # Document metadata filters never admit unrelated files/tables.
+                if (not doc_type or doc_type == "table") and not (doc_types or tags) and source_type in {None, "table"}:
                     t_params: list = []
                     t_conds: list[str] = []
                     if vaults:
@@ -546,13 +551,15 @@ class SearchService:
                     if source_uris:
                         t_conds.append(f"t.id = ANY(${len(t_params) + 1}::uuid[])")
                         t_params.append(src_table_ids)
-                    q = "SELECT t.id FROM vault_tables t JOIN vaults v ON t.vault_id = v.id"
+                    if collection:
+                        t_conds.append(collection_predicate("col.path", collection, t_params))
+                    q = "SELECT t.id FROM vault_tables t JOIN vaults v ON t.vault_id = v.id LEFT JOIN collections col ON col.id = t.collection_id"
                     if t_conds:
                         q += " WHERE " + " AND ".join(t_conds)
                     trows = await conn.fetch(q, *t_params)
                     candidate_source_ids.extend(str(r["id"]) for r in trows)
 
-                if not doc_type or doc_type == "file":
+                if (not doc_type or doc_type == "file") and not (doc_types or tags) and source_type in {None, "file"}:
                     f_params: list = []
                     # Editor attachments are storage implementation details,
                     # never standalone searchable File resources.
@@ -565,8 +572,7 @@ class SearchService:
                         # migration 020 → collection_id FK. Filter via the
                         # joined collections.path with a prefix match, same
                         # semantics as the documents branch above.
-                        f_conds.append(f"c.path LIKE ${len(f_params) + 1} || '%'")
-                        f_params.append(collection)
+                        f_conds.append(collection_predicate("c.path", collection, f_params))
                     acl_sql, acl_params = _vault_acl(len(f_params) + 1)
                     if acl_sql:
                         f_conds.append(acl_sql)
@@ -1239,6 +1245,9 @@ class SearchService:
         count_only: bool = False,
         files_with_matches: bool = False,
         measurement_include_text_files: bool = False,
+        doc_types: list[str] | None = None,
+        tags: list[str] | None = None,
+        include_archived: bool = True,
     ) -> dict:
         """Exact text / regex search across document content.
 
@@ -1278,13 +1287,7 @@ class SearchService:
             try:
                 _re.compile(pattern)
             except _re.error as e:
-                return {
-                    "error": f"Invalid regex pattern: {e}",
-                    "pattern": pattern,
-                    "total_docs": 0,
-                    "total_matches": 0,
-                    "results": [],
-                }
+                raise ValidationError(f"Invalid regex pattern: {e}") from e
 
         vaults = _normalize_vault_scope(vault)  # str | list | None → canonical list | None
         # ACL guard: when no vault is given we MUST have a user_id so the
@@ -1325,6 +1328,7 @@ class SearchService:
                 count_only=count_only,
                 files_with_matches=files_with_matches,
                 include_text_files=measurement_include_text_files,
+                doc_types=doc_types, tags=tags, include_archived=include_archived,
             )
 
         if replace is not None and doc_service is None:
@@ -1346,7 +1350,7 @@ class SearchService:
                     conditions.append(f"c.content LIKE '%' || ${idx} || '%'")
                 else:
                     conditions.append(f"c.content ILIKE '%' || ${idx} || '%'")
-                params.append(pattern)
+                params.append(escape_like(pattern))
             idx += 1
 
             if vaults:
@@ -1368,9 +1372,17 @@ class SearchService:
                 idx += 1
 
             if collection:
-                conditions.append(f"d.path LIKE ${idx} || '%'")
-                params.append(collection)
+                conditions.append(collection_predicate("d.path", collection, params))
+                idx = len(params) + 1
+            if doc_types:
+                conditions.append(f"d.doc_type = ANY(${idx}::text[])")
+                params.append(doc_types)
                 idx += 1
+            if tags:
+                conditions.append(f"d.tags && ${idx}")
+                params.append(tags)
+            if not include_archived:
+                conditions.append("d.status != 'archived'")
 
             where_sql = " AND ".join(conditions)
             # No prefetch cap. The old `LIMIT (limit * 5)` cap was inherited

--- a/backend/tests/test_search_filter_contract_unit.py
+++ b/backend/tests/test_search_filter_contract_unit.py
@@ -1,0 +1,168 @@
+"""Search filters are applied before retrieval limits, across REST and storage arms."""
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+import uuid
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from app.api.deps import get_current_user
+from app.api.routes import search as routes
+from app.exceptions import ValidationError
+from app.models.document import SearchResponse
+from app.services import search_service as ss
+from app.services.search_filters import collection_predicate, escape_like, metadata_matches
+from app.services.m1_native_grep_service import HeadBody, M1NativeGrepService
+
+
+def test_collection_boundary_and_literal_metacharacters():
+    params = ["existing"]
+    sql = collection_predicate("c.path", "/guide_%/", params)
+    assert params == ["existing", "guide_%", "guide\\_\\%/%"]
+    assert sql == "(c.path = $2 OR c.path LIKE $3 ESCAPE '\\')"
+    assert escape_like("100%_\\") == "100\\%\\_\\\\"
+
+
+def test_metadata_filters_are_or_within_and_between():
+    meta = {"type": "report", "tags": ["ops"], "status": "archived"}
+    assert metadata_matches(meta, ["note", "report"], ["ops", "dev"], True)
+    assert not metadata_matches(meta, ["note"], ["ops"], True)
+    assert not metadata_matches(meta, ["report"], ["dev"], True)
+    assert not metadata_matches(meta, ["report"], ["ops"], False)
+
+
+async def test_rest_serializes_all_search_and_grep_filters(monkeypatch):
+    app = FastAPI()
+    app.include_router(routes.router)
+    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(user_id="user")
+    search = AsyncMock(return_value=SearchResponse(query="x", total=0, returned=0, total_matches=0, results=[]))
+    grep = AsyncMock(return_value={"pattern": "x", "total_docs": 0, "total_matches": 0, "results": []})
+    monkeypatch.setattr(routes.search_service, "search", search)
+    monkeypatch.setattr(routes.search_service, "grep", grep)
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        params = [("q", "x"), ("vault", "a"), ("vault", "b"), ("collection", "guide_%"),
+                  ("doc_types", "report"), ("doc_types", "note"), ("tags", "ops"), ("include_archived", "false")]
+        assert (await client.get("/search", params=params + [("source_type", "document")])).status_code == 200
+        assert search.call_args.kwargs["doc_types"] == ["report", "note"]
+        assert search.call_args.kwargs["vault"] == ["a", "b"]
+        assert search.call_args.kwargs["source_type"] == "document"
+        assert (await client.get("/grep", params=params + [("regex", "true"), ("case_sensitive", "true")])).status_code == 200
+        assert grep.call_args.kwargs["regex"] is True
+        assert grep.call_args.kwargs["case_sensitive"] is True
+        assert grep.call_args.kwargs["include_archived"] is False
+        assert grep.call_args.kwargs["collection"] == "guide_%"
+        assert grep.call_args.kwargs["tags"] == ["ops"]
+        assert grep.call_args.kwargs["doc_types"] == ["report", "note"]
+        await client.get("/grep?q=x")
+        assert grep.call_args.kwargs["include_archived"] is True  # existing API default
+
+
+class CandidateConnection:
+    def __init__(self):
+        self.queries = []
+
+    async def fetchval(self, *_args):
+        return False
+
+    async def fetch(self, query, *params):
+        self.queries.append((query, params))
+        if "FROM documents d" in query:
+            return [{"id": uuid.UUID(int=30)}]
+        if "FROM vault_tables t" in query:
+            return [{"id": uuid.UUID(int=40)}]
+        if "FROM vault_files f" in query:
+            return [{"id": uuid.UUID(int=50)}]
+        return []
+
+
+class Pool:
+    def __init__(self, conn):
+        self.conn = conn
+
+    @asynccontextmanager
+    async def acquire(self):
+        yield self.conn
+
+
+@pytest.mark.parametrize("source,expected", [("document", 30), ("table", 40), ("file", 50)])
+async def test_source_and_collection_constrain_candidates_before_vector_limit(monkeypatch, source, expected):
+    conn = CandidateConnection()
+    monkeypatch.setattr(ss, "get_pool", AsyncMock(return_value=Pool(conn)))
+    monkeypatch.setattr(ss, "generate_embeddings", AsyncMock(return_value=[[0.1]]))
+    monkeypatch.setattr(ss, "_configured_document_source_type", lambda: ss.LEGACY_DOCUMENT_SOURCE)
+    service = ss.SearchService()
+    vector = AsyncMock(return_value=([], None))
+    monkeypatch.setattr(service, "_run_vector_search", vector)
+    await service.search("x", vault=["mine", "private"], user_id=str(uuid.UUID(int=1)), collection="guide_%", source_type=source, limit=25)
+    assert vector.call_args.kwargs["candidate_source_ids"] == [str(uuid.UUID(int=expected))]
+    for query, params in conn.queries:
+        assert "vault_access" in query  # every candidate query retains ACL
+        assert "guide\\_\\%/%" in params
+        assert "LIKE" in query and "ESCAPE" in query
+
+
+async def test_document_metadata_filters_do_not_admit_unrelated_tables_and_files(monkeypatch):
+    conn = CandidateConnection()
+    monkeypatch.setattr(ss, "get_pool", AsyncMock(return_value=Pool(conn)))
+    monkeypatch.setattr(ss, "generate_embeddings", AsyncMock(return_value=[[0.1]]))
+    monkeypatch.setattr(ss, "_configured_document_source_type", lambda: ss.LEGACY_DOCUMENT_SOURCE)
+    service = ss.SearchService()
+    vector = AsyncMock(return_value=([], None))
+    monkeypatch.setattr(service, "_run_vector_search", vector)
+    await service.search("x", vault="mine", doc_types=["report", "note"], tags=["ops"], limit=25)
+    assert len(conn.queries) == 1
+    query, params = conn.queries[0]
+    assert "d.doc_type = ANY" in query and "d.tags &&" in query and "d.status != 'archived'" in query
+    assert ["report", "note"] in params and ["ops"] in params
+    assert vector.call_args.kwargs["candidate_source_ids"] == [str(uuid.UUID(int=30))]
+
+
+async def test_native_grep_filters_before_counting_and_limiting(monkeypatch):
+    bodies = [HeadBody(namespace_id=uuid.UUID(int=1), vault="mine", resource_id=uuid.UUID(int=i + 1),
+                       surface="document", path=f"guides/{i}.md", revision_id="r", digest="d", byte_size=100,
+                       canonical_bytes=(f"---\ntype: {'report' if i >= 25 else 'note'}\ntags: [ops]\nstatus: {'archived' if i == 29 else 'active'}\n---\nAPI-223\n").encode())
+              for i in range(30)]
+    service = M1NativeGrepService(None)
+    monkeypatch.setattr(service, "_head_bodies", AsyncMock(return_value=bodies))
+    response = await service.grep_public("API-223", user_id=uuid.UUID(int=1), doc_types=["report"], tags=["ops"], include_archived=False, limit=2)
+    assert response["total_docs"] == 4
+    assert response["returned_docs"] == 2
+    assert response["truncated"] is True
+    assert all(int(item["path"].split("/")[-1][:-3]) >= 25 for item in response["results"])
+    response = await service.grep_public("API-223", user_id=uuid.UUID(int=1), doc_types=["report"], include_archived=True)
+    assert response["total_docs"] == 5
+
+
+async def test_invalid_regex_is_an_error_not_a_successful_zero_match():
+    with pytest.raises(ValidationError, match="Invalid regex"):
+        await ss.SearchService().grep("[", vault="mine", regex=True)
+
+
+async def test_standard_grep_binds_filters_before_scanning(monkeypatch):
+    conn = CandidateConnection()
+    monkeypatch.setattr(ss, "get_pool", AsyncMock(return_value=Pool(conn)))
+    monkeypatch.setattr(ss, "_configured_document_source_type", lambda: ss.LEGACY_DOCUMENT_SOURCE)
+    await ss.SearchService().grep("100%_", vault=["mine", "private"], user_id=str(uuid.UUID(int=1)),
+                                 collection="guide_%", doc_types=["report"], tags=["ops"], include_archived=False)
+    query, params = conn.queries[0]
+    assert "vault_access" in query
+    assert "d.doc_type = ANY" in query and "d.tags &&" in query
+    assert "d.status != 'archived'" in query
+    assert "100\\%\\_" in params and "guide\\_\\%/%" in params
+    assert ["report"] in params and ["ops"] in params
+
+
+@pytest.mark.parametrize("pattern,regex,case_sensitive,count", [
+    ("api-223", False, False, 1), ("api-223", False, True, 0),
+    ("API-[0-9]+", True, True, 1), ("api-[0-9]+", True, True, 0),
+])
+async def test_native_exact_and_regex_options_affect_results(monkeypatch, pattern, regex, case_sensitive, count):
+    body = HeadBody(namespace_id=uuid.UUID(int=1), vault="mine", resource_id=uuid.UUID(int=2),
+                    surface="document", path="x.md", revision_id="r", digest="d", byte_size=8,
+                    canonical_bytes=b"API-223\n")
+    service = M1NativeGrepService(None)
+    monkeypatch.setattr(service, "_head_bodies", AsyncMock(return_value=[body]))
+    response = await service.grep_public(pattern, user_id=uuid.UUID(int=1), regex=regex, case_sensitive=case_sensitive)
+    assert response["total_matches"] == count

--- a/backend/tests/test_search_filters_http.py
+++ b/backend/tests/test_search_filters_http.py
@@ -1,0 +1,125 @@
+"""Opt-in real HTTP/DB regression; use an isolated local E2E runtime only.
+
+AKB_SEARCH_TEST_URL=http://127.0.0.1:18080 uv run pytest tests/test_search_filters_http.py
+The runtime must enable local registration and its deterministic embedding stub.
+"""
+
+import asyncio
+import os
+import secrets
+from urllib.parse import urlparse
+import uuid
+
+import httpx
+import pytest
+
+
+async def test_live_login_search_filters_and_vault_isolation():
+    origin = os.getenv("AKB_SEARCH_TEST_URL")
+    if not origin:
+        pytest.skip("requires isolated local AKB_SEARCH_TEST_URL")
+    assert urlparse(origin).hostname in {"localhost", "127.0.0.1", "::1"}
+    suffix = uuid.uuid4().hex[:12]
+    vault = f"search-contract-{suffix}"
+    password = secrets.token_urlsafe(24)
+    async with httpx.AsyncClient(base_url=f"{origin}/api/v1", timeout=60) as client:
+        async def call(method, path, **kwargs):
+            response = await client.request(method, path, **kwargs)
+            assert response.is_success, (method, path, response.status_code, response.text[:1000])
+            return response.json()
+
+        async def login(name):
+            await call("POST", "/auth/register", json={
+                "username": name, "email": f"{name}@example.invalid", "password": password,
+            })
+            session = await call("POST", "/auth/login", json={"username": name, "password": password})
+            return {"Authorization": f"Bearer {session['token']}"}
+
+        owner = await login(f"search_{suffix}")
+        outsider = await login(f"outside_{suffix}")
+        await call("GET", "/auth/me", headers=owner)
+        await call("POST", "/vaults", headers=owner, params={"name": vault})
+        try:
+            for collection in ["guide", "guide/child", "guide-old"]:
+                await call("POST", f"/collections/{vault}", headers=owner, json={"path": collection})
+            for index in range(30):
+                await call("POST", "/documents", headers=owner, json={
+                    "vault": vault, "collection": "guide/child" if index == 28 else "guide",
+                    "title": f"Filter fixture {index}", "slug": f"fixture-{index}",
+                    "content": f"DeploymentNeedle API-223 literal 100%_ item {index}",
+                    "type": "report" if index >= 25 else "note",
+                    "status": "archived" if index == 29 else "active",
+                    "tags": ["ops", f"item-{index}"],
+                })
+            await call("POST", "/documents", headers=owner, json={
+                "vault": vault, "collection": "guide-old", "title": "Sibling excluded",
+                "content": "DeploymentNeedle", "type": "report", "status": "active", "tags": ["ops"],
+            })
+            base = {"q": "DeploymentNeedle", "vault": vault, "collection": "guide", "include_archived": "false"}
+            async def grep(**filters):
+                return await call("GET", "/grep", headers=owner, params={**base, **filters})
+
+            initial = await grep(limit=25)
+            assert initial["total_docs"] == 29 and len(initial["results"]) == 25
+            reports = await grep(doc_types="report", tags="ops", limit=2)
+            assert reports["total_docs"] == 4 and len(reports["results"]) == 2
+            assert reports["truncated"] is True
+            assert (await grep(doc_types="report", include_archived="true"))["total_docs"] == 5
+            assert (await grep(doc_types="report", tags="missing"))["total_docs"] == 0
+            assert (await grep(q="deploymentneedle", case_sensitive="true"))["total_docs"] == 0
+            assert (await grep(q="deploymentneedle", case_sensitive="false"))["total_docs"] == 29
+            assert (await grep(q="API-[0-9]+", regex="true", case_sensitive="true"))["total_docs"] == 29
+            assert (await grep(q="100%_"))["total_docs"] == 29
+            invalid = await client.get("/grep", headers=owner, params={**base, "q": "[", "regex": "true"})
+            assert invalid.status_code == 422
+            hidden = await call("GET", "/grep", headers=outsider, params=base)
+            assert hidden["total_docs"] == 0
+
+            # Wait for asynchronous indexing, then identify a result outside the first 25.
+            for _ in range(60):
+                all_docs = await call("GET", "/search", headers=owner, params={**base, "limit": 100})
+                if len(all_docs["results"]) == 29:
+                    break
+                await asyncio.sleep(1)
+            assert len(all_docs["results"]) == 29, all_docs
+            top = await call("GET", "/search", headers=owner, params={**base, "limit": 25})
+            shown = {item["title"] for item in top["results"]}
+            omitted = next(item for item in all_docs["results"] if item["title"] not in shown)
+            index = int(omitted["title"].rsplit(" ", 1)[1])
+            filtered = await call("GET", "/search", headers=owner, params={**base, "tags": f"item-{index}", "limit": 25})
+            assert [item["title"] for item in filtered["results"]] == [omitted["title"]]
+            typed = await call("GET", "/search", headers=owner, params={**base, "doc_types": "report", "source_type": "document"})
+            assert len(typed["results"]) == 4
+            assert all(item["doc_type"] == "report" for item in typed["results"])
+            hidden = await call("GET", "/search", headers=outsider, params={**base, "tags": f"item-{index}"})
+            assert hidden["results"] == []
+
+            # Real file/table candidates must obey the same collection boundary.
+            for number, collection in enumerate(["guide/child", "guide-old"]):
+                await call("POST", f"/tables/{vault}", headers=owner, json={
+                    "name": f"filter_{suffix}_{number}", "collection": collection,
+                    "description": "DeploymentNeedle", "columns": [{"name": "value", "type": "text"}],
+                })
+                upload = await call("POST", f"/files/{vault}/upload", headers=owner, params={
+                    "filename": f"fixture-{number}.txt", "collection": collection,
+                    "description": "DeploymentNeedle", "mime_type": "text/plain",
+                })
+                # The isolated runtime exposes its own local MinIO endpoint.
+                assert urlparse(upload["upload_url"]).hostname in {"localhost", "127.0.0.1"}
+                uploaded = await client.put(upload["upload_url"], content=b"DeploymentNeedle", headers={"Content-Type": "text/plain"})
+                assert uploaded.is_success
+                file_id = upload["uri"].rsplit("/", 1)[1]
+                await call("POST", f"/files/{vault}/{file_id}/confirm", headers=owner)
+            for source in ["file", "table"]:
+                for _ in range(60):
+                    results = await call("GET", "/search", headers=owner, params={**base, "source_type": source})
+                    if results["results"]:
+                        break
+                    await asyncio.sleep(1)
+                assert len(results["results"]) == 1, results
+                assert results["results"][0]["source_type"] == source
+                contradiction = await call("GET", "/search", headers=owner, params={**base, "source_type": source, "tags": "ops"})
+                assert contradiction["results"] == []
+        finally:
+            response = await client.delete(f"/vaults/{vault}", headers=owner)
+            assert response.is_success, response.text

--- a/docs/designs/search-filter-contract.md
+++ b/docs/designs/search-filter-contract.md
@@ -1,0 +1,155 @@
+# Server-driven search filters
+
+Search refinement must happen before retrieval limits, not by filtering the
+first page in the browser. Otherwise a matching document outside the first
+25 results can never be discovered by selecting its type or tag.
+
+## Request flow
+
+```text
+Search URL -> typed request options -> authorized server candidates
+                                      -> hybrid retrieval or document grep
+                                      -> bounded results and status feedback
+```
+
+The existing search engine and indexes remain unchanged. No schema migration,
+new service, or additional deployment dependency is required.
+
+Release the backend changes together with the frontend. An older backend can
+silently ignore the new query parameters, so a frontend-only rollout does not
+provide this filtering contract.
+
+## REST contract
+
+Both `/api/v1/search` and `/api/v1/grep` accept repeated `vault`, repeated
+`doc_types`, repeated `tags`, `collection`, `include_archived`, `q`, and `limit`.
+
+- Values within Vault, document-type and tag lists are OR conditions; different
+  filter dimensions are intersected with each other and the caller's access.
+- `collection` includes the named collection and descendants, not similarly
+  named siblings. `%`, `_` and backslashes in names are literal, not SQL
+  wildcards. When multiple Vaults are selected, the same path applies to each.
+- Hybrid search additionally accepts `source_type=document|file|table`.
+  Document metadata filters do not admit unrelated files or tables. Contradictory
+  source/metadata constraints return no candidates, rather than broadening scope.
+- The existing hybrid `type` parameter remains supported; `doc_types` intersects
+  it when both are present.
+- Grep additionally accepts `regex` and `case_sensitive`. Ordinary literal search
+  means substring matching, not whole-document equality. Invalid regular
+  expressions are validation errors, not successful empty responses.
+- Hybrid search excludes archived documents by default. Grep retains its
+  existing include-by-default behavior for older callers. The Search UI sends
+  `include_archived=false` explicitly for both modes unless selected otherwise.
+
+Grep remains a document-body search in the UI. The experimental native text-file
+measurement option is not enabled by the UI. Existing measurement callers remain
+unchanged when they omit the new metadata options.
+
+## Candidate selection
+
+Standard document queries bind type, tags, lifecycle, collection and ACL before
+vector retrieval or grep scanning. File and table candidate queries apply source,
+collection and Vault access; document-only metadata predicates exclude them.
+Native documents apply the same metadata semantics to their verified heads before
+search result counting and limiting. Native scope/resource/byte limits remain in
+effect; narrowing metadata does not remove those safety boundaries.
+
+The Vault-only vector optimization cannot express source or document lifecycle
+filters. Searches requiring those constraints therefore use the existing source-ID
+candidate path. This preserves filtering correctness at the cost of enumerating
+authorized candidates. Large-corpus performance should be measured before rollout;
+adding lifecycle metadata to vector drivers is a separate optimization, not part
+of this change.
+
+## Browser state
+
+The Search route uses `q`, `v`, `mode`, `source`, repeated `doc_type`, repeated
+`tag`, `collection`, `include_archived`, `regex`, and `case_sensitive` query
+parameters. Confirmed changes create history entries; only unsubmitted input
+drafts stay component-local. Reload, browser Back, and document previews preserve
+the search URL. The existing comma-separated `v` URL format remains supported.
+
+Filters remain editable before results and after zero matches. Type/tag selection
+selects document scope; selecting another resource kind clears document metadata
+filters. Literal mode retains the Semantic resource choice in the URL but explicitly
+searches documents only. Tags can be entered independently of the loaded results;
+result-derived tags are suggestions, not a complete facet inventory.
+
+The global search panel also sends its selected resource kind to the server and
+passes it into the advanced-search URL. Debouncing reports loading immediately,
+so a pending request is not briefly displayed as a genuine empty response.
+
+## Result feedback
+
+- Hybrid `returned` is the number of returned resources. `total_matches` is a
+  candidate-pool count, **not** a corpus-wide total. The UI labels top results.
+- Grep distinguishes returned documents/lines from total matching documents/lines.
+- Truncation copy is specific to each mode; narrowing scope is the recovery path.
+- A degraded response is incomplete, whether it contains results or not. It must
+  never be labelled a genuine zero-match. Retry is available without changing the
+  query, and raw server diagnostic details are not displayed as user guidance.
+- During a same-mode refresh the previous ledger is labelled busy; request
+  generations prevent late responses from replacing newer results.
+
+## Verification
+
+Backend contract and service tests:
+
+```sh
+cd backend
+uv run pytest tests/test_search_filter_contract_unit.py -q
+```
+
+Frontend gates:
+
+```sh
+cd frontend
+pnpm run design:check
+pnpm run typecheck
+pnpm run lint
+pnpm run test
+pnpm run build
+```
+
+Real-browser contract scenarios (production build with intercepted API fixtures):
+
+```sh
+cd frontend
+pnpm run preview --host 127.0.0.1 --port 4176
+# In another terminal:
+AKB_FRONTEND_URL=http://127.0.0.1:4176 pnpm exec playwright test search-contract.spec.ts
+```
+
+These browser tests exercise HTTP request serialization, filter selection, reload,
+history, viewport overflow, and light/dark rendering. They do not prove real login,
+database SQL execution, or indexing. Use the isolated runtime documented in
+`backend/scripts/ci/README.md` for live-backend verification; never point fixture
+tests at a production endpoint.
+
+Live HTTP/DB scenario, against an isolated local runtime:
+
+```sh
+cd backend
+AKB_SEARCH_TEST_URL=http://127.0.0.1:18080 uv run pytest tests/test_search_filters_http.py -q
+```
+
+This registers temporary users and creates its own Vault, documents, files and
+tables. It checks results outside the original top 25, collection boundaries,
+metadata, literal/regex/case options, archival status and private-Vault access.
+It waits for asynchronous indexing and removes its Vault afterward. The runtime
+owns the remaining temporary accounts and dependencies. Use its deterministic
+embedding stub: this checks retrieval/filter wiring, not model relevance quality.
+
+For the non-mocked Chromium scenario, serve the production frontend build with
+`/api` proxied to that same isolated backend, then run:
+
+```sh
+cd frontend
+AKB_SEARCH_LIVE=1 AKB_FRONTEND_URL=http://127.0.0.1:4177 \
+  pnpm exec playwright test search-live.spec.ts
+```
+
+This signs in through the actual local-login form and exercises search filters,
+reload, archive inclusion, regex and Semantic/Literal switching using real HTTP
+responses. Both live tests are opt-in and reject non-local target hosts. Do not
+configure their local proxy to forward to a production backend.

--- a/frontend/DESIGN_SYSTEM.md
+++ b/frontend/DESIGN_SYSTEM.md
@@ -722,9 +722,9 @@ A connected two-row command bar leads the page: the first row owns the strongly
 bounded query field, Semantic / Literal mode, on-demand Filters, and Search
 action; the thinner second row owns Vault scope plus honest loading/result
 status. The remaining height belongs to one independently scrolling,
-full-working-width results ledger. Source-kind and document-type facets stay
-behind the labelled Filters control and appear only after results provide useful
-counts; active filters remain visible through the control's count badge. This
+full-working-width results ledger. Source-kind and document-type filters stay
+behind the labelled Filters control and remain available before searching and
+after zero results; active filters remain visible through the control's count badge. This
 keeps refinement close to the query without allowing a fixed rail to tax every
 result row or compete with the collapsed Collections rail. On narrow screens,
 the first row wraps controls below the query without separating mode from its
@@ -744,13 +744,19 @@ only—never result bodies—and silently disappears when browser storage is not
 available. Each semantic or literal row uses a stable,
 non-zero-padded rank followed by source identity, compact location, one focused
 match context, and a calibrated label or literal match count. Optional backend
-tags progressively add compact result badges and a local tag facet; older
-responses omit both without reserving empty space. Indexed chunk headers and
+tags progressively add compact result badges and optional tag suggestions.
+Tag entry remains available independently of loaded results. Indexed chunk headers and
 markdown list markers are presentation metadata and are cleaned from semantic
 previews, while Literal results keep their source text intact. Raw semantic
 scores are ranking inputs, not percentages, so the UI never presents them as
-confidence or relevance percentages. Filters update the visible ledger without
-re-fetching unless the matching strategy or Vault scope changes.
+confidence or relevance percentages. Filters are URL-backed server predicates:
+source kind, collection (including children), document types, tags and archived
+inclusion all re-fetch before the result limit. Document metadata filters target
+documents only. Literal search uses document-body grep with optional regex and
+case sensitivity; its exact counts are distinct from Semantic's top-K candidate
+counts. Degraded empty responses never appear as a genuine zero-match. Confirmed
+filter changes create browser history entries; pending requests retain the
+previous ledger with explicit busy feedback and discard stale responses.
 Document rows open the route-backed document preview described in the Document
 workspace contract in both Semantic and Literal modes; table and file rows
 continue to open their native resource routes. Closing with Escape, the close
@@ -772,8 +778,8 @@ user-scoped recent global queries beside recently viewed documents, followed by
 the shared suggestions. Recent document history is browser-local and must be
 filtered through the current accessible Vault list before rendering; either
 history block disappears cleanly when no valid entries exist. The source choice
-persists into the result ledger and filters client-side without issuing another
-request. If the selected kind has no matches, the stable empty state provides a
+persists into the result ledger, requests a server-filtered result set and carries
+into the advanced-search URL. If the selected kind has no matches, the stable empty state provides a
 `Show all results` recovery action rather than silently resetting the choice.
 Selecting a document opens the same route-backed preview over the launching
 page; tables and files go directly to their native resource. The full Search route remains

--- a/frontend/e2e/search-contract.spec.ts
+++ b/frontend/e2e/search-contract.spec.ts
@@ -1,0 +1,145 @@
+// Real-browser search interaction contract with intercepted HTTP fixtures.
+// Does not replace the live-backend login/indexing E2E suite.
+import { test, expect } from "@playwright/test";
+
+for (const viewport of [
+  { width: 1440, height: 1000 },
+  { width: 390, height: 844 },
+]) {
+  for (const dark of [false, true]) {
+    test(`search filters, history and exact options at ${viewport.width}px (${dark ? "dark" : "light"})`, async ({
+      page,
+    }) => {
+      await page.setViewportSize(viewport);
+      await page.addInitScript(() =>
+        localStorage.setItem("akb_token", "browser-contract-fixture"),
+      );
+      const requests: URL[] = [];
+      await page.route("**/api/v1/**", async (route) => {
+        const url = new URL(route.request().url());
+        if (url.pathname.endsWith("/auth/config"))
+          return route.fulfill({
+            json: {
+              schema_version: 2,
+              auth_mode: "local",
+              local_auth: { enabled: true },
+              keycloak: { enabled: false, browser_session_ready: false },
+              providers: [],
+              mcp_oauth: { enabled: false },
+            },
+          });
+        if (url.pathname.endsWith("/auth/me"))
+          return route.fulfill({
+            json: {
+              user_id: "fixture-user",
+              username: "fixture",
+              email: "fixture@example.invalid",
+              display_name: "Fixture user",
+              is_admin: false,
+              auth_method: "local",
+              key_class: null,
+            },
+          });
+        if (url.pathname.endsWith("/search")) {
+          requests.push(url);
+          const title = url.searchParams.has("doc_types")
+            ? "Report outside initial top 25"
+            : "Initial result";
+          return route.fulfill({
+            json: {
+              query: "deployment",
+              total: 1,
+              returned: 1,
+              total_matches: 30,
+              truncated: true,
+              results: [
+                {
+                  title,
+                  uri: "akb://fixture/doc/report.md",
+                  vault: "fixture",
+                  path: "report.md",
+                  doc_type: "report",
+                  source_type: "document",
+                  score: 1,
+                },
+              ],
+            },
+          });
+        }
+        if (url.pathname.endsWith("/grep")) {
+          requests.push(url);
+          return route.fulfill({
+            json: {
+              pattern: "deployment",
+              regex: url.searchParams.get("regex") === "true",
+              total_docs: 0,
+              total_matches: 0,
+              returned_docs: 0,
+              returned_matches: 0,
+              results: [],
+            },
+          });
+        }
+        return route.fulfill({ json: { vaults: [], items: [], total: 0 } });
+      });
+      await page.goto("/search?q=deployment");
+      await page.evaluate(
+        (isDark) => document.documentElement.classList.toggle("dark", isDark),
+        dark,
+      );
+      await expect(page.getByText("Initial result")).toBeVisible();
+      await page
+        .getByRole("button", { name: "Filter by document type" })
+        .click();
+      await page.getByRole("button", { name: "Toggle report" }).click();
+      await expect(
+        page.getByText("Report outside initial top 25"),
+      ).toBeVisible();
+      await expect(page).toHaveURL(/doc_type=report/);
+      await page.reload();
+      await page.evaluate(
+        (isDark) => document.documentElement.classList.toggle("dark", isDark),
+        dark,
+      );
+      await expect(
+        page.getByText("Report outside initial top 25"),
+      ).toBeVisible();
+      await page
+        .getByRole("button", { name: "Literal", pressed: false })
+        .click();
+      await page
+        .getByRole("button", { name: "Filter by document type" })
+        .click();
+      // URL navigation is a React transition; wait for its controlled state.
+      for (const label of [
+        "Regular expression",
+        "Case sensitive",
+        "Include archived documents",
+      ]) {
+        await page.getByLabel(label).click();
+        await expect(page.getByLabel(label)).toBeChecked();
+      }
+      await expect
+        .poll(() => requests.at(-1)?.searchParams.get("include_archived"))
+        .toBe("true");
+      expect(requests.at(-1)?.searchParams.get("regex")).toBe("true");
+      expect(requests.at(-1)?.searchParams.get("case_sensitive")).toBe("true");
+      expect(requests.at(-1)?.searchParams.getAll("doc_types")).toEqual([
+        "report",
+      ]);
+      await page.goBack();
+      await expect(
+        page.getByLabel("Include archived documents"),
+      ).not.toBeChecked();
+      expect(
+        await page.evaluate(
+          () => document.documentElement.scrollWidth <= innerWidth,
+        ),
+      ).toBe(true);
+      await page.screenshot({
+        path: test.info().outputPath("search-filters.png"),
+        fullPage: true,
+      });
+    });
+  }
+}

--- a/frontend/e2e/search-live.spec.ts
+++ b/frontend/e2e/search-live.spec.ts
@@ -1,0 +1,134 @@
+// Opt-in isolated local runtime: no intercepted API responses or injected sessions.
+import { randomBytes } from "node:crypto";
+import { test, expect } from "@playwright/test";
+
+test("real login, search filters, reload and exact-search options", async ({
+  page,
+  request,
+  baseURL,
+}) => {
+  test.setTimeout(90000);
+  test.skip(
+    process.env.AKB_SEARCH_LIVE !== "1",
+    "Requires an isolated local backend and frontend proxy",
+  );
+  expect(["127.0.0.1", "localhost"]).toContain(new URL(baseURL!).hostname);
+  const suffix = randomBytes(6).toString("hex");
+  const username = `browser_${suffix}`;
+  const password = randomBytes(24).toString("base64url");
+  const vault = `browser-search-${suffix}`;
+  const registration = await request.post("/api/v1/auth/register", {
+    data: { username, password, email: `${username}@example.invalid` },
+  });
+  expect(registration.ok()).toBeTruthy();
+  await page.goto("/auth");
+  await page.getByLabel("Username", { exact: true }).fill(username);
+  await page.getByLabel("Password", { exact: true }).fill(password);
+  await page.getByRole("button", { name: "Sign in", exact: true }).click();
+  await expect(page).not.toHaveURL(/\/auth/);
+  const token = await page.evaluate(() => localStorage.getItem("akb_token"));
+  expect(token).toBeTruthy();
+  const headers = { Authorization: `Bearer ${token}` };
+  expect(
+    (await request.post(`/api/v1/vaults?name=${vault}`, { headers })).ok(),
+  ).toBeTruthy();
+  try {
+    expect(
+      (
+        await request.post(`/api/v1/collections/${vault}`, {
+          headers,
+          data: { path: "guide" },
+        })
+      ).ok(),
+    ).toBeTruthy();
+    for (const [title, type, status] of [
+      ["Live active report", "report", "active"],
+      ["Live archived report", "report", "archived"],
+      ["Live note", "note", "active"],
+    ]) {
+      expect(
+        (
+          await request.post("/api/v1/documents", {
+            headers,
+            data: {
+              vault,
+              collection: "guide",
+              title,
+              type,
+              status,
+              tags: ["ops"],
+              content: "DeploymentNeedle API-223",
+            },
+          })
+        ).ok(),
+      ).toBeTruthy();
+    }
+    await page.goto(`/search?q=DeploymentNeedle&v=${vault}&mode=literal`);
+    await expect(page.getByText("Live note", { exact: true })).toBeVisible();
+    await expect(
+      page.getByText("Live archived report", { exact: true }),
+    ).toHaveCount(0);
+    await page.getByRole("button", { name: "Filter by document type" }).click();
+    await page.getByRole("button", { name: "Toggle report" }).click();
+    await expect(
+      page.getByText("Live active report", { exact: true }),
+    ).toBeVisible();
+    await expect(page.getByText("Live note", { exact: true })).toHaveCount(0);
+    await page.getByLabel("Include archived documents").click();
+    await expect(
+      page.getByText("Live archived report", { exact: true }),
+    ).toBeVisible();
+    await page.reload();
+    await expect(
+      page.getByText("Live archived report", { exact: true }),
+    ).toBeVisible();
+    await page.getByLabel("Search query", { exact: true }).fill("API-[0-9]+");
+    await page.getByLabel("Search query", { exact: true }).press("Enter");
+    await expect(
+      page.getByText("Live active report", { exact: true }),
+    ).toHaveCount(0);
+    await page.getByRole("button", { name: "Filter by document type" }).click();
+    await page.getByLabel("Regular expression").click();
+    await expect(
+      page.getByText("Live active report", { exact: true }),
+    ).toBeVisible();
+    await page
+      .getByLabel("Search query", { exact: true })
+      .fill("DeploymentNeedle");
+    await page.getByLabel("Search query", { exact: true }).press("Enter");
+    await expect
+      .poll(
+        async () => {
+          const response = await request.get(
+            `/api/v1/search?q=DeploymentNeedle&vault=${vault}&doc_types=report`,
+            { headers },
+          );
+          return (await response.json()).results?.length;
+        },
+        { timeout: 30000 },
+      )
+      .toBe(1);
+    const semanticResponse = page.waitForResponse((response) => {
+      const url = new URL(response.url());
+      return url.pathname === "/api/v1/search" && url.searchParams.get("vault") === vault;
+    });
+    await page.getByRole("button", { name: "Semantic", exact: true }).click();
+    const semantic = await semanticResponse;
+    expect(semantic.ok()).toBeTruthy();
+    expect((await semantic.json()).results).toHaveLength(2);
+    await expect(page.getByRole("button", { name: "Semantic", exact: true })).toHaveAttribute("aria-pressed", "true");
+    await expect(page.getByRole("region", { name: "Search results", exact: true })).toHaveAttribute("aria-busy", "false");
+    await expect(
+      page.getByText("Live active report", { exact: true }),
+    ).toBeVisible({ timeout: 30000 });
+    await expect(page.getByText("Live note", { exact: true })).toHaveCount(0);
+    await page.screenshot({
+      path: test.info().outputPath("live-search.png"),
+      fullPage: true,
+    });
+  } finally {
+    expect(
+      (await request.delete(`/api/v1/vaults/${vault}`, { headers })).ok(),
+    ).toBeTruthy();
+  }
+});

--- a/frontend/src/components/__tests__/global-search-dialog.test.tsx
+++ b/frontend/src/components/__tests__/global-search-dialog.test.tsx
@@ -87,6 +87,23 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("GlobalSearchDialog", () => {
+  it("does not expose or activate hidden partial results during a degraded response", async () => {
+    const response = await searchDocsMock("postgres");
+    searchDocsMock.mockResolvedValue({ ...response, degraded: true });
+    const user = userEvent.setup();
+    renderDialog();
+    await user.click(screen.getByRole("button", { name: "Search knowledge" }));
+    const input = screen.getByRole("combobox");
+    await user.type(input, "postgres");
+    await screen.findByText(/Search is incomplete/);
+    expect(input).toHaveAttribute("aria-expanded", "false");
+    expect(input).not.toHaveAttribute("aria-controls");
+    expect(input).not.toHaveAttribute("aria-activedescendant");
+    await user.keyboard("{ArrowDown}{Enter}");
+    expect(screen.getByTestId("location")).toHaveTextContent(/^\/$/);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
   it("opens in place, focuses the search field, and returns focus on Escape", async () => {
     const user = userEvent.setup();
     renderDialog();
@@ -121,7 +138,7 @@ describe("GlobalSearchDialog", () => {
     const input = screen.getByRole("combobox", { name: "Search all accessible vaults" });
     await user.type(input, "postgres");
 
-    await waitFor(() => expect(searchDocsMock).toHaveBeenCalledWith("postgres", [], 12));
+    await waitFor(() => expect(searchDocsMock).toHaveBeenCalledWith("postgres", [], 12, expect.any(Object)));
     expect(await screen.findByRole("option", { name: /PostgreSQL tuning/i })).toHaveAttribute(
       "aria-selected",
       "true",
@@ -158,7 +175,7 @@ describe("GlobalSearchDialog", () => {
     await user.click(screen.getByRole("button", { name: /postgres tuning/i }));
 
     await waitFor(() =>
-      expect(searchDocsMock).toHaveBeenCalledWith("postgres tuning", [], 12),
+      expect(searchDocsMock).toHaveBeenCalledWith("postgres tuning", [], 12, expect.any(Object)),
     );
   });
 
@@ -193,7 +210,7 @@ describe("GlobalSearchDialog", () => {
     );
   });
 
-  it("filters mixed top matches locally and cleans indexed context", async () => {
+  it("filters mixed top matches on the server and cleans indexed context", async () => {
     searchDocsMock.mockResolvedValue({
       query: "platform",
       total: 2,
@@ -234,7 +251,11 @@ describe("GlobalSearchDialog", () => {
     expect(await screen.findByText("Worker and API responsibilities.")).toBeInTheDocument();
     expect(screen.queryByText(/\[# Platform guide/)).toBeNull();
 
+    searchDocsMock.mockResolvedValueOnce({ query: "platform", total: 1, returned: 1, total_matches: 1,
+      results: [{ source_type: "table", uri: "akb://alpha/table/services", vault: "alpha", path: "services", title: "Services", score: 1 }] });
     await user.click(screen.getByRole("button", { name: /Tables, 1 result/i }));
+    await waitFor(() => expect(searchDocsMock).toHaveBeenLastCalledWith("platform", [], 12, { source_type: "table" }));
+    await screen.findByRole("option", { name: /Services/i });
     expect(screen.getByRole("option", { name: /Services/i })).toBeInTheDocument();
     expect(screen.queryByRole("option", { name: /Platform guide/i })).toBeNull();
   });
@@ -244,20 +265,21 @@ describe("GlobalSearchDialog", () => {
     renderDialog();
 
     await user.click(screen.getByRole("button", { name: "Search knowledge" }));
+    searchDocsMock.mockResolvedValueOnce({ query: "postgres", total: 0, returned: 0, total_matches: 0, results: [] });
     await user.click(screen.getByRole("button", { name: "Tables" }));
     await user.type(
       screen.getByRole("combobox", { name: "Search all accessible vaults" }),
       "postgres",
     );
 
-    expect(await screen.findByText("No tables in these matches")).toBeInTheDocument();
+    expect(await screen.findByText(/No results for/)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Tables, 0 results/ })).toHaveAttribute(
       "aria-pressed",
       "true",
     );
     await user.click(screen.getByRole("button", { name: "Show all results" }));
     expect(
-      screen.getByRole("option", { name: /PostgreSQL tuning/i }),
+      await screen.findByRole("option", { name: /PostgreSQL tuning/i }),
     ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/global-search-dialog.tsx
+++ b/frontend/src/components/global-search-dialog.tsx
@@ -101,7 +101,6 @@ export function GlobalSearchDialog() {
   const location = useLocation();
   const inputRef = useRef<HTMLInputElement>(null);
   const requestId = useRef(0);
-  const activeSourceRef = useRef<SearchSourceFilter>("all");
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<GlobalSearchResult[]>([]);
@@ -121,12 +120,7 @@ export function GlobalSearchDialog() {
     },
     { document: 0, table: 0, file: 0 } as Record<SearchSource, number>,
   );
-  const visibleResults =
-    activeSource === "all"
-      ? results
-      : results.filter(
-          (result) => (result.source_type || "document") === activeSource,
-        );
+  const visibleResults = loading || error ? [] : results;
   const hasRecentSearches = recentSearches.length > 0;
   const hasRecentDocuments = recentDocuments.length > 0;
 
@@ -184,22 +178,15 @@ export function GlobalSearchDialog() {
     setResults([]);
     setError(null);
     setActiveIndex(-1);
+    setLoading(true);
     const timer = window.setTimeout(() => {
-      setLoading(true);
-      void searchDocs(normalizedQuery, [], 12)
+      void searchDocs(normalizedQuery, [], 12, { source_type: activeSource === "all" ? undefined : activeSource })
         .then((response) => {
           if (currentRequest !== requestId.current) return;
           const nextResults = (response.results || []) as GlobalSearchResult[];
-          const selectedSource = activeSourceRef.current;
-          const nextVisibleResults =
-            selectedSource === "all"
-              ? nextResults
-              : nextResults.filter(
-                  (result) =>
-                    (result.source_type || "document") === selectedSource,
-                );
           setResults(nextResults);
-          setActiveIndex(nextVisibleResults.length > 0 ? 0 : -1);
+          setActiveIndex(nextResults.length > 0 ? 0 : -1);
+          if (response.degraded) setError("Search is incomplete; the retrieval service is temporarily unavailable. Please retry.");
         })
         .catch((caught: unknown) => {
           if (currentRequest !== requestId.current) return;
@@ -213,7 +200,7 @@ export function GlobalSearchDialog() {
     }, 220);
 
     return () => window.clearTimeout(timer);
-  }, [normalizedQuery, open, retryKey]);
+  }, [normalizedQuery, open, retryKey, activeSource]);
 
   function rememberGlobalSearch() {
     if (!currentUserId || !normalizedQuery) return;
@@ -323,7 +310,7 @@ export function GlobalSearchDialog() {
                 visibleResults.length > 0 ? "global-search-results" : undefined
               }
               aria-activedescendant={
-                activeIndex >= 0 ? `global-search-result-${activeIndex}` : undefined
+                activeIndex >= 0 && activeIndex < visibleResults.length ? `global-search-result-${activeIndex}` : undefined
               }
               autoComplete="off"
               spellCheck={false}
@@ -385,7 +372,6 @@ export function GlobalSearchDialog() {
                       : label
                   }
                   onClick={() => {
-                    activeSourceRef.current = key;
                     setActiveSource(key);
                     setActiveIndex(
                       key === "all"
@@ -604,40 +590,9 @@ export function GlobalSearchDialog() {
               <p className="mt-1 text-xs text-foreground-muted">
                 Try fewer words or open advanced search for exact matching.
               </p>
+              {activeSource !== "all" && <Button type="button" variant="outline" className="mt-3" onClick={() => setActiveSource("all")}>Show all results</Button>}
             </div>
           )}
-
-          {normalizedQuery &&
-            !loading &&
-            !error &&
-            results.length > 0 &&
-            visibleResults.length === 0 && (
-              <div className="flex min-h-56 flex-col items-center justify-center px-5 text-center">
-                <Search className="h-5 w-5 text-foreground-muted" aria-hidden />
-                <p className="mt-3 text-sm font-semibold text-foreground">
-                  No{" "}
-                  {SOURCE_FILTERS.find(
-                    (filter) => filter.key === activeSource,
-                  )?.label.toLowerCase()} in these matches
-                </p>
-                <p className="mt-1 text-xs text-foreground-muted">
-                  The query has results in another content type.
-                </p>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="mt-3"
-                  onClick={() => {
-                    activeSourceRef.current = "all";
-                    setActiveSource("all");
-                    setActiveIndex(0);
-                  }}
-                >
-                  Show all results
-                </Button>
-              </div>
-            )}
 
           {visibleResults.length > 0 && !loading && !error && (
             <section aria-labelledby="global-search-results-heading">
@@ -728,7 +683,10 @@ export function GlobalSearchDialog() {
             onClick={() => {
               rememberGlobalSearch();
               setOpen(false);
-              navigate(normalizedQuery ? `/search?q=${encodeURIComponent(normalizedQuery)}` : "/search");
+              const params = new URLSearchParams();
+              if (normalizedQuery) params.set("q", normalizedQuery);
+              if (activeSource !== "all") params.set("source", activeSource);
+              navigate(`/search?${params}`);
             }}
             className="inline-flex h-8 items-center gap-1.5 rounded-[var(--radius-sm)] px-2 text-xs font-medium text-link transition-token hover:bg-surface-hover hover:text-link-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >

--- a/frontend/src/lib/__tests__/api-search-contract.test.ts
+++ b/frontend/src/lib/__tests__/api-search-contract.test.ts
@@ -74,6 +74,33 @@ describe("search response contract — returned vs total_matches (PR #39)", () =
 });
 
 describe("grep response contract — total_matches + total_docs", () => {
+  it("serializes scope and metadata filters and keeps regex options exclusive to grep", async () => {
+    const requests: URL[] = [];
+    server.use(http.get("*/api/v1/search", ({ request }) => {
+      requests.push(new URL(request.url));
+      return HttpResponse.json({ results: [] });
+    }), http.get("*/api/v1/grep", ({ request }) => {
+      requests.push(new URL(request.url));
+      return HttpResponse.json({ results: [] });
+    }));
+    const options = { collection: "guide_%", doc_types: ["report", "note"], tags: ["ops", "한글"],
+      source_type: "document" as const, include_archived: false, regex: true, case_sensitive: true };
+    await searchDocs("x", ["a", "b"], 25, options);
+    await grepDocs("A.*B", ["a", "b"], 20, options);
+    for (const url of requests) {
+      expect(url.searchParams.getAll("vault")).toEqual(["a", "b"]);
+      expect(url.searchParams.get("collection")).toBe("guide_%");
+      expect(url.searchParams.getAll("doc_types")).toEqual(["report", "note"]);
+      expect(url.searchParams.getAll("tags")).toEqual(["ops", "한글"]);
+      expect(url.searchParams.get("include_archived")).toBe("false");
+    }
+    expect(requests[0].searchParams.has("regex")).toBe(false);
+    expect(requests[0].searchParams.get("source_type")).toBe("document");
+    expect(requests[1].searchParams.has("source_type")).toBe(false);
+    expect(requests[1].searchParams.get("regex")).toBe("true");
+    expect(requests[1].searchParams.get("case_sensitive")).toBe("true");
+  });
+
   it("returns the count fields for the default response shape", async () => {
     server.use(
       http.get(`*/api/v1/grep`, () =>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1861,9 +1861,31 @@ export interface SearchResponse {
 const vaultScopeParams = (vaults?: string[] | string): string[] =>
   (Array.isArray(vaults) ? vaults : vaults ? [vaults] : []).filter(Boolean);
 
-export const searchDocs = (query: string, vaults?: string[] | string, limit = 10) => {
+export interface SearchOptions {
+  collection?: string;
+  source_type?: "document" | "file" | "table";
+  doc_types?: string[];
+  tags?: string[];
+  include_archived?: boolean;
+  regex?: boolean;
+  case_sensitive?: boolean;
+}
+
+function appendSearchOptions(p: URLSearchParams, options: SearchOptions, literal: boolean) {
+  if (options.collection) p.set("collection", options.collection);
+  for (const type of options.doc_types || []) p.append("doc_types", type);
+  for (const tag of options.tags || []) p.append("tags", tag);
+  if (options.include_archived !== undefined) p.set("include_archived", String(options.include_archived));
+  if (literal) {
+    if (options.regex !== undefined) p.set("regex", String(options.regex));
+    if (options.case_sensitive !== undefined) p.set("case_sensitive", String(options.case_sensitive));
+  } else if (options.source_type) p.set("source_type", options.source_type);
+}
+
+export const searchDocs = (query: string, vaults?: string[] | string, limit = 10, options: SearchOptions = {}) => {
   const p = new URLSearchParams({ q: query, limit: String(limit) });
   for (const v of vaultScopeParams(vaults)) p.append("vault", v);
+  appendSearchOptions(p, options, false);
   return api<SearchResponse>(`/search?${p}`);
 };
 
@@ -1894,9 +1916,10 @@ export interface GrepResponse {
   hint?: string | null;
   results: GrepDoc[];
 }
-export const grepDocs = (query: string, vaults?: string[] | string, limit = 20) => {
+export const grepDocs = (query: string, vaults?: string[] | string, limit = 20, options: SearchOptions = {}) => {
   const p = new URLSearchParams({ q: query, limit: String(limit) });
   for (const v of vaultScopeParams(vaults)) p.append("vault", v);
+  appendSearchOptions(p, options, true);
   return api<GrepResponse>(`/grep?${p}`);
 };
 

--- a/frontend/src/lib/search-state.ts
+++ b/frontend/src/lib/search-state.ts
@@ -1,0 +1,39 @@
+import type { SearchOptions } from "./api";
+
+export const SEARCH_FILTER_KEYS = [
+  "source",
+  "doc_type",
+  "tag",
+  "collection",
+  "include_archived",
+  "regex",
+  "case_sensitive",
+] as const;
+
+export function readSearchOptions(params: URLSearchParams): SearchOptions {
+  const source = params.get("source");
+  return {
+    collection: params.get("collection") || undefined,
+    source_type:
+      source === "document" || source === "file" || source === "table"
+        ? source
+        : undefined,
+    doc_types: [...new Set(params.getAll("doc_type").filter(Boolean))],
+    tags: [...new Set(params.getAll("tag").filter(Boolean))],
+    include_archived: params.get("include_archived") === "true",
+    regex: params.get("regex") === "true",
+    case_sensitive: params.get("case_sensitive") === "true",
+  };
+}
+
+export function setSearchValues(
+  params: URLSearchParams,
+  key: string,
+  values: string[],
+): URLSearchParams {
+  const next = new URLSearchParams(params);
+  next.delete(key);
+  for (const value of [...new Set(values.filter(Boolean))])
+    next.append(key, value);
+  return next;
+}

--- a/frontend/src/pages/__tests__/search-filter-chips.test.tsx
+++ b/frontend/src/pages/__tests__/search-filter-chips.test.tsx
@@ -1,204 +1,260 @@
-// RTL coverage for doc-type filter chips on SearchPage.
-//
-// The chips filter `doc_type` on dense results client-side — no backend
-// changes needed. This file covers:
-//   - chip row renders with ALL_TYPES including "skill"
-//   - toggling a chip off hides matching results without a re-fetch
-//
-// DenseResult shape: { source_type, uri, vault, path, title, doc_type, score }
-// The filter field is `doc_type` (not `type`).
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
-
+import { MemoryRouter, useLocation, useNavigate } from "react-router-dom";
 import SearchPage from "../search";
-import { searchDocs, listVaults } from "@/lib/api";
+import { searchDocs, grepDocs, listVaults } from "@/lib/api";
 
 vi.mock("@/lib/api", () => ({
   searchDocs: vi.fn(),
   grepDocs: vi.fn(),
   listVaults: vi.fn(),
 }));
-
-const mockedSearch = vi.mocked(searchDocs);
-const mockedListVaults = vi.mocked(listVaults);
-
-afterEach(cleanup);
-beforeEach(() => {
-  vi.clearAllMocks();
-  mockedListVaults.mockResolvedValue({ vaults: [] });
+const search = vi.mocked(searchDocs);
+const grep = vi.mocked(grepDocs);
+const response = (results: object[] = []) => ({
+  query: "x",
+  total: results.length,
+  returned: results.length,
+  total_matches: results.length,
+  results,
 });
-
-function renderAt(url: string) {
+const hit = (title: string) => ({
+  title,
+  uri: "akb://v/doc/x.md",
+  vault: "v",
+  path: "x.md",
+  source_type: "document",
+  doc_type: "report",
+  score: 1,
+});
+function Navigation() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  return (
+    <>
+      <output data-testid="url">{location.search}</output>
+      <button onClick={() => navigate(-1)}>Back</button>
+    </>
+  );
+}
+function renderAt(url = "/search?q=x") {
   return render(
     <MemoryRouter initialEntries={[url]}>
       <SearchPage />
+      <Navigation />
     </MemoryRouter>,
   );
 }
-
-describe("Search filter chips", () => {
-  it("progressively reveals type filters when results exist", async () => {
-    mockedSearch.mockResolvedValue({
-      query: "test",
-      total: 1,
-      returned: 1,
-      total_matches: 1,
-      results: [
-        {
-          source_type: "document",
-          uri: "akb://v/document/d-1",
-          vault: "v",
-          path: "overview/vault-skill.md",
-          title: "A skill doc",
-          doc_type: "skill",
-          score: 0.95,
-        },
-      ],
-    });
-    const u = userEvent.setup();
-    renderAt("/search?q=test");
-    await screen.findByText("A skill doc");
-    await u.click(
-      screen.getByRole("button", { name: "Filter by document type" }),
-    );
-    expect(screen.getByRole("button", { name: /toggle skill/i })).toBeTruthy();
-    expect(screen.getByRole("button", { name: /toggle note/i })).toBeTruthy();
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(listVaults).mockResolvedValue({ vaults: [] });
+  search.mockResolvedValue(response());
+  grep.mockResolvedValue({
+    pattern: "x",
+    regex: false,
+    total_docs: 0,
+    total_matches: 0,
+    results: [],
   });
+});
+afterEach(cleanup);
+const openFilters = async (user: ReturnType<typeof userEvent.setup>) =>
+  user.click(screen.getByRole("button", { name: "Filter by document type" }));
 
-  it("toggling NOTE off hides NOTE results but keeps SKILL results", async () => {
-    mockedSearch.mockResolvedValue({
-      query: "x",
-      total: 2,
-      returned: 2,
-      total_matches: 2,
-      results: [
-        {
-          source_type: "document",
-          uri: "akb://v/document/d-1",
-          vault: "v",
-          path: "overview/vault-skill.md",
-          title: "A skill doc",
-          doc_type: "skill",
-          score: 0.95,
-        },
-        {
-          source_type: "document",
-          uri: "akb://v/document/d-2",
-          vault: "v",
-          path: "n.md",
-          title: "A note",
-          doc_type: "note",
-          score: 0.85,
-        },
-      ],
-    });
-    const u = userEvent.setup();
-    renderAt("/search?q=x");
-
-    // wait for results to render
-    await screen.findByText("A skill doc");
-    expect(screen.queryByText("A note")).toBeTruthy();
-
-    // toggle NOTE chip off
-    await u.click(
-      screen.getByRole("button", { name: "Filter by document type" }),
-    );
-    await u.click(screen.getByRole("button", { name: /toggle note/i }));
-
-    // NOTE is now filtered out client-side; skill doc remains
-    expect(screen.queryByText("A note")).toBeNull();
-    expect(screen.queryByText("A skill doc")).toBeTruthy();
-
-    // only one searchDocs call — no re-fetch
-    expect(mockedSearch).toHaveBeenCalledTimes(1);
-  });
-
-  it("filters resource kinds in the progressive filter tray without re-fetching", async () => {
-    mockedSearch.mockResolvedValue({
-      query: "platform",
-      total: 2,
-      returned: 2,
-      total_matches: 2,
-      results: [
-        {
-          source_type: "document",
-          uri: "akb://v/document/d-1",
-          vault: "v",
-          path: "platform.md",
-          title: "Platform guide",
-          doc_type: "note",
-          score: 0.95,
-        },
-        {
-          source_type: "table",
-          uri: "akb://v/table/services",
-          vault: "v",
-          path: "services",
-          title: "Services",
-          score: 0.84,
-        },
-      ],
-    });
+describe("server search filters", () => {
+  it("keeps filters available before results and after a zero-match response", async () => {
+    renderAt();
     const user = userEvent.setup();
-    renderAt("/search?q=platform");
+    await openFilters(user);
+    expect(screen.getByRole("button", { name: "Toggle report" })).toBeEnabled();
+    expect(screen.getByLabelText("Tags (match any)")).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Tables" })).toBeEnabled();
+  });
 
-    await screen.findByText("Platform guide");
-    expect(screen.getByText("Services")).toBeTruthy();
-    await user.click(
-      screen.getByRole("button", { name: "Filter by document type" }),
+  it("finds a matching document outside the initial 25 results by re-searching on the server", async () => {
+    const first25 = Array.from({ length: 25 }, (_, i) => hit(`Initial ${i}`));
+    search.mockImplementation(async (_q, _v, _l, options) =>
+      response(
+        options?.doc_types?.includes("report")
+          ? [hit("Previously outside top 25")]
+          : first25,
+      ),
     );
+    renderAt();
+    const user = userEvent.setup();
+    await screen.findByText("Initial 0");
+    await openFilters(user);
+    await user.click(screen.getByRole("button", { name: "Toggle report" }));
+    await screen.findByText("Previously outside top 25");
+    expect(screen.queryByText("Initial 0")).not.toBeInTheDocument();
+    expect(search).toHaveBeenLastCalledWith(
+      "x",
+      [],
+      25,
+      expect.objectContaining({
+        doc_types: ["report"],
+        source_type: "document",
+      }),
+    );
+    expect(screen.getByTestId("url")).toHaveTextContent("doc_type=report");
+    await user.click(screen.getByRole("button", { name: "Back" }));
+    await screen.findByText("Initial 0");
+    expect(
+      screen.getByRole("button", { name: "Toggle report" }),
+    ).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("sends resource type, collection, tags and archive filters rather than slicing results", async () => {
+    renderAt();
+    const user = userEvent.setup();
+    await openFilters(user);
     await user.click(screen.getByRole("button", { name: "Tables" }));
-
-    expect(screen.queryByText("Platform guide")).toBeNull();
-    expect(screen.getByText("Services")).toBeTruthy();
-    expect(mockedSearch).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(search).toHaveBeenLastCalledWith(
+        "x",
+        [],
+        25,
+        expect.objectContaining({ source_type: "table" }),
+      ),
+    );
+    await user.type(
+      screen.getByLabelText("Collection path (including children)"),
+      "guides/api",
+    );
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+    await user.type(
+      screen.getByLabelText("Tags (match any)"),
+      "rare-tag{Enter}",
+    );
+    await user.click(screen.getByLabelText("Include archived documents"));
+    await waitFor(() =>
+      expect(search).toHaveBeenLastCalledWith(
+        "x",
+        [],
+        25,
+        expect.objectContaining({
+          collection: "guides/api",
+          tags: ["rare-tag"],
+          source_type: "document",
+          include_archived: true,
+        }),
+      ),
+    );
+    await user.click(screen.getByRole("button", { name: "Reset filters" }));
+    await waitFor(() =>
+      expect(search).toHaveBeenLastCalledWith(
+        "x",
+        [],
+        25,
+        expect.objectContaining({
+          collection: undefined,
+          tags: [],
+          source_type: undefined,
+          include_archived: false,
+        }),
+      ),
+    );
   });
 
-  it("filters optional backend tags locally and cleans indexed context headers", async () => {
-    mockedSearch.mockResolvedValue({
-      query: "worker",
-      total: 2,
-      returned: 2,
-      total_matches: 2,
+  it("restores full URL state and preserves filters across mode changes", async () => {
+    renderAt(
+      "/search?q=API&v=eng&collection=guides&doc_type=report&doc_type=note&tag=ops&include_archived=true&regex=true&case_sensitive=true",
+    );
+    const user = userEvent.setup();
+    await waitFor(() => expect(search).toHaveBeenCalled());
+    await user.click(
+      screen.getByRole("button", { name: "Literal", pressed: false }),
+    );
+    await waitFor(() =>
+      expect(grep).toHaveBeenLastCalledWith(
+        "API",
+        ["eng"],
+        20,
+        expect.objectContaining({
+          collection: "guides",
+          doc_types: ["report", "note"],
+          tags: ["ops"],
+          include_archived: true,
+          regex: true,
+          case_sensitive: true,
+        }),
+      ),
+    );
+    await openFilters(user);
+    expect(screen.getByLabelText("Regular expression")).toBeChecked();
+    await user.click(screen.getByLabelText("Case sensitive"));
+    await waitFor(() =>
+      expect(grep).toHaveBeenLastCalledWith(
+        "API",
+        ["eng"],
+        20,
+        expect.objectContaining({ case_sensitive: false }),
+      ),
+    );
+  });
+
+  it("does not call an incomplete empty response a genuine zero-match and retries unchanged queries", async () => {
+    search.mockResolvedValue({
+      ...response(),
+      degraded: true,
+      degradation_reason: "vector_store_unavailable",
+    });
+    renderAt();
+    const user = userEvent.setup();
+    await screen.findByText(/Search is incomplete/);
+    expect(
+      screen.queryByRole("heading", { name: /No results/ }),
+    ).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+    expect(search).toHaveBeenCalledTimes(2);
+    await user.click(screen.getByRole("button", { name: "Search" }));
+    await waitFor(() => expect(search).toHaveBeenCalledTimes(3));
+  });
+
+  it("uses literal-specific truncation copy and exact line/document counts", async () => {
+    grep.mockResolvedValue({
+      pattern: "x",
+      regex: false,
+      total_docs: 40,
+      total_matches: 60,
+      returned_docs: 1,
+      returned_matches: 1,
+      truncated: true,
       results: [
-        {
-          source_type: "document",
-          uri: "akb://v/document/d-1",
-          vault: "v",
-          path: "worker.md",
-          title: "Worker guide",
-          doc_type: "note",
-          tags: ["runtime", "operations"],
-          matched_section:
-            "[# Worker guide > ## Results] * API stays available while the worker restarts.",
-          score: 0.95,
-        },
-        {
-          source_type: "document",
-          uri: "akb://v/document/d-2",
-          vault: "v",
-          path: "auth.md",
-          title: "Authentication guide",
-          doc_type: "note",
-          tags: ["security"],
-          score: 0.85,
-        },
+        { ...hit("Literal result"), matches: [{ section: null, text: "x" }] },
       ],
     });
-    const user = userEvent.setup();
-    renderAt("/search?q=worker");
+    renderAt("/search?q=x&mode=literal");
+    await screen.findByText("Literal result");
+    expect(
+      screen.getByText("Showing some matching documents"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/1 of 40 documents and 1 of 60/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Semantic search returns/),
+    ).not.toBeInTheDocument();
+  });
 
-    expect(await screen.findByText("API stays available while the worker restarts.")).toBeTruthy();
-    expect(screen.queryByText(/\[# Worker guide/)).toBeNull();
-    await user.click(
-      screen.getByRole("button", { name: "Filter by document type" }),
+  it("ignores an older response that arrives after a filter request", async () => {
+    let resolveOld!: (value: ReturnType<typeof response>) => void;
+    search.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveOld = resolve;
+      }),
     );
-    await user.click(screen.getByRole("button", { name: "Toggle tag security" }));
-
-    expect(screen.queryByText("Worker guide")).toBeNull();
-    expect(screen.getByText("Authentication guide")).toBeTruthy();
-    expect(mockedSearch).toHaveBeenCalledTimes(1);
+    search.mockResolvedValue(response([hit("Current result")]));
+    renderAt();
+    const user = userEvent.setup();
+    await openFilters(user);
+    await user.click(screen.getByRole("button", { name: "Toggle report" }));
+    await screen.findByText("Current result");
+    resolveOld(response([hit("Stale result")]));
+    await waitFor(() =>
+      expect(screen.queryByText("Stale result")).not.toBeInTheDocument(),
+    );
+    expect(screen.getByText("Current result")).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/__tests__/search-mode-and-counters.test.tsx
+++ b/frontend/src/pages/__tests__/search-mode-and-counters.test.tsx
@@ -146,7 +146,7 @@ describe("SearchPage · semantic (dense) mode", () => {
     });
     renderAt("/search?q=postgres");
     await waitFor(() =>
-      expect(mockedSearch).toHaveBeenCalledWith("postgres", [], 25),
+      expect(mockedSearch).toHaveBeenCalledWith("postgres", [], 25, expect.any(Object)),
     );
     expect(await screen.findByText("PostgreSQL tuning")).toBeTruthy();
     expect(screen.getByText("Top match")).toBeTruthy();
@@ -217,7 +217,7 @@ describe("SearchPage · semantic (dense) mode", () => {
     const u = userEvent.setup();
     await u.click(screen.getByRole("button", { name: "deployment guide" }));
     await waitFor(() =>
-      expect(mockedSearch).toHaveBeenCalledWith("deployment guide", [], 25),
+      expect(mockedSearch).toHaveBeenCalledWith("deployment guide", [], 25, expect.any(Object)),
     );
 
     await u.click(screen.getByRole("button", { name: "Clear search query" }));
@@ -260,7 +260,7 @@ describe("SearchPage · semantic (dense) mode", () => {
 
     await user.click(screen.getByRole("button", { name: /worker isolation/i }));
     await waitFor(() =>
-      expect(mockedSearch).toHaveBeenCalledWith("worker isolation", [], 25),
+      expect(mockedSearch).toHaveBeenCalledWith("worker isolation", [], 25, expect.any(Object)),
     );
   });
 });
@@ -356,6 +356,6 @@ describe("SearchPage · mode toggle re-issues the correct call", () => {
       .find((b) => b.hasAttribute("aria-pressed"));
     if (!toggle) throw new Error("Literal toggle button not found");
     await u.click(toggle);
-    await waitFor(() => expect(mockedGrep).toHaveBeenCalledWith("k8s", []));
+    await waitFor(() => expect(mockedGrep).toHaveBeenCalledWith("k8s", [], 20, expect.objectContaining({ regex: false, case_sensitive: false })));
   });
 });

--- a/frontend/src/pages/__tests__/search-multi-vault-scope.test.tsx
+++ b/frontend/src/pages/__tests__/search-multi-vault-scope.test.tsx
@@ -46,7 +46,7 @@ describe("SearchPage · multi-vault scope", () => {
   it("passes the comma-joined ?v= as a string[] to searchDocs", async () => {
     renderAt("/search?q=postgres&v=alpha,beta");
     await waitFor(() =>
-      expect(mockedSearch).toHaveBeenCalledWith("postgres", ["alpha", "beta"], 25),
+      expect(mockedSearch).toHaveBeenCalledWith("postgres", ["alpha", "beta"], 25, expect.any(Object)),
     );
   });
 
@@ -74,12 +74,12 @@ describe("SearchPage · multi-vault scope · interactions (write path)", () => {
     const user = userEvent.setup();
     renderAt("/search?q=x&v=alpha");
     await waitFor(() =>
-      expect(mockedSearch).toHaveBeenCalledWith("x", ["alpha"], 25),
+      expect(mockedSearch).toHaveBeenCalledWith("x", ["alpha"], 25, expect.any(Object)),
     );
     await user.click(await screen.findByRole("button", { name: /Search scope/ }));
     await user.click(await screen.findByRole("menuitemcheckbox", { name: "beta" }));
     await waitFor(() =>
-      expect(mockedSearch).toHaveBeenLastCalledWith("x", ["alpha", "beta"], 25),
+      expect(mockedSearch).toHaveBeenLastCalledWith("x", ["alpha", "beta"], 25, expect.any(Object)),
     );
   });
 
@@ -87,13 +87,13 @@ describe("SearchPage · multi-vault scope · interactions (write path)", () => {
     const user = userEvent.setup();
     renderAt("/search?q=x&v=alpha,beta");
     await waitFor(() =>
-      expect(mockedSearch).toHaveBeenCalledWith("x", ["alpha", "beta"], 25),
+      expect(mockedSearch).toHaveBeenCalledWith("x", ["alpha", "beta"], 25, expect.any(Object)),
     );
     await user.click(
       await screen.findByRole("button", { name: "Remove alpha from search scope" }),
     );
     await waitFor(() =>
-      expect(mockedSearch).toHaveBeenLastCalledWith("x", ["beta"], 25),
+      expect(mockedSearch).toHaveBeenLastCalledWith("x", ["beta"], 25, expect.any(Object)),
     );
   });
 
@@ -104,7 +104,7 @@ describe("SearchPage · multi-vault scope · interactions (write path)", () => {
     await user.click(await screen.findByRole("button", { name: /Search scope/ }));
     await user.click(await screen.findByRole("menuitem", { name: /Clear/ }));
     await waitFor(() =>
-      expect(mockedSearch).toHaveBeenLastCalledWith("x", [], 25),
+      expect(mockedSearch).toHaveBeenLastCalledWith("x", [], 25, expect.any(Object)),
     );
     expect(await screen.findByText("All vaults (3)")).toBeTruthy();
   });

--- a/frontend/src/pages/search.tsx
+++ b/frontend/src/pages/search.tsx
@@ -49,6 +49,14 @@ import { cleanSearchContext, safeSearchTags } from "@/lib/search-display";
 import { parseUri } from "@/lib/uri";
 import { cn } from "@/lib/utils";
 import { documentPreviewState } from "@/lib/document-preview-navigation";
+import { Input } from "@/components/ui/input";
+import { TagInput } from "@/components/ui/tag-input";
+import { InlineLoadingState } from "@/components/ui/loading-state";
+import {
+  readSearchOptions,
+  SEARCH_FILTER_KEYS,
+  setSearchValues,
+} from "@/lib/search-state";
 
 type Mode = "dense" | "literal";
 type SourceType = "document" | "table" | "file";
@@ -136,6 +144,10 @@ export default function SearchPage() {
   const mode: Mode =
     searchParams.get("mode") === "literal" ? "literal" : "dense";
   const vaultParam = searchParams.get("v") || "";
+  const options = useMemo(
+    () => readSearchOptions(searchParams),
+    [searchParams],
+  );
   const scopeVaults = useMemo(
     () =>
       scopedVault
@@ -159,25 +171,25 @@ export default function SearchPage() {
   const [searched, setSearched] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [vaults, setVaults] = useState<{ name: string }[]>([]);
-  const [activeTypes, setActiveTypes] = useState<Set<DocTypeFilter>>(
-    () => new Set(ALL_TYPES),
+  const activeTypes = new Set(options.doc_types);
+  const activeSource: SourceFilter = options.source_type || "all";
+  const activeTags = new Set(options.tags);
+  const [collectionDraft, setCollectionDraft] = useState(
+    options.collection || "",
   );
-  const [activeSource, setActiveSource] = useState<SourceFilter>("all");
-  const [activeTags, setActiveTags] = useState<Set<string>>(() => new Set());
+  const [degradationReason, setDegradationReason] = useState<string | null>(
+    null,
+  );
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [draft, setDraft] = useState(q);
   const [recentSearches, setRecentSearches] = useState<RecentSearch[]>([]);
-  const [recentDocuments, setRecentDocuments] = useState<
-    RecentDocumentView[]
-  >([]);
+  const [recentDocuments, setRecentDocuments] = useState<RecentDocumentView[]>(
+    [],
+  );
   const reqId = useRef(0);
 
   const doSearch = useCallback(
-    async (
-      searchQuery: string,
-      searchMode: Mode,
-      selectedVaults: string[],
-    ) => {
+    async (searchQuery: string, searchMode: Mode, selectedVaults: string[]) => {
       if (!searchQuery.trim()) return;
       const id = ++reqId.current;
       setLoading(true);
@@ -186,7 +198,12 @@ export default function SearchPage() {
 
       try {
         if (searchMode === "dense") {
-          const response = await searchDocs(searchQuery, selectedVaults, 25);
+          const response = await searchDocs(
+            searchQuery,
+            selectedVaults,
+            25,
+            options,
+          );
           if (id !== reqId.current) return;
           setDenseResults(response.results);
           setLiteralResults([]);
@@ -196,8 +213,14 @@ export default function SearchPage() {
           setReturnedMatches(0);
           setTruncated(Boolean(response.truncated));
           setDegraded(Boolean(response.degraded));
+          setDegradationReason(response.degradation_reason || null);
         } else {
-          const response = await grepDocs(searchQuery, selectedVaults);
+          const response = await grepDocs(
+            searchQuery,
+            selectedVaults,
+            20,
+            options,
+          );
           if (id !== reqId.current) return;
           setLiteralResults(response.results);
           setDenseResults([]);
@@ -234,7 +257,7 @@ export default function SearchPage() {
         if (id === reqId.current) setLoading(false);
       }
     },
-    [currentUserId],
+    [currentUserId, options],
   );
 
   useEffect(() => {
@@ -251,10 +274,10 @@ export default function SearchPage() {
     setDraft(q);
   }, [q]);
 
-  useEffect(() => {
-    setActiveSource("all");
-    setActiveTags(new Set());
-  }, [q, mode]);
+  useEffect(
+    () => setCollectionDraft(options.collection || ""),
+    [options.collection],
+  );
 
   useEffect(() => {
     if (!scopedVault) {
@@ -295,7 +318,7 @@ export default function SearchPage() {
     if (trimmed) next.set("q", trimmed);
     if (nextMode === "dense") next.delete("mode");
     else next.set("mode", nextMode);
-    setSearchParams(next, { replace: true });
+    setSearchParams(next);
   }
 
   function setScopeVaults(selectedVaults: string[]) {
@@ -304,25 +327,42 @@ export default function SearchPage() {
     if (trimmed) next.set("q", trimmed);
     if (selectedVaults.length) next.set("v", selectedVaults.join(","));
     else next.delete("v");
-    setSearchParams(next, { replace: true });
+    setSearchParams(next);
   }
 
   function toggleType(type: DocTypeFilter) {
-    setActiveTypes((current) => {
-      const next = new Set(current);
-      if (next.has(type)) next.delete(type);
-      else next.add(type);
-      return next;
-    });
+    setFilter(
+      "doc_type",
+      activeTypes.has(type)
+        ? [...activeTypes].filter((t) => t !== type)
+        : [...activeTypes, type],
+    );
   }
 
   function toggleTag(tag: string) {
-    setActiveTags((current) => {
-      const next = new Set(current);
-      if (next.has(tag)) next.delete(tag);
-      else next.add(tag);
-      return next;
-    });
+    setFilter(
+      "tag",
+      activeTags.has(tag)
+        ? [...activeTags].filter((t) => t !== tag)
+        : [...activeTags, tag],
+    );
+  }
+
+  function setFilter(key: string, values: string[]) {
+    const next = setSearchValues(searchParams, key, values);
+    if ((key === "doc_type" || key === "tag") && values.length)
+      next.set("source", "document");
+    if (key === "source" && values[0] !== "document") {
+      next.delete("doc_type");
+      next.delete("tag");
+    }
+    setSearchParams(next);
+  }
+
+  function resetFilters() {
+    const next = new URLSearchParams(searchParams);
+    for (const key of SEARCH_FILTER_KEYS) next.delete(key);
+    setSearchParams(next);
   }
 
   function commitQuery(value: string) {
@@ -330,8 +370,10 @@ export default function SearchPage() {
     const next = new URLSearchParams(searchParams);
     if (trimmed) next.set("q", trimmed);
     else next.delete("q");
+    if (next.toString() === searchParams.toString() && trimmed)
+      void doSearch(trimmed, mode, scopeVaults);
     setDraft(trimmed);
-    setSearchParams(next, { replace: true });
+    setSearchParams(next);
   }
 
   function repeatRecentSearch(item: RecentSearch) {
@@ -344,7 +386,7 @@ export default function SearchPage() {
       else next.delete("v");
     }
     setDraft(item.query);
-    setSearchParams(next, { replace: true });
+    setSearchParams(next);
   }
 
   function clearSearchHistory() {
@@ -362,24 +404,7 @@ export default function SearchPage() {
       normalizedQuery === normalizedQuery.toUpperCase());
   const showLiteralHint =
     mode === "dense" && looksLikeIdentifier && searched && !loading;
-  const allTypesActive = activeTypes.size === ALL_TYPES.length;
-  const knownTypes = new Set<string>(ALL_TYPES);
-  const typeFilteredDense = allTypesActive
-    ? denseResults
-    : denseResults.filter(
-        (result) =>
-          !result.doc_type ||
-          !knownTypes.has(result.doc_type) ||
-          activeTypes.has(result.doc_type as DocTypeFilter),
-      );
-  const filteredDense =
-    activeTags.size === 0
-      ? typeFilteredDense
-      : typeFilteredDense.filter((result) =>
-          safeSearchTags(result.tags).some((tag) => activeTags.has(tag)),
-        );
-  const groupedDense = groupByType(filteredDense);
-  const sourceCounts = groupByType(denseResults);
+  const allTypesActive = activeTypes.size === 0;
   const tagCounts = new Map<string, number>();
   for (const result of denseResults) {
     for (const tag of safeSearchTags(result.tags)) {
@@ -390,34 +415,28 @@ export default function SearchPage() {
     ([leftTag, leftCount], [rightTag, rightCount]) =>
       rightCount - leftCount || leftTag.localeCompare(rightTag),
   );
-  const visibleDense =
-    activeSource === "all" ? filteredDense : groupedDense[activeSource];
+  const visibleDense = denseResults;
   const resultCount =
     mode === "dense" ? visibleDense.length : literalResults.length;
   const hasResults = resultCount > 0;
-  const hasRawResults =
-    mode === "dense" ? denseResults.length > 0 : literalResults.length > 0;
 
-  const denseCountSummary =
-    activeSource !== "all" || !allTypesActive
-      ? `${visibleDense.length} visible · ${returnedDocs} loaded`
-      : returnedDocs !== total
-        ? `${returnedDocs} of ${total} top results loaded`
-        : `${visibleDense.length} result${visibleDense.length === 1 ? "" : "s"}`;
+  const denseCountSummary = `${returnedDocs} top results loaded`;
   const literalCountSummary =
     returnedDocs !== total || returnedMatches !== totalMatches
       ? `${returnedDocs} of ${total} ${total === 1 ? "doc" : "docs"} · ${returnedMatches} of ${totalMatches} ${totalMatches === 1 ? "match" : "matches"}`
       : `${total} ${total === 1 ? "doc" : "docs"} · ${totalMatches} ${totalMatches === 1 ? "match" : "matches"}`;
-  const allVaultsHref = `/search${
-    q
-      ? `?q=${encodeURIComponent(q)}${mode !== "dense" ? `&mode=${mode}` : ""}`
-      : ""
-  }`;
+  const allVaultParams = new URLSearchParams(searchParams);
+  allVaultParams.delete("v");
+  const allVaultsHref = `/search?${allVaultParams}`;
 
   const activeFilterCount =
     (activeSource === "all" ? 0 : 1) +
     (allTypesActive ? 0 : 1) +
-    (activeTags.size === 0 ? 0 : 1);
+    (activeTags.size === 0 ? 0 : 1) +
+    Number(Boolean(options.collection)) +
+    Number(options.include_archived) +
+    Number(options.regex) +
+    Number(options.case_sensitive);
   const accessibleVaultNames = new Set(
     scopedVault ? [scopedVault] : vaults.map((vault) => vault.name),
   );
@@ -433,9 +452,11 @@ export default function SearchPage() {
       ? "Search unavailable"
       : !searched
         ? "Ready to search"
-        : mode === "dense"
-          ? denseCountSummary
-          : literalCountSummary;
+        : degraded
+          ? "Search incomplete"
+          : mode === "dense"
+            ? denseCountSummary
+            : literalCountSummary;
 
   return (
     <div
@@ -450,9 +471,11 @@ export default function SearchPage() {
             ? "Search failed"
             : !searched
               ? ""
-              : !hasResults
-                ? `No visible results for ${q}`
-                : `${resultCount} results for ${q}`}
+              : degraded
+                ? "Search incomplete; results may be missing"
+                : !hasResults
+                  ? `No visible results for ${q}`
+                  : `${resultCount} results for ${q}`}
       </p>
 
       <section
@@ -478,39 +501,39 @@ export default function SearchPage() {
                 : "Literal search matches exact text or a regular expression."}
             </span>
             <div className="flex h-10 min-w-0 flex-1 basis-72 items-center rounded-[var(--radius-md)] border border-border-strong bg-surface-2 px-3 shadow-xs transition-token focus-within:border-primary focus-within:bg-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-surface">
-                <SearchIcon
-                  className="mr-2.5 h-4 w-4 shrink-0 text-foreground-muted"
-                  aria-hidden
-                />
-                <label htmlFor="vault-search" className="sr-only">
-                  Search query
-                </label>
-                <input
-                  id="vault-search"
-                  type="search"
-                  enterKeyHint="search"
-                  aria-describedby="search-query-help"
-                  placeholder="Search documents, tables, and files…"
-                  value={draft}
-                  onChange={(event) => setDraft(event.target.value)}
-                  onKeyDown={(event) => {
-                    if (event.key === "Escape" && draft) {
-                      event.preventDefault();
-                      commitQuery("");
-                    }
-                  }}
-                  className="min-w-0 flex-1 appearance-none bg-transparent text-sm text-foreground placeholder:text-foreground-muted focus:outline-none [&::-webkit-search-cancel-button]:hidden"
-                />
-                {draft && !loading && (
-                  <button
-                    type="button"
-                    aria-label="Clear search query"
-                    onClick={() => commitQuery("")}
-                    className="ml-2 inline-flex h-8 shrink-0 cursor-pointer items-center justify-center rounded-[var(--radius-sm)] px-2 text-xs font-medium text-foreground-muted transition-token hover:bg-surface-hover hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  >
-                    Clear
-                  </button>
-                )}
+              <SearchIcon
+                className="mr-2.5 h-4 w-4 shrink-0 text-foreground-muted"
+                aria-hidden
+              />
+              <label htmlFor="vault-search" className="sr-only">
+                Search query
+              </label>
+              <input
+                id="vault-search"
+                type="search"
+                enterKeyHint="search"
+                aria-describedby="search-query-help"
+                placeholder="Search documents, tables, and files…"
+                value={draft}
+                onChange={(event) => setDraft(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Escape" && draft) {
+                    event.preventDefault();
+                    commitQuery("");
+                  }
+                }}
+                className="min-w-0 flex-1 appearance-none bg-transparent text-sm text-foreground placeholder:text-foreground-muted focus:outline-none [&::-webkit-search-cancel-button]:hidden"
+              />
+              {draft && !loading && (
+                <button
+                  type="button"
+                  aria-label="Clear search query"
+                  onClick={() => commitQuery("")}
+                  className="ml-2 inline-flex h-8 shrink-0 cursor-pointer items-center justify-center rounded-[var(--radius-sm)] px-2 text-xs font-medium text-foreground-muted transition-token hover:bg-surface-hover hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  Clear
+                </button>
+              )}
             </div>
             <div
               role="group"
@@ -539,7 +562,7 @@ export default function SearchPage() {
               </button>
             </div>
 
-            {mode === "dense" && (
+            {
               <button
                 type="button"
                 aria-label="Filter by document type"
@@ -559,7 +582,7 @@ export default function SearchPage() {
                   <Badge variant="secondary">{activeFilterCount}</Badge>
                 )}
               </button>
-            )}
+            }
 
             <Button
               type="submit"
@@ -580,7 +603,9 @@ export default function SearchPage() {
               data-testid="search-scope-row"
               className="flex min-w-0 flex-1 flex-wrap items-center gap-2 text-foreground-muted"
             >
-              <span className="shrink-0 font-medium text-foreground">Search in</span>
+              <span className="shrink-0 font-medium text-foreground">
+                Search in
+              </span>
               {scopedVault ? (
                 <>
                   <div
@@ -619,30 +644,27 @@ export default function SearchPage() {
 
             <div className="flex w-full shrink-0 items-center justify-between gap-2 text-foreground-muted sm:w-auto sm:justify-start">
               <span className="tabular-nums">{resultStatus}</span>
-              <span className="hidden sm:inline" aria-hidden>·</span>
+              <span className="hidden sm:inline" aria-hidden>
+                ·
+              </span>
               <span className="hidden sm:inline">
-                {mode === "dense" ? "Meaning and context" : "Exact text or regex"}
+                {mode === "dense"
+                  ? "Meaning and context"
+                  : "Exact text or regex"}
               </span>
             </div>
           </div>
 
-          {filtersOpen && mode === "dense" && (
+          {filtersOpen && (
             <aside
               id="search-filter-tray"
               aria-label="Search filters"
-              className="border-b border-border-strong bg-surface px-3 py-3 sm:px-4"
+              className="max-h-[50vh] overflow-y-auto border-b border-border-strong bg-surface px-3 py-3 sm:px-4"
             >
-              {denseResults.length > 0 ? (
-                <div
-                  className={cn(
-                    "grid gap-4",
-                    availableTags.length > 0
-                      ? "lg:grid-cols-2 xl:grid-cols-[minmax(16rem,0.8fr)_minmax(0,1.35fr)_minmax(15rem,1fr)]"
-                      : "lg:grid-cols-[minmax(18rem,0.8fr)_minmax(0,1.6fr)]",
-                  )}
-                >
+              <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                {mode === "dense" && (
                   <fieldset>
-                    <legend className="mb-2 text-xs font-semibold text-foreground">
+                    <legend className="mb-2 text-xs font-semibold">
                       Content
                     </legend>
                     <div
@@ -650,275 +672,343 @@ export default function SearchPage() {
                       role="group"
                       aria-label="Filter by content kind"
                     >
-                      {SOURCE_FILTERS.map(({ key, label, icon: Icon }) => {
-                        const count =
-                          key === "all"
-                            ? denseResults.length
-                            : sourceCounts[key].length;
-                        return (
-                          <button
-                            key={key}
-                            type="button"
-                            aria-label={label}
-                            aria-pressed={activeSource === key}
-                            disabled={count === 0}
-                            onClick={() => setActiveSource(key)}
-                            className={sourceFilterClass(activeSource === key)}
-                          >
-                            <Icon className="h-3.5 w-3.5" aria-hidden />
-                            {label}
-                            <span className="tabular-nums text-foreground-muted">
-                              {count}
-                            </span>
-                          </button>
-                        );
-                      })}
+                      {SOURCE_FILTERS.map(({ key, label, icon: Icon }) => (
+                        <button
+                          key={key}
+                          type="button"
+                          aria-label={label}
+                          aria-pressed={activeSource === key}
+                          onClick={() =>
+                            setFilter("source", key === "all" ? [] : [key])
+                          }
+                          className={sourceFilterClass(activeSource === key)}
+                        >
+                          <Icon className="h-3.5 w-3.5" aria-hidden />
+                          {label}
+                        </button>
+                      ))}
                     </div>
                   </fieldset>
-
-                  <fieldset>
-                    <legend className="mb-2 text-xs font-semibold text-foreground">
-                      Document type
-                    </legend>
-                    <div
-                      className="flex flex-wrap gap-1.5"
-                      role="group"
-                      aria-label="Filter by document type"
+                )}
+                <fieldset>
+                  <legend className="mb-2 text-xs font-semibold">
+                    Document type
+                  </legend>
+                  <div
+                    className="flex flex-wrap gap-1.5"
+                    role="group"
+                    aria-label="Filter by document type"
+                  >
+                    <button
+                      type="button"
+                      aria-label="Show all types"
+                      aria-pressed={allTypesActive}
+                      onClick={() => setFilter("doc_type", [])}
+                      className={filterButtonClass(allTypesActive)}
                     >
+                      All types
+                    </button>
+                    {ALL_TYPES.map((type) => (
                       <button
+                        key={type}
                         type="button"
-                        aria-label="Show all types"
-                        aria-pressed={allTypesActive}
-                        onClick={() => setActiveTypes(new Set(ALL_TYPES))}
-                        className={filterButtonClass(allTypesActive)}
+                        aria-label={`Toggle ${type}`}
+                        aria-pressed={activeTypes.has(type)}
+                        onClick={() => toggleType(type)}
+                        className={filterButtonClass(activeTypes.has(type))}
                       >
-                        All types
+                        <span className="capitalize">{type}</span>
                       </button>
-                      {ALL_TYPES.map((type) => {
-                        const count = denseResults.filter(
-                          (result) => result.doc_type === type,
-                        ).length;
-                        return (
-                          <button
-                            key={type}
-                            type="button"
-                            aria-label={`Toggle ${type}`}
-                            aria-pressed={activeTypes.has(type)}
-                            disabled={count === 0}
-                            onClick={() => toggleType(type)}
-                            className={filterButtonClass(activeTypes.has(type))}
-                          >
-                            <span className="capitalize">{type}</span>
-                            <span className="tabular-nums text-foreground-muted">
-                              {count}
-                            </span>
-                          </button>
-                        );
-                      })}
-                    </div>
-                  </fieldset>
-
+                    ))}
+                  </div>
+                </fieldset>
+                <div>
+                  <label
+                    htmlFor="search-tags"
+                    className="mb-2 block text-xs font-semibold"
+                  >
+                    Tags (match any)
+                  </label>
+                  <TagInput
+                    id="search-tags"
+                    value={[...activeTags]}
+                    onChange={(tags) => setFilter("tag", tags)}
+                  />
                   {availableTags.length > 0 && (
-                    <fieldset>
-                      <legend className="mb-2 flex items-center gap-1.5 text-xs font-semibold text-foreground">
-                        <Tag className="h-3.5 w-3.5 text-foreground-muted" aria-hidden />
-                        Tags
-                      </legend>
-                      <div
-                        className="flex flex-wrap gap-1.5"
-                        role="group"
-                        aria-label="Filter by tag"
-                      >
-                        {availableTags.slice(0, 12).map(([tag, count]) => (
-                          <button
-                            key={tag}
-                            type="button"
-                            aria-label={`Toggle tag ${tag}`}
-                            aria-pressed={activeTags.has(tag)}
-                            onClick={() => toggleTag(tag)}
-                            className={filterButtonClass(activeTags.has(tag))}
-                          >
-                            <span>{tag}</span>
-                            <span className="tabular-nums text-foreground-muted">
-                              {count}
-                            </span>
-                          </button>
-                        ))}
-                      </div>
-                    </fieldset>
+                    <div
+                      className="mt-2 flex flex-wrap gap-1.5"
+                      role="group"
+                      aria-label="Suggested tags from loaded results"
+                    >
+                      {availableTags.slice(0, 12).map(([tag]) => (
+                        <button
+                          key={tag}
+                          type="button"
+                          aria-label={`Toggle tag ${tag}`}
+                          aria-pressed={activeTags.has(tag)}
+                          onClick={() => toggleTag(tag)}
+                          className={filterButtonClass(activeTags.has(tag))}
+                        >
+                          <Tag className="h-3 w-3" aria-hidden />
+                          {tag}
+                        </button>
+                      ))}
+                    </div>
                   )}
                 </div>
-              ) : (
+                <form
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    setFilter("collection", [
+                      collectionDraft.trim().replace(/^\/+|\/+$/g, ""),
+                    ]);
+                  }}
+                >
+                  <label
+                    htmlFor="search-collection"
+                    className="mb-2 block text-xs font-semibold"
+                  >
+                    Collection path (including children)
+                  </label>
+                  <div className="flex gap-2">
+                    <Input
+                      id="search-collection"
+                      value={collectionDraft}
+                      onChange={(event) =>
+                        setCollectionDraft(event.target.value)
+                      }
+                      placeholder="e.g. guides/api"
+                    />
+                    <Button type="submit" variant="outline" size="sm">
+                      Apply
+                    </Button>
+                  </div>
+                  <p className="mt-1 text-xs text-foreground-muted">
+                    The same path is used in each selected Vault.
+                  </p>
+                </form>
+                <div className="flex flex-col gap-3 text-sm">
+                  <label className="flex min-h-9 items-center gap-2">
+                    <input
+                      type="checkbox"
+                      className="accent-primary focus-visible:outline-ring"
+                      checked={Boolean(options.include_archived)}
+                      onChange={(event) =>
+                        setFilter(
+                          "include_archived",
+                          event.target.checked ? ["true"] : [],
+                        )
+                      }
+                    />
+                    Include archived documents
+                  </label>
+                  {mode === "literal" && (
+                    <>
+                      <label className="flex min-h-9 items-center gap-2">
+                        <input
+                          type="checkbox"
+                          className="accent-primary focus-visible:outline-ring"
+                          checked={Boolean(options.regex)}
+                          onChange={(event) =>
+                            setFilter(
+                              "regex",
+                              event.target.checked ? ["true"] : [],
+                            )
+                          }
+                        />
+                        Regular expression
+                      </label>
+                      <label className="flex min-h-9 items-center gap-2">
+                        <input
+                          type="checkbox"
+                          className="accent-primary focus-visible:outline-ring"
+                          checked={Boolean(options.case_sensitive)}
+                          onChange={(event) =>
+                            setFilter(
+                              "case_sensitive",
+                              event.target.checked ? ["true"] : [],
+                            )
+                          }
+                        />
+                        Case sensitive
+                      </label>
+                    </>
+                  )}
+                </div>
+              </div>
+              <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
                 <p className="text-xs text-foreground-muted">
-                  Content and document-type filters appear after AKB finds
-                  matches.
+                  {mode === "literal"
+                    ? "Literal search searches document bodies only. Content-kind selection is retained for Semantic search."
+                    : "Document type and tag filters search documents only. Filters apply on the server before the result limit."}
                 </p>
-              )}
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={resetFilters}
+                >
+                  Reset filters
+                </Button>
+              </div>
             </aside>
           )}
         </header>
 
-          <div
-            role="region"
-            aria-label="Search results"
-            data-testid="search-results-pane"
-            className="rail-scroll min-h-0 min-w-0 flex-1 overflow-y-auto bg-surface"
-          >
-            {degraded && (
-              <Alert
-                variant="warning"
-                className="rounded-none border-x-0 border-t-0"
+        <div
+          role="region"
+          aria-label="Search results"
+          aria-busy={loading}
+          data-testid="search-results-pane"
+          className="rail-scroll min-h-0 min-w-0 flex-1 overflow-y-auto bg-surface"
+        >
+          {degraded && !loading && (
+            <Alert
+              variant="warning"
+              className="rounded-none border-x-0 border-t-0"
+            >
+              Search is incomplete.{" "}
+              {degradationReason === "sparse_encoder_degraded"
+                ? "Keyword retrieval is temporarily unavailable."
+                : "The retrieval service is temporarily unavailable."}{" "}
+              <button
+                type="button"
+                onClick={() => void doSearch(q, mode, scopeVaults)}
+                className={inlineActionClass}
               >
-                Search is degraded, so these results may be incomplete. Try
-                again shortly or switch to{" "}
-                <button
-                  type="button"
-                  onClick={() => switchMode("literal")}
-                  className={inlineActionClass}
-                >
-                  Literal
-                </button>{" "}
-                search.
-              </Alert>
-            )}
-
-            {showLiteralHint && (
-              <Alert
-                variant="info"
-                className="rounded-none border-x-0 border-t-0"
+                Retry
+              </button>{" "}
+              or switch to{" "}
+              <button
+                type="button"
+                onClick={() => switchMode("literal")}
+                className={inlineActionClass}
               >
-                Short identifiers are usually easier to find with{" "}
-                <button
-                  type="button"
-                  onClick={() => switchMode("literal")}
-                  className={inlineActionClass}
-                >
-                  Literal
-                </button>{" "}
-                search.
-              </Alert>
-            )}
+                Literal
+              </button>{" "}
+              search.
+            </Alert>
+          )}
 
-            {loading && <SearchLoadingState />}
-
-            {error && !loading && (
-              <Alert
-                variant="destructive"
-                title="Search unavailable"
-                className="rounded-none border-x-0 border-t-0"
+          {showLiteralHint && (
+            <Alert
+              variant="info"
+              className="rounded-none border-x-0 border-t-0"
+            >
+              Short identifiers are usually easier to find with{" "}
+              <button
+                type="button"
+                onClick={() => switchMode("literal")}
+                className={inlineActionClass}
               >
-                {error}.{" "}
-                <button
-                  type="button"
-                  onClick={() => void doSearch(q, mode, scopeVaults)}
-                  className={inlineActionClass}
-                >
-                  Retry
-                </button>
-              </Alert>
-            )}
+                Literal
+              </button>{" "}
+              search.
+            </Alert>
+          )}
 
-            {!searched && (
-              <SearchStartState
-                mode={mode}
-                recentSearches={visibleRecentSearches}
-                recentDocuments={visibleRecentDocuments}
-                onRepeatSearch={repeatRecentSearch}
-                onClearSearches={clearSearchHistory}
-                onSuggestion={commitQuery}
-              />
-            )}
+          {loading &&
+            (hasResults ? (
+              <InlineLoadingState label="Updating search; previous results shown" />
+            ) : (
+              <SearchLoadingState />
+            ))}
 
-            {searched && !loading && !error && !hasRawResults && (
-              <section aria-labelledby="no-search-results-heading">
-                <div className="border-b border-border bg-surface-2/60 px-4 py-3 sm:px-5">
-                  <h2
-                    id="no-search-results-heading"
-                    className="text-sm font-semibold text-foreground"
-                  >
-                    No results for “{q}”
-                  </h2>
-                  <p className="mt-1 text-xs leading-relaxed text-foreground-muted">
-                    {mode === "dense"
-                      ? "Try fewer terms, broaden the Vault scope, or look for the exact phrase."
-                      : "Check the phrase or switch to meaning-based search."}
-                  </p>
-                </div>
-                <div className="flex flex-wrap gap-2 px-4 py-4 sm:px-5">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() =>
-                      switchMode(mode === "dense" ? "literal" : "dense")
-                    }
-                  >
-                    Try {mode === "dense" ? "Literal" : "Semantic"}
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => commitQuery("")}
-                  >
-                    Clear query
-                  </Button>
-                </div>
-              </section>
-            )}
-
-            {!loading && !error && hasRawResults && !hasResults && (
-              <Alert
-                variant="info"
-                className="rounded-none border-x-0 border-t-0"
+          {error && !loading && (
+            <Alert
+              variant="destructive"
+              title="Search unavailable"
+              className="rounded-none border-x-0 border-t-0"
+            >
+              {error}.{" "}
+              <button
+                type="button"
+                onClick={() => void doSearch(q, mode, scopeVaults)}
+                className={inlineActionClass}
               >
-                No results match the active filters.{" "}
-                <button
-                  type="button"
-                  onClick={() => {
-                    setActiveSource("all");
-                    setActiveTypes(new Set(ALL_TYPES));
-                    setActiveTags(new Set());
-                  }}
-                  className={inlineActionClass}
-                >
-                  Reset filters
-                </button>
-              </Alert>
-            )}
+                Retry
+              </button>
+            </Alert>
+          )}
 
-            {truncated && hasResults && !loading && (
-              <Alert
-                variant="info"
-                title="Showing the strongest matches"
-                className="rounded-none border-x-0 border-t-0"
-              >
-                Semantic search ranks a focused result set. Refine the query, or
-                use{" "}
-                <button
-                  type="button"
-                  onClick={() => switchMode("literal")}
-                  className={inlineActionClass}
-                >
-                  Literal
-                </button>{" "}
-                for an exact count.
-              </Alert>
-            )}
+          {!searched && (
+            <SearchStartState
+              mode={mode}
+              recentSearches={visibleRecentSearches}
+              recentDocuments={visibleRecentDocuments}
+              onRepeatSearch={repeatRecentSearch}
+              onClearSearches={clearSearchHistory}
+              onSuggestion={commitQuery}
+            />
+          )}
 
-            {!loading && !error && hasResults && (
-              <section aria-labelledby="search-results-heading">
-                <h2 id="search-results-heading" className="sr-only">
-                  Results for {q}
+          {searched && !loading && !error && !degraded && !hasResults && (
+            <section aria-labelledby="no-search-results-heading">
+              <div className="border-b border-border bg-surface-2/60 px-4 py-3 sm:px-5">
+                <h2
+                  id="no-search-results-heading"
+                  className="text-sm font-semibold text-foreground"
+                >
+                  No results for “{q}”
                 </h2>
-                {mode === "dense" ? (
-                  <DenseResultList items={visibleDense} />
-                ) : (
-                  <LiteralResultList items={literalResults} />
-                )}
-              </section>
-            )}
-          </div>
+                <p className="mt-1 text-xs leading-relaxed text-foreground-muted">
+                  {mode === "dense"
+                    ? "Try fewer terms, broaden the Vault scope, or look for the exact phrase."
+                    : "Check the phrase or switch to meaning-based search."}
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2 px-4 py-4 sm:px-5">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() =>
+                    switchMode(mode === "dense" ? "literal" : "dense")
+                  }
+                >
+                  Try {mode === "dense" ? "Literal" : "Semantic"}
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => commitQuery("")}
+                >
+                  Clear query
+                </Button>
+              </div>
+            </section>
+          )}
+
+          {truncated && !loading && !error && (
+            <Alert
+              variant="info"
+              title={
+                mode === "dense"
+                  ? "Showing the strongest matches"
+                  : "Showing some matching documents"
+              }
+              className="rounded-none border-x-0 border-t-0"
+            >
+              {mode === "dense"
+                ? "Semantic search returns a ranked candidate set, not an exhaustive count. Narrow the filters or use Literal for text-match counts."
+                : `${returnedDocs} of ${total} documents and ${returnedMatches} of ${totalMatches} matching lines returned. Narrow the query or filters to see the remaining matches.`}
+            </Alert>
+          )}
+
+          {hasResults && (
+            <section aria-labelledby="search-results-heading">
+              <h2 id="search-results-heading" className="sr-only">
+                Results for {q}
+              </h2>
+              {mode === "dense" ? (
+                <DenseResultList items={visibleDense} />
+              ) : (
+                <LiteralResultList items={literalResults} />
+              )}
+            </section>
+          )}
+        </div>
       </section>
     </div>
   );
@@ -980,110 +1070,131 @@ function SearchStartState({
             )}
           >
             {hasSearches && (
-            <section aria-labelledby="recent-searches-heading">
-              <div className="flex min-h-11 items-center justify-between gap-3 border-b border-border bg-surface-2/60 px-4 sm:px-5">
-                <div className="flex min-w-0 items-center gap-2">
-                  <Clock3 className="h-3.5 w-3.5 shrink-0 text-foreground-muted" aria-hidden />
-                  <h2
-                    id="recent-searches-heading"
-                    className="text-xs font-semibold text-foreground"
-                  >
-                    Recent searches
-                  </h2>
-                </div>
-                <button
-                  type="button"
-                  onClick={onClearSearches}
-                  className="inline-flex h-8 cursor-pointer items-center rounded-[var(--radius-sm)] px-2 text-xs font-medium text-foreground-muted transition-token hover:bg-surface-hover hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                >
-                  Clear
-                </button>
-              </div>
-              <div className="divide-y divide-border" aria-label="Recent searches">
-                {visibleSearches.map((search) => (
-                  <button
-                    key={`${search.surface}:${search.mode}:${search.vaults.join(",")}:${search.query}`}
-                    type="button"
-                    onClick={() => onRepeatSearch(search)}
-                    className="group flex min-h-14 w-full cursor-pointer items-center gap-3 px-4 py-2.5 text-left transition-token hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:px-5"
-                  >
-                    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-md)] border border-border bg-surface-2 text-foreground-muted transition-colors group-hover:text-link">
-                      <SearchIcon className="h-4 w-4" aria-hidden />
-                    </span>
-                    <span className="min-w-0 flex-1">
-                      <span className="block truncate text-sm font-medium text-foreground">
-                        {search.query}
-                      </span>
-                      <span className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-foreground-muted">
-                        <span>{search.mode === "semantic" ? "Semantic" : "Literal"}</span>
-                        <span aria-hidden>·</span>
-                        <span className="truncate">
-                          {search.vaults.length === 0
-                            ? "All vaults"
-                            : search.vaults.length === 1
-                              ? search.vaults[0]
-                              : `${search.vaults.length} vaults`}
-                        </span>
-                      </span>
-                    </span>
-                    <RelativeTime
-                      iso={search.searchedAt}
-                      className="hidden shrink-0 text-xs text-foreground-muted sm:block"
+              <section aria-labelledby="recent-searches-heading">
+                <div className="flex min-h-11 items-center justify-between gap-3 border-b border-border bg-surface-2/60 px-4 sm:px-5">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <Clock3
+                      className="h-3.5 w-3.5 shrink-0 text-foreground-muted"
+                      aria-hidden
                     />
-                  </button>
-                ))}
-              </div>
-            </section>
-            )}
-
-            {hasDocuments && (
-            <section
-              aria-labelledby="recent-documents-heading"
-              className={cn(hasSearches && "border-t border-border lg:border-l lg:border-t-0")}
-            >
-              <div className="flex min-h-11 items-center justify-between gap-3 border-b border-border bg-surface-2/60 px-4 sm:px-5">
-                <div className="flex min-w-0 items-center gap-2">
-                  <FileText className="h-3.5 w-3.5 shrink-0 text-foreground-muted" aria-hidden />
-                  <h2
-                    id="recent-documents-heading"
-                    className="text-xs font-semibold text-foreground"
+                    <h2
+                      id="recent-searches-heading"
+                      className="text-xs font-semibold text-foreground"
+                    >
+                      Recent searches
+                    </h2>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={onClearSearches}
+                    className="inline-flex h-8 cursor-pointer items-center rounded-[var(--radius-sm)] px-2 text-xs font-medium text-foreground-muted transition-token hover:bg-surface-hover hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   >
-                    Recently viewed
-                  </h2>
+                    Clear
+                  </button>
                 </div>
-                <span className="text-xs text-foreground-muted">This browser</span>
-              </div>
-              <div className="divide-y divide-border" aria-label="Recently viewed documents">
-                {visibleDocuments.map((document, index) => {
-                  const returnFocusId = `recent-search-document-${index}`;
-                  return (
-                    <Link
-                      key={`${document.vault}:${document.path}`}
-                      id={returnFocusId}
-                      to={`/vault/${document.vault}/doc/${encodeURIComponent(document.path)}`}
-                      state={documentPreviewState(location, returnFocusId)}
-                      className="group flex min-h-14 items-center gap-3 px-4 py-2.5 transition-token hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:px-5"
+                <div
+                  className="divide-y divide-border"
+                  aria-label="Recent searches"
+                >
+                  {visibleSearches.map((search) => (
+                    <button
+                      key={`${search.surface}:${search.mode}:${search.vaults.join(",")}:${search.query}`}
+                      type="button"
+                      onClick={() => onRepeatSearch(search)}
+                      className="group flex min-h-14 w-full cursor-pointer items-center gap-3 px-4 py-2.5 text-left transition-token hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:px-5"
                     >
                       <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-md)] border border-border bg-surface-2 text-foreground-muted transition-colors group-hover:text-link">
-                        <FileText className="h-4 w-4" aria-hidden />
+                        <SearchIcon className="h-4 w-4" aria-hidden />
                       </span>
                       <span className="min-w-0 flex-1">
-                        <span className="block truncate text-sm font-medium text-foreground transition-colors group-hover:text-link">
-                          {document.title}
+                        <span className="block truncate text-sm font-medium text-foreground">
+                          {search.query}
                         </span>
-                        <span className="mt-0.5 block truncate text-xs text-foreground-muted">
-                          {document.vault} · {document.path}
+                        <span className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-foreground-muted">
+                          <span>
+                            {search.mode === "semantic"
+                              ? "Semantic"
+                              : "Literal"}
+                          </span>
+                          <span aria-hidden>·</span>
+                          <span className="truncate">
+                            {search.vaults.length === 0
+                              ? "All vaults"
+                              : search.vaults.length === 1
+                                ? search.vaults[0]
+                                : `${search.vaults.length} vaults`}
+                          </span>
                         </span>
                       </span>
                       <RelativeTime
-                        iso={document.viewedAt}
+                        iso={search.searchedAt}
                         className="hidden shrink-0 text-xs text-foreground-muted sm:block"
                       />
-                    </Link>
-                  );
-                })}
-              </div>
-            </section>
+                    </button>
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {hasDocuments && (
+              <section
+                aria-labelledby="recent-documents-heading"
+                className={cn(
+                  hasSearches &&
+                    "border-t border-border lg:border-l lg:border-t-0",
+                )}
+              >
+                <div className="flex min-h-11 items-center justify-between gap-3 border-b border-border bg-surface-2/60 px-4 sm:px-5">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <FileText
+                      className="h-3.5 w-3.5 shrink-0 text-foreground-muted"
+                      aria-hidden
+                    />
+                    <h2
+                      id="recent-documents-heading"
+                      className="text-xs font-semibold text-foreground"
+                    >
+                      Recently viewed
+                    </h2>
+                  </div>
+                  <span className="text-xs text-foreground-muted">
+                    This browser
+                  </span>
+                </div>
+                <div
+                  className="divide-y divide-border"
+                  aria-label="Recently viewed documents"
+                >
+                  {visibleDocuments.map((document, index) => {
+                    const returnFocusId = `recent-search-document-${index}`;
+                    return (
+                      <Link
+                        key={`${document.vault}:${document.path}`}
+                        id={returnFocusId}
+                        to={`/vault/${document.vault}/doc/${encodeURIComponent(document.path)}`}
+                        state={documentPreviewState(location, returnFocusId)}
+                        className="group flex min-h-14 items-center gap-3 px-4 py-2.5 transition-token hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:px-5"
+                      >
+                        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-md)] border border-border bg-surface-2 text-foreground-muted transition-colors group-hover:text-link">
+                          <FileText className="h-4 w-4" aria-hidden />
+                        </span>
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate text-sm font-medium text-foreground transition-colors group-hover:text-link">
+                            {document.title}
+                          </span>
+                          <span className="mt-0.5 block truncate text-xs text-foreground-muted">
+                            {document.vault} · {document.path}
+                          </span>
+                        </span>
+                        <RelativeTime
+                          iso={document.viewedAt}
+                          className="hidden shrink-0 text-xs text-foreground-muted sm:block"
+                        />
+                      </Link>
+                    );
+                  })}
+                </div>
+              </section>
             )}
           </div>
         )}
@@ -1343,20 +1454,4 @@ function filterButtonClass(active: boolean) {
       ? "border-border-strong bg-surface-selected text-surface-selected-foreground"
       : "border-border bg-surface text-foreground-muted hover:border-border-strong hover:bg-surface-hover hover:text-foreground",
   );
-}
-
-function groupByType(
-  results: DenseResult[],
-): Record<SourceType, DenseResult[]> {
-  const groups: Record<SourceType, DenseResult[]> = {
-    document: [],
-    table: [],
-    file: [],
-  };
-  for (const result of results) {
-    const type = (result.source_type || "document") as SourceType;
-    if (groups[type]) groups[type].push(result);
-    else groups.document.push(result);
-  }
-  return groups;
 }


### PR DESCRIPTION
## Summary

Apply search filters on the server before ranking and result limits, instead of filtering only the results already loaded in the browser.

Previously, a matching document outside the first 25 results could not be discovered by selecting its type or tag. The global search panel had the same issue with resource-kind filters.

## Changes

- Add repeated `doc_types` and explicit `source_type` options to hybrid search; add document metadata and archive filters to grep.
- Intersect filters with Vault access before retrieval. Values within type/tag lists use OR; different dimensions use AND.
- Match collections and descendants without admitting similarly named siblings; escape literal LIKE metacharacters.
- Connect Search and global-search controls to server requests. Preserve confirmed filters in the URL, including reload and browser Back.
- Expose free-form tags, archive inclusion, regular expressions and case sensitivity.
- Distinguish genuine empty results, degraded responses and truncation. Prevent keyboard activation of hidden partial results.
- Add contract tests, opt-in local HTTP/browser scenarios, an English design document and changelog notes.

## Compatibility and rollout

- Existing single-`type` callers remain supported. Grep retains its legacy archive default; the Search UI explicitly excludes archived documents unless requested.
- Literal mode searches document bodies; it does not introduce a full file-body or table-cell search engine.
- Deploy the backend and frontend together: older servers may silently ignore the new parameters.
- No schema migration, new index, service, configuration or deployment dependency.
- Lifecycle/source filters use the existing source-ID candidate path where the Vault-only optimization cannot express them. Large-corpus latency and memory still require workload-specific measurement.
- The secrets baseline change only tracks an existing changelog entry's new line number; no new secret allowlist entries.

## Validation

- [x] `bash scripts/check.sh` — full repository static/package/unit gate, including 741 frontend tests and secret scanning
- [x] Frontend production build and design-token checks
- [x] 102 focused backend search/grep/native-path regression tests
- [x] Isolated real HTTP/DB scenario: login, 30-document corpus, a match outside the initial top 25, metadata/archive filters, collection boundaries, file upload, table creation and private-Vault isolation
- [x] Existing MCP E2E suite: 88 checks passed
- [x] Chromium contract scenarios: desktop/mobile × light/dark
- [x] Non-mocked Chromium local-login and search scenario

The live tests used the repository-owned isolated runtime and deterministic embedding stub. They verify API/index/filter wiring, not production model relevance or large-corpus performance. Native storage was covered by focused service tests, not a separate live native deployment. The full collection of endpoint-driven E2E suites was not run.

See [the design and test instructions](docs/designs/search-filter-contract.md) for the request contract, trade-offs and local reproduction steps.