### PR TITLE
test(mcp): migrate comprehensive product E2E to SDK pytest

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -6937,7 +6937,7 @@
         "filename": "scripts/ci/README.md",
         "hashed_secret": "f017223a0417e247cdef8c5c3e5681c6d5439219",
         "is_verified": false,
-        "line_number": 145
+        "line_number": 157
       }
     ],
     "scripts/ci/dependency-compose.yaml": [
@@ -6987,5 +6987,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-07T07:57:29Z"
+  "generated_at": "2026-09-07T09:12:52Z"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,10 +95,11 @@ unset AKB_E2E_USERNAME AKB_E2E_PASSWORD
 cd frontend && pnpm test
 ```
 
-The authenticated MCP pytest scenario is run by the repository-owned runtime
-gate and can also consume a ready schema-v2 descriptor directly. Local and
-hosted CI use the same pytest entrypoint and the same `akb_list_vaults({})`
-assertion:
+The authenticated MCP pytest behavior suite is run by the repository-owned
+runtime gate and can also consume a ready schema-v2 descriptor directly.
+Local and hosted CI use the same pytest entrypoint: the list-vaults canary and
+the migrated MCP product scenarios consume the same descriptor and fixture
+lifecycle. Transport/session and direct REST checks remain in the shell suite:
 
 ```bash
 uv run --locked --extra dev --project backend python -m pytest \

--- a/backend/tests/mcp_e2e/conftest.py
+++ b/backend/tests/mcp_e2e/conftest.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import os
+import secrets as secrets_module
 from collections.abc import AsyncIterator, Iterator, Mapping
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from urllib.parse import urljoin
@@ -177,10 +180,26 @@ def runtime_session(request: pytest.FixtureRequest) -> Iterator[RuntimeContext]:
         client.close()
 
 
-@pytest.fixture
-async def mcp_client(runtime_session: RuntimeContext) -> AsyncIterator[Client]:
+@dataclass(frozen=True, slots=True)
+class SecondaryMcpSession:
+    """A second authenticated SDK client used for role-boundary scenarios."""
+
+    client: Client
+    username: str
+
+
+@asynccontextmanager
+async def _open_mcp_client(
+    runtime_session: RuntimeContext,
+    *,
+    pat: str,
+    secrets: tuple[str, ...],
+    scenario: str,
+) -> AsyncIterator[Client]:
+    """Own one SDK client's complete enter/exit lifecycle in one task."""
+
     http_client = httpx2.AsyncClient(
-        headers={"Authorization": f"Bearer {runtime_session.pat}"},
+        headers={"Authorization": f"Bearer {pat}"},
         timeout=httpx2.Timeout(30.0, read=300.0),
         follow_redirects=True,
         trust_env=False,
@@ -229,15 +248,15 @@ async def mcp_client(runtime_session: RuntimeContext) -> AsyncIterator[Client]:
         if cancelled:
             raise asyncio.CancelledError
 
-    task = asyncio.create_task(run_client(), name="mcp-sdk-client")
+    task = asyncio.create_task(run_client(), name=f"mcp-sdk-client-{scenario}")
     reported_startup_error = False
     try:
         await ready.wait()
         if lifecycle_error is not None:
             reported_startup_error = True
             pytest.fail(
-                "scenario=akb_list_vaults SDK connection: "
-                + redact_error(lifecycle_error, runtime_session.secrets)
+                f"scenario={scenario} SDK connection: "
+                + redact_error(lifecycle_error, secrets)
             )
         yield client
     finally:
@@ -246,3 +265,87 @@ async def mcp_client(runtime_session: RuntimeContext) -> AsyncIterator[Client]:
         if lifecycle_error is not None and not reported_startup_error:
             raise lifecycle_error
         await task
+
+
+@pytest.fixture
+async def mcp_client(runtime_session: RuntimeContext) -> AsyncIterator[Client]:
+    async with _open_mcp_client(
+        runtime_session,
+        pat=runtime_session.pat,
+        secrets=runtime_session.secrets,
+        scenario="akb_list_vaults",
+    ) as client:
+        yield client
+
+
+def _prepare_secondary_user(runtime_session: RuntimeContext) -> tuple[str, str, tuple[str, ...]]:
+    username = f"mcp-pytest-u2-{secrets_module.token_hex(8)}"
+    password = secrets_module.token_urlsafe(24)
+    login_url = urljoin(
+        f"{runtime_session.descriptor.app_origin}/",
+        runtime_session.descriptor.login_path.lstrip("/"),
+    )
+    register_url = urljoin(f"{runtime_session.descriptor.app_origin}/", "api/v1/auth/register")
+    token_url = urljoin(f"{runtime_session.descriptor.app_origin}/", "api/v1/auth/tokens")
+
+    with httpx.Client(timeout=30.0, trust_env=False) as client:
+        try:
+            registration = client.post(
+                register_url,
+                json={
+                    "username": username,
+                    "email": f"{username}@example.test",
+                    "password": password,
+                },
+            )
+        except httpx.HTTPError:
+            raise RuntimeSetupError("secondary user registration request failed") from None
+        if registration.status_code not in {200, 201}:
+            raise RuntimeSetupError(
+                f"secondary user registration returned HTTP {registration.status_code}"
+            )
+
+        login = _request_json(
+            client,
+            "POST",
+            login_url,
+            stage="secondary user login",
+            body={"username": username, "password": password},
+        )
+        jwt = login.get("token")
+        if not isinstance(jwt, str) or not jwt:
+            raise RuntimeSetupError("secondary user login returned no session token")
+
+        minted = _request_json(
+            client,
+            "POST",
+            token_url,
+            stage="secondary user credential mint",
+            authorization=f"Bearer {jwt}",
+            body={"name": "mcp-pytest-secondary"},
+        )
+        pat = minted.get("token")
+        if not isinstance(pat, str) or not pat.startswith("akb_"):
+            raise RuntimeSetupError("secondary user credential mint returned an invalid PAT")
+
+    return username, pat, (username, password, jwt, pat)
+
+
+@pytest.fixture
+async def secondary_mcp_client(
+    runtime_session: RuntimeContext,
+) -> AsyncIterator[SecondaryMcpSession]:
+    try:
+        username, pat, secrets = _prepare_secondary_user(runtime_session)
+    except Exception as exc:
+        pytest.fail(
+            "scenario=mcp_product_e2e secondary user preparation: "
+            + redact_error(exc, runtime_session.secrets)
+        )
+    async with _open_mcp_client(
+        runtime_session,
+        pat=pat,
+        secrets=(*runtime_session.secrets, *secrets),
+        scenario="mcp_product_e2e-secondary",
+    ) as client:
+        yield SecondaryMcpSession(client=client, username=username)

--- a/backend/tests/mcp_e2e/conftest.py
+++ b/backend/tests/mcp_e2e/conftest.py
@@ -158,21 +158,24 @@ def _prepare_runtime(descriptor: RuntimeDescriptor, client: httpx.Client) -> Run
     return RuntimeContext(descriptor=descriptor, pat=pat, secrets=(*secrets, pat))
 
 
-@pytest.fixture
-def runtime_session(request: pytest.FixtureRequest) -> Iterator[RuntimeContext]:
+@pytest.fixture(scope="session")
+def runtime_descriptor(request: pytest.FixtureRequest) -> RuntimeDescriptor:
     source = request.config.getoption("--runtime-descriptor")
     if not source:
         pytest.fail("scenario=akb_list_vaults preparation: --runtime-descriptor is required")
     try:
         capture_manager = request.config.pluginmanager.getplugin("capturemanager")
-        descriptor = RuntimeDescriptor.from_json(_read_descriptor(source, capture_manager))
+        return RuntimeDescriptor.from_json(_read_descriptor(source, capture_manager))
     except Exception as exc:
         pytest.fail(f"scenario=akb_list_vaults preparation: {redact_error(exc)}")
 
+
+@pytest.fixture
+def runtime_session(runtime_descriptor: RuntimeDescriptor) -> Iterator[RuntimeContext]:
     client = httpx.Client(timeout=30.0)
     try:
         try:
-            context = _prepare_runtime(descriptor, client)
+            context = _prepare_runtime(runtime_descriptor, client)
         except Exception as exc:
             pytest.fail(f"scenario=akb_list_vaults preparation: {redact_error(exc)}")
         yield context

--- a/backend/tests/mcp_e2e/test_product_e2e.py
+++ b/backend/tests/mcp_e2e/test_product_e2e.py
@@ -44,19 +44,25 @@ async def _call_json(
     except Exception as exc:
         pytest.fail(f"scenario={SCENARIO} operation={operation}: {redact_error(exc, runtime_session.secrets)}")
 
-    if bool(result.is_error) != expect_error:
-        state = "error" if result.is_error else "success"
-        pytest.fail(
-            f"scenario={SCENARIO} operation={operation}: expected "
-            f"{('an error' if expect_error else 'success')}, got {state}"
-        )
-
     try:
         public = json.loads(_text_content(result, operation))
     except (TypeError, ValueError) as exc:
         pytest.fail(f"scenario={SCENARIO} operation={operation}: tool returned invalid public JSON: {exc}")
     if not isinstance(public, dict):
         pytest.fail(f"scenario={SCENARIO} operation={operation}: public result is not an object")
+
+    # The HTTP MCP backend returns product failures as a JSON error envelope;
+    # the SDK's is_error flag is not guaranteed to mirror that application
+    # payload. Keep the shell suite's public error-envelope contract while
+    # still rejecting protocol-level failures on successful calls.
+    if expect_error:
+        if "error" not in public:
+            state = "SDK error" if result.is_error else "success"
+            pytest.fail(
+                f"scenario={SCENARIO} operation={operation}: expected an error envelope, got {state}"
+            )
+    elif result.is_error:
+        pytest.fail(f"scenario={SCENARIO} operation={operation}: tool returned an SDK error")
     return public
 
 

--- a/backend/tests/mcp_e2e/test_product_e2e.py
+++ b/backend/tests/mcp_e2e/test_product_e2e.py
@@ -497,14 +497,14 @@ async def test_tables_sql_and_ddl(
         "akb_sql",
         {"vault": vault, "sql": "SELECT * FROM mcp_items"},
     )
-    assert rows.get("total") == 2
+    assert str(rows.get("total")) == "2"
     aggregate = await _call_json(
         mcp_client,
         runtime_session,
         "akb_sql",
         {"vault": vault, "sql": "SELECT SUM(qty) as total_qty, COUNT(*) as cnt FROM mcp_items"},
     )
-    assert aggregate.get("items", [{}])[0].get("total_qty") == 150
+    assert str(aggregate.get("items", [{}])[0].get("total_qty")) == "150"
 
     info = await _call_json(mcp_client, runtime_session, "akb_vault_info", {"vault": vault})
     tables = info.get("tables") or []
@@ -546,7 +546,7 @@ async def test_tables_sql_and_ddl(
         "akb_sql",
         {"vault": vault, "sql": f"SELECT COUNT(*) as cnt FROM {sql_name}"},
     )
-    assert round_trip.get("items", [{}])[0].get("cnt") == 2
+    assert str(round_trip.get("items", [{}])[0].get("cnt")) == "2"
 
     altered = await _call_json(
         mcp_client,

--- a/backend/tests/mcp_e2e/test_product_e2e.py
+++ b/backend/tests/mcp_e2e/test_product_e2e.py
@@ -1,0 +1,760 @@
+"""Authenticated MCP product behavior through the official Python SDK."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from mcp import Client
+from mcp import types as mcp_types
+
+from .conftest import SecondaryMcpSession
+from .runtime import RuntimeContext, redact_error
+
+
+SCENARIO = "mcp_product_e2e"
+
+
+def _new_vault_name(prefix: str) -> str:
+    return f"mcp-sdk-{prefix}-{uuid4().hex[:10]}"
+
+
+def _text_content(result: mcp_types.CallToolResult, operation: str) -> str:
+    for item in result.content:
+        if isinstance(item, mcp_types.TextContent):
+            return item.text
+    pytest.fail(f"scenario={SCENARIO} operation={operation}: tool returned no public JSON text")
+
+
+async def _call_json(
+    client: Client,
+    runtime_session: RuntimeContext,
+    name: str,
+    arguments: dict[str, Any],
+    *,
+    expect_error: bool = False,
+) -> dict[str, Any]:
+    operation = f"tools/call {name}"
+    try:
+        result = await client.call_tool(name, arguments)
+    except Exception as exc:
+        pytest.fail(f"scenario={SCENARIO} operation={operation}: {redact_error(exc, runtime_session.secrets)}")
+
+    if bool(result.is_error) != expect_error:
+        state = "error" if result.is_error else "success"
+        pytest.fail(
+            f"scenario={SCENARIO} operation={operation}: expected "
+            f"{('an error' if expect_error else 'success')}, got {state}"
+        )
+
+    try:
+        public = json.loads(_text_content(result, operation))
+    except (TypeError, ValueError) as exc:
+        pytest.fail(f"scenario={SCENARIO} operation={operation}: tool returned invalid public JSON: {exc}")
+    if not isinstance(public, dict):
+        pytest.fail(f"scenario={SCENARIO} operation={operation}: public result is not an object")
+    return public
+
+
+async def _create_vault(
+    client: Client,
+    runtime_session: RuntimeContext,
+    prefix: str,
+    *,
+    description: str = "MCP SDK behavior test",
+) -> str:
+    name = _new_vault_name(prefix)
+    result = await _call_json(
+        client,
+        runtime_session,
+        "akb_create_vault",
+        {"name": name, "description": description},
+    )
+    assert result.get("name") == name
+    assert isinstance(result.get("vault_id"), str)
+    return name
+
+
+async def test_documents_browse_search_and_versioned_reads(
+    mcp_client: Client,
+    runtime_session: RuntimeContext,
+) -> None:
+    vault = await _create_vault(mcp_client, runtime_session, "documents")
+
+    created = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_put",
+        {
+            "vault": vault,
+            "collection": "specs",
+            "title": "MCP Created Spec",
+            "content": (
+                "## API Spec\n\nCreated via MCP tool call.\n\n"
+                "## Endpoints\n\nGET /api/v1/health"
+            ),
+            "type": "spec",
+            "tags": ["mcp", "test"],
+        },
+    )
+    doc_uri = created["uri"]
+    assert isinstance(doc_uri, str)
+    assert isinstance(created.get("chunks_indexed"), int)
+
+    linked = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_put",
+        {
+            "vault": vault,
+            "collection": "plans",
+            "title": "Migration Plan",
+            "content": f"## Plan\n\nMigrate based on [API Spec]({created['path']}).",
+            "type": "plan",
+            "tags": ["mcp"],
+            "depends_on": [doc_uri],
+        },
+    )
+    linked_uri = linked["uri"]
+    assert isinstance(linked_uri, str)
+
+    fetched = await _call_json(mcp_client, runtime_session, "akb_get", {"uri": doc_uri})
+    assert fetched.get("title") == "MCP Created Spec"
+
+    updated = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_update",
+        {"uri": doc_uri, "status": "active", "message": "Promote via MCP"},
+    )
+    assert isinstance(updated.get("commit_hash"), str)
+
+    root = await _call_json(mcp_client, runtime_session, "akb_browse", {"vault": vault})
+    assert len(root.get("items", [])) >= 2
+    specs = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_browse",
+        {"vault": vault, "collection": "specs"},
+    )
+    assert len(specs.get("items", [])) >= 1
+
+    search = await _call_json(mcp_client, runtime_session, "akb_search", {"query": "API spec endpoint"})
+    assert type(search.get("total")) is int
+    assert search["total"] >= 0
+
+    drilled = await _call_json(mcp_client, runtime_session, "akb_drill_down", {"uri": doc_uri})
+    sections = drilled.get("sections")
+    assert isinstance(sections, list) and sections
+    assert not any(
+        re.match(r"^(TITLE|SUMMARY|TAGS|PATH|TYPE):", str(section.get("content") or ""))
+        for section in sections
+    )
+
+    trailing = await _call_json(mcp_client, runtime_session, "akb_get", {"uri": f"{doc_uri}/"})
+    assert trailing.get("path") == "specs/mcp-created-spec.md"
+
+    first_collision = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_put",
+        {"vault": vault, "collection": "specs", "title": "collision probe", "content": "BODY_FIRST"},
+    )
+    second_collision = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_put",
+        {"vault": vault, "collection": "specs", "title": "collision probe", "content": "BODY_SECOND"},
+    )
+    first_uri = first_collision["uri"]
+    second_uri = second_collision["uri"]
+    assert first_uri != second_uri
+    first_body = await _call_json(mcp_client, runtime_session, "akb_get", {"uri": first_uri})
+    second_body = await _call_json(mcp_client, runtime_session, "akb_get", {"uri": second_uri})
+    assert "BODY_FIRST" in first_body["content"] and "BODY_SECOND" not in first_body["content"]
+    assert "BODY_SECOND" in second_body["content"] and "BODY_FIRST" not in second_body["content"]
+
+    await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_put",
+        {"vault": vault, "collection": "specs", "title": "api", "content": "FIRST_ONLY_TAG"},
+    )
+    await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_put",
+        {"vault": vault, "collection": "specs", "title": "api v2", "content": "SECOND_ONLY_TAG"},
+    )
+    exact = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_get",
+        {"uri": f"akb://{vault}/doc/specs/api.md"},
+    )
+    assert "FIRST_ONLY_TAG" in exact["content"]
+    assert "SECOND_ONLY_TAG" not in exact["content"]
+
+    history = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_history",
+        {"uri": doc_uri},
+    )
+    versions = history.get("history")
+    assert isinstance(versions, list) and len(versions) >= 2
+    version = versions[0].get("hash")
+    assert isinstance(version, str)
+    historical = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_get",
+        {"uri": doc_uri, "version": version},
+    )
+    assert not str(historical.get("content", "")).lstrip().startswith("---")
+
+
+async def test_document_move_preserves_aliases_and_collision_rules(
+    mcp_client: Client,
+    runtime_session: RuntimeContext,
+) -> None:
+    vault = await _create_vault(mcp_client, runtime_session, "moves")
+
+    original = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_put",
+        {"vault": vault, "collection": "movetest", "title": "Move Me", "content": "MOVE_BODY_TAG"},
+    )
+    old_uri = original["uri"]
+    moved = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_move",
+        {"uri": old_uri, "slug": "moved-final"},
+    )
+    new_uri = moved["uri"]
+    assert new_uri != old_uri
+    assert moved.get("action") == "moved"
+    assert "MOVE_BODY_TAG" in (await _call_json(mcp_client, runtime_session, "akb_get", {"uri": new_uri}))["content"]
+    assert "MOVE_BODY_TAG" in (await _call_json(mcp_client, runtime_session, "akb_get", {"uri": old_uri}))["content"]
+
+    moved_again = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_move",
+        {"uri": new_uri, "collection": "archive"},
+    )
+    archive_uri = moved_again["uri"]
+    assert "/archive/" in archive_uri
+    assert "MOVE_BODY_TAG" in (await _call_json(mcp_client, runtime_session, "akb_get", {"uri": old_uri}))["content"]
+    assert "MOVE_BODY_TAG" in (await _call_json(mcp_client, runtime_session, "akb_get", {"uri": new_uri}))["content"]
+
+    no_op = await _call_json(mcp_client, runtime_session, "akb_move", {"uri": archive_uri}, expect_error=True)
+    assert no_op.get("code") == "invalid_argument"
+
+    twin_a = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_put",
+        {"vault": vault, "collection": "dups", "title": "Twin", "content": "TWIN_A"},
+    )
+    twin_b = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_put",
+        {"vault": vault, "collection": "dupsrc", "title": "Twin", "content": "TWIN_B"},
+    )
+    twin_b_moved = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_move",
+        {"uri": twin_b["uri"], "collection": "dups"},
+    )
+    assert twin_b_moved["uri"] != twin_a["uri"]
+    twin_a_body = await _call_json(mcp_client, runtime_session, "akb_get", {"uri": twin_a["uri"]})
+    twin_b_body = await _call_json(mcp_client, runtime_session, "akb_get", {"uri": twin_b_moved["uri"]})
+    assert "TWIN_A" in twin_a_body["content"] and "TWIN_B" not in twin_a_body["content"]
+    assert "TWIN_B" in twin_b_body["content"] and "TWIN_A" not in twin_b_body["content"]
+
+    recycled = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_put",
+        {"vault": vault, "collection": "reuse", "title": "Recycle", "content": "ORIG_DOC"},
+    )
+    recycled_old = recycled["uri"]
+    await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_move",
+        {"uri": recycled_old, "slug": "recycled"},
+    )
+    await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_put",
+        {"vault": vault, "collection": "reuse", "title": "Recycle", "content": "NEW_DOC"},
+    )
+    reused = await _call_json(mcp_client, runtime_session, "akb_get", {"uri": recycled_old})
+    assert "NEW_DOC" in reused["content"] and "ORIG_DOC" not in reused["content"]
+
+    await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_put",
+        {"vault": vault, "collection": "sfxa", "title": "Sfx", "content": "S1"},
+    )
+    suffixed = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_put",
+        {"vault": vault, "collection": "sfxa", "title": "Sfx", "content": "S2"},
+    )
+    moved_suffix = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_move",
+        {"uri": suffixed["uri"], "collection": "sfxb"},
+    )
+    assert suffixed["uri"] != moved_suffix["uri"]
+    assert moved_suffix["uri"].endswith("/sfx.md")
+
+    await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_put",
+        {"vault": vault, "collection": "rej", "title": "Taken", "content": "T1"},
+    )
+    mover = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_put",
+        {"vault": vault, "collection": "rej", "title": "Mover", "content": "T2"},
+    )
+    rejected = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_move",
+        {"uri": mover["uri"], "slug": "taken"},
+        expect_error=True,
+    )
+    assert rejected.get("code") == "conflict"
+    malformed = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_move",
+        {"uri": "not-a-valid-uri", "slug": "x"},
+        expect_error=True,
+    )
+    assert malformed.get("code") == "invalid_uri"
+
+
+async def test_relations_activity_provenance_and_document_deletion(
+    mcp_client: Client,
+    runtime_session: RuntimeContext,
+) -> None:
+    vault = await _create_vault(mcp_client, runtime_session, "relations")
+    first = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_put",
+        {"vault": vault, "collection": "specs", "title": "First", "content": "FIRST"},
+    )
+    second = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_put",
+        {
+            "vault": vault,
+            "collection": "plans",
+            "title": "Second",
+            "content": "SECOND",
+            "depends_on": [first["uri"]],
+        },
+    )
+
+    relations = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_relations",
+        {"uri": second["uri"]},
+    )
+    assert len(relations.get("relations", [])) >= 1
+    graph = await _call_json(mcp_client, runtime_session, "akb_graph", {"vault": vault})
+    assert len(graph.get("nodes", [])) >= 2
+    assert len(graph.get("edges", [])) >= 1
+    provenance = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_provenance",
+        {"uri": second["uri"]},
+    )
+    assert provenance.get("title")
+
+    activity = await _call_json(mcp_client, runtime_session, "akb_activity", {"vault": vault})
+    assert type(activity.get("returned")) is int and activity["returned"] >= 2
+    assert activity["activity"] and activity["activity"][0].get("files")
+    first_hash = activity["activity"][0].get("hash")
+    assert isinstance(first_hash, str)
+    diff = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_diff",
+        {"uri": first["uri"], "commit": first_hash},
+    )
+    assert diff.get("type")
+
+    username = os.environ[runtime_session.descriptor.username_env]
+    users = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_search_users",
+        {"query": username},
+    )
+    assert len(users.get("users", [])) >= 1
+    info = await _call_json(mcp_client, runtime_session, "akb_vault_info", {"vault": vault})
+    assert info.get("owner")
+    members = await _call_json(mcp_client, runtime_session, "akb_vault_members", {"vault": vault})
+    assert len(members.get("members", [])) >= 1
+
+    deleted = await _call_json(mcp_client, runtime_session, "akb_delete", {"uri": first["uri"]})
+    assert deleted.get("deleted") is True
+    missing = await _call_json(mcp_client, runtime_session, "akb_get", {"uri": first["uri"]}, expect_error=True)
+    assert missing.get("code") == "not_found"
+
+    await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_create_collection",
+        {"vault": vault, "path": "keepempty"},
+    )
+    keep = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_put",
+        {"vault": vault, "collection": "keepempty", "title": "keep-t", "content": "## c"},
+    )
+    await _call_json(mcp_client, runtime_session, "akb_delete", {"uri": keep["uri"]})
+    after_delete = await _call_json(mcp_client, runtime_session, "akb_browse", {"vault": vault})
+    assert sum(
+        item.get("name") == "keepempty" and item.get("type") == "collection"
+        for item in after_delete.get("items", [])
+    ) == 1
+
+
+async def test_tables_sql_and_ddl(
+    mcp_client: Client,
+    runtime_session: RuntimeContext,
+) -> None:
+    vault = await _create_vault(mcp_client, runtime_session, "tables")
+    table = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_create_table",
+        {
+            "vault": vault,
+            "name": "mcp_items",
+            "columns": [{"name": "product", "type": "text"}, {"name": "qty", "type": "number"}],
+        },
+    )
+    table_uri = table["uri"]
+    assert isinstance(table_uri, str)
+
+    overlong = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_create_table",
+        {
+            "vault": vault,
+            "name": "a" * 70,
+            "columns": [{"name": "x", "type": "text"}],
+        },
+        expect_error=True,
+    )
+    assert overlong.get("code") == "invalid_argument"
+
+    inserted = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_sql",
+        {"vault": vault, "sql": "INSERT INTO mcp_items (product, qty) VALUES ('Widget', 100), ('Gadget', 50)"},
+    )
+    assert inserted.get("result")
+    rows = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_sql",
+        {"vault": vault, "sql": "SELECT * FROM mcp_items"},
+    )
+    assert rows.get("total") == 2
+    aggregate = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_sql",
+        {"vault": vault, "sql": "SELECT SUM(qty) as total_qty, COUNT(*) as cnt FROM mcp_items"},
+    )
+    assert aggregate.get("items", [{}])[0].get("total_qty") == 150
+
+    info = await _call_json(mcp_client, runtime_session, "akb_vault_info", {"vault": vault})
+    tables = info.get("tables") or []
+    table_info = next(item for item in tables if item.get("name") == "mcp_items")
+    assert any(column.get("name") == "product" for column in table_info.get("columns", []))
+
+    wrong_column = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_sql",
+        {"vault": vault, "sql": "SELECT * FROM mcp_items WHERE producct = 'Widget'"},
+        expect_error=True,
+    )
+    assert "Did you mean" in wrong_column.get("hint", "")
+    assert "product" in (wrong_column.get("details") or {}).get("available_columns", [])
+    wrong_table = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_sql",
+        {"vault": vault, "sql": "SELECT * FROM mcp_itms"},
+        expect_error=True,
+    )
+    assert "Did you mean" in wrong_table.get("hint", "")
+    assert "mcp_items" in wrong_table.get("hint", "")
+
+    browsed_tables = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_browse",
+        {"vault": vault, "content_type": "tables"},
+    )
+    table_items = [item for item in browsed_tables.get("items", []) if item.get("type") == "table"]
+    assert table_items
+    sql_name = next(item.get("sql_name") for item in table_items if item.get("name") == "mcp_items")
+    assert sql_name == "mcp_items"
+    round_trip = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_sql",
+        {"vault": vault, "sql": f"SELECT COUNT(*) as cnt FROM {sql_name}"},
+    )
+    assert round_trip.get("items", [{}])[0].get("cnt") == 2
+
+    altered = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_alter_table",
+        {"uri": table_uri, "add_columns": [{"name": "category", "type": "text"}]},
+    )
+    assert any(column.get("name") == "category" for column in altered.get("columns", []))
+    dropped = await _call_json(mcp_client, runtime_session, "akb_drop_table", {"uri": table_uri})
+    assert dropped.get("deleted") is True
+    remaining = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_browse",
+        {"vault": vault, "content_type": "tables"},
+    )
+    assert not [item for item in remaining.get("items", []) if item.get("type") == "table"]
+
+
+async def test_publication_help_and_vault_lifecycle(
+    mcp_client: Client,
+    runtime_session: RuntimeContext,
+) -> None:
+    vault = await _create_vault(mcp_client, runtime_session, "publication")
+    document = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_put",
+        {
+            "vault": vault,
+            "collection": "specs",
+            "title": "Pub Test",
+            "content": "## Public\n\nTest.",
+        },
+    )
+    publication = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_publish",
+        {"uri": document["uri"]},
+    )
+    assert isinstance(publication.get("slug"), str) and publication["slug"]
+    unpublished = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_unpublish",
+        {"uri": document["uri"]},
+    )
+    assert unpublished.get("deleted", 0) >= 1
+
+    help_root = await _call_json(mcp_client, runtime_session, "akb_help", {})
+    assert "Quick Start" in help_root.get("help", "")
+    help_sql = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_help",
+        {"topic": "akb_sql"},
+    )
+    assert "SELECT" in help_sql.get("help", "")
+
+    lifecycle = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_create_vault",
+        {"name": _new_vault_name("lifecycle")},
+    )
+    lifecycle_vault = lifecycle["name"]
+    archived = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_archive_vault",
+        {"vault": lifecycle_vault},
+    )
+    assert archived.get("status") == "archived"
+    blocked = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_put",
+        {
+            "vault": lifecycle_vault,
+            "collection": "test",
+            "title": "Fail",
+            "content": "#No",
+        },
+        expect_error=True,
+    )
+    assert blocked.get("code")
+    deleted = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_delete_vault",
+        {"vault": lifecycle_vault},
+    )
+    assert deleted.get("deleted") is True
+    gone = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_browse",
+        {"vault": lifecycle_vault},
+        expect_error=True,
+    )
+    assert gone.get("code") == "not_found"
+
+
+async def test_access_roles_and_public_levels(
+    mcp_client: Client,
+    secondary_mcp_client: SecondaryMcpSession,
+    runtime_session: RuntimeContext,
+) -> None:
+    vault = await _create_vault(mcp_client, runtime_session, "access")
+    second = secondary_mcp_client.client
+
+    no_access = await _call_json(
+        second,
+        runtime_session,
+        "akb_browse",
+        {"vault": vault},
+        expect_error=True,
+    )
+    assert no_access.get("code")
+
+    granted_reader = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_grant",
+        {"vault": vault, "user": secondary_mcp_client.username, "role": "reader"},
+    )
+    assert granted_reader.get("granted") is True
+    readable = await _call_json(second, runtime_session, "akb_browse", {"vault": vault})
+    assert "items" in readable
+    searchable = await _call_json(
+        second,
+        runtime_session,
+        "akb_search",
+        {"query": "test", "vault": vault},
+    )
+    assert "total" in searchable or "results" in searchable
+    reader_write = await _call_json(
+        second,
+        runtime_session,
+        "akb_put",
+        {"vault": vault, "collection": "hack", "title": "Unauthorized", "content": "# No"},
+        expect_error=True,
+    )
+    assert reader_write.get("code")
+
+    granted_writer = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_grant",
+        {"vault": vault, "user": secondary_mcp_client.username, "role": "writer"},
+    )
+    assert granted_writer.get("granted") is True
+    writer_doc = await _call_json(
+        second,
+        runtime_session,
+        "akb_put",
+        {"vault": vault, "collection": "user2-docs", "title": "Writer Test", "content": "## Written"},
+    )
+    assert isinstance(writer_doc.get("uri"), str)
+
+    revoked = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_revoke",
+        {"vault": vault, "user": secondary_mcp_client.username},
+    )
+    assert revoked.get("revoked") is True
+    await _call_json(second, runtime_session, "akb_browse", {"vault": vault}, expect_error=True)
+    await _call_json(
+        second,
+        runtime_session,
+        "akb_search",
+        {"query": "test", "vault": vault},
+        expect_error=True,
+    )
+
+    public_writer = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_set_public",
+        {"vault": vault, "level": "writer"},
+    )
+    assert public_writer.get("public_access") == "writer"
+    public_doc = await _call_json(
+        second,
+        runtime_session,
+        "akb_put",
+        {"vault": vault, "collection": "public-test", "title": "Public Write", "content": "# Public"},
+    )
+    assert isinstance(public_doc.get("uri"), str)
+
+    public_reader = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_set_public",
+        {"vault": vault, "level": "reader"},
+    )
+    assert public_reader.get("public_access") == "reader"
+    await _call_json(
+        second,
+        runtime_session,
+        "akb_put",
+        {"vault": vault, "collection": "public-test", "title": "Should Fail", "content": "#No"},
+        expect_error=True,
+    )
+    public_read = await _call_json(second, runtime_session, "akb_browse", {"vault": vault})
+    assert "items" in public_read
+
+    public_none = await _call_json(
+        mcp_client,
+        runtime_session,
+        "akb_set_public",
+        {"vault": vault, "level": "none"},
+    )
+    assert public_none.get("public_access") == "none"
+    await _call_json(second, runtime_session, "akb_browse", {"vault": vault}, expect_error=True)

--- a/backend/tests/test_e2e_runtime_unit.py
+++ b/backend/tests/test_e2e_runtime_unit.py
@@ -1213,7 +1213,7 @@ def test_ubuntu_bootstrap_is_bash_safe_and_keeps_descriptor_stdout_clean():
     apt_update = next(index for index, line in enumerate(lines) if '"${SUDO[@]}" apt-get update' in line)
     assert "exec 3>&1 1>&2" in text
     assert ubuntu_check < sysctl_persist < apt_update
-    assert "net.ipv4.tcp_mtu_probing = 1" in text
+    assert "net.ipv4.tcp_mtu_probing = 2" in text
     assert 'sysctl --load "$SYSCTL_CONF"' in text
     assert "TCP MTU probing configuration" in text
     assert "--scenario empty" in text

--- a/backend/tests/test_e2e_runtime_unit.py
+++ b/backend/tests/test_e2e_runtime_unit.py
@@ -1215,6 +1215,7 @@ def test_ubuntu_bootstrap_is_bash_safe_and_keeps_descriptor_stdout_clean():
     assert ubuntu_check < sysctl_persist < apt_update
     assert "net.ipv4.tcp_mtu_probing = 2" in text
     assert 'sysctl --load "$SYSCTL_CONF"' in text
+    assert '[ "$SYSCTL_VALUE" = "2" ]' in text
     assert "TCP MTU probing configuration" in text
     assert "--scenario empty" in text
     assert "app-installation-lifecycle" in text

--- a/backend/tests/test_e2e_runtime_unit.py
+++ b/backend/tests/test_e2e_runtime_unit.py
@@ -1207,7 +1207,15 @@ def test_ubuntu_bootstrap_is_bash_safe_and_keeps_descriptor_stdout_clean():
     result = subprocess.run(["bash", "-n", str(BOOTSTRAP)], check=False)
     assert result.returncode == 0
     text = BOOTSTRAP.read_text()
+    lines = text.splitlines()
+    ubuntu_check = next(index for index, line in enumerate(lines) if "Ubuntu 24.04 is required" in line)
+    sysctl_persist = next(index for index, line in enumerate(lines) if "99-akb-e2e-tcp-mtu-probing.conf" in line)
+    apt_update = next(index for index, line in enumerate(lines) if '"${SUDO[@]}" apt-get update' in line)
     assert "exec 3>&1 1>&2" in text
+    assert ubuntu_check < sysctl_persist < apt_update
+    assert "net.ipv4.tcp_mtu_probing = 1" in text
+    assert 'sysctl --load "$SYSCTL_CONF"' in text
+    assert "TCP MTU probing configuration" in text
     assert "--scenario empty" in text
     assert "app-installation-lifecycle" in text
     assert "--with-frontend" in text

--- a/backend/tests/test_mcp_e2e.sh
+++ b/backend/tests/test_mcp_e2e.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 #
-# AKB MCP E2E Test Suite
-# Tests MCP tool calls via Streamable HTTP transport
+# MCP transport and REST-boundary checks.
+# Authenticated MCP product behavior lives in backend/tests/mcp_e2e and is
+# executed through the official Python SDK by the repository-owned runtime.
 #
 set -uo pipefail
 
 BASE_URL="${AKB_URL:-http://localhost:8000}"
-VAULT="mcp-e2e-$(date +%s)"
-E2E_USER="mcp-user-$(date +%s)"
+VAULT="mcp-boundary-$(date +%s)"
+E2E_USER="mcp-boundary-user-$(date +%s)"
 PASS=0
 FAIL=0
 ERRORS=()
@@ -16,13 +17,13 @@ pass() { PASS=$((PASS+1)); echo "  ✓ $1"; }
 fail() { FAIL=$((FAIL+1)); ERRORS+=("$1: $2"); echo "  ✗ $1 — $2"; }
 
 echo "╔══════════════════════════════════════════╗"
-echo "║   AKB MCP E2E Test Suite                 ║"
+echo "║   AKB MCP Boundary E2E Suite             ║"
 echo "║   Target: $BASE_URL/mcp/"
 echo "╚══════════════════════════════════════════╝"
 echo ""
 
-# ── 0. Setup: register user + get PAT ───────────────────────
-echo "▸ 0. Setup"
+# ── 0. REST auth setup ───────────────────────────────────────
+echo "▸ REST authentication"
 
 curl -sk -X POST "$BASE_URL/api/v1/auth/register" \
   -H 'Content-Type: application/json' \
@@ -30,33 +31,34 @@ curl -sk -X POST "$BASE_URL/api/v1/auth/register" \
 
 JWT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/login" \
   -H 'Content-Type: application/json' \
-  -d "{\"username\":\"$E2E_USER\",\"password\":\"test1234\"}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
+  -d "{\"username\":\"$E2E_USER\",\"password\":\"test1234\"}" \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
 
 PAT=$(curl -sk -X POST "$BASE_URL/api/v1/auth/tokens" \
   -H "Authorization: Bearer $JWT" \
   -H 'Content-Type: application/json' \
-  -d '{"name":"mcp-e2e"}' | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
+  -d '{"name":"mcp-boundary"}' \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
 
-[ -n "$PAT" ] && pass "PAT acquired" || { fail "PAT" "could not get PAT"; exit 1; }
+[ -n "$PAT" ] && pass "REST PAT acquired" || { fail "REST PAT" "could not get PAT"; exit 1; }
 
-# ── 1. MCP Initialize ───────────────────────────────────────
+# ── 1. MCP initialize/session boundary ───────────────────────
 echo ""
-echo "▸ 1. MCP Protocol"
+echo "▸ MCP transport boundary"
 
 INIT_RESP=$(curl -sk -i -X POST "$BASE_URL/mcp/" \
   -H "Authorization: Bearer $PAT" \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"e2e-test","version":"1.0"}}}' 2>&1)
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"boundary-test","version":"1.0"}}}' 2>&1)
 
 SID=$(echo "$INIT_RESP" | grep -i "mcp-session-id" | tr -d '\r' | awk '{print $2}')
 INIT_BODY=$(echo "$INIT_RESP" | tail -1)
 PROTO=$(echo "$INIT_BODY" | python3 -c "import sys,json; print(json.load(sys.stdin)['result']['protocolVersion'])" 2>/dev/null)
 
-[ -n "$SID" ] && pass "Session ID received ($SID)" || fail "Session ID" "missing"
-[ "$PROTO" = "2025-03-26" ] && pass "Protocol version: $PROTO" || fail "Protocol" "expected 2025-03-26, got $PROTO"
+[ -n "$SID" ] && pass "MCP session ID received" || fail "MCP session ID" "missing"
+[ "$PROTO" = "2025-03-26" ] && pass "MCP protocol version negotiated" || fail "MCP protocol" "expected 2025-03-26, got $PROTO"
 
-# Send initialized notification
 curl -sk -X POST "$BASE_URL/mcp/" \
   -H "Authorization: Bearer $PAT" \
   -H "Content-Type: application/json" \
@@ -64,38 +66,10 @@ curl -sk -X POST "$BASE_URL/mcp/" \
   -H "mcp-session-id: $SID" \
   -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null 2>&1
 
-# Auth rejection without PAT
 AUTH_RESP=$(curl -sk -o /dev/null -w "%{http_code}" -X POST "$BASE_URL/mcp/" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' 2>/dev/null)
-[ "$AUTH_RESP" = "401" ] && pass "MCP rejects unauthenticated (401)" || fail "MCP auth" "expected 401, got $AUTH_RESP"
-
-# Helper: MCP tool call
-MCP_ID=10
-mcp_call() {
-  local tool=$1 args=$2
-  MCP_ID=$((MCP_ID+1))
-  curl -sk -X POST "$BASE_URL/mcp/" \
-    -H "Authorization: Bearer $PAT" \
-    -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" \
-    -H "mcp-session-id: $SID" \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$MCP_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}" 2>&1
-}
-
-# Extract tool result text
-mcp_result() {
-  python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d['result']['content'][0]['text'])" 2>/dev/null
-}
-
-mcp_result_field() {
-  local field=$1
-  python3 -c "import sys,json; d=json.loads(json.loads(sys.stdin.read())['result']['content'][0]['text']); print(d$field)" 2>/dev/null
-}
-
-# ── 2. Tools List ────────────────────────────────────────────
-echo ""
-echo "▸ 2. Tools List"
+[ "$AUTH_RESP" = "401" ] && pass "MCP rejects unauthenticated requests" || fail "MCP auth" "expected 401, got $AUTH_RESP"
 
 TOOLS_RESP=$(curl -sk -X POST "$BASE_URL/mcp/" \
   -H "Authorization: Bearer $PAT" \
@@ -104,631 +78,80 @@ TOOLS_RESP=$(curl -sk -X POST "$BASE_URL/mcp/" \
   -H "mcp-session-id: $SID" \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' 2>&1)
 TOOL_COUNT=$(echo "$TOOLS_RESP" | python3 -c "import sys,json; print(len(json.load(sys.stdin)['result']['tools']))" 2>/dev/null)
-[ "$TOOL_COUNT" -ge 22 ] 2>/dev/null && pass "tools/list returns $TOOL_COUNT tools" || fail "tools/list" "expected >=22, got $TOOL_COUNT"
+[ "$TOOL_COUNT" -ge 22 ] 2>/dev/null && pass "MCP tools/list exposes $TOOL_COUNT tools" || fail "MCP tools/list" "expected >=22, got $TOOL_COUNT"
 
-# ── 3. Vault Operations ─────────────────────────────────────
+# ── 2. Direct REST shape checks retained from the mixed suite ─
 echo ""
-echo "▸ 3. Vault Operations"
+echo "▸ REST response boundaries"
 
-R=$(mcp_call akb_create_vault "{\"name\":\"$VAULT\",\"description\":\"MCP E2E test\"}" | mcp_result)
-VAULT_ID=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['vault_id'])" 2>/dev/null)
-[ -n "$VAULT_ID" ] && pass "akb_create_vault ($VAULT)" || fail "akb_create_vault" "no vault_id"
+VAULT_RESP=$(curl -sk -X POST "$BASE_URL/api/v1/vaults?name=$VAULT&description=MCP+boundary+test" \
+  -H "Authorization: Bearer $PAT")
+VAULT_ID=$(echo "$VAULT_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("vault_id",""))' 2>/dev/null)
+[ -n "$VAULT_ID" ] && pass "REST vault setup" || fail "REST vault setup" "no vault_id"
 
-R=$(mcp_call akb_list_vaults '{}' | mcp_result)
-HAS_VAULT=$(echo "$R" | python3 -c "import sys,json; print(any(v['name']=='$VAULT' for v in json.load(sys.stdin)['vaults']))" 2>/dev/null)
-[ "$HAS_VAULT" = "True" ] && pass "akb_list_vaults contains $VAULT" || fail "akb_list_vaults" "vault not found"
+TABLE_RESP=$(curl -sk -X POST "$BASE_URL/api/v1/tables/$VAULT" \
+  -H "Authorization: Bearer $PAT" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"mcp_items","description":"MCP boundary table","columns":[{"name":"product","type":"text"}]}' 2>/dev/null)
+TABLE_ID=$(echo "$TABLE_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("id",""))' 2>/dev/null)
+[ -n "$TABLE_ID" ] && pass "REST table setup" || fail "REST table setup" "no id"
 
-# ── 4. Document CRUD ─────────────────────────────────────────
-echo ""
-echo "▸ 4. Document CRUD via MCP"
-
-R=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"specs\",\"title\":\"MCP Created Spec\",\"content\":\"## API Spec\\n\\nCreated via MCP tool call.\\n\\n## Endpoints\\n\\nGET /api/v1/health\",\"type\":\"spec\",\"tags\":[\"mcp\",\"test\"]}" | mcp_result)
-DOC_URI=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['uri'])" 2>/dev/null)
-CHUNKS=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['chunks_indexed'])" 2>/dev/null)
-[ -n "$DOC_URI" ] && pass "akb_put created doc ($DOC_URI, $CHUNKS chunks)" || fail "akb_put" "no uri"
-
-# Put a second doc that links to the first
-DOC_PATH=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['path'])" 2>/dev/null)
-R=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"plans\",\"title\":\"Migration Plan\",\"content\":\"## Plan\\n\\nMigrate based on [API Spec]($DOC_PATH).\\n\\n## Timeline\\n\\n- Week 1: Review\",\"type\":\"plan\",\"tags\":[\"mcp\"],\"depends_on\":[\"$DOC_URI\"]}" | mcp_result)
-DOC2_URI=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['uri'])" 2>/dev/null)
-[ -n "$DOC2_URI" ] && pass "akb_put with link ($DOC2_URI)" || fail "akb_put link" "no uri"
-
-# Get document
-R=$(mcp_call akb_get "{\"uri\":\"$DOC_URI\"}" | mcp_result)
-GET_TITLE=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['title'])" 2>/dev/null)
-[ "$GET_TITLE" = "MCP Created Spec" ] && pass "akb_get returns correct title" || fail "akb_get" "wrong title: $GET_TITLE"
-
-# Update document
-R=$(mcp_call akb_update "{\"uri\":\"$DOC_URI\",\"status\":\"active\",\"message\":\"Promote via MCP\"}" | mcp_result)
-UPD_COMMIT=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['commit_hash'])" 2>/dev/null)
-[ -n "$UPD_COMMIT" ] && pass "akb_update ($UPD_COMMIT)" || fail "akb_update" "no commit"
-
-# ── 5. Browse & Search ───────────────────────────────────────
-echo ""
-echo "▸ 5. Browse & Search via MCP"
-
-R=$(mcp_call akb_browse "{\"vault\":\"$VAULT\"}" | mcp_result)
-COLL_COUNT=$(echo "$R" | python3 -c "import sys,json; print(len(json.load(sys.stdin)['items']))" 2>/dev/null)
-[ "$COLL_COUNT" -ge 2 ] 2>/dev/null && pass "akb_browse L1: $COLL_COUNT collections" || fail "akb_browse" "expected >=2"
-
-R=$(mcp_call akb_browse "{\"vault\":\"$VAULT\",\"collection\":\"specs\"}" | mcp_result)
-DOC_COUNT=$(echo "$R" | python3 -c "import sys,json; print(len(json.load(sys.stdin)['items']))" 2>/dev/null)
-[ "$DOC_COUNT" -ge 1 ] 2>/dev/null && pass "akb_browse L2 specs: $DOC_COUNT docs" || fail "akb_browse L2" "expected >=1"
-
-R=$(mcp_call akb_search "{\"query\":\"API spec endpoint\"}" | mcp_result)
-SEARCH_TOTAL=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['total'])" 2>/dev/null)
-[ "$SEARCH_TOTAL" -ge 1 ] 2>/dev/null && pass "akb_search: $SEARCH_TOTAL results" || pass "akb_search: 0 results (embedding may not index in MCP context)"
-
-# Drill down
-R=$(mcp_call akb_drill_down "{\"uri\":\"$DOC_URI\"}" | mcp_result)
-SECT_COUNT=$(echo "$R" | python3 -c "import sys,json; print(len(json.load(sys.stdin)['sections']))" 2>/dev/null)
-[ "$SECT_COUNT" -ge 1 ] 2>/dev/null && pass "akb_drill_down: $SECT_COUNT sections" || fail "akb_drill_down" "expected >=1"
-
-# Chunk header strip — drill_down content must not leak the
-# indexing-time enrichment header (TITLE:/SUMMARY:/TAGS:/PATH:/TYPE:).
-HEADER_LEAKED=$(echo "$R" | python3 -c "
-import sys, json, re
-d = json.load(sys.stdin)
-leaked = any(re.match(r'^(TITLE|SUMMARY|TAGS|PATH|TYPE):', (s.get('content') or ''))
-             for s in d.get('sections', []))
-print(leaked)
-" 2>/dev/null)
-[ "$HEADER_LEAKED" = "False" ] && pass "drill_down strips chunk header" || fail "drill_down header leak" "TITLE:/SUMMARY: visible in response"
-
-# URI trailing-slash normalization — akb_get must resolve the same
-# doc whether the URI has a trailing slash or not.
-R=$(mcp_call akb_get "{\"uri\":\"${DOC_URI}/\"}" | mcp_result)
-GOT_PATH=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('path','MISSING'))" 2>/dev/null)
-[ "$GOT_PATH" = "specs/mcp-created-spec.md" ] && pass "akb_get tolerates trailing slash on URI" || fail "trailing slash" "got path: $GOT_PATH"
-
-# Slug-collision resolution — two docs whose titles slugify to the same base
-# must BOTH persist: the first takes the clean path, the second gets a distinct
-# `-{shortid}` suffixed path (collision is resolved, not rejected). Each keeps
-# its own body (no overwrite). Capture the returned URIs instead of predicting
-# the path — the suffixed path is non-deterministic by design (MCP rule: use
-# returned URIs, don't reassemble paths).
-C1=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"specs\",\"title\":\"collision probe\",\"content\":\"BODY_FIRST\"}" | mcp_result)
-URI1=$(echo "$C1" | python3 -c "import sys,json; print(json.load(sys.stdin).get('uri',''))" 2>/dev/null)
-C2=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"specs\",\"title\":\"collision probe\",\"content\":\"BODY_SECOND\"}" | mcp_result)
-URI2=$(echo "$C2" | python3 -c "import sys,json; print(json.load(sys.stdin).get('uri',''))" 2>/dev/null)
-B1=$(mcp_call akb_get "{\"uri\":\"$URI1\"}" | mcp_result | python3 -c "import sys,json; print(json.load(sys.stdin).get('content',''))" 2>/dev/null)
-B2=$(mcp_call akb_get "{\"uri\":\"$URI2\"}" | mcp_result | python3 -c "import sys,json; print(json.load(sys.stdin).get('content',''))" 2>/dev/null)
-ISO1=$(echo "$B1" | grep -q "BODY_FIRST" && ! echo "$B1" | grep -q "BODY_SECOND" && echo yes || echo no)
-ISO2=$(echo "$B2" | grep -q "BODY_SECOND" && ! echo "$B2" | grep -q "BODY_FIRST" && echo yes || echo no)
-[ -n "$URI1" ] && [ -n "$URI2" ] && [ "$URI1" != "$URI2" ] && [ "$ISO1" = "yes" ] && [ "$ISO2" = "yes" ] && pass "akb_put slug collision → 2nd persists at suffixed path (bodies isolated)" || fail "put collision suffix" "uri1=$URI1 uri2=$URI2 iso1=$ISO1 iso2=$ISO2"
-
-# find_by_ref must not return a wrong doc when one path is a prefix
-# of another. Create two docs whose paths differ only by suffix and
-# verify each get returns its own content.
-mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"specs\",\"title\":\"api\",\"content\":\"## v1\\n\\nFIRST_ONLY_TAG\"}" >/dev/null
-mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"specs\",\"title\":\"api v2\",\"content\":\"## v2\\n\\nSECOND_ONLY_TAG\"}" >/dev/null
-R=$(mcp_call akb_get "{\"uri\":\"akb://$VAULT/doc/specs/api.md\"}" | mcp_result)
-HAS_FIRST=$(echo "$R" | python3 -c "import sys,json; print('FIRST_ONLY_TAG' in json.load(sys.stdin).get('content',''))" 2>/dev/null)
-NO_SECOND=$(echo "$R" | python3 -c "import sys,json; print('SECOND_ONLY_TAG' not in json.load(sys.stdin).get('content',''))" 2>/dev/null)
-[ "$HAS_FIRST" = "True" ] && [ "$NO_SECOND" = "True" ] && pass "find_by_ref: exact path match (api.md ≠ api-v2.md)" || fail "find_by_ref bleed" "wrong-doc match on prefix overlap"
-
-# Versioned akb_get must strip YAML frontmatter from the historical
-# body — older commits stored the `---\n…\n---` block inline.
-HISTORY=$(mcp_call akb_history "{\"uri\":\"$DOC_URI\",\"limit\":1}" | mcp_result)
-COMMIT=$(echo "$HISTORY" | python3 -c "import sys,json; h=json.load(sys.stdin).get('history',[]); print(h[0]['hash'] if h else '')" 2>/dev/null)
-if [ -n "$COMMIT" ]; then
-  R=$(mcp_call akb_get "{\"uri\":\"$DOC_URI\",\"version\":\"$COMMIT\"}" | mcp_result)
-  CLEAN=$(echo "$R" | python3 -c "import sys,json; c=json.load(sys.stdin).get('content',''); print(not c.lstrip().startswith('---'))" 2>/dev/null)
-  [ "$CLEAN" = "True" ] && pass "akb_get(version=…) strips frontmatter" || fail "versioned frontmatter leak" "content starts with ---"
-fi
-
-# ── 5b. Document Move / Rename (Phase 2) ─────────────────────
-echo ""
-echo "▸ 5b. Document Move / Rename"
-
-# Create a doc, then rename its slug. action=moved, URIs distinct.
-R=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"movetest\",\"title\":\"Move Me\",\"content\":\"MOVE_BODY_TAG\"}" | mcp_result)
-MV_OLD=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['uri'])" 2>/dev/null)
-R=$(mcp_call akb_move "{\"uri\":\"$MV_OLD\",\"slug\":\"moved-final\"}" | mcp_result)
-MV_NEW=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('uri',''))" 2>/dev/null)
-MV_ACTION=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('action',''))" 2>/dev/null)
-[ -n "$MV_NEW" ] && [ "$MV_NEW" != "$MV_OLD" ] && [ "$MV_ACTION" = "moved" ] && pass "akb_move renamed slug ($MV_ACTION)" || fail "akb_move" "new=$MV_NEW action=$MV_ACTION"
-
-# New URI resolves with the original body.
-NB=$(mcp_call akb_get "{\"uri\":\"$MV_NEW\"}" | mcp_result | python3 -c "import sys,json; print('MOVE_BODY_TAG' in json.load(sys.stdin).get('content',''))" 2>/dev/null)
-[ "$NB" = "True" ] && pass "akb_move: new URI resolves with content" || fail "move new resolve" "body missing at new uri"
-
-# OLD URI still resolves via the alias redirect → same doc.
-OB=$(mcp_call akb_get "{\"uri\":\"$MV_OLD\"}" | mcp_result | python3 -c "import sys,json; print('MOVE_BODY_TAG' in json.load(sys.stdin).get('content',''))" 2>/dev/null)
-[ "$OB" = "True" ] && pass "akb_move: OLD URI still resolves (alias redirect)" || fail "move alias resolve" "old uri 404 after move"
-
-# Move across collections; the path lands under the new collection.
-R=$(mcp_call akb_move "{\"uri\":\"$MV_NEW\",\"collection\":\"archive\"}" | mcp_result)
-MV_NEW2=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('uri',''))" 2>/dev/null)
-echo "$MV_NEW2" | grep -q "archive" && pass "akb_move across collections ($MV_NEW2)" || fail "move collection" "uri=$MV_NEW2"
-
-# Every prior URI resolves to the doc — aliases point at the id, never chain.
-O1=$(mcp_call akb_get "{\"uri\":\"$MV_OLD\"}" | mcp_result | python3 -c "import sys,json; print('MOVE_BODY_TAG' in json.load(sys.stdin).get('content',''))" 2>/dev/null)
-O2=$(mcp_call akb_get "{\"uri\":\"$MV_NEW\"}" | mcp_result | python3 -c "import sys,json; print('MOVE_BODY_TAG' in json.load(sys.stdin).get('content',''))" 2>/dev/null)
-[ "$O1" = "True" ] && [ "$O2" = "True" ] && pass "akb_move: all prior URIs resolve (no redirect chain)" || fail "move chain" "o1=$O1 o2=$O2"
-
-# No-op move (neither collection nor slug) is rejected.
-R=$(mcp_call akb_move "{\"uri\":\"$MV_NEW2\"}" | mcp_result)
-ISERR=$(echo "$R" | python3 -c "import sys,json; print('error' in json.load(sys.stdin))" 2>/dev/null)
-[ "$ISERR" = "True" ] && pass "akb_move: no-op (no collection/slug) rejected" || fail "move no-op" "expected error"
-
-# Collision on move — move a SAME-TITLE doc into a collection that already has
-# one. Both must survive at distinct paths (the mover gets a -shortid suffix),
-# and each resolves to its own body. This is the case the user flagged.
-R=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"dups\",\"title\":\"Twin\",\"content\":\"TWIN_A\"}" | mcp_result)
-TWIN_A=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['uri'])" 2>/dev/null)
-R=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"dupsrc\",\"title\":\"Twin\",\"content\":\"TWIN_B\"}" | mcp_result)
-TWIN_B=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['uri'])" 2>/dev/null)
-# Move B (dupsrc/twin.md) into 'dups' where A (dups/twin.md) already lives.
-R=$(mcp_call akb_move "{\"uri\":\"$TWIN_B\",\"collection\":\"dups\"}" | mcp_result)
-TWIN_B2=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('uri',''))" 2>/dev/null)
-DISTINCT=$([ -n "$TWIN_B2" ] && [ "$TWIN_B2" != "$TWIN_A" ] && echo yes || echo no)
-AB=$(mcp_call akb_get "{\"uri\":\"$TWIN_A\"}" | mcp_result | python3 -c "import sys,json; d=json.load(sys.stdin); print('TWIN_A' in d.get('content','') and 'TWIN_B' not in d.get('content',''))" 2>/dev/null)
-BB=$(mcp_call akb_get "{\"uri\":\"$TWIN_B2\"}" | mcp_result | python3 -c "import sys,json; d=json.load(sys.stdin); print('TWIN_B' in d.get('content','') and 'TWIN_A' not in d.get('content',''))" 2>/dev/null)
-[ "$DISTINCT" = "yes" ] && [ "$AB" = "True" ] && [ "$BB" = "True" ] && pass "akb_move: same-title collision into a collection → both survive, isolated ($TWIN_B2)" || fail "move title collision" "distinct=$DISTINCT a=$AB b=$BB"
-
-# Reuse of a vacated path — after a doc moves away, creating a NEW doc at the
-# OLD path must make the OLD URI resolve to the NEW doc (real doc beats a stale
-# redirect; exact match wins over alias).
-R=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"reuse\",\"title\":\"Recycle\",\"content\":\"ORIG_DOC\"}" | mcp_result)
-RC_OLD=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['uri'])" 2>/dev/null)
-mcp_call akb_move "{\"uri\":\"$RC_OLD\",\"slug\":\"recycled\"}" >/dev/null
-mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"reuse\",\"title\":\"Recycle\",\"content\":\"NEW_DOC\"}" >/dev/null
-RC=$(mcp_call akb_get "{\"uri\":\"$RC_OLD\"}" | mcp_result | python3 -c "import sys,json; d=json.load(sys.stdin); print('NEW_DOC' in d.get('content','') and 'ORIG_DOC' not in d.get('content',''))" 2>/dev/null)
-[ "$RC" = "True" ] && pass "akb_move: reused old path → old URI resolves to the new doc (alias cleared)" || fail "move path reuse" "old uri did not resolve to new doc"
-
-# Suffix is not nested on re-move — a doc that got a collision suffix, moved to a
-# collision-free collection (slug kept), reclaims the clean slug (no -hex-hex).
-R=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"sfxa\",\"title\":\"Sfx\",\"content\":\"S1\"}" | mcp_result)
-R=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"sfxa\",\"title\":\"Sfx\",\"content\":\"S2\"}" | mcp_result)
-SFX2=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['uri'])" 2>/dev/null)
-echo "$SFX2" | grep -q "sfx-" && SUFFIXED=yes || SUFFIXED=no   # 2nd got a -hex suffix
-R=$(mcp_call akb_move "{\"uri\":\"$SFX2\",\"collection\":\"sfxb\"}" | mcp_result)
-MOVED=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('uri',''))" 2>/dev/null)
-CLEAN=$(echo "$MOVED" | python3 -c "import sys; u=sys.stdin.read().strip(); print(u.endswith('/sfx.md'))" 2>/dev/null)
-[ "$SUFFIXED" = "yes" ] && [ "$CLEAN" = "True" ] && pass "akb_move: collision suffix stripped on move to free collection ($MOVED)" || fail "move suffix nest" "suffixed=$SUFFIXED moved=$MOVED"
-
-# Explicit slug rename onto a taken path is REJECTED (not silently suffixed) —
-# matches create's pinned-slug semantics.
-mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"rej\",\"title\":\"Taken\",\"content\":\"T1\"}" >/dev/null
-R=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"rej\",\"title\":\"Mover\",\"content\":\"T2\"}" | mcp_result)
-REJ_SRC=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['uri'])" 2>/dev/null)
-R=$(mcp_call akb_move "{\"uri\":\"$REJ_SRC\",\"slug\":\"taken\"}" | mcp_result)
-REJERR=$(echo "$R" | python3 -c "import sys,json; print('error' in json.load(sys.stdin))" 2>/dev/null)
-[ "$REJERR" = "True" ] && pass "akb_move: explicit slug onto taken path rejected (no silent suffix)" || fail "move explicit reject" "expected error, got $R"
-
-# Bad URI to akb_move returns a clean error (not an internal 500 envelope).
-R=$(mcp_call akb_move "{\"uri\":\"not-a-valid-uri\",\"slug\":\"x\"}" | mcp_result)
-BADERR=$(echo "$R" | python3 -c "import sys,json; print('error' in json.load(sys.stdin))" 2>/dev/null)
-[ "$BADERR" = "True" ] && pass "akb_move: malformed URI rejected cleanly" || fail "move bad uri" "expected error"
-
-# ── 6. Relations & Graph ─────────────────────────────────────
-echo ""
-echo "▸ 6. Relations & Graph via MCP"
-
-R=$(mcp_call akb_relations "{\"uri\":\"$DOC2_URI\"}" | mcp_result)
-REL_COUNT=$(echo "$R" | python3 -c "import sys,json; print(len(json.load(sys.stdin)['relations']))" 2>/dev/null)
-[ "$REL_COUNT" -ge 1 ] 2>/dev/null && pass "akb_relations: $REL_COUNT relations" || fail "akb_relations" "expected >=1"
-
-R=$(mcp_call akb_graph "{\"vault\":\"$VAULT\"}" | mcp_result)
-NODE_COUNT=$(echo "$R" | python3 -c "import sys,json; print(len(json.load(sys.stdin)['nodes']))" 2>/dev/null)
-EDGE_COUNT=$(echo "$R" | python3 -c "import sys,json; print(len(json.load(sys.stdin)['edges']))" 2>/dev/null)
-[ "$NODE_COUNT" -ge 2 ] 2>/dev/null && pass "akb_graph: $NODE_COUNT nodes, $EDGE_COUNT edges" || fail "akb_graph" "expected >=2 nodes"
-
-R=$(mcp_call akb_provenance "{\"uri\":\"$DOC2_URI\"}" | mcp_result)
-PROV_TITLE=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['title'])" 2>/dev/null)
-[ -n "$PROV_TITLE" ] && pass "akb_provenance: $PROV_TITLE" || fail "akb_provenance" "no title"
-
-# ── 7. Activity ──────────────────────────────────────────────
-echo ""
-echo "▸ 7. Activity via MCP"
-
-# Activity (Git-based, replaces akb_recent)
-R=$(mcp_call akb_activity "{\"vault\":\"$VAULT\"}" | mcp_result)
-# 0.3.0: `total` was a misnomer (it was len(entries) = post-limit count
-# masquerading as corpus total). Response now reports `returned` and
-# `truncated`. Use `returned` for the count assertion.
-ACT_COUNT=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['returned'])" 2>/dev/null)
-[ "$ACT_COUNT" -ge 2 ] 2>/dev/null && pass "akb_activity: $ACT_COUNT commits" || fail "akb_activity" "expected >=2"
-
-# Verify activity has file change info
-HAS_FILES=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d['activity'][0].get('files',[])) > 0)" 2>/dev/null)
-[ "$HAS_FILES" = "True" ] && pass "akb_activity includes changed files" || fail "akb_activity files" "no files"
-
-# Diff — get first commit hash and check diff for the doc
-FIRST_HASH=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['activity'][0]['hash'])" 2>/dev/null)
-R=$(mcp_call akb_diff "{\"uri\":\"$DOC_URI\",\"commit\":\"$FIRST_HASH\"}" | mcp_result)
-DIFF_TYPE=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('type',''))" 2>/dev/null)
-[ -n "$DIFF_TYPE" ] && pass "akb_diff: type=$DIFF_TYPE" || fail "akb_diff" "no type"
-
-# ── 8. User & Access Management ──────────────────────────────
-echo ""
-echo "▸ 8. User & Access via MCP"
-
-R=$(mcp_call akb_search_users "{\"query\":\"$E2E_USER\"}" | mcp_result)
-FOUND=$(echo "$R" | python3 -c "import sys,json; print(len(json.load(sys.stdin)['users']))" 2>/dev/null)
-[ "$FOUND" -ge 1 ] 2>/dev/null && pass "akb_search_users found $FOUND" || fail "akb_search_users" "not found"
-
-R=$(mcp_call akb_vault_info "{\"vault\":\"$VAULT\"}" | mcp_result)
-V_OWNER=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('owner',''))" 2>/dev/null)
-[ -n "$V_OWNER" ] && pass "akb_vault_info (owner: $V_OWNER)" || pass "akb_vault_info responded"
-
-R=$(mcp_call akb_vault_members "{\"vault\":\"$VAULT\"}" | mcp_result)
-MEM_COUNT=$(echo "$R" | python3 -c "import sys,json; print(len(json.load(sys.stdin)['members']))" 2>/dev/null)
-[ "$MEM_COUNT" -ge 1 ] 2>/dev/null && pass "akb_vault_members: $MEM_COUNT members" || fail "akb_vault_members" "expected >=1"
-
-# ── 9. Delete ─────────────────────────────────────────────────
-echo ""
-echo "▸ 9. Delete via MCP"
-
-R=$(mcp_call akb_delete "{\"uri\":\"$DOC_URI\"}" | mcp_result)
-DELETED=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['deleted'])" 2>/dev/null)
-[ "$DELETED" = "True" ] && pass "akb_delete" || fail "akb_delete" "expected True"
-
-# Verify deleted
-R=$(mcp_call akb_get "{\"uri\":\"$DOC_URI\"}" | mcp_result)
-IS_ERROR=$(echo "$R" | python3 -c "import sys,json; print('error' in json.load(sys.stdin))" 2>/dev/null)
-[ "$IS_ERROR" = "True" ] && pass "Deleted doc returns error" || fail "Delete verify" "doc still exists"
-
-# Empty-is-valid invariant — deleting the last doc in a collection
-# leaves the row in place (Plan: 2026-05-12 collection lifecycle).
-echo ""
-echo "▸ Empty collection survives last-doc delete"
-
-mcp_call akb_create_collection "{\"vault\":\"$VAULT\",\"path\":\"keepempty\"}" >/dev/null
-PUTR=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"keepempty\",\"title\":\"keep-t\",\"content\":\"## c\",\"type\":\"note\",\"tags\":[]}" | mcp_result)
-KEEP_DOC_URI=$(echo "$PUTR" | python3 -c "import sys,json; print(json.load(sys.stdin)['uri'])" 2>/dev/null)
-mcp_call akb_delete "{\"uri\":\"$KEEP_DOC_URI\"}" >/dev/null
-BROWSE_KEEP=$(mcp_call akb_browse "{\"vault\":\"$VAULT\"}" | mcp_result)
-HAS_KEEP=$(echo "$BROWSE_KEEP" | python3 -c "import sys,json; d=json.load(sys.stdin); print(sum(1 for i in d.get('items', []) if i.get('name') == 'keepempty' and i.get('type') == 'collection'))" 2>/dev/null)
-[ "$HAS_KEEP" = "1" ] && pass "empty collection survives last-doc delete" || fail "empty-is-valid" "keepempty not found in browse"
-
-# ── 11. Tables via MCP ───────────────────────────────────────
-echo ""
-echo "▸ 11. Tables via MCP"
-
-# Create table (real PG table via DDL)
-R=$(mcp_call akb_create_table "{\"vault\":\"$VAULT\",\"name\":\"mcp_items\",\"columns\":[{\"name\":\"product\",\"type\":\"text\"},{\"name\":\"qty\",\"type\":\"number\"}]}" | mcp_result)
-TBL_URI=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['uri'])" 2>/dev/null)
-[ -n "$TBL_URI" ] && pass "akb_create_table ($TBL_URI)" || fail "akb_create_table" "no uri"
-
-# Over-long name → the derived `vt_<vault>__<table>` PG identifier exceeds
-# NAMEDATALEN (63). Must come back as a caller-fixable `invalid_argument`,
-# NOT an opaque `internal` (regression guard for the ValidationError fix:
-# the MCP handler's except must catch ValidationError, not just ValueError).
-LONGNAME=$(printf 'a%.0s' {1..70})
-CODE=$(mcp_call akb_create_table "{\"vault\":\"$VAULT\",\"name\":\"$LONGNAME\",\"columns\":[{\"name\":\"x\",\"type\":\"text\"}]}" | mcp_result_field "['code']")
-[ "$CODE" = "invalid_argument" ] && pass "akb_create_table over-long name → invalid_argument" || fail "akb_create_table over-long name" "expected invalid_argument, got '$CODE'"
-
-# Insert via akb_sql
-R=$(mcp_call akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"INSERT INTO mcp_items (product, qty) VALUES ('Widget', 100), ('Gadget', 50)\"}" | mcp_result)
-SQL_RES=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('result',''))" 2>/dev/null)
-[ -n "$SQL_RES" ] && pass "akb_sql INSERT: $SQL_RES" || fail "akb_sql INSERT" "no result"
-
-# Query via akb_sql
-R=$(mcp_call akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"SELECT * FROM mcp_items\"}" | mcp_result)
-ROWS=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['total'])" 2>/dev/null)
-[ "$ROWS" = "2" ] && pass "akb_sql SELECT: $ROWS rows" || fail "akb_sql SELECT" "expected 2, got $ROWS"
-
-# Aggregate via akb_sql
-R=$(mcp_call akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"SELECT SUM(qty) as total_qty, COUNT(*) as cnt FROM mcp_items\"}" | mcp_result)
-SUM=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['items'][0]['total_qty'])" 2>/dev/null)
-[ "$SUM" = "150" ] && pass "akb_sql SUM=150" || pass "Aggregate responded ($SUM)"
-
-# vault_info now embeds table schema (#34) so agents don't run mid-flow
-# information_schema lookups. Verify columns + row_count + jsonb hint.
-R=$(mcp_call akb_vault_info "{\"vault\":\"$VAULT\"}" | mcp_result)
-TBLS=$(echo "$R" | python3 -c "
-import sys, json
-d = json.load(sys.stdin)
-tables = d.get('tables') or []
-print(len(tables))
-" 2>/dev/null)
-[ "$TBLS" -ge 1 ] 2>/dev/null && pass "vault_info has tables[] ($TBLS)" || fail "vault_info tables" "got $TBLS"
-
-HAS_COLS=$(echo "$R" | python3 -c "
-import sys, json
-d = json.load(sys.stdin)
-t = next((x for x in (d.get('tables') or []) if x.get('name') == 'mcp_items'), None)
-print('yes' if t and any(c.get('name')=='product' for c in t.get('columns', [])) else 'no')
-" 2>/dev/null)
-[ "$HAS_COLS" = "yes" ] && pass "vault_info.tables.columns include 'product'" || fail "vault_info columns" "got=$HAS_COLS"
-
-# Wrong column name → fuzzy hint (issue #36)
-R=$(mcp_call akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"SELECT * FROM mcp_items WHERE producct = 'Widget'\"}" | mcp_result)
-HINT=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('hint',''))" 2>/dev/null)
-AVAIL=$(echo "$R" | python3 -c "import sys,json; print(','.join(json.load(sys.stdin).get('details',{}).get('available_columns',[])))" 2>/dev/null)
-case "$HINT" in
-  *"Did you mean"*"product"*) pass "akb_sql wrong column suggests 'product'" ;;
-  *) fail "akb_sql column hint" "got hint=$HINT, avail=$AVAIL" ;;
-esac
-
-# Wrong table name → fuzzy hint
-R=$(mcp_call akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"SELECT * FROM mcp_itms\"}" | mcp_result)
-HINT=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('hint',''))" 2>/dev/null)
-case "$HINT" in
-  *"Did you mean"*"mcp_items"*) pass "akb_sql wrong table suggests 'mcp_items'" ;;
-  *) fail "akb_sql table hint" "got hint=$HINT" ;;
-esac
-
-# Browse tables (unified browse replaces akb_list_tables)
-R=$(mcp_call akb_browse "{\"vault\":\"$VAULT\",\"content_type\":\"tables\"}" | mcp_result)
-TBL_COUNT=$(echo "$R" | python3 -c "import sys,json; print(len([i for i in json.load(sys.stdin)['items'] if i['type']=='table']))" 2>/dev/null)
-[ "$TBL_COUNT" -ge 1 ] 2>/dev/null && pass "akb_browse(tables): $TBL_COUNT" || fail "akb_browse tables" "expected >=1"
-
-# ── 11b. Browse advertises sql_name + rewriter accepts it ─────
-# Issues #110 / #111: browse must expose the SQL identifier the
-# client should pass to akb_sql, and the rewriter must accept it.
-# `_TABLE_NAME_RE` currently rejects hyphen / non-ASCII at create
-# time, so the interesting legacy cases can't be reproduced from
-# scratch via the MCP surface — those are covered by
-# test_table_identifier_unit. Here we confirm the ASCII contract:
-# `sql_name` is present, equals the queryable identifier, and
-# round-trips through the rewriter.
-R=$(mcp_call akb_browse "{\"vault\":\"$VAULT\",\"content_type\":\"tables\"}" | mcp_result)
-ASCII_SQL=$(echo "$R" | python3 -c "import sys,json; print(next((i.get('sql_name') for i in json.load(sys.stdin)['items'] if i.get('name')=='mcp_items'), 'MISSING'))" 2>/dev/null)
-[ "$ASCII_SQL" = "mcp_items" ] && pass "browse exposes sql_name (ascii: $ASCII_SQL)" || fail "browse sql_name" "got: $ASCII_SQL"
-
-R=$(mcp_call akb_sql "{\"vault\":\"$VAULT\",\"sql\":\"SELECT COUNT(*) as cnt FROM $ASCII_SQL\"}" | mcp_result)
-CNT=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('items',[{}])[0].get('cnt','MISSING'))" 2>/dev/null)
-[ -n "$CNT" ] && [ "$CNT" != "MISSING" ] && pass "akb_sql round-trip via sql_name" || fail "akb_sql round-trip" "got: $R"
-
-# 0.5.7: REST `GET /tables/{vault}` must mirror the MCP shape and
-# include `sql_name` too — issue #110 originally only fixed the MCP
-# path, leaving direct REST clients to guess the sanitisation rule.
-REST_SQL=$(curl -sk "$BASE_URL/api/v1/tables/$VAULT" -H "Authorization: Bearer $PAT" \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); print(next((t.get('sql_name','MISSING') for t in d.get('items',[]) if t.get('name')=='mcp_items'), 'MISSING'))" 2>/dev/null)
+REST_SQL=$(curl -sk "$BASE_URL/api/v1/tables/$VAULT" \
+  -H "Authorization: Bearer $PAT" \
+  | python3 -c 'import sys,json; print(next((t.get("sql_name","MISSING") for t in json.load(sys.stdin).get("items",[]) if t.get("name")=="mcp_items"), "MISSING"))' 2>/dev/null)
 [ "$REST_SQL" = "mcp_items" ] && pass "REST /tables exposes sql_name" || fail "REST sql_name" "got: $REST_SQL"
 
-# ── 12. Publish via MCP ──────────────────────────────────────
-echo ""
-echo "▸ 12. Publish via MCP"
-
-# Re-create a doc for publish test (previous was deleted)
-R=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"specs\",\"title\":\"Pub Test\",\"content\":\"## Public\\n\\nTest.\",\"type\":\"note\",\"tags\":[]}" | mcp_result)
-PUB_DOC_URI=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['uri'])" 2>/dev/null)
-
-R=$(mcp_call akb_publish "{\"uri\":\"$PUB_DOC_URI\"}" | mcp_result)
-PUB_SLUG=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['slug'])" 2>/dev/null)
-[ -n "$PUB_SLUG" ] && pass "akb_publish (slug: $PUB_SLUG)" || fail "akb_publish" "no slug"
-
-# Public access without auth
-PUB_TITLE=$(curl -sk "$BASE_URL/api/v1/public/$PUB_SLUG" 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin)['title'])" 2>/dev/null)
-[ "$PUB_TITLE" = "Pub Test" ] && pass "Public access works" || fail "Public access" "wrong title: $PUB_TITLE"
-
-R=$(mcp_call akb_unpublish "{\"uri\":\"$PUB_DOC_URI\"}" | mcp_result)
-DELETED=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['deleted'])" 2>/dev/null)
-[ "$DELETED" -ge 1 ] 2>/dev/null && pass "akb_unpublish (deleted=$DELETED)" || fail "akb_unpublish" "expected deleted≥1 got $DELETED"
-
-# ── 13. Second-user setup (for access-control + cross-user tests below) ─
-echo ""
-echo "▸ 13. Second-user setup"
-
-TODO_USER="e2e-u2-$(date +%s)"
-curl -sk -X POST "$BASE_URL/api/v1/auth/register" -H 'Content-Type: application/json' \
-  -d "{\"username\":\"$TODO_USER\",\"email\":\"${TODO_USER}@test.com\",\"password\":\"test1234\"}" >/dev/null 2>&1
-
-JWT2=$(curl -sk -X POST "$BASE_URL/api/v1/auth/login" -H 'Content-Type: application/json' \
-  -d "{\"username\":\"$TODO_USER\",\"password\":\"test1234\"}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
-PAT2=$(curl -sk -X POST "$BASE_URL/api/v1/auth/tokens" -H "Authorization: Bearer $JWT2" -H 'Content-Type: application/json' \
-  -d '{"name":"u2-test"}' | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])' 2>/dev/null)
-
-INIT2=$(curl -sk -i -X POST "$BASE_URL/mcp/" \
-  -H "Authorization: Bearer $PAT2" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"user2","version":"1.0"}}}' 2>&1)
-SID2=$(echo "$INIT2" | grep -i "mcp-session-id" | tr -d '\r' | awk '{print $2}')
-[ -n "$SID2" ] && pass "User2 registered + MCP session" || fail "User2 setup" "no SID"
-
-mcp_call2() {
-  curl -sk -X POST "$BASE_URL/mcp/" \
-    -H "Authorization: Bearer $PAT2" \
-    -H "Content-Type: application/json" \
-    -H "Accept: application/json, text/event-stream" \
-    -H "mcp-session-id: $SID2" \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$((RANDOM)),\"method\":\"tools/call\",\"params\":{\"name\":\"$1\",\"arguments\":$2}}" 2>/dev/null
-}
-mcp_result2() { python3 -c "import sys,json; d=json.load(sys.stdin); print(d['result']['content'][0]['text'])" 2>/dev/null; }
-
-# ── 14. Access Control (grant/revoke, reader vs writer) ──────
-echo ""
-echo "▸ 15. Access Control"
-
-# User2 has no access to User1's vault
-R=$(mcp_call2 akb_browse "{\"vault\":\"$VAULT\"}" | mcp_result2)
-NO_ACCESS=$(echo "$R" | python3 -c "import sys,json; print('error' in json.load(sys.stdin))" 2>/dev/null)
-[ "$NO_ACCESS" = "True" ] && pass "User2 cannot browse User1's vault (no access)" || fail "No access check" "should be denied"
-
-# User1 grants User2 reader access
-R=$(mcp_call akb_grant "{\"vault\":\"$VAULT\",\"user\":\"$TODO_USER\",\"role\":\"reader\"}" | mcp_result)
-GRANTED=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('granted',False))" 2>/dev/null)
-[ "$GRANTED" = "True" ] && pass "Grant reader to User2" || fail "Grant reader" "not granted"
-
-# User2 can now browse (reader)
-R=$(mcp_call2 akb_browse "{\"vault\":\"$VAULT\"}" | mcp_result2)
-CAN_READ=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print('items' in d)" 2>/dev/null)
-[ "$CAN_READ" = "True" ] && pass "User2 can browse as reader" || fail "Reader browse" "denied"
-
-# User2 can search
-R=$(mcp_call2 akb_search "{\"query\":\"test\",\"vault\":\"$VAULT\"}" | mcp_result2)
-CAN_SEARCH=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print('total' in d or 'results' in d)" 2>/dev/null)
-[ "$CAN_SEARCH" = "True" ] && pass "User2 can search as reader" || fail "Reader search" "denied"
-
-# User2 CANNOT write (reader only)
-R=$(mcp_call2 akb_put "{\"vault\":\"$VAULT\",\"collection\":\"hack\",\"title\":\"Unauthorized\",\"content\":\"# No\",\"type\":\"note\",\"tags\":[]}" | mcp_result2)
-WRITE_DENIED=$(echo "$R" | python3 -c "import sys,json; print('error' in json.load(sys.stdin))" 2>/dev/null)
-[ "$WRITE_DENIED" = "True" ] && pass "User2 cannot write as reader (403)" || fail "Reader write block" "should be denied"
-
-# User1 upgrades User2 to writer
-R=$(mcp_call akb_grant "{\"vault\":\"$VAULT\",\"user\":\"$TODO_USER\",\"role\":\"writer\"}" | mcp_result)
-UPGRADED=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('granted',False))" 2>/dev/null)
-[ "$UPGRADED" = "True" ] && pass "Upgrade User2 to writer" || fail "Upgrade writer" "not granted"
-
-# User2 CAN now write
-R=$(mcp_call2 akb_put "{\"vault\":\"$VAULT\",\"collection\":\"user2-docs\",\"title\":\"Writer Test\",\"content\":\"## Written by User2\",\"type\":\"note\",\"tags\":[]}" | mcp_result2)
-WRITE_OK=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print('uri' in d)" 2>/dev/null)
-[ "$WRITE_OK" = "True" ] && pass "User2 can write as writer" || fail "Writer write" "denied"
-
-# User1 revokes User2's access
-R=$(mcp_call akb_revoke "{\"vault\":\"$VAULT\",\"user\":\"$TODO_USER\"}" | mcp_result)
-REVOKED=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('revoked',False))" 2>/dev/null)
-[ "$REVOKED" = "True" ] && pass "Revoke User2 access" || fail "Revoke" "not revoked"
-
-# User2 cannot browse again
-R=$(mcp_call2 akb_browse "{\"vault\":\"$VAULT\"}" | mcp_result2)
-DENIED_AGAIN=$(echo "$R" | python3 -c "import sys,json; print('error' in json.load(sys.stdin))" 2>/dev/null)
-[ "$DENIED_AGAIN" = "True" ] && pass "User2 denied after revoke" || fail "Post-revoke check" "still has access"
-
-# User2 cannot search again after revoke
-R=$(mcp_call2 akb_search "{\"query\":\"test\",\"vault\":\"$VAULT\"}" | mcp_result2)
-SEARCH_DENIED_AGAIN=$(echo "$R" | python3 -c "import sys,json; print('error' in json.load(sys.stdin))" 2>/dev/null)
-[ "$SEARCH_DENIED_AGAIN" = "True" ] && pass "User2 denied search after revoke" || fail "Post-revoke search" "still returned search access"
-
-# ── 16. Public Access Levels ─────────────────────────────────
-echo ""
-echo "▸ 16. Public Access Levels"
-
-# Set vault to public writer
-R=$(mcp_call akb_set_public "{\"vault\":\"$VAULT\",\"level\":\"writer\"}" | mcp_result)
-PUB_LVL=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('public_access',''))" 2>/dev/null)
-[ "$PUB_LVL" = "writer" ] && pass "Set public_access=writer" || fail "set_public writer" "$PUB_LVL"
-
-# User2 (no grant) can now write
-R=$(mcp_call2 akb_put "{\"vault\":\"$VAULT\",\"collection\":\"public-test\",\"title\":\"Public Write\",\"content\":\"# Public\",\"type\":\"note\",\"tags\":[]}" | mcp_result2)
-PUB_WRITE=$(echo "$R" | python3 -c "import sys,json; print('uri' in json.load(sys.stdin))" 2>/dev/null)
-[ "$PUB_WRITE" = "True" ] && pass "User2 can write (public writer)" || fail "Public write" "denied"
-
-# Set to reader — write should be blocked
-R=$(mcp_call akb_set_public "{\"vault\":\"$VAULT\",\"level\":\"reader\"}" | mcp_result)
-R=$(mcp_call2 akb_put "{\"vault\":\"$VAULT\",\"collection\":\"public-test\",\"title\":\"Should Fail\",\"content\":\"#No\",\"type\":\"note\",\"tags\":[]}" | mcp_result2)
-PUB_BLOCKED=$(echo "$R" | python3 -c "import sys,json; print('error' in json.load(sys.stdin))" 2>/dev/null)
-[ "$PUB_BLOCKED" = "True" ] && pass "User2 cannot write (public reader)" || fail "Public reader block" "should deny"
-
-# User2 can still read
-R=$(mcp_call2 akb_browse "{\"vault\":\"$VAULT\"}" | mcp_result2)
-PUB_READ=$(echo "$R" | python3 -c "import sys,json; print('items' in json.load(sys.stdin))" 2>/dev/null)
-[ "$PUB_READ" = "True" ] && pass "User2 can read (public reader)" || fail "Public read" "denied"
-
-# Set to none — read should be blocked
-R=$(mcp_call akb_set_public "{\"vault\":\"$VAULT\",\"level\":\"none\"}" | mcp_result)
-R=$(mcp_call2 akb_browse "{\"vault\":\"$VAULT\"}" | mcp_result2)
-PUB_NONE=$(echo "$R" | python3 -c "import sys,json; print('error' in json.load(sys.stdin))" 2>/dev/null)
-[ "$PUB_NONE" = "True" ] && pass "User2 cannot read (public none)" || fail "Public none block" "should deny"
-
-# ── 17. Help System ──────────────────────────────────────────
-echo ""
-echo "▸ 17. Help System"
-
-R=$(mcp_call akb_help '{}' | mcp_result)
-HELP_OK=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print('Quick Start' in d.get('help',''))" 2>/dev/null)
-[ "$HELP_OK" = "True" ] && pass "akb_help root" || fail "akb_help" "no content"
-
-R=$(mcp_call akb_help '{"topic":"akb_sql"}' | mcp_result)
-SQL_HELP=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print('SELECT' in d.get('help',''))" 2>/dev/null)
-[ "$SQL_HELP" = "True" ] && pass "akb_help topic=akb_sql" || fail "akb_help sql" "no content"
-
-# ── 18. Document History & Diff ──────────────────────────────
-echo ""
-echo "▸ 18. Document History & Diff"
-
-# Create a doc, then update it to create history
-R=$(mcp_call akb_put "{\"vault\":\"$VAULT\",\"collection\":\"history-test\",\"title\":\"History Doc\",\"content\":\"## V1\",\"type\":\"note\",\"tags\":[]}" | mcp_result)
-HIST_DOC_URI=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['uri'])" 2>/dev/null)
-
-R=$(mcp_call akb_update "{\"uri\":\"$HIST_DOC_URI\",\"content\":\"## V2 Updated\",\"message\":\"history test\"}" | mcp_result)
-
-R=$(mcp_call akb_history "{\"uri\":\"$HIST_DOC_URI\"}" | mcp_result)
-HIST_COUNT=$(echo "$R" | python3 -c "import sys,json; print(len(json.load(sys.stdin).get('history',[])))" 2>/dev/null)
-[ "$HIST_COUNT" -ge 2 ] 2>/dev/null && pass "akb_history: $HIST_COUNT versions" || fail "akb_history" "expected >=2"
-
-HIST_HASH=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin)['history'][0]['hash'])" 2>/dev/null)
-R=$(mcp_call akb_diff "{\"uri\":\"$HIST_DOC_URI\",\"commit\":\"$HIST_HASH\"}" | mcp_result)
-DIFF_TYPE=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('type',''))" 2>/dev/null)
-[ "$DIFF_TYPE" = "modified" ] && pass "akb_diff: $DIFF_TYPE" || fail "akb_diff" "expected modified, got $DIFF_TYPE"
-
-# ── 19. Vault Lifecycle (archive + delete) ───────────────────
-echo ""
-echo "▸ 19. Vault Lifecycle"
-
-# Create temp vault
-R=$(mcp_call akb_create_vault "{\"name\":\"lifecycle-e2e-$VAULT\"}" | mcp_result)
-LC_VID=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('vault_id',''))" 2>/dev/null)
-
-if [ -n "$LC_VID" ]; then
-  # Archive
-  R=$(mcp_call akb_archive_vault "{\"vault\":\"lifecycle-e2e-$VAULT\"}" | mcp_result)
-  ARC_STATUS=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null)
-  [ "$ARC_STATUS" = "archived" ] && pass "Archive vault" || fail "Archive" "$ARC_STATUS"
-
-  # Write to archived vault should fail
-  R=$(mcp_call akb_put "{\"vault\":\"lifecycle-e2e-$VAULT\",\"collection\":\"test\",\"title\":\"Fail\",\"content\":\"#No\",\"type\":\"note\",\"tags\":[]}" | mcp_result)
-  ARC_BLOCK=$(echo "$R" | python3 -c "import sys,json; print('error' in json.load(sys.stdin))" 2>/dev/null)
-  [ "$ARC_BLOCK" = "True" ] && pass "Archived vault blocks write" || fail "Archive block" "should deny"
-
-  # Hard delete
-  R=$(mcp_call akb_delete_vault "{\"vault\":\"lifecycle-e2e-$VAULT\"}" | mcp_result)
-  DEL_OK=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('deleted',False))" 2>/dev/null)
-  [ "$DEL_OK" = "True" ] && pass "Delete vault" || fail "Delete vault" "not deleted"
-
-  # Verify gone
-  R=$(mcp_call akb_browse "{\"vault\":\"lifecycle-e2e-$VAULT\"}" | mcp_result)
-  GONE=$(echo "$R" | python3 -c "import sys,json; print('error' in json.load(sys.stdin))" 2>/dev/null)
-  [ "$GONE" = "True" ] && pass "Deleted vault not found" || fail "Delete verify" "still exists"
-else
-  fail "Create lifecycle vault" "no vault_id"
-fi
-
-# ── 20. Profile Update (REST PATCH /auth/me) ────────────────
-echo ""
-echo "▸ 20. Profile Update"
-
-R=$(curl -sk -X PATCH "$BASE_URL/api/v1/auth/me" \
-  -H "Authorization: Bearer $JWT" \
+DOC_RESP=$(curl -sk -X POST "$BASE_URL/api/v1/documents" \
+  -H "Authorization: Bearer $PAT" \
   -H 'Content-Type: application/json' \
-  -d '{"display_name":"E2E Test User"}')
-PROF_OK=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('updated',False))" 2>/dev/null)
-[ "$PROF_OK" = "True" ] && pass "Update profile via REST PATCH /auth/me" || fail "Update profile" "not updated"
+  -d "{\"vault\":\"$VAULT\",\"collection\":\"specs\",\"title\":\"REST Boundary Document\",\"content\":\"## Public\\n\\nREST boundary check.\",\"type\":\"note\",\"tags\":[]}" 2>/dev/null)
+DOC_ID=$(echo "$DOC_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("doc_id",""))' 2>/dev/null)
+[ -n "$DOC_ID" ] && pass "REST document setup" || fail "REST document setup" "no doc_id"
 
-# ── 21. Table DDL (alter + drop) ─────────────────────────────
+PROFILE=$(curl -sk -X PATCH "$BASE_URL/api/v1/auth/me" \
+  -H "Authorization: Bearer $PAT" \
+  -H 'Content-Type: application/json' \
+  -d '{"display_name":"MCP Boundary User"}')
+PROFILE_OK=$(echo "$PROFILE" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("updated",False))' 2>/dev/null)
+[ "$PROFILE_OK" = "True" ] && pass "REST profile update" || fail "REST profile update" "not updated"
+
+PUBLISH_RESP=$(curl -sk -X POST "$BASE_URL/api/v1/documents/$VAULT/$DOC_ID/publish" \
+  -H "Authorization: Bearer $PAT")
+PUB_SLUG=$(echo "$PUBLISH_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("slug",""))' 2>/dev/null)
+[ -n "$PUB_SLUG" ] && pass "REST publish" || fail "REST publish" "no slug"
+
+PUB_TITLE=$(curl -sk "$BASE_URL/api/v1/public/$PUB_SLUG" \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin).get("title",""))' 2>/dev/null)
+[ "$PUB_TITLE" = "REST Boundary Document" ] && pass "REST public access" || fail "REST public access" "wrong title: $PUB_TITLE"
+
+curl -sk -X POST "$BASE_URL/api/v1/documents/$VAULT/$DOC_ID/unpublish" \
+  -H "Authorization: Bearer $PAT" >/dev/null 2>&1
+PUBLIC_STATUS=$(curl -sk -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/public/$PUB_SLUG" 2>/dev/null)
+[ "$PUBLIC_STATUS" = "404" ] && pass "REST unpublish revokes public access" || fail "REST unpublish" "expected 404, got $PUBLIC_STATUS"
+
+# ── 3. Session termination ───────────────────────────────────
 echo ""
-echo "▸ 21. Table DDL"
-
-# Alter table — add column
-R=$(mcp_call akb_alter_table "{\"uri\":\"akb://$VAULT/table/mcp_items\",\"add_columns\":[{\"name\":\"category\",\"type\":\"text\"}]}" | mcp_result)
-ALT_OK=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(any(c['name']=='category' for c in d.get('columns',[])))" 2>/dev/null)
-[ "$ALT_OK" = "True" ] && pass "Alter table: add column" || fail "Alter table" "column not added"
-
-# Drop table
-R=$(mcp_call akb_drop_table "{\"uri\":\"akb://$VAULT/table/mcp_items\"}" | mcp_result)
-DROP_OK=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('deleted',False))" 2>/dev/null)
-[ "$DROP_OK" = "True" ] && pass "Drop table" || fail "Drop table" "not dropped"
-
-# Verify gone
-R=$(mcp_call akb_browse "{\"vault\":\"$VAULT\",\"content_type\":\"tables\"}" | mcp_result)
-TBL_GONE=$(echo "$R" | python3 -c "import sys,json; print(len([i for i in json.load(sys.stdin)['items'] if i['type']=='table']))" 2>/dev/null)
-[ "$TBL_GONE" = "0" ] && pass "Table dropped (0 tables)" || pass "Tables remaining: $TBL_GONE"
-
-# ── 22. MCP Session Termination ──────────────────────────────
-echo ""
-echo "▸ 22. MCP Session Termination"
+echo "▸ MCP session termination"
 
 TERM_RESP=$(curl -sk -X DELETE "$BASE_URL/mcp/" \
   -H "Authorization: Bearer $PAT" \
   -H "mcp-session-id: $SID" 2>&1)
-TERMINATED=$(echo "$TERM_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('terminated',False))" 2>/dev/null)
-[ "$TERMINATED" = "True" ] && pass "MCP session terminated" || fail "Session termination" "failed"
+TERMINATED=$(echo "$TERM_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("terminated",False))' 2>/dev/null)
+[ "$TERMINATED" = "True" ] && pass "MCP session terminated" || fail "MCP session termination" "failed"
 
-# ── Results ──────────────────────────────────────────────────
+# Best-effort REST cleanup. The suite result is determined by assertions above.
+curl -sk -X DELETE "$BASE_URL/api/v1/vaults/$VAULT" \
+  -H "Authorization: Bearer $PAT" >/dev/null 2>&1 || true
+
 echo ""
 echo "╔══════════════════════════════════════════╗"
 echo "║   Results: $PASS passed, $FAIL failed"
 echo "╚══════════════════════════════════════════╝"
 
-if [ $FAIL -gt 0 ]; then
+if [ "$FAIL" -gt 0 ]; then
   echo ""
   echo "Failures:"
-  for e in "${ERRORS[@]}"; do echo "  ✗ $e"; done
+  for error in "${ERRORS[@]}"; do echo "  ✗ $error"; done
   exit 1
 fi
 exit 0

--- a/backend/tests/test_mcp_e2e.sh
+++ b/backend/tests/test_mcp_e2e.sh
@@ -93,8 +93,8 @@ TABLE_RESP=$(curl -sk -X POST "$BASE_URL/api/v1/tables/$VAULT" \
   -H "Authorization: Bearer $PAT" \
   -H 'Content-Type: application/json' \
   -d '{"name":"mcp_items","description":"MCP boundary table","columns":[{"name":"product","type":"text"}]}' 2>/dev/null)
-TABLE_ID=$(echo "$TABLE_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("id",""))' 2>/dev/null)
-[ -n "$TABLE_ID" ] && pass "REST table setup" || fail "REST table setup" "no id"
+TABLE_URI=$(echo "$TABLE_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("uri",""))' 2>/dev/null)
+[ -n "$TABLE_URI" ] && pass "REST table setup" || fail "REST table setup" "no uri"
 
 REST_SQL=$(curl -sk "$BASE_URL/api/v1/tables/$VAULT" \
   -H "Authorization: Bearer $PAT" \
@@ -105,8 +105,8 @@ DOC_RESP=$(curl -sk -X POST "$BASE_URL/api/v1/documents" \
   -H "Authorization: Bearer $PAT" \
   -H 'Content-Type: application/json' \
   -d "{\"vault\":\"$VAULT\",\"collection\":\"specs\",\"title\":\"REST Boundary Document\",\"content\":\"## Public\\n\\nREST boundary check.\",\"type\":\"note\",\"tags\":[]}" 2>/dev/null)
-DOC_ID=$(echo "$DOC_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("doc_id",""))' 2>/dev/null)
-[ -n "$DOC_ID" ] && pass "REST document setup" || fail "REST document setup" "no doc_id"
+DOC_URI=$(echo "$DOC_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("uri",""))' 2>/dev/null)
+[ -n "$DOC_URI" ] && pass "REST document setup" || fail "REST document setup" "no uri"
 
 PROFILE=$(curl -sk -X PATCH "$BASE_URL/api/v1/auth/me" \
   -H "Authorization: Bearer $PAT" \
@@ -115,8 +115,10 @@ PROFILE=$(curl -sk -X PATCH "$BASE_URL/api/v1/auth/me" \
 PROFILE_OK=$(echo "$PROFILE" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("updated",False))' 2>/dev/null)
 [ "$PROFILE_OK" = "True" ] && pass "REST profile update" || fail "REST profile update" "not updated"
 
-PUBLISH_RESP=$(curl -sk -X POST "$BASE_URL/api/v1/documents/$VAULT/$DOC_ID/publish" \
-  -H "Authorization: Bearer $PAT")
+PUBLISH_RESP=$(curl -sk -X POST "$BASE_URL/api/v1/publications/$VAULT/create" \
+  -H "Authorization: Bearer $PAT" \
+  -H 'Content-Type: application/json' \
+  -d "{\"uri\":\"$DOC_URI\"}")
 PUB_SLUG=$(echo "$PUBLISH_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("slug",""))' 2>/dev/null)
 [ -n "$PUB_SLUG" ] && pass "REST publish" || fail "REST publish" "no slug"
 
@@ -124,7 +126,7 @@ PUB_TITLE=$(curl -sk "$BASE_URL/api/v1/public/$PUB_SLUG" \
   | python3 -c 'import sys,json; print(json.load(sys.stdin).get("title",""))' 2>/dev/null)
 [ "$PUB_TITLE" = "REST Boundary Document" ] && pass "REST public access" || fail "REST public access" "wrong title: $PUB_TITLE"
 
-curl -sk -X POST "$BASE_URL/api/v1/documents/$VAULT/$DOC_ID/unpublish" \
+curl -sk -X DELETE "$BASE_URL/api/v1/publications/$VAULT/$PUB_SLUG" \
   -H "Authorization: Bearer $PAT" >/dev/null 2>&1
 PUBLIC_STATUS=$(curl -sk -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/public/$PUB_SLUG" 2>/dev/null)
 [ "$PUBLIC_STATUS" = "404" ] && pass "REST unpublish revokes public access" || fail "REST unpublish" "expected 404, got $PUBLIC_STATUS"

--- a/backend/tests/test_mcp_sdk_fixture_unit.py
+++ b/backend/tests/test_mcp_sdk_fixture_unit.py
@@ -13,9 +13,11 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from mcp import types as mcp_types
 
 import tests.mcp_e2e.conftest as mcp_conftest
 from tests.mcp_e2e.conftest import mcp_client as mcp_client_fixture
+from tests.mcp_e2e.test_product_e2e import _call_json as product_call_json
 from tests.mcp_e2e.runtime import RuntimeContext, RuntimeDescriptor
 
 
@@ -175,6 +177,28 @@ def _runtime_context() -> RuntimeContext:
         pat="akb_test_pat",
         secrets=("fixture-user", "fixture-pass", "akb_test_pat"),
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sdk_is_error", [False, True])
+async def test_product_error_envelope_does_not_require_sdk_is_error(
+    sdk_is_error: bool,
+) -> None:
+    class RecordingClient:
+        async def call_tool(self, _name: str, _arguments: dict[str, Any]) -> mcp_types.CallToolResult:
+            return mcp_types.CallToolResult(
+                content=[mcp_types.TextContent(text='{"error":"denied","code":"forbidden"}')],
+                isError=sdk_is_error,
+            )
+
+    result = await product_call_json(
+        RecordingClient(),  # type: ignore[arg-type]
+        _runtime_context(),
+        "akb_browse",
+        {"vault": "missing"},
+        expect_error=True,
+    )
+    assert result == {"error": "denied", "code": "forbidden"}
 
 
 class _RecordingHttpClient:

--- a/backend/tests/test_mcp_sdk_fixture_unit.py
+++ b/backend/tests/test_mcp_sdk_fixture_unit.py
@@ -76,6 +76,60 @@ def test_descriptor_stdin_read_is_compatible_with_pytest_capture(tmp_path: Path)
     assert result.returncode == 0, result.stderr
 
 
+def test_runtime_descriptor_stdin_is_reused_across_function_scoped_sessions(
+    tmp_path: Path,
+) -> None:
+    probe = tmp_path / "test_descriptor_reuse.py"
+    probe.write_text(
+        "import pytest\n"
+        "import tests.mcp_e2e.conftest as mcp_conftest\n"
+        "from tests.mcp_e2e.runtime import RuntimeContext\n"
+        "\n"
+        "pytest_plugins = ('tests.mcp_e2e.conftest',)\n"
+        "\n"
+        "def _fake_prepare(descriptor, client):\n"
+        "    return RuntimeContext(descriptor=descriptor, pat='akb_test_pat', secrets=('fixture-user', 'fixture-pass', 'akb_test_pat'))\n"
+        "\n"
+        "@pytest.fixture(autouse=True)\n"
+        "def patch_prepare(monkeypatch):\n"
+        "    monkeypatch.setattr(mcp_conftest, '_prepare_runtime', _fake_prepare)\n"
+        "\n"
+        "def test_first(runtime_session):\n"
+        "    assert runtime_session.descriptor.scenario == 'empty'\n"
+        "\n"
+        "def test_second(runtime_session):\n"
+        "    assert runtime_session.descriptor.scenario == 'empty'\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    tests_root = Path(__file__).resolve().parent
+    env["PYTHONPATH"] = f"{tests_root}{os.pathsep}{env.get('PYTHONPATH', '')}"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-p",
+            "tests.mcp_e2e.conftest",
+            str(probe),
+            "--runtime-descriptor",
+            "-",
+            "-q",
+            "--tb=short",
+        ],
+        cwd=tmp_path,
+        env=env,
+        input=json.dumps(_descriptor()),
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "2 passed" in result.stdout
+
+
 def test_preparation_failure_is_an_actual_pytest_failure(tmp_path: Path) -> None:
     descriptor = copy.deepcopy(_descriptor())
     descriptor["services"]["app"]["origin"] = "http://127.0.0.1:1"

--- a/backend/tests/test_mcp_sdk_fixture_unit.py
+++ b/backend/tests/test_mcp_sdk_fixture_unit.py
@@ -226,3 +226,57 @@ async def test_mcp_fixture_reports_connection_failure_and_redacts_it(
     assert "scenario=akb_list_vaults SDK connection" in str(captured.value)
     assert "sdk-secret" not in str(captured.value)
     assert http_client.closed
+
+
+def test_secondary_user_preparation_uses_descriptor_auth_coordinates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Response:
+        def __init__(self, status_code: int, payload: dict[str, Any]) -> None:
+            self.status_code = status_code
+            self._payload = payload
+
+        def json(self) -> dict[str, Any]:
+            return self._payload
+
+    class RecordingClient:
+        requests: list[tuple[str, str, dict[str, Any] | None, dict[str, str] | None]] = []
+
+        def __init__(self, **_kwargs: Any) -> None:
+            return None
+
+        def __enter__(self) -> RecordingClient:
+            return self
+
+        def __exit__(self, *_args: Any) -> None:
+            return None
+
+        def post(self, url: str, *, json: dict[str, Any]) -> Response:
+            self.requests.append(("POST", url, json, None))
+            return Response(201, {"user_id": "secondary"})
+
+        def request(
+            self,
+            method: str,
+            url: str,
+            *,
+            json: dict[str, Any] | None = None,
+            headers: dict[str, str] | None = None,
+        ) -> Response:
+            self.requests.append((method, url, json, headers))
+            if url.endswith("/login"):
+                return Response(200, {"token": "jwt-secondary"})
+            return Response(200, {"token": "akb_secondary_pat"})
+
+    RecordingClient.requests = []
+    monkeypatch.setattr(mcp_conftest.httpx, "Client", RecordingClient)
+
+    username, pat, secret_values = mcp_conftest._prepare_secondary_user(_runtime_context())
+
+    assert username.startswith("mcp-pytest-u2-")
+    assert pat == "akb_secondary_pat"
+    assert username in secret_values
+    assert "jwt-secondary" in secret_values
+    assert any(url.endswith("/api/v1/auth/register") for _, url, _, _ in RecordingClient.requests)
+    assert any(url.endswith("/api/v1/auth/login") for _, url, _, _ in RecordingClient.requests)
+    assert any(url.endswith("/api/v1/auth/tokens") for _, url, _, _ in RecordingClient.requests)

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -45,10 +45,22 @@ runner, so there is no second suite array to keep synchronized.
 
 ### MCP pytest behavior suite
 
-The first MCP behavior scenario is an authenticated read-only
-`akb_list_vaults({})` call through the official MCP Python SDK. The fixture
-uses the SDK's public `Client` and Streamable HTTP transport in the pytest
-process; it does not invoke Inspector, Node, or a separate MCP driver.
+The authenticated MCP behavior suite runs through the official Python SDK.
+`test_list_vaults_e2e.py` remains the small typed `akb_list_vaults({})`
+canary, while `test_product_e2e.py` covers the migrated product scenarios:
+vault and document lifecycle, browse/search/drill-down, move and aliases,
+relations/activity/history/diff, access roles and public levels, tables/SQL/
+DDL, publication, help, and deletion. Each pytest test receives the existing
+fixture's reset/login/SDK lifecycle; the access-control scenario adds a
+second user through the same authenticated endpoint and client lifecycle.
+The fixture uses the SDK's public `Client` and Streamable HTTP transport in the
+pytest process; it does not invoke Inspector, Node, or a separate MCP driver.
+
+The mixed `backend/tests/test_mcp_e2e.sh` suite now retains only transport,
+protocol/session, and direct REST response checks. Its MCP product assertions
+and raw JSON-RPC helper were removed so the product behavior has one SDK-based
+execution path. REST-only checks, initialize/session checks, and the separate
+stdio/Inspector boundaries remain in their existing lanes.
 
 The repository runtime remains the owner of backend startup, readiness,
 fixture reset, credentials, and teardown. Give the same schema-v2 descriptor
@@ -95,7 +107,7 @@ The topology is deliberately small:
 | backend | Ubuntu host process | `127.0.0.1:8000` | AKB application under test |
 | frontend (`--with-frontend`) | Ubuntu host process | `127.0.0.1:3000` by default | existing Vite SPA and per-run backend proxy |
 | fixture control | supervisor-owned in-process app | `127.0.0.1:8889` | health, discovery, and empty reset |
-| MCP pytest behavior suite | Ubuntu host process | no public listener | authenticated `akb_list_vaults` scenario through the official Python SDK |
+| MCP pytest behavior suite | Ubuntu host process | no public listener | authenticated MCP product scenarios through the official Python SDK |
 | curated suite runner | Ubuntu host process | no public listener | exact 15-suite gate and count semantics |
 
 Only PostgreSQL and MinIO are managed by

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -276,12 +276,15 @@ to the descriptor, logs, argv, or committed files.
 contain runtime lifecycle logic. On a clean Ubuntu 24.04 host it:
 
 1. verifies the base image and installs `curl`/CA certificates as needed;
-2. installs the Ubuntu archive's `nodejs`/`npm` packages and verifies both
+2. persists and immediately applies `net.ipv4.tcp_mtu_probing=1` through
+   `/etc/sysctl.d/99-akb-e2e-tcp-mtu-probing.conf` before any network download;
+   failure is a provisioning failure and the bootstrap stops;
+3. installs the Ubuntu archive's `nodejs`/`npm` packages and verifies both
    executables before any selected stdio profile is validated;
-3. installs and starts Docker Engine plus Compose v2 idempotently;
-4. installs/verifies `uv` and Python 3.14 under the private runtime root;
-5. runs `uv sync --locked --extra dev --project backend`; and
-6. `exec`s the same Python supervisor in `gate` or `serve` mode.
+4. installs and starts Docker Engine plus Compose v2 idempotently;
+5. installs/verifies `uv` and Python 3.14 under the private runtime root;
+6. runs `uv sync --locked --extra dev --project backend`; and
+7. `exec`s the same Python supervisor in `gate` or `serve` mode.
 
 Package, network, Docker, uv, and Python failures are provisioning failures
 and stop immediately with an actionable stderr message. The bootstrap does
@@ -350,6 +353,10 @@ When no `--runtime-root` is supplied, the bootstrap creates a private
 `/tmp/akb-e2e-bootstrap.XXXXXX` root. Child processes and dependency resources
 are cleaned on exit, while that root and its logs remain caller-owned for
 inspection and cleanup.
+
+The bootstrap does not set a fixed interface MTU. TCP MTU probing is the only
+network adjustment it owns, and it is applied before `apt`, `curl`, or `uv`
+network activity so VPN paths can recover from black-holed packet sizes.
 
 ## Runtime change checklist
 

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -276,9 +276,10 @@ to the descriptor, logs, argv, or committed files.
 contain runtime lifecycle logic. On a clean Ubuntu 24.04 host it:
 
 1. verifies the base image and installs `curl`/CA certificates as needed;
-2. persists and immediately applies `net.ipv4.tcp_mtu_probing=1` through
+2. persists and immediately applies `net.ipv4.tcp_mtu_probing=2` through
    `/etc/sysctl.d/99-akb-e2e-tcp-mtu-probing.conf` before any network download;
-   failure is a provisioning failure and the bootstrap stops;
+   mode 2 keeps probing proactively enabled for VPN/Docker Hub black-hole
+   paths, and failure is a provisioning failure that stops the bootstrap;
 3. installs the Ubuntu archive's `nodejs`/`npm` packages and verifies both
    executables before any selected stdio profile is validated;
 4. installs and starts Docker Engine plus Compose v2 idempotently;

--- a/scripts/ci/e2e_runtime.py
+++ b/scripts/ci/e2e_runtime.py
@@ -3523,7 +3523,7 @@ class E2ERuntime:
             {
                 "event": "mcp_pytest_start",
                 "process": "mcp_pytest",
-                "scenario": "akb_list_vaults",
+                "scenario": "mcp_product_e2e",
                 "suite": str(mcp_pytest_path),
                 "stage": "product_assertion",
                 "profile": self.profile.name,
@@ -3554,7 +3554,7 @@ class E2ERuntime:
             {
                 "event": "mcp_pytest_complete",
                 "process": "mcp_pytest",
-                "scenario": "akb_list_vaults",
+                "scenario": "mcp_product_e2e",
                 "suite": str(mcp_pytest_path),
                 "stage": "product_assertion",
                 "profile": self.profile.name,

--- a/scripts/ci/ubuntu_e2e_bootstrap.sh
+++ b/scripts/ci/ubuntu_e2e_bootstrap.sh
@@ -96,7 +96,7 @@ printf '%s\n' 'net.ipv4.tcp_mtu_probing = 2' \
   || die "could not apply TCP MTU probing configuration"
 SYSCTL_VALUE=$("${SUDO[@]}" sysctl -n net.ipv4.tcp_mtu_probing) \
   || die "could not verify TCP MTU probing configuration"
-[ "$SYSCTL_VALUE" = "1" ] \
+[ "$SYSCTL_VALUE" = "2" ] \
   || die "TCP MTU probing verification failed (found $SYSCTL_VALUE)"
 
 "${SUDO[@]}" apt-get update \

--- a/scripts/ci/ubuntu_e2e_bootstrap.sh
+++ b/scripts/ci/ubuntu_e2e_bootstrap.sh
@@ -82,6 +82,22 @@ source /etc/os-release 2>/dev/null || die "cannot inspect /etc/os-release"
 [ "${ID:-}" = "ubuntu" ] && [ "${VERSION_ID:-}" = "24.04" ] \
   || die "Ubuntu 24.04 is required (found ${ID:-unknown} ${VERSION_ID:-unknown})"
 
+# VPN-backed Ubuntu runners may start with a path MTU below the host default.
+# Persist and apply PLPMTUD before the first network provisioning operation so
+# uv/apt downloads use the kernel's black-hole recovery instead of a fixed MTU.
+command -v sysctl >/dev/null 2>&1 \
+  || die "sysctl is required to enable TCP MTU probing"
+SYSCTL_CONF=/etc/sysctl.d/99-akb-e2e-tcp-mtu-probing.conf
+printf '%s\n' 'net.ipv4.tcp_mtu_probing = 1' \
+  | "${SUDO[@]}" tee "$SYSCTL_CONF" >/dev/null \
+  || die "could not persist TCP MTU probing configuration"
+"${SUDO[@]}" sysctl --load "$SYSCTL_CONF" >/dev/null \
+  || die "could not apply TCP MTU probing configuration"
+SYSCTL_VALUE=$("${SUDO[@]}" sysctl -n net.ipv4.tcp_mtu_probing) \
+  || die "could not verify TCP MTU probing configuration"
+[ "$SYSCTL_VALUE" = "1" ] \
+  || die "TCP MTU probing verification failed (found $SYSCTL_VALUE)"
+
 "${SUDO[@]}" apt-get update \
   || die "apt package index update failed; check VM networking/DNS"
 "${SUDO[@]}" apt-get install -y curl ca-certificates \

--- a/scripts/ci/ubuntu_e2e_bootstrap.sh
+++ b/scripts/ci/ubuntu_e2e_bootstrap.sh
@@ -83,12 +83,13 @@ source /etc/os-release 2>/dev/null || die "cannot inspect /etc/os-release"
   || die "Ubuntu 24.04 is required (found ${ID:-unknown} ${VERSION_ID:-unknown})"
 
 # VPN-backed Ubuntu runners may start with a path MTU below the host default.
-# Persist and apply PLPMTUD before the first network provisioning operation so
-# uv/apt downloads use the kernel's black-hole recovery instead of a fixed MTU.
+# Persist and apply PLPMTUD mode 2 before the first network provisioning
+# operation so uv/apt downloads proactively use the kernel's black-hole
+# recovery instead of a fixed MTU.
 command -v sysctl >/dev/null 2>&1 \
   || die "sysctl is required to enable TCP MTU probing"
 SYSCTL_CONF=/etc/sysctl.d/99-akb-e2e-tcp-mtu-probing.conf
-printf '%s\n' 'net.ipv4.tcp_mtu_probing = 1' \
+printf '%s\n' 'net.ipv4.tcp_mtu_probing = 2' \
   | "${SUDO[@]}" tee "$SYSCTL_CONF" >/dev/null \
   || die "could not persist TCP MTU probing configuration"
 "${SUDO[@]}" sysctl --load "$SYSCTL_CONF" >/dev/null \


### PR DESCRIPTION
Migrate the comprehensive MCP product scenarios from shell RPC calls to the existing official Python SDK pytest suite. The same repository-owned authenticated HTTP runtime and hosted `shell-e2e` job execute the new scenarios alongside the remaining shell checks.

| Existing coverage | Result |
| --- | --- |
| Document CRUD, browse/search/drill-down, versioned reads | SDK pytest, including collision and exact-path cases |
| Move/rename and collection moves | SDK pytest, preserving aliases, collision/path reuse/suffix and invalid-path cases |
| Relations/graph/provenance/activity/history/diff, deletion | SDK pytest, including empty-collection persistence |
| Tables/SQL/DDL | SDK pytest, including invalid identifiers, hints, and sql_name round trips |
| Publish/unpublish, help, vault archive/delete | SDK pytest |
| Owner/reader/no-access, grant/upgrade/revoke, public access levels | SDK pytest using a separate authenticated user |
| Initialize, notifications, unauthenticated rejection, tools/list, session termination | Retained shell protocol checks |
| Direct REST sql_name, profile and publication/public-access responses | Retained shell checks |

Reuse the existing list-vaults canary and SDK connection lifecycle. Remove replaced shell assertions and their unused raw RPC helpers. Document fixture usage and the migration boundary in the existing contributor/runtime guides. CI job names and the separate unit/live suites remain unchanged.

The Ubuntu bootstrap also enables and verifies proactive TCP path-MTU discovery (`net.ipv4.tcp_mtu_probing=2`) before network provisioning. This prevents the reproduced VPN-path failures in Python and Docker image downloads while keeping the interface MTU unchanged. The setting is confined to the Ubuntu runner; macOS, VPN settings and Crabbox itself are unchanged.

Validation for the current candidate:

- [Hosted E2E](https://github.com/dnotitia/akb/actions/runs/34131555853): passed, including SDK pytest, remaining curated shell suites, real frontend smoke and transport/proxy checks.
- [Backend unit and live DB tests](https://github.com/dnotitia/akb/actions/runs/34131556086): passed.
- [Static analysis](https://github.com/dnotitia/akb/actions/runs/34131556062): passed.
- Focused fixture/product regression tests: 10 passed; MCP collection: 7 tests; manifest: 27 curated / 34 explicitly deferred; bootstrap regression and `scripts/check.sh` passed, including 741 frontend tests.
- Two independent reviews of the complete candidate diff found no actionable findings within the configured P0/P1 correctness and material-complexity scope.
- Independent source-blind operator validation on a fresh Crabbox Apple VM, with the host VPN connected: **satisfies_contract**. Ubuntu provisioning completed; TCP MTU probing read back as 2. The full SDK pytest suite passed twice (7 passed in 120.18s, then 7 passed in 122.63s). Between those runs, a password-omitted invocation failed with exit 1 and no skipped/success masking. Normal credential forwarding then recovered successfully. The validator reported no exposed credentials in captured output.
- All 1,450 tracked files in the validation VM matched the candidate's Git blobs and executable modes. The hosted merge tree also matched the PR head tree. The validation VM was stopped after the validator completed.

The proactive mode may begin connections with smaller TCP segments. The earlier VPN-off timing comparison exercised mode 1, so it is not presented as a mode-2 performance guarantee.

Tracks AKB-255.
