### PR TITLE
fix: audit REST Vault grant and revoke

### DIFF
--- a/backend/app/api/routes/access.py
+++ b/backend/app/api/routes/access.py
@@ -59,6 +59,7 @@ from app.services.admission_service import (
     list_pending_admissions,
 )
 from app.util.text import NFCModel
+from app.services import audit_log
 
 
 def _require_admin(user: AuthenticatedUser) -> None:
@@ -242,17 +243,36 @@ async def vault_members(vault: str, user: AuthenticatedUser = Depends(get_curren
 @router.post("/vaults/{vault}/grant", summary="Grant vault access to a user")
 async def grant(vault: str, req: GrantRequest, user: AuthenticatedUser = Depends(get_current_user)):
     kwargs = {} if req.source_key is None else {"source_key": req.source_key}
-    return await grant_access(
-        user.user_id, vault, req.user, req.role, revision=req.revision, **kwargs,
+    return await _audited_access(
+        "akb_grant", {"vault": vault, **req.model_dump(exclude_none=True)}, user,
+        grant_access(user.user_id, vault, req.user, req.role, revision=req.revision, **kwargs),
     )
 
 
 @router.post("/vaults/{vault}/revoke", summary="Revoke vault access from a user")
 async def revoke(vault: str, req: RevokeRequest, user: AuthenticatedUser = Depends(get_current_user)):
-    return await revoke_access(
-        user.user_id, vault, req.user,
-        source_key=req.source_key, revision=req.revision,
+    return await _audited_access(
+        "akb_revoke", {"vault": vault, **req.model_dump()}, user,
+        revoke_access(user.user_id, vault, req.user, source_key=req.source_key, revision=req.revision),
     )
+
+
+async def _audited_access(name, args, user, operation):
+    """Use the existing API audit producer for REST's two access operations.
+
+    The canonical action matches MCP; transport metadata identifies REST.
+    Domain events remain separate. Preserve the handler's result or exception,
+    and never copy exception messages (which may contain private details).
+    """
+    result = {"error": True, "code": "interrupted"}
+    try:
+        result = await operation
+        return result
+    except Exception as error:
+        result = {"error": True, "code": getattr(error, "code", None)}
+        raise
+    finally:
+        audit_log.record_tool(name, args, user, result, is_write=True, protocol={"transport": "rest"})
 
 
 @router.get(

--- a/backend/app/services/audit_log.py
+++ b/backend/app/services/audit_log.py
@@ -10,7 +10,8 @@ in `backend/CHANGELOG.md` 0.8.1.
 
 Capture model — **best-effort post-operation append.** Every MCP tool call
 passes through `record_tool()` from the dispatch chokepoint *after* the
-handler runs, so reads and writes are captured uniformly (the Kubernetes
+handler runs. REST grant/revoke use the same producer and canonical action,
+with `transport=rest` metadata. MCP reads and writes are captured uniformly (the Kubernetes
 audit-backend model: log at the API layer, not per-service). There is no
 transactional outbox: an AKB domain write already spans PG + git + vector
 store + S3 and is not globally atomic, so binding the audit line to the PG
@@ -406,8 +407,8 @@ def record_tool(
     is_write: bool = False,
     protocol: dict[str, str] | None = None,
 ) -> None:
-    """Audit one MCP tool call from the dispatch chokepoint. ``user`` is the
-    resolved _MCPUser; ``result`` is the handler's return envelope (or the
+    """Audit a canonical API operation from MCP dispatch or REST access routes.
+    ``user`` is the resolved principal; ``result`` is the handler's return envelope (or the
     final error envelope) — outcome is derived from it.
 
     Schema note — this is deliberately NOT the `events` outbox schema
@@ -434,7 +435,27 @@ def record_tool(
         code = result.get("code")
     if name == "akb_grep" and is_write:
         _record_grep_replace_receipts(args, user, result, protocol)
-    audit_meta = dict(protocol or {})
+    audit_meta: dict[str, Any] = dict(protocol or {})
+    if name in {"akb_grant", "akb_revoke"}:
+        # Bounded metadata identifies the recipient and basis, including a
+        # failed attempt. A revoke with no key means all bases; a grant with no
+        # key means direct. Never serialize the request or exception wholesale.
+        source_key = args.get("source_key")
+        if name == "akb_grant" and source_key is None:
+            source_key = "direct"
+        access_meta: dict[str, Any] = {
+            "user": str(args.get("user", ""))[:_TARGET_MAX],
+            "source_key": str(source_key)[:_TARGET_MAX] if source_key is not None else None,
+            "revision": args.get("revision") if type(args.get("revision")) is int else None,
+        }
+        if name == "akb_grant":
+            access_meta["role"] = str(args.get("role", ""))[:_TARGET_MAX]
+        if outcome == "ok" and isinstance(result, dict):
+            access_meta.update({
+                "effective_role": result.get("effective_role"),
+                "applied": result.get("applied"),
+            })
+        audit_meta["access"] = access_meta
     if name == "akb_grep" and is_write:
         audit_meta.update(_grep_replace_meta(args, result) or {})
     record(

--- a/backend/tests/test_rest_access_audit.py
+++ b/backend/tests/test_rest_access_audit.py
@@ -1,0 +1,69 @@
+"""REST grants must reach the same metadata audit producer as MCP grants."""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.api.routes import access
+from app.exceptions import ForbiddenError
+from app.services import audit_log
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["grant", "revoke"])
+@pytest.mark.parametrize("denied", [False, True])
+async def test_rest_and_mcp_access_audit_match(monkeypatch, operation, denied):
+    monkeypatch.setattr(audit_log.settings.audit, "enabled", True)
+    records = []
+    monkeypatch.setattr(audit_log, "record", lambda **entry: records.append(entry))
+    actor = SimpleNamespace(user_id="actor-id", username="operator")
+    args = {"vault": "documents", "user": "colleague", "source_key": "team:example", "revision": 7}
+    if operation == "grant":
+        args["role"] = "reader"
+    result = {"effective_role": "reader", "applied": True}
+    error = ForbiddenError("private details must not be copied into audit")
+    service = AsyncMock(side_effect=error) if denied else AsyncMock(return_value=result)
+    monkeypatch.setattr(access, f"{operation}_access", service)
+    req_type = access.GrantRequest if operation == "grant" else access.RevokeRequest
+    req = req_type(**{key: val for key, val in args.items() if key != "vault"})
+    if denied:
+        with pytest.raises(ForbiddenError) as caught:
+            await getattr(access, operation)("documents", req, actor)
+        assert caught.value is error
+    else:
+        assert await getattr(access, operation)("documents", req, actor) is result
+    assert len(records) == 1, "REST operation disappeared from the audit producer"
+    rest = records.pop()
+    audit_log.record_tool(f"akb_{operation}", args, actor,
+                          {"error": True} if denied else result, is_write=True,
+                          protocol={"transport": "mcp"})
+    mcp = records.pop()
+    for field in ("action", "actor", "actor_id", "vault", "target", "outcome"):
+        assert rest[field] == mcp[field]
+    assert rest["outcome"] == ("error" if denied else "ok")
+    assert rest["meta"]["transport"] == "rest"
+    assert rest["meta"]["access"] == mcp["meta"]["access"]
+    assert rest["meta"]["access"]["user"] == "colleague"
+    assert rest["meta"]["access"]["source_key"] == "team:example"
+    assert "private details" not in str(rest)
+    assert service.call_args.kwargs["source_key"] == "team:example"
+    assert service.call_args.kwargs["revision"] == 7
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["grant", "revoke"])
+async def test_omitted_source_keeps_grant_and_revoke_meanings(monkeypatch, operation):
+    monkeypatch.setattr(audit_log.settings.audit, "enabled", True)
+    records = []
+    monkeypatch.setattr(audit_log, "record", lambda **entry: records.append(entry))
+    service = AsyncMock(return_value={"applied": True, "effective_role": None})
+    monkeypatch.setattr(access, f"{operation}_access", service)
+    actor = SimpleNamespace(user_id="actor-id", username="operator")
+    req = access.GrantRequest(user="u", role="reader") if operation == "grant" else access.RevokeRequest(user="u")
+    await getattr(access, operation)("documents", req, actor)
+    if operation == "grant":
+        assert "source_key" not in service.call_args.kwargs
+        assert records[0]["meta"]["access"]["source_key"] == "direct"
+    else:
+        assert service.call_args.kwargs["source_key"] is None
+        assert records[0]["meta"]["access"]["source_key"] is None


### PR DESCRIPTION
REST Vault grant/revoke changed access without reaching the audit producer, while the equivalent MCP calls emitted records. Both REST operations now use the existing producer with their canonical action and REST transport metadata, preserving results and exceptions.

Both paths include bounded recipient, source-key, revision and applied/effective-role metadata. Grant still defaults to direct; revoke without a source still removes all bases. Domain outbox events remain separate.

Validation at 459c547c01f9bf35772d01aabbb6802249e2a93c: all five CI jobs passed (backend units 2,607 passed / 663 skipped; runtime contracts 40 passed; PostgreSQL 456 passed; static analysis; mock and real frontend + repository shell E2E). Six new regressions failed before the fix; 29 focused access/audit tests passed afterward. The local host has Git 2.34 below the unchanged 2.37 minimum; that failure was reproduced on pristine main and the redundant local full run was stopped once exact-head CI was green.

The dedicated HTTPS fixture already proves REST/MCP access parity. Audit producer parity will be rechecked against the merged image.
