### PR TITLE
feat: support managed workload tokens and refreshable S3 identity

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3703
+        "line_number": 3717
       }
     ],
     "backend/mcp_server/help.py": [
@@ -6987,5 +6987,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-07T07:57:29Z"
+  "generated_at": "2026-09-08T00:17:55Z"
 }

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -212,6 +212,20 @@ untouched. Adopted or retained tables reject generic alter/drop and structured
 migrations, while the owning rollout worker retains its exact installation
 context.
 
+## 0.14.3 — 2026-09-08  *(fix — managed workload identity)*
+
+Managed `platform_hard` deployments now read rotating Gateway tokens for model
+calls and use refreshable RGW WebIdentity sessions for file and audit storage.
+Static model/S3/audit keys are rejected. Internal S3 operations and public
+presigns share the workload credentials; URL lifetime is bounded by the exact
+signing session, and API `expires_in` reports the actual lifetime. Managed
+startup requires an accessible pre-provisioned bucket and never creates one.
+
+Standalone static credentials and MinIO bucket creation remain available.
+Explicit `s3_auth_mode: default_chain` supports native cloud credentials,
+including AWS WebIdentity, with cleanup workers enabled even when no custom
+S3 endpoint is configured. See [workload identity configuration](../docs/managed-workload-identity.md).
+
 ## 0.14.2 — 2026-08-13  *(feat — exact PAT authority self-verification)*
 
 ### Added PAT authority self-verification

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -23,6 +23,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, cast
+from urllib.parse import urlsplit
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -592,6 +593,7 @@ class Settings(BaseModel):
     # route must use; startup rejects a direct-provider escape.
     model_api_governance_mode: Literal["external_metering", "platform_hard"] = "external_metering"
     platform_gateway_base_url: str = ""
+    platform_gateway_token_file: str = ""
 
     # LLM — optional. Only consumed by metadata_worker (auto-tagging
     # external_git imports). When unset, metadata_worker stays disabled
@@ -666,27 +668,28 @@ class Settings(BaseModel):
         gateway = self.platform_gateway_base_url.strip().rstrip("/")
         if not gateway:
             raise ValueError("platform_gateway_base_url is required in platform_hard mode")
+        if not Path(self.platform_gateway_token_file).is_absolute():
+            raise ValueError("platform_gateway_token_file must be an absolute token path in platform_hard mode")
+        for name in ("embed_api_key", "llm_api_key", "rerank_api_key"):
+            if getattr(self, name):
+                raise ValueError(f"{name} is forbidden in platform_hard mode")
 
-        routes = [
-            ("embed_base_url", self.embed_base_url, "embed_api_key", self.embed_api_key),
-        ]
+        routes = []
+        if self.embed_base_url:
+            routes.append(("embed_base_url", self.embed_base_url))
         if self.llm_base_url:
-            routes.append(("llm_base_url", self.llm_base_url, "llm_api_key", self.llm_api_key))
+            routes.append(("llm_base_url", self.llm_base_url))
         if self.rerank_enabled:
             routes.append(
                 (
                     "rerank_base_url",
                     self.rerank_base_url or self.llm_base_url,
-                    "rerank_api_key",
-                    self.rerank_api_key or self.llm_api_key,
                 )
             )
 
-        for url_name, url, key_name, key in routes:
+        for url_name, url in routes:
             if not url or url.strip().rstrip("/") != gateway:
                 raise ValueError(f"{url_name} must exactly match platform_gateway_base_url in platform_hard mode")
-            if not key.strip():
-                raise ValueError(f"{key_name} is required in platform_hard mode")
         return self
 
     @model_validator(mode="after")
@@ -760,6 +763,49 @@ class Settings(BaseModel):
     s3_secret_key: str = ""
     s3_bucket: str = "akb-files"
     s3_region: str = ""
+    # Static retains the existing standalone/MinIO configuration. The native
+    # chain supports cloud roles without requiring a custom S3 endpoint.
+    # platform_hard narrows default_chain to this explicit WebIdentity tuple;
+    # no environment or shared-profile credential can override that identity.
+    s3_auth_mode: Literal["static", "default_chain"] = "static"
+    s3_web_identity_token_file: str = ""
+    s3_role_arn: str = ""
+    s3_sts_endpoint_url: str = ""
+
+    @property
+    def object_storage_enabled(self) -> bool:
+        return bool(self.s3_endpoint_url) or self.s3_auth_mode == "default_chain"
+
+    @model_validator(mode="after")
+    def validate_storage_identity(self) -> "Settings":
+        managed = self.model_api_governance_mode == "platform_hard"
+        if managed and self.s3_auth_mode != "default_chain":
+            raise ValueError("s3_auth_mode must be default_chain in platform_hard mode")
+        if self.s3_auth_mode == "default_chain":
+            for name in ("s3_access_key", "s3_secret_key"):
+                if getattr(self, name):
+                    raise ValueError(f"{name} is forbidden with s3_auth_mode=default_chain")
+        if managed:
+            for name in ("access_key", "secret_key"):
+                if getattr(self.audit, name):
+                    raise ValueError(f"audit.{name} is forbidden in platform_hard mode")
+            if not self.s3_endpoint_url.strip():
+                raise ValueError("s3_endpoint_url is required in platform_hard mode")
+
+        fields = ("s3_web_identity_token_file", "s3_role_arn", "s3_sts_endpoint_url")
+        if managed or any(getattr(self, name) for name in fields):
+            if self.s3_auth_mode != "default_chain":
+                raise ValueError("s3_auth_mode must be default_chain for WebIdentity")
+            for name in fields:
+                if not getattr(self, name).strip():
+                    raise ValueError(f"{name} is required for explicit S3 WebIdentity")
+            if not Path(self.s3_web_identity_token_file).is_absolute():
+                raise ValueError("s3_web_identity_token_file must be an absolute token path")
+            endpoint = urlsplit(self.s3_sts_endpoint_url)
+            if (endpoint.scheme not in ("https", "http") or not endpoint.hostname
+                    or endpoint.username or endpoint.password or endpoint.query or endpoint.fragment):
+                raise ValueError("s3_sts_endpoint_url must be an HTTP(S) endpoint without credentials or query")
+        return self
     # boto3/botocore default to a 60 s connect AND 60 s read timeout with NO
     # retries. A stalled MinIO/S3 (network blip, cold bucket, dead endpoint)
     # then blocks the caller for up to 60 s — and several S3 primitives run on

--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -1858,7 +1858,7 @@ async def delete_vault(user_id: str, vault_name: str) -> dict:
                 "SELECT id, s3_key, upload_state FROM vault_files WHERE vault_id = $1",
                 vault_id,
             )
-            if file_rows and settings.s3_endpoint_url:
+            if file_rows and settings.object_storage_enabled:
                 from app.services.s3_delete_worker import (
                     enqueue_delete,
                     enqueue_pending_upload_delete,
@@ -1875,7 +1875,7 @@ async def delete_vault(user_id: str, vault_name: str) -> dict:
                 " WHERE vault_id = $1 AND snapshot_s3_key IS NOT NULL",
                 vault_id,
             )
-            if snap_rows and settings.s3_endpoint_url:
+            if snap_rows and settings.object_storage_enabled:
                 from app.services.s3_delete_worker import enqueue_delete
                 for sr in snap_rows:
                     await enqueue_delete(conn, sr["snapshot_s3_key"])
@@ -1891,7 +1891,7 @@ async def delete_vault(user_id: str, vault_name: str) -> dict:
             for fr in file_rows:
                 await _drop_source_chunks_with_outbox(conn, "file", str(fr["id"]))
 
-            if file_rows and settings.s3_endpoint_url:
+            if file_rows and settings.object_storage_enabled:
                 await conn.execute("DELETE FROM vault_files WHERE vault_id = $1", vault_id)
 
             await conn.execute("DELETE FROM edges WHERE vault_id = $1", vault_id)

--- a/backend/app/services/adapters/s3_adapter.py
+++ b/backend/app/services/adapters/s3_adapter.py
@@ -17,7 +17,10 @@ and uses these primitives. Anything S3-shaped — but no domain concepts
 from __future__ import annotations
 
 import logging
-from typing import Any, Iterator
+import threading
+from contextvars import ContextVar
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterator, NamedTuple
 
 import boto3
 from botocore.config import Config as BotoConfig
@@ -25,6 +28,7 @@ from botocore.exceptions import ClientError
 
 from app.config import settings
 from app.exceptions import AKBError, NotFoundError
+from app.services.adapters.s3_credentials import build_session, frozen_snapshot
 
 logger = logging.getLogger("akb.s3")
 
@@ -59,10 +63,36 @@ def wrap_error(e: ClientError, context: str) -> AKBError:
 
 _internal_client = None
 _presign_client = None
-_bucket_verified = False
+_session = None
+_client_lock = threading.RLock()
+_bucket_verified: set[str] = set()
+
+
+class PresignedURL(NamedTuple):
+    url: str
+    expires_in: int
+
+
+# A request-local snapshot prevents one thread's refresh from changing another
+# thread's presign keys after its TTL was calculated. No shared signer mutates.
+_signing_snapshot: ContextVar[tuple[Any, datetime | None, int] | None] = ContextVar(
+    "s3_signing_snapshot", default=None,
+)
 
 _DEFAULT_PRESIGN_TTL = 3600
 _STREAM_CHUNK_SIZE = 64 * 1024
+_PRESIGN_CLOCK_MARGIN = 60
+
+
+def _boto_config(*, endpoint_url: str = ""):
+    return BotoConfig(
+        signature_version="s3v4",
+        connect_timeout=settings.s3_connect_timeout_secs,
+        read_timeout=settings.s3_read_timeout_secs,
+        retries={"max_attempts": settings.s3_max_attempts, "mode": "standard"},
+        s3={"addressing_style": "path" if endpoint_url else "auto"},
+        ignore_configured_endpoint_urls=settings.model_api_governance_mode == "platform_hard",
+    )
 
 
 def make_client(endpoint_url: str, access_key: str, secret_key: str, region: str = ""):
@@ -72,33 +102,43 @@ def make_client(endpoint_url: str, access_key: str, secret_key: str, region: str
     so the primary file store (`client`/`presign_client`) and a
     credential-isolated audit store (`audit_log`) all construct clients the
     same way instead of each re-deriving the boto kwargs."""
+    if settings.model_api_governance_mode == "platform_hard":
+        raise StorageError("Static S3 clients are forbidden in platform_hard mode")
     return boto3.client(
         "s3",
         endpoint_url=endpoint_url or None,
         aws_access_key_id=access_key,
         aws_secret_access_key=secret_key,
-        config=BotoConfig(
-            signature_version="s3v4",
-            # Bound every S3 op so a stalled endpoint can't block the caller
-            # (and, on the on-loop paths, the whole event loop) for the boto
-            # default of 60 s. See settings.s3_* for the rationale.
-            connect_timeout=settings.s3_connect_timeout_secs,
-            read_timeout=settings.s3_read_timeout_secs,
-            retries={"max_attempts": settings.s3_max_attempts, "mode": "standard"},
-        ),
+        config=_boto_config(endpoint_url=endpoint_url),
         **({"region_name": region} if region else {}),
     )
+
+
+def _credential_session():
+    global _session
+    with _client_lock:
+        if _session is None:
+            _session = build_session(settings)
+        return _session
+
+
+def session_client(endpoint_url: str, region: str = ""):
+    """Build an S3 client sharing the selected, refreshable runtime session."""
+    with _client_lock:
+        return _credential_session().client(
+            "s3", endpoint_url=endpoint_url or None,
+            config=_boto_config(endpoint_url=endpoint_url),
+            **({"region_name": region} if region else {}),
+        )
 
 
 def client():
     """boto3 S3 client targeting the internal endpoint. Used for
     server-side operations (head, get, put, delete)."""
     global _internal_client
-    if _internal_client is None:
-        _internal_client = make_client(
-            settings.s3_endpoint_url, settings.s3_access_key,
-            settings.s3_secret_key, settings.s3_region,
-        )
+    with _client_lock:
+        if _internal_client is None:
+            _internal_client = session_client(settings.s3_endpoint_url, settings.s3_region)
     return _internal_client
 
 
@@ -107,31 +147,62 @@ def presign_client():
     that clients reach from outside the cluster. Falls back to the
     internal endpoint when no public URL is configured."""
     global _presign_client
-    if _presign_client is None:
-        _presign_client = make_client(
-            settings.s3_public_url or settings.s3_endpoint_url,
-            settings.s3_access_key, settings.s3_secret_key, settings.s3_region,
-        )
+    with _client_lock:
+        if _presign_client is None:
+            _presign_client = session_client(
+                settings.s3_public_url or settings.s3_endpoint_url, settings.s3_region,
+            )
+            _presign_client.meta.events.register("before-sign.s3", _bind_signing_snapshot)
     return _presign_client
 
 
-def ensure_bucket(bucket: str) -> None:
-    """Verify the bucket exists; create it on first miss. Idempotent
-    and cached after the first successful check."""
-    global _bucket_verified
-    if _bucket_verified:
+def _bind_signing_snapshot(request, **_kwargs):
+    snapshot = _signing_snapshot.get()
+    if snapshot is None or not request.context.get("is_presign_request"):
         return
-    s3 = client()
+    credentials, expiry, ttl = snapshot
+    if expiry is not None and datetime.now(timezone.utc) + timedelta(seconds=ttl) >= expiry:
+        raise StorageError("S3 session expired before signing")
+    # Botocore's request-specific credential hook avoids replacing the shared
+    # client's credentials. The pinned-runtime tests exercise actual SigV4.
+    request.context.setdefault("signing", {})["request_credentials"] = credentials
+
+
+def _presign(operation: str, params: dict[str, Any], ttl: int) -> PresignedURL:
+    if isinstance(ttl, bool) or not isinstance(ttl, int) or ttl < 1:
+        raise StorageError("Presign lifetime must be a positive integer")
+    signer = presign_client()
+    credentials, expiry = frozen_snapshot(_credential_session())
+    if expiry is not None:
+        remaining = int((expiry - datetime.now(timezone.utc)).total_seconds()) - _PRESIGN_CLOCK_MARGIN
+        ttl = min(ttl, remaining)
+    if ttl < 1:
+        raise StorageError("S3 session has insufficient lifetime for a presigned URL")
+    context_token = _signing_snapshot.set((credentials, expiry, ttl))
     try:
-        s3.head_bucket(Bucket=bucket)
-    except ClientError as e:
-        code = e.response["Error"].get("Code", "")
-        if code in ("404", "NoSuchBucket"):
-            s3.create_bucket(Bucket=bucket)
-            logger.info("Created S3 bucket: %s", bucket)
-        else:
-            raise wrap_error(e, "check bucket") from e
-    _bucket_verified = True
+        url = signer.generate_presigned_url(operation, Params=params, ExpiresIn=ttl)
+        return PresignedURL(url, ttl)
+    finally:
+        _signing_snapshot.reset(context_token)
+
+
+def ensure_bucket(bucket: str) -> None:
+    """Head-only for managed/native-chain storage; standalone static can create."""
+    with _client_lock:
+        if bucket in _bucket_verified:
+            return
+        s3 = client()
+        try:
+            s3.head_bucket(Bucket=bucket)
+        except ClientError as e:
+            code = e.response["Error"].get("Code", "")
+            if (code in ("404", "NoSuchBucket") and settings.s3_auth_mode == "static"
+                    and settings.model_api_governance_mode != "platform_hard"):
+                s3.create_bucket(Bucket=bucket)
+                logger.info("Created S3 bucket: %s", bucket)
+            else:
+                raise wrap_error(e, "check bucket") from e
+        _bucket_verified.add(bucket)
 
 
 # ── Primitives ───────────────────────────────────────────────────
@@ -226,7 +297,7 @@ def presign_get(
     ttl: int = _DEFAULT_PRESIGN_TTL,
     response_content_type: str | None = None,
     response_content_disposition: str | None = None,
-) -> str:
+) -> PresignedURL:
     """Presigned GET URL for direct download from S3."""
     try:
         params: dict[str, Any] = {"Bucket": settings.s3_bucket, "Key": key}
@@ -234,9 +305,7 @@ def presign_get(
             params["ResponseContentType"] = response_content_type
         if response_content_disposition:
             params["ResponseContentDisposition"] = response_content_disposition
-        return presign_client().generate_presigned_url(
-            "get_object", Params=params, ExpiresIn=ttl,
-        )
+        return _presign("get_object", params, ttl)
     except ClientError as e:
         raise StorageError(wrap_error(e, f"presign download {key}").message) from e
 
@@ -246,13 +315,13 @@ def presign_put(
     *,
     content_type: str = "application/octet-stream",
     ttl: int = _DEFAULT_PRESIGN_TTL,
-) -> str:
+) -> PresignedURL:
     """Presigned PUT URL for direct upload to S3 by an external client."""
     try:
-        return presign_client().generate_presigned_url(
+        return _presign(
             "put_object",
-            Params={"Bucket": settings.s3_bucket, "Key": key, "ContentType": content_type},
-            ExpiresIn=ttl,
+            {"Bucket": settings.s3_bucket, "Key": key, "ContentType": content_type},
+            ttl,
         )
     except ClientError as e:
         raise wrap_error(e, f"presign upload {key}") from e

--- a/backend/app/services/adapters/s3_credentials.py
+++ b/backend/app/services/adapters/s3_credentials.py
@@ -1,0 +1,119 @@
+"""S3 credential selection and atomic snapshots of refreshable credentials.
+
+Botocore owns refresh serialization. Its expiration and frozen-credential
+fields have no public atomic accessor; the small snapshot function below is
+covered against the botocore version in uv.lock, including concurrent refresh.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime
+
+import boto3
+from botocore import UNSIGNED
+from botocore.config import Config
+from botocore.credentials import (
+    CredentialProvider, CredentialResolver, Credentials,
+    DeferredRefreshableCredentials, RefreshableCredentials,
+)
+from botocore.session import Session
+
+from app.config import Settings
+from app.services.workload_identity import WorkloadIdentityError, read_projected_token
+
+
+class _WebIdentityProvider(CredentialProvider):
+    METHOD = "assume-role-with-web-identity"
+
+    def __init__(self, sts, token_path: str, role_arn: str):
+        self._sts = sts
+        self._token_path = token_path
+        self._role_arn = role_arn
+        self._session_name = "akb-" + uuid.uuid4().hex
+
+    def load(self):
+        credentials = DeferredRefreshableCredentials(
+            refresh_using=self._refresh, method=self.METHOD,
+        )
+        credentials._advisory_refresh_timeout = 300
+        credentials._mandatory_refresh_timeout = 60
+        return credentials
+
+    def _refresh(self):
+        try:
+            response = self._sts.assume_role_with_web_identity(
+                RoleArn=self._role_arn,
+                RoleSessionName=self._session_name,
+                WebIdentityToken=read_projected_token(self._token_path),
+            )["Credentials"]
+            if not all(response.get(key) for key in ("AccessKeyId", "SecretAccessKey", "SessionToken", "Expiration")):
+                raise ValueError("Incomplete STS credentials")
+            return {
+                "access_key": response["AccessKeyId"],
+                "secret_key": response["SecretAccessKey"],
+                "token": response["SessionToken"],
+                "expiry_time": response["Expiration"].isoformat(),
+            }
+        except Exception:
+            # STS error text and validation errors can contain caller input.
+            # Botocore logs refresh exceptions; expose only this safe diagnostic.
+            raise WorkloadIdentityError("S3 workload identity refresh failed") from None
+
+
+def build_session(settings: Settings) -> boto3.Session:
+    core = Session()
+    managed = settings.model_api_governance_mode == "platform_hard"
+    if managed and (settings.s3_auth_mode != "default_chain" or settings.s3_access_key or settings.s3_secret_key):
+        raise WorkloadIdentityError("Static S3 credentials are forbidden in platform_hard mode")
+    if managed or settings.s3_web_identity_token_file:
+        if not all((settings.s3_web_identity_token_file, settings.s3_role_arn, settings.s3_sts_endpoint_url)):
+            raise WorkloadIdentityError("S3 workload identity configuration is incomplete")
+        # Do not read shared profiles, credential_process, or ambient AWS role
+        # selectors. ConfigValueStore overrides also suppress a set AWS_PROFILE
+        # when the selected value is None (Session.set_config_variable does not).
+        config_store = core.get_component("config_store")
+        for name, value in (("profile", None), ("config_file", os.devnull), ("credentials_file", os.devnull)):
+            config_store.set_config_variable(name, value)
+        config_store.set_config_variable("region", settings.s3_region or "us-east-1")
+        sts = core.create_client(
+            "sts", endpoint_url=settings.s3_sts_endpoint_url,
+            region_name=settings.s3_region or "us-east-1",
+            config=Config(
+                signature_version=UNSIGNED,
+                ignore_configured_endpoint_urls=True,
+                connect_timeout=settings.s3_connect_timeout_secs,
+                read_timeout=settings.s3_read_timeout_secs,
+                retries={"max_attempts": settings.s3_max_attempts, "mode": "standard"},
+            ),
+        )
+        core.register_component("credential_provider", CredentialResolver([
+            _WebIdentityProvider(sts, settings.s3_web_identity_token_file, settings.s3_role_arn),
+        ]))
+    elif settings.s3_auth_mode == "static":
+        # Set even empty values explicitly. boto3.Session's constructor treats
+        # empty strings as absent and would silently select ambient credentials.
+        core.set_credentials(settings.s3_access_key, settings.s3_secret_key)
+    return boto3.Session(botocore_session=core)
+
+
+def frozen_snapshot(session: boto3.Session) -> tuple[Credentials, datetime | None]:
+    """Freeze the signing keys and their expiration from the same generation."""
+    try:
+        credentials = session.get_credentials()
+        if credentials is None:
+            raise WorkloadIdentityError("S3 credentials are unavailable")
+        frozen = credentials.get_frozen_credentials()
+        expiry = None
+        if isinstance(credentials, RefreshableCredentials):
+            # Refresh can finish between get_frozen_credentials and this lock.
+            # Read BOTH fields again under the provider's own refresh lock.
+            with credentials._refresh_lock:
+                frozen = credentials._frozen_credentials
+                expiry = credentials._expiry_time
+        return Credentials(frozen.access_key, frozen.secret_key, frozen.token), expiry
+    except WorkloadIdentityError:
+        raise
+    except Exception:
+        raise WorkloadIdentityError("S3 credentials are unavailable") from None

--- a/backend/app/services/audit_log.py
+++ b/backend/app/services/audit_log.py
@@ -499,25 +499,28 @@ _s3 = None
 
 def _s3_client():
     """Dedicated audit-storage client. Uses the ``audit.*`` credentials when
-    set, otherwise falls back to the system S3 connection (see
+    set in standalone mode, otherwise shares the selected runtime session (see
     ``AuditSettings``). Built once and cached. We never need Delete on this
     client — only PutObject — so the bucket credential can be write-only.
 
     Note we don't reuse the `s3_adapter.put_bytes/get_bytes` primitives:
     those are bound to the single `settings.s3_bucket` on the shared
     file-store client, whereas audit must target a *different* bucket on a
-    *credential-isolated* client. We share only the boto-config via
-    `make_client` and issue `put_object` directly."""
+    client. Standalone can use a credential-isolated `make_client`; managed
+    uploads share the refreshable workload identity and its bucket policy."""
     global _s3
     if _s3 is None:
         from app.services.adapters import s3_adapter  # boto3 imported lazily
         a = settings.audit
-        _s3 = s3_adapter.make_client(
-            a.endpoint_url or settings.s3_endpoint_url,
-            a.access_key or settings.s3_access_key,
-            a.secret_key or settings.s3_secret_key,
-            a.region or settings.s3_region,
-        )
+        endpoint = a.endpoint_url or settings.s3_endpoint_url
+        region = a.region or settings.s3_region
+        if a.access_key or a.secret_key:
+            _s3 = s3_adapter.make_client(
+                endpoint, a.access_key or settings.s3_access_key,
+                a.secret_key or settings.s3_secret_key, region,
+            )
+        else:
+            _s3 = s3_adapter.session_client(endpoint, region)
     return _s3
 
 

--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -451,9 +451,9 @@ class FileService:
             "uri": file_uri(vault_name, str(file_id), collection=collection_path),
             "vault": vault_name,
             "collection": collection_path or None,
-            "upload_url": presigned_url,
+            "upload_url": presigned_url.url,
             "s3_key": s3_key,
-            "expires_in": _PRESIGN_UPLOAD_TTL,
+            "expires_in": presigned_url.expires_in,
             "deduplicated": deduplicated,
         }
 
@@ -542,8 +542,8 @@ class FileService:
             "name": row["name"],
             "mime_type": upload_mime_type,
             "replacement_id": str(replacement_id),
-            "upload_url": upload_url,
-            "expires_in": _PRESIGN_UPLOAD_TTL,
+            "upload_url": upload_url.url,
+            "expires_in": upload_url.expires_in,
             "current_content_hash": row.get("content_hash"),
             "current_version": current_version,
             "unchanged": False,
@@ -984,7 +984,7 @@ class FileService:
         return {
             "kind": "file",
             "name": row["name"],
-            "download_url": presigned_url,
+            "download_url": presigned_url.url,
             "mime_type": row["mime_type"],
             "size_bytes": row["size_bytes"],
             "content_hash": row["content_hash"],
@@ -992,7 +992,7 @@ class FileService:
             "etag": row["etag"],
             "storage_version": row["storage_version"],
             "version": _file_version(row),
-            "expires_in": _PRESIGN_DOWNLOAD_TTL,
+            "expires_in": presigned_url.expires_in,
         }
 
     async def list_files(

--- a/backend/app/services/index_service.py
+++ b/backend/app/services/index_service.py
@@ -435,7 +435,10 @@ async def _embed_call(
         caller must not fan the same denied batch out into per-item calls.
     `detail` is a short human-readable string suffix for logs/errors.
     """
-    headers = model_gateway.request_headers(settings.embed_api_key)
+    try:
+        headers = model_gateway.request_headers(settings.embed_api_key)
+    except model_gateway.WorkloadIdentityError:
+        return "transient", None, "Workload identity is unavailable"
     # Send `dimensions` so MRL-capable models (qwen3-embedding-8b native
     # 4096, text-embedding-3-* native 3072) truncate to the deployed
     # vector schema dim. Native-dim models (bge-m3@1024) accept it as a

--- a/backend/app/services/lifecycle.py
+++ b/backend/app/services/lifecycle.py
@@ -184,6 +184,12 @@ def _validate_required_settings() -> None:
 async def init_storage() -> None:
     """Initialize DB schema/migrations and eagerly construct vector-store driver."""
     _validate_required_settings()
+    if settings.model_api_governance_mode == "platform_hard":
+        from app.services.adapters import s3_adapter
+
+        # Provisioning is owned by the managed control plane. Never become
+        # ready with an absent/inaccessible bucket or unusable STS identity.
+        await asyncio.to_thread(s3_adapter.ensure_bucket, settings.s3_bucket)
     await pre_migration_revision_authority_guard()
     await init_db()
     logger.info("Database initialized")
@@ -374,7 +380,7 @@ def start_workers(*, include_api_local: bool = True) -> None:
     # s3_delete_worker drains s3_delete_outbox into S3 deletes. Only
     # makes sense when S3 is configured; otherwise file uploads are
     # disabled altogether and the outbox stays empty forever.
-    if settings.s3_endpoint_url:
+    if settings.object_storage_enabled:
         asset_gc_worker.start()
         s3_delete_worker.start()
         started.append("asset_gc_worker")
@@ -394,7 +400,9 @@ def start_workers(*, include_api_local: bool = True) -> None:
             "metadata_worker disabled (external_git_enabled=false; it only "
             "fills metadata on external_git mirror imports)"
         )
-    elif settings.llm_base_url and settings.llm_api_key:
+    elif settings.llm_base_url and (
+        settings.llm_api_key or settings.model_api_governance_mode == "platform_hard"
+    ):
         metadata_worker.start()
         started.append("metadata_worker")
     else:

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -66,7 +66,10 @@ async def chat_json(
     }
     if disable_reasoning:
         payload["reasoning"] = {"enabled": False}
-    headers = model_gateway.request_headers(settings.llm_api_key)
+    try:
+        headers = model_gateway.request_headers(settings.llm_api_key)
+    except model_gateway.WorkloadIdentityError:
+        raise LLMError("Workload identity is unavailable") from None
 
     client = http_pool.get_client()
     resp = await client.post(

--- a/backend/app/services/model_gateway.py
+++ b/backend/app/services/model_gateway.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import uuid
 
 from app.config import settings
+from app.services.workload_identity import WorkloadIdentityError, read_projected_token
 
 
 def request_headers(api_key: str) -> dict[str, str]:
@@ -14,8 +15,12 @@ def request_headers(api_key: str) -> dict[str, str]:
     the same call reuses the header map, while a distinct call gets a new ID.
     """
     headers: dict[str, str] = {}
-    if api_key:
-        headers["Authorization"] = f"Bearer {api_key}"
     if settings.model_api_governance_mode == "platform_hard":
+        if api_key:
+            raise WorkloadIdentityError("Static model API keys are forbidden in platform_hard mode")
+        token = read_projected_token(settings.platform_gateway_token_file)
+        headers["Authorization"] = f"Bearer {token}"
         headers["Idempotency-Key"] = str(uuid.uuid4())
+    elif api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
     return headers

--- a/backend/app/services/rerank_service.py
+++ b/backend/app/services/rerank_service.py
@@ -55,7 +55,7 @@ async def rerank(
 
     base_url = (settings.rerank_base_url or settings.llm_base_url).rstrip("/")
     api_key = settings.rerank_api_key or settings.llm_api_key
-    if not api_key:
+    if not api_key and settings.model_api_governance_mode != "platform_hard":
         raise RerankError("no API key configured (rerank_api_key / llm_api_key)")
 
     payload: dict[str, object] = {
@@ -76,6 +76,8 @@ async def rerank(
         )
         resp.raise_for_status()
         body = resp.json()
+    except model_gateway.WorkloadIdentityError:
+        raise RerankError("Workload identity is unavailable") from None
     except (httpx.ConnectError, httpx.HTTPStatusError,
             httpx.TimeoutException, httpx.UnsupportedProtocol) as e:
         raise RerankError(f"rerank HTTP call failed: {e}") from e

--- a/backend/app/services/workload_identity.py
+++ b/backend/app/services/workload_identity.py
@@ -1,0 +1,26 @@
+"""Read rotating projected tokens without retaining or logging their values."""
+
+from pathlib import Path
+
+from app.exceptions import AKBError
+
+_MAX_TOKEN_BYTES = 64 * 1024
+
+
+class WorkloadIdentityError(AKBError):
+    def __init__(self, message: str = "Workload identity is unavailable"):
+        super().__init__(message, status_code=503)
+
+
+def read_projected_token(path: str) -> str:
+    # Kubernetes atomically replaces symlinks when it rotates a projection.
+    # Open the configured path on each call, never a cached/resolved handle.
+    try:
+        with Path(path).open("rb") as stream:
+            raw = stream.read(_MAX_TOKEN_BYTES + 1)
+        token = raw.decode("ascii").strip()
+    except (OSError, UnicodeError, ValueError):
+        raise WorkloadIdentityError() from None
+    if len(raw) > _MAX_TOKEN_BYTES or not token or any(c.isspace() or not c.isprintable() for c in token):
+        raise WorkloadIdentityError()
+    return token

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akb"
-version = "0.14.2"
+version = "0.14.3"
 description = "Agent Knowledge Base - Organizational Memory for Agents"
 requires-python = ">=3.14"
 license = "BUSL-1.1"
@@ -28,6 +28,9 @@ dependencies = [
     "cryptography==48.0.0",
     "bcrypt==5.0.0",
     "boto3==1.43.23",
+    # Atomic refresh snapshots and request-scoped signing use botocore's
+    # credential hooks; pin the already-locked runtime for pip installs too.
+    "botocore==1.43.27",
     "qdrant-client==1.18.0",
     "kiwipiepy==0.23.1",
     "redis==8.0.0",

--- a/backend/tests/concurrency/test_invariants_unit.py
+++ b/backend/tests/concurrency/test_invariants_unit.py
@@ -398,7 +398,8 @@ async def test_inv7_delete_vault_no_orphan_chunks(pool, tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_inv7b_delete_vault_file_outbox_with_s3(pool, tmp_path, monkeypatch):
+@pytest.mark.parametrize("native_cloud", [False, True])
+async def test_inv7b_delete_vault_file_outbox_with_s3(pool, tmp_path, monkeypatch, native_cloud):
     """When S3 is configured, delete_vault records both durable outboxes.
 
     The file ids must reach the vector outbox before the metadata cascade, and
@@ -415,7 +416,8 @@ async def test_inv7b_delete_vault_file_outbox_with_s3(pool, tmp_path, monkeypatc
     from app.services import access_service
 
     monkeypatch.setattr(settings, "git_storage_path", str(tmp_path / "vaults"))
-    monkeypatch.setattr(settings, "s3_endpoint_url", "http://stub-s3:9000")
+    monkeypatch.setattr(settings, "s3_endpoint_url", "" if native_cloud else "http://stub-s3:9000")
+    monkeypatch.setattr(settings, "s3_auth_mode", "default_chain" if native_cloud else "static")
     try:
         get_role_sync()
     except RuntimeError:

--- a/backend/tests/test_file_idempotent_upload_unit.py
+++ b/backend/tests/test_file_idempotent_upload_unit.py
@@ -377,7 +377,7 @@ async def test_file_initiation_serializes_with_a_concurrent_vault_delete(
     monkeypatch.setattr(
         fs.s3_adapter,
         "presign_put",
-        lambda key, **_kwargs: f"https://storage.invalid/{key}",
+        lambda key, **_kwargs: fs.s3_adapter.PresignedURL(f"https://storage.invalid/{key}", 3600),
     )
 
     upload = asyncio.create_task(fs.FileService().initiate_upload(
@@ -609,7 +609,7 @@ async def test_file_initiation_does_not_wait_for_same_key_cleanup(
     monkeypatch.setattr(
         fs.s3_adapter,
         "presign_put",
-        lambda key, **_kwargs: f"https://storage.invalid/{key}",
+        lambda key, **_kwargs: fs.s3_adapter.PresignedURL(f"https://storage.invalid/{key}", 3600),
     )
 
     async with pool.acquire() as cleanup_conn:

--- a/backend/tests/test_file_replace_unit.py
+++ b/backend/tests/test_file_replace_unit.py
@@ -222,7 +222,10 @@ async def test_initiate_replace_schedules_abandoned_staging_cleanup(monkeypatch)
 
     monkeypatch.setattr(fs.vault_files_repo, "find_by_id", _find)
     monkeypatch.setattr(fs.s3_adapter, "ensure_bucket", lambda _bucket: None)
-    monkeypatch.setattr(fs.s3_adapter, "presign_put", lambda *_args, **_kwargs: "https://upload.test")
+    monkeypatch.setattr(
+        fs.s3_adapter, "presign_put",
+        lambda *_args, **_kwargs: fs.s3_adapter.PresignedURL("https://upload.test", 123),
+    )
     monkeypatch.setattr(fs, "_enqueue_s3_delete", _enqueue)
 
     result = await service.initiate_replace(
@@ -234,6 +237,7 @@ async def test_initiate_replace_schedules_abandoned_staging_cleanup(monkeypatch)
 
     assert result["unchanged"] is False
     assert result["upload_url"] == "https://upload.test"
+    assert result["expires_in"] == 123
     assert scheduled == [
         (
             fs._replacement_staging_key(
@@ -244,6 +248,46 @@ async def test_initiate_replace_schedules_abandoned_staging_cleanup(monkeypatch)
             fs._REPLACEMENT_STAGING_DELETE_DELAY,
         )
     ]
+
+
+async def test_upload_response_reports_actual_signing_lifetime(monkeypatch):
+    service, _pool = await _service(monkeypatch)
+
+    async def allowed(*_args, **_kwargs):
+        return True
+
+    async def inserted(_conn, **kwargs):
+        return kwargs["file_id"]
+
+    monkeypatch.setattr(fs, "lock_vault_for_child_write", allowed)
+    monkeypatch.setattr(fs.vault_files_repo, "s3_key_available_for_registration", allowed)
+    monkeypatch.setattr(fs.vault_files_repo, "insert_or_adopt", inserted)
+    monkeypatch.setattr(fs.s3_adapter, "ensure_bucket", lambda _bucket: None)
+    monkeypatch.setattr(
+        fs.s3_adapter, "presign_put",
+        lambda *_args, **_kwargs: fs.s3_adapter.PresignedURL("https://upload.test", 234),
+    )
+    result = await service.initiate_upload(
+        "team", _row()["vault_id"], "", "test.bin", actor_id="tester",
+    )
+    assert result["upload_url"] == "https://upload.test"
+    assert result["expires_in"] == 234
+
+
+async def test_download_response_reports_actual_signing_lifetime(monkeypatch):
+    service, _pool = await _service(monkeypatch)
+
+    async def find(*_args):
+        return {**_row(), "upload_state": "confirmed", "hash_algorithm": "sha256"}
+
+    monkeypatch.setattr(fs.vault_files_repo, "find_by_id", find)
+    monkeypatch.setattr(
+        fs.s3_adapter, "presign_get",
+        lambda *_args, **_kwargs: fs.s3_adapter.PresignedURL("https://download.test", 345),
+    )
+    result = await service.get_download_url(_row()["vault_id"], str(_row()["id"]))
+    assert result["download_url"] == "https://download.test"
+    assert result["expires_in"] == 345
 
 
 async def test_confirm_replace_switches_metadata_only_after_locked_recheck(monkeypatch):

--- a/backend/tests/test_lifecycle_init_storage_git_composition_unit.py
+++ b/backend/tests/test_lifecycle_init_storage_git_composition_unit.py
@@ -7,10 +7,30 @@ import uuid
 import pytest
 
 from app.config import Settings
+from app.exceptions import AKBError
+from tests.test_workload_identity_config_unit import managed_values
 
 
 _DATABASE_ID = uuid.UUID("11111111-1111-4111-8111-111111111111")
 _IMAGE_DIGEST = "sha256:" + "a" * 64
+
+
+async def test_managed_missing_bucket_prevents_startup(monkeypatch, tmp_path):
+    from app.services import lifecycle
+    from app.services.adapters import s3_adapter
+
+    events = []
+    configured = Settings(**managed_values(git_storage_path=str(tmp_path / "vaults")))
+    _stub_init_storage_dependencies(monkeypatch, lifecycle, configured, events)
+
+    def missing_bucket(bucket):
+        assert bucket == configured.s3_bucket
+        raise AKBError("bucket is not provisioned", status_code=503)
+
+    monkeypatch.setattr(s3_adapter, "ensure_bucket", missing_bucket)
+    with pytest.raises(AKBError, match="not provisioned"):
+        await lifecycle.init_storage()
+    assert events == []
 
 
 def _settings(tmp_path, backend: str | None = None) -> Settings:

--- a/backend/tests/test_lifecycle_workers.py
+++ b/backend/tests/test_lifecycle_workers.py
@@ -72,6 +72,8 @@ def _settings(
         tokenizer_processes=2,
         bm25_recompute_interval_secs=3600,
         s3_endpoint_url=None,
+        object_storage_enabled=False,
+        model_api_governance_mode="external_metering",
         llm_base_url="http://llm.local/v1" if llm_configured else None,
         llm_api_key="sk-test" if llm_configured else None,  # pragma: allowlist secret
         redis_url=None,
@@ -79,6 +81,35 @@ def _settings(
         tool_usage=types.SimpleNamespace(enabled=False),
         role_sync_reconcile_interval_secs=0,
     )
+
+
+def test_managed_keyless_metadata_worker_starts(monkeypatch, tmp_path):
+    lifecycle = _import_lifecycle(monkeypatch, tmp_path)
+    started = []
+    _stub_workers(monkeypatch, lifecycle, started)
+    configured = _settings(external_git_enabled=True, llm_configured=True)
+    configured.llm_api_key = ""
+    configured.model_api_governance_mode = "platform_hard"
+    monkeypatch.setattr(lifecycle, "settings", configured)
+    lifecycle.start_workers()
+    assert "metadata_worker" in started
+
+
+def test_native_cloud_storage_starts_cleanup_without_custom_endpoint(monkeypatch, tmp_path):
+    from app.config import Settings
+
+    lifecycle = _import_lifecycle(monkeypatch, tmp_path)
+    started = []
+    _stub_workers(monkeypatch, lifecycle, started)
+    configured = _settings(external_git_enabled=False)
+    cloud = Settings(s3_auth_mode="default_chain")
+    configured.object_storage_enabled = cloud.object_storage_enabled
+    monkeypatch.setattr(lifecycle, "settings", configured)
+    monkeypatch.setattr(lifecycle.s3_delete_worker, "start", lambda: started.append("s3_delete"))
+    monkeypatch.setattr(lifecycle.asset_gc_worker, "start", lambda: started.append("asset_gc"))
+    lifecycle.start_workers()
+    assert "s3_delete" in started
+    assert "asset_gc" in started
 
 
 def test_start_workers_starts_poller_when_enabled(monkeypatch, tmp_path):

--- a/backend/tests/test_model_gateway_governance.py
+++ b/backend/tests/test_model_gateway_governance.py
@@ -6,7 +6,8 @@ import pytest
 from pydantic import ValidationError
 
 from app.config import Settings, settings
-from app.services import http_pool, index_service, llm_service, rerank_service
+from app.services import http_pool, index_service, llm_service, model_gateway, rerank_service
+from tests.test_workload_identity_config_unit import managed_values
 
 
 class _Response:
@@ -37,15 +38,18 @@ class _Client:
         return self.responses.pop(0)
 
 
-def _set_hard_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+def _set_hard_mode(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    token = tmp_path / "gateway-token"
+    token.write_text("projected-first\n")
+    monkeypatch.setattr(settings, "platform_gateway_token_file", str(token))
     monkeypatch.setattr(settings, "model_api_governance_mode", "platform_hard")
     monkeypatch.setattr(
         settings, "platform_gateway_base_url", "https://gateway.example/v1"
     )
     monkeypatch.setattr(settings, "embed_base_url", "https://gateway.example/v1")
-    monkeypatch.setattr(settings, "embed_api_key", "gw_test")  # pragma: allowlist secret
+    monkeypatch.setattr(settings, "embed_api_key", "")
     monkeypatch.setattr(settings, "llm_base_url", "https://gateway.example/v1")
-    monkeypatch.setattr(settings, "llm_api_key", "gw_test")  # pragma: allowlist secret
+    monkeypatch.setattr(settings, "llm_api_key", "")
     monkeypatch.setattr(settings, "rerank_enabled", True)
     monkeypatch.setattr(settings, "rerank_base_url", "")
     monkeypatch.setattr(settings, "rerank_api_key", "")
@@ -53,47 +57,28 @@ def _set_hard_mode(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def _assert_managed_idempotency_key(call: dict) -> None:
     value = call["headers"].get("Idempotency-Key")
+    assert call["headers"]["Authorization"] == "Bearer projected-first"
     assert value
     assert str(uuid.UUID(value)) == value
 
 
 def test_platform_hard_config_rejects_direct_or_uncredentialed_model_routes():
     with pytest.raises(ValidationError, match="embed_base_url"):
-        Settings(
-            model_api_governance_mode="platform_hard",
-            platform_gateway_base_url="https://gateway.example/v1",
-            embed_base_url="https://api.openai.com/v1",
-            embed_api_key="gw_test",  # pragma: allowlist secret
-        )
-
-    with pytest.raises(ValidationError, match="embed_api_key"):
-        Settings(
-            model_api_governance_mode="platform_hard",
-            platform_gateway_base_url="https://gateway.example/v1",
-            embed_base_url="https://gateway.example/v1/",
-        )
-
-    configured = Settings(
-        model_api_governance_mode="platform_hard",
+        Settings(**managed_values(embed_base_url="https://api.openai.com/v1"))
+    with pytest.raises(ValidationError, match="platform_gateway_token_file"):
+        Settings(**managed_values(platform_gateway_token_file=""))
+    configured = Settings(**managed_values(
         platform_gateway_base_url="https://gateway.example/v1/",
-        embed_base_url="https://gateway.example/v1",
-        embed_api_key="gw_test",  # pragma: allowlist secret
-        llm_base_url="https://gateway.example/v1",
-        llm_api_key="gw_test",  # pragma: allowlist secret
-        rerank_enabled=True,
-    )
+        llm_base_url="https://gateway.example/v1", rerank_enabled=True,
+    ))
     assert configured.model_api_governance_mode == "platform_hard"
-
-    standalone = Settings(
-        model_api_governance_mode="external_metering",
-        embed_base_url="https://api.openai.com/v1",
-    )
+    standalone = Settings(embed_base_url="https://api.openai.com/v1")
     assert standalone.embed_base_url == "https://api.openai.com/v1"
 
 
 @pytest.mark.asyncio
-async def test_platform_hard_model_calls_send_one_caller_generated_identity(monkeypatch):
-    _set_hard_mode(monkeypatch)
+async def test_platform_hard_model_calls_send_one_caller_generated_identity(monkeypatch, tmp_path):
+    _set_hard_mode(monkeypatch, tmp_path)
 
     embed_client = _Client([_Response(200, {"data": [{"index": 0, "embedding": [1.0]}]})])
     status, embeddings, _ = await index_service._embed_call(embed_client, ["text"], 5.0)
@@ -144,9 +129,9 @@ async def test_external_metering_preserves_legacy_4xx_classification(monkeypatch
 @pytest.mark.asyncio
 @pytest.mark.parametrize("status_code", [401, 402, 403, 404, 409, 422, 428])
 async def test_embedding_governance_rejection_does_not_fan_out_batch(
-    monkeypatch, status_code
+    monkeypatch, status_code, tmp_path
 ):
-    _set_hard_mode(monkeypatch)
+    _set_hard_mode(monkeypatch, tmp_path)
     client = _Client([_Response(status_code)])
     monkeypatch.setattr(http_pool, "get_client", lambda: client)
 
@@ -157,8 +142,8 @@ async def test_embedding_governance_rejection_does_not_fan_out_batch(
 
 
 @pytest.mark.asyncio
-async def test_chat_budget_denial_remains_deferred_instead_of_abandoned(monkeypatch):
-    _set_hard_mode(monkeypatch)
+async def test_chat_budget_denial_remains_deferred_instead_of_abandoned(monkeypatch, tmp_path):
+    _set_hard_mode(monkeypatch, tmp_path)
     client = _Client([_Response(402)])
     monkeypatch.setattr(http_pool, "get_client", lambda: client)
 
@@ -167,3 +152,46 @@ async def test_chat_budget_denial_remains_deferred_instead_of_abandoned(monkeypa
 
     assert not isinstance(caught.value, llm_service.LLMPermanentError)
     assert len(client.calls) == 1
+
+
+def test_gateway_reopens_rotated_projection_and_mints_distinct_request_ids(monkeypatch, tmp_path):
+    _set_hard_mode(monkeypatch, tmp_path)
+    first = model_gateway.request_headers("")
+    replacement = tmp_path / "replacement"
+    replacement.write_text("projected-second\n")
+    replacement.replace(tmp_path / "gateway-token")
+    second = model_gateway.request_headers("")
+    assert first["Authorization"] == "Bearer projected-first"
+    assert second["Authorization"] == "Bearer projected-second"
+    assert first["Idempotency-Key"] != second["Idempotency-Key"]
+
+
+@pytest.mark.parametrize("contents", ["", " \n", "injected\nheader", "x" * 65537])
+async def test_invalid_projected_token_never_sends_a_model_request(monkeypatch, tmp_path, contents):
+    _set_hard_mode(monkeypatch, tmp_path)
+    (tmp_path / "gateway-token").write_text(contents)
+    client = _Client([])
+    monkeypatch.setattr(http_pool, "get_client", lambda: client)
+    assert await index_service.generate_embeddings(["one", "two"]) == [[], []]
+    with pytest.raises(llm_service.LLMError, match="identity"):
+        await llm_service.chat_json(system="system", user="user")
+    with pytest.raises(rerank_service.RerankError, match="identity"):
+        await rerank_service.rerank("query", ["document"])
+    assert client.calls == []
+
+
+def test_gateway_missing_token_and_static_argument_fail_closed(monkeypatch, tmp_path):
+    from app.exceptions import AKBError
+
+    _set_hard_mode(monkeypatch, tmp_path)
+    with pytest.raises(AKBError, match="Static"):
+        model_gateway.request_headers("legacy-key")
+    (tmp_path / "gateway-token").unlink()
+    with pytest.raises(AKBError, match="identity"):
+        model_gateway.request_headers("")
+
+
+def test_standalone_headers_preserve_direct_provider_keys(monkeypatch):
+    monkeypatch.setattr(settings, "model_api_governance_mode", "external_metering")
+    assert model_gateway.request_headers("provider-fixture") == {"Authorization": "Bearer provider-fixture"}
+    assert model_gateway.request_headers("") == {}

--- a/backend/tests/test_s3_workload_identity_unit.py
+++ b/backend/tests/test_s3_workload_identity_unit.py
@@ -241,7 +241,8 @@ def test_standalone_static_presign_keeps_existing_keys(monkeypatch):
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "ambient-key")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "ambient-secret")
     monkeypatch.setattr(s3_adapter, "settings", Settings(
-        s3_endpoint_url="http://minio:9000", s3_access_key="local-key", s3_secret_key="local-fixture",
+        s3_endpoint_url="http://minio:9000", s3_access_key="local-key",
+        s3_secret_key="local-fixture",  # pragma: allowlist secret -- offline test fixture
     ))
     for name in ("_internal_client", "_presign_client", "_session"):
         monkeypatch.setattr(s3_adapter, name, None, raising=False)
@@ -287,8 +288,9 @@ def test_failed_mandatory_refresh_does_not_use_expired_session(storage):
 
 def test_standalone_audit_credentials_remain_isolated(monkeypatch, tmp_path):
     configured = Settings(
-        s3_endpoint_url="http://minio:9000", s3_access_key="file-key", s3_secret_key="file-fixture",
-        audit={"access_key": "audit-key", "secret_key": "audit-fixture"},
+        s3_endpoint_url="http://minio:9000", s3_access_key="file-key",
+        s3_secret_key="file-fixture",  # pragma: allowlist secret -- offline test fixture
+        audit={"access_key": "audit-key", "secret_key": "audit-fixture"},  # pragma: allowlist secret -- offline fixture
     )
     monkeypatch.delenv("AWS_PROFILE", raising=False)
     monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "missing-config"))

--- a/backend/tests/test_s3_workload_identity_unit.py
+++ b/backend/tests/test_s3_workload_identity_unit.py
@@ -1,0 +1,299 @@
+"""Real botocore STS serialization and SigV4 signing against an offline RGW."""
+
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+from botocore.awsrequest import AWSResponse
+from botocore.exceptions import ClientError
+from botocore.httpsession import URLLib3Session
+
+from app.config import Settings
+from app.exceptions import AKBError
+from app.services import audit_log
+from app.services.adapters import s3_adapter
+from tests.test_workload_identity_config_unit import managed_values
+
+
+class _Body:
+    def __init__(self, body):
+        self.body = body
+
+    def stream(self, **_kwargs):
+        yield self.body
+
+
+@pytest.fixture
+def storage(monkeypatch, tmp_path):
+    token = tmp_path / "rgw-token"
+    token.write_text("projected-first\n")
+    configured = Settings(**managed_values(
+        s3_web_identity_token_file=str(token),
+        s3_region="us-east-1", s3_public_url="https://public.example",
+        s3_bucket="tenant-files",
+    ))
+    monkeypatch.setattr(s3_adapter, "settings", configured)
+    monkeypatch.setattr(audit_log, "settings", configured)
+    for name in ("_internal_client", "_presign_client", "_session"):
+        monkeypatch.setattr(s3_adapter, name, None, raising=False)
+    monkeypatch.setattr(s3_adapter, "_bucket_verified", set())
+    monkeypatch.setattr(audit_log, "_s3", None)
+    # Deliberately hostile ambient values must never affect managed identity.
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "ambient-key")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "ambient-secret")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "ambient-session")
+    monkeypatch.setenv("AWS_ROLE_ARN", "arn:aws:iam:::role/wrong-tenant")
+    monkeypatch.setenv("AWS_WEB_IDENTITY_TOKEN_FILE", str(tmp_path / "missing"))
+    monkeypatch.setenv("AWS_PROFILE", "untrusted-missing-profile")
+    monkeypatch.setenv("AWS_ENDPOINT_URL_STS", "https://untrusted.example")
+    monkeypatch.setenv("AWS_ENDPOINT_URL_S3", "https://untrusted.example")
+    monkeypatch.setenv("AWS_EC2_METADATA_DISABLED", "true")
+
+    class Storage:
+        settings = configured
+        token_path = token
+        requests = []
+        exchanges = []
+        duration = 3600
+        reject = False
+
+    state = Storage()
+
+    def send(_self, request):
+        state.requests.append(request)
+        if urlsplit(request.url).hostname == "sts.example":
+            assert "Authorization" not in request.headers
+            params = parse_qs(request.body.decode() if isinstance(request.body, bytes) else request.body)
+            assert params["Action"] == ["AssumeRoleWithWebIdentity"]
+            assert params["RoleArn"] == [configured.s3_role_arn]
+            state.exchanges.append(params)
+            if state.reject:
+                return AWSResponse(request.url, 403, {}, _Body(
+                    b"<ErrorResponse><Error><Code>AccessDenied</Code><Message>rejected</Message></Error></ErrorResponse>"
+                ))
+            generation = len(state.exchanges)
+            expiry = (datetime.now(timezone.utc) + timedelta(seconds=state.duration)).isoformat()
+            payload = (
+                '<AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">'
+                '<AssumeRoleWithWebIdentityResult><Credentials>'
+                f'<AccessKeyId>ASIAFIXTURE{generation:06}</AccessKeyId>'
+                '<SecretAccessKey>offline-fixture-secret</SecretAccessKey>'
+                f'<SessionToken>temporary-session-{generation}</SessionToken><Expiration>{expiry}</Expiration>'
+                '</Credentials></AssumeRoleWithWebIdentityResult></AssumeRoleWithWebIdentityResponse>'
+            ).encode()
+            return AWSResponse(request.url, 200, {}, _Body(payload))
+        assert urlsplit(request.url).hostname == "storage.example"
+        return AWSResponse(request.url, 200, {}, _Body(b""))
+
+    monkeypatch.setattr(URLLib3Session, "send", send)
+    return state
+
+
+def _query(signed):
+    return parse_qs(urlsplit(signed.url).query)
+
+
+def test_managed_server_and_public_signer_share_refreshable_session(storage):
+    private = s3_adapter.client()
+    public = s3_adapter.presign_client()
+    assert private._request_signer._credentials is public._request_signer._credentials
+    s3_adapter.head("hello.bin")
+    assert storage.exchanges[0]["WebIdentityToken"] == ["projected-first"]
+    request = storage.requests[-1]
+    assert b"ASIAFIXTURE000001" in request.headers["Authorization"]
+    assert request.headers["X-Amz-Security-Token"] == b"temporary-session-1"
+    signed = s3_adapter.presign_put("hello.bin")
+    assert _query(signed)["X-Amz-Security-Token"] == ["temporary-session-1"]
+    assert urlsplit(signed.url).path == "/tenant-files/hello.bin"
+    assert urlsplit(signed.url).hostname == "public.example"
+    assert len(storage.exchanges) == 1
+
+
+def test_rotated_token_refreshes_both_existing_clients(storage):
+    s3_adapter.presign_get("before")
+    credentials = s3_adapter.client()._request_signer._credentials
+    storage.token_path.write_text("projected-second\n")
+    credentials._expiry_time = datetime.now(timezone.utc) - timedelta(seconds=1)
+    signed = s3_adapter.presign_put("after")
+    s3_adapter.head("after")
+    assert len(storage.exchanges) == 2
+    assert storage.exchanges[1]["WebIdentityToken"] == ["projected-second"]
+    assert _query(signed)["X-Amz-Security-Token"] == ["temporary-session-2"]
+    assert storage.requests[-1].headers["X-Amz-Security-Token"] == b"temporary-session-2"
+
+
+def test_presign_clamps_ttl_and_returns_actual_expiry(storage):
+    signed = s3_adapter.presign_get("download", ttl=7200)
+    assert 3500 <= signed.expires_in <= 3540
+    assert _query(signed)["X-Amz-Expires"] == [str(signed.expires_in)]
+    assert s3_adapter.presign_put("upload", ttl=30).expires_in == 30
+
+
+def test_signing_keeps_exact_snapshot_when_another_request_refreshes(storage):
+    public = s3_adapter.presign_client()
+    s3_adapter.presign_get("seed")
+    credentials = public._request_signer._credentials
+
+    def refresh_shared_generation(**_kwargs):
+        storage.token_path.write_text("projected-second")
+        credentials._expiry_time = datetime.now(timezone.utc) - timedelta(seconds=1)
+        credentials.get_frozen_credentials()
+
+    public.meta.events.register_first("before-sign.s3.GetObject", refresh_shared_generation)
+    signed = s3_adapter.presign_get("snapshot", ttl=7200)
+    assert len(storage.exchanges) == 2
+    assert _query(signed)["X-Amz-Security-Token"] == ["temporary-session-1"]
+    assert 3500 <= signed.expires_in <= 3540
+    assert credentials.token == "temporary-session-2"
+
+
+def test_concurrent_first_signers_share_one_exchange(storage):
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        signed = list(pool.map(lambda i: s3_adapter.presign_get(f"object-{i}"), range(16)))
+    assert len(storage.exchanges) == 1
+    assert all(_query(url)["X-Amz-Security-Token"] == ["temporary-session-1"] for url in signed)
+
+
+@pytest.mark.parametrize("failure", ["missing-token", "sts-denied", "near-expiry", "expired"])
+def test_unusable_identity_never_falls_back_to_ambient_keys(storage, failure):
+    if failure == "missing-token":
+        storage.token_path.unlink()
+    elif failure == "sts-denied":
+        storage.reject = True
+    else:
+        storage.duration = 30 if failure == "near-expiry" else -1
+    with pytest.raises(AKBError):
+        s3_adapter.presign_get("denied")
+
+
+def test_managed_audit_upload_uses_the_same_session(storage):
+    storage.settings.audit.bucket = "audit-files"
+    audit_client = audit_log._s3_client()
+    assert audit_client._request_signer._credentials is s3_adapter.client()._request_signer._credentials
+    audit_client.put_object(Bucket="audit-files", Key="audit/day.json", Body=b"{}")
+    assert storage.requests[-1].headers["X-Amz-Security-Token"] == b"temporary-session-1"
+
+
+def test_managed_static_client_factory_is_not_an_escape(storage):
+    with pytest.raises(AKBError):
+        s3_adapter.make_client("https://storage.example", "static", "static")
+
+
+@pytest.mark.parametrize("mode,managed,creates", [
+    ("static", False, True), ("default_chain", False, False), ("default_chain", True, False),
+])
+def test_bucket_creation_only_exists_for_standalone_static(monkeypatch, mode, managed, creates):
+    values = managed_values() if managed else {}
+    monkeypatch.setattr(s3_adapter, "settings", Settings(**{**values, "s3_auth_mode": mode}))
+    monkeypatch.setattr(s3_adapter, "_bucket_verified", set())
+
+    class Client:
+        created = []
+
+        def head_bucket(self, **kwargs):
+            raise ClientError({"Error": {"Code": "NoSuchBucket"}}, "HeadBucket")
+
+        def create_bucket(self, **kwargs):
+            self.created.append(kwargs["Bucket"])
+
+    client = Client()
+    monkeypatch.setattr(s3_adapter, "client", lambda: client)
+    if creates:
+        s3_adapter.ensure_bucket("tenant")
+        assert client.created == ["tenant"]
+    else:
+        with pytest.raises(AKBError):
+            s3_adapter.ensure_bucket("tenant")
+        assert client.created == []
+
+
+def test_bucket_verification_cache_is_per_bucket(monkeypatch):
+    seen = []
+
+    class Client:
+        def head_bucket(self, **kwargs):
+            seen.append(kwargs["Bucket"])
+
+    monkeypatch.setattr(s3_adapter, "_bucket_verified", set())
+    monkeypatch.setattr(s3_adapter, "client", lambda: Client())
+    for bucket in ("first", "second", "first"):
+        s3_adapter.ensure_bucket(bucket)
+    assert seen == ["first", "second"]
+
+
+def test_standalone_native_chain_uses_standard_environment(monkeypatch, tmp_path):
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "missing-config"))
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(tmp_path / "missing-credentials"))
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "cloud-fixture")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "cloud-fixture-secret")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "cloud-session")
+    monkeypatch.setattr(s3_adapter, "settings", Settings(s3_auth_mode="default_chain", s3_region="us-east-1"))
+    for name in ("_internal_client", "_presign_client", "_session"):
+        monkeypatch.setattr(s3_adapter, name, None, raising=False)
+    signed = s3_adapter.presign_get("native-cloud")
+    assert _query(signed)["X-Amz-Security-Token"] == ["cloud-session"]
+    assert signed.expires_in == 3600
+
+
+def test_standalone_static_presign_keeps_existing_keys(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "ambient-key")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "ambient-secret")
+    monkeypatch.setattr(s3_adapter, "settings", Settings(
+        s3_endpoint_url="http://minio:9000", s3_access_key="local-key", s3_secret_key="local-fixture",
+    ))
+    for name in ("_internal_client", "_presign_client", "_session"):
+        monkeypatch.setattr(s3_adapter, name, None, raising=False)
+    signed = s3_adapter.presign_put("static")
+    assert _query(signed)["X-Amz-Credential"][0].startswith("local-key/")
+    assert "X-Amz-Security-Token" not in _query(signed)
+    assert signed.expires_in == 3600
+
+
+def test_standalone_rgw_identity_needs_no_model_gateway(storage):
+    storage.settings.model_api_governance_mode = "external_metering"
+    storage.settings.platform_gateway_base_url = ""
+    storage.settings.platform_gateway_token_file = ""
+    signed = s3_adapter.presign_put("standalone-rgw")
+    assert _query(signed)["X-Amz-Security-Token"] == ["temporary-session-1"]
+
+
+def test_standalone_native_webidentity_provider_is_preserved(storage, monkeypatch, tmp_path):
+    monkeypatch.delenv("AWS_PROFILE")
+    for name in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"):
+        monkeypatch.delenv(name)
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "missing-config"))
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(tmp_path / "missing-credentials"))
+    monkeypatch.setenv("AWS_WEB_IDENTITY_TOKEN_FILE", str(storage.token_path))
+    monkeypatch.setenv("AWS_ROLE_ARN", storage.settings.s3_role_arn)
+    monkeypatch.setenv("AWS_ENDPOINT_URL_STS", "https://sts.example")
+    monkeypatch.setenv("AWS_ENDPOINT_URL_S3", "https://storage.example")
+    monkeypatch.setattr(s3_adapter, "settings", Settings(s3_auth_mode="default_chain", s3_region="us-east-1"))
+    signed = s3_adapter.presign_get("native-webidentity")
+    assert _query(signed)["X-Amz-Security-Token"] == ["temporary-session-1"]
+    assert 3500 <= signed.expires_in <= 3540
+
+
+def test_failed_mandatory_refresh_does_not_use_expired_session(storage):
+    s3_adapter.presign_get("before")
+    credentials = s3_adapter.client()._request_signer._credentials
+    credentials._expiry_time = datetime.now(timezone.utc) - timedelta(seconds=1)
+    storage.reject = True
+    with pytest.raises(AKBError):
+        s3_adapter.head("after")
+    assert all(urlsplit(request.url).hostname == "sts.example" for request in storage.requests)
+
+
+def test_standalone_audit_credentials_remain_isolated(monkeypatch, tmp_path):
+    configured = Settings(
+        s3_endpoint_url="http://minio:9000", s3_access_key="file-key", s3_secret_key="file-fixture",
+        audit={"access_key": "audit-key", "secret_key": "audit-fixture"},
+    )
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "missing-config"))
+    monkeypatch.setattr(s3_adapter, "settings", configured)
+    monkeypatch.setattr(audit_log, "settings", configured)
+    monkeypatch.setattr(audit_log, "_s3", None)
+    credentials = audit_log._s3_client()._request_signer._credentials.get_frozen_credentials()
+    assert credentials.access_key == "audit-key"

--- a/backend/tests/test_workload_identity_config_unit.py
+++ b/backend/tests/test_workload_identity_config_unit.py
@@ -1,0 +1,85 @@
+"""Managed identity rejects secret fallback; standalone stays independent."""
+
+import pytest
+from pydantic import ValidationError
+
+from app.config import Settings
+
+
+def managed_values(**overrides):
+    return {
+        "model_api_governance_mode": "platform_hard",
+        "platform_gateway_base_url": "https://gateway.example/v1",
+        "platform_gateway_token_file": "/var/run/identity/gateway/token",
+        "embed_base_url": "https://gateway.example/v1",
+        "s3_auth_mode": "default_chain",
+        "s3_endpoint_url": "https://storage.example",
+        "s3_sts_endpoint_url": "https://sts.example",
+        "s3_role_arn": "arn:aws:iam:::role/tenant-files",
+        "s3_web_identity_token_file": "/var/run/identity/rgw/token",
+        **overrides,
+    }
+
+
+def test_managed_profile_accepts_keyless_configuration():
+    configured = Settings(**managed_values())
+    assert configured.s3_auth_mode == "default_chain"
+    assert configured.object_storage_enabled
+
+
+@pytest.mark.parametrize("name", [
+    "platform_gateway_token_file", "s3_web_identity_token_file",
+    "s3_role_arn", "s3_sts_endpoint_url", "s3_endpoint_url",
+])
+def test_managed_profile_requires_explicit_identity_inputs(name):
+    with pytest.raises(ValidationError, match=name):
+        Settings(**managed_values(**{name: ""}))
+
+
+@pytest.mark.parametrize("name", [
+    "embed_api_key", "llm_api_key", "rerank_api_key", "s3_access_key", "s3_secret_key",
+])
+def test_managed_profile_rejects_static_keys_even_on_disabled_routes(name):
+    with pytest.raises(ValidationError, match=name):
+        Settings(**managed_values(**{name: "forbidden-fixture"}))
+
+
+@pytest.mark.parametrize("name", ["access_key", "secret_key"])
+def test_managed_profile_rejects_dedicated_audit_keys(name):
+    with pytest.raises(ValidationError, match=f"audit.{name}"):
+        Settings(**managed_values(audit={name: "forbidden-fixture"}))
+
+
+def test_managed_profile_rejects_static_auth_and_direct_routes():
+    with pytest.raises(ValidationError, match="s3_auth_mode"):
+        Settings(**managed_values(s3_auth_mode="static"))
+    with pytest.raises(ValidationError, match="llm_base_url"):
+        Settings(**managed_values(llm_base_url="https://provider.example/v1"))
+
+
+def test_managed_profile_allows_disabled_embedding_route():
+    assert Settings(**managed_values(embed_base_url="")).embed_base_url == ""
+
+
+@pytest.mark.parametrize("name", ["platform_gateway_token_file", "s3_web_identity_token_file"])
+def test_projected_token_paths_are_absolute(name):
+    with pytest.raises(ValidationError, match=name):
+        Settings(**managed_values(**{name: "relative/token"}))
+
+
+def test_standalone_static_and_native_cloud_storage_are_explicit():
+    disabled = Settings(embed_base_url="")
+    assert disabled.s3_auth_mode == "static"
+    assert not disabled.object_storage_enabled
+    static = Settings(s3_endpoint_url="http://minio:9000", s3_access_key="local", s3_secret_key="fixture")
+    assert static.object_storage_enabled
+    cloud = Settings(s3_auth_mode="default_chain", s3_region="us-east-1")
+    assert cloud.object_storage_enabled
+    assert not cloud.platform_gateway_token_file
+    with pytest.raises(ValidationError, match="s3_access_key"):
+        Settings(s3_auth_mode="default_chain", s3_access_key="not-selected")
+
+
+def test_explicit_standalone_rgw_identity_requires_complete_tuple():
+    with pytest.raises(ValidationError, match="s3_role_arn"):
+        Settings(s3_auth_mode="default_chain", s3_web_identity_token_file="/run/token")

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -8,12 +8,13 @@ resolution-markers = [
 
 [[package]]
 name = "akb"
-version = "0.14.2"
+version = "0.14.3"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },
     { name = "bcrypt" },
     { name = "boto3" },
+    { name = "botocore" },
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "gitpython" },
@@ -54,6 +55,7 @@ requires-dist = [
     { name = "bandit", extras = ["toml"], marker = "extra == 'dev'", specifier = "==1.9.4" },
     { name = "bcrypt", specifier = "==5.0.0" },
     { name = "boto3", specifier = "==1.43.23" },
+    { name = "botocore", specifier = "==1.43.27" },
     { name = "cryptography", specifier = "==48.0.0" },
     { name = "fastapi", specifier = "==0.136.3" },
     { name = "gitpython", specifier = "==3.1.50" },

--- a/config/app.yaml.example
+++ b/config/app.yaml.example
@@ -77,9 +77,12 @@ embed_dimensions: 1536
 
 # Standalone default keeps direct-provider routing. A managed akb-platform
 # deployment sets platform_hard plus the exact gateway URL; startup then rejects
-# any active embed/LLM/rerank route that points elsewhere or lacks a credential.
+# any active embed/LLM/rerank route that points elsewhere. Managed requests read
+# the projected token for every call; all model API-key fields must be blank.
+# See docs/managed-workload-identity.md for token projection and S3 configuration.
 model_api_governance_mode: external_metering  # external_metering | platform_hard
 platform_gateway_base_url: ""
+platform_gateway_token_file: ""
 
 # === LLM (optional) ===
 # Only used by metadata_worker to auto-tag external_git imports.
@@ -137,11 +140,19 @@ search_limit_max: 50
 vault_filter_enabled: false
 
 # === S3-compatible object storage (for vault file uploads) ===
-# Leave endpoints blank to disable file storage features.
+# static + blank endpoint disables object storage. default_chain enables native
+# cloud storage even without an endpoint; never set static key fields with it.
+s3_auth_mode: static # static | default_chain
 s3_endpoint_url: "http://minio:9000" # local Compose; blank disables object storage
 s3_public_url: "http://localhost:9000" # browser endpoint; change for remote access
 s3_bucket: akb-files
 s3_region: ""
+# Explicit WebIdentity (required in platform_hard): configured token → STS only,
+# without AWS environment/profile credential fallback. The bucket must exist.
+# Standalone default_chain can leave all three blank for the native AWS chain.
+s3_web_identity_token_file: ""
+s3_role_arn: ""
+s3_sts_endpoint_url: ""
 
 # Hidden document images follow live Markdown references. Removed/deleted
 # images remain available only to matching Git revisions for this window;
@@ -396,6 +407,8 @@ redis_stream_maxlen: 100000
 #   # duties point these at a SEPARATE account with a WRITE-ONLY key
 #   # (PutObject, no Delete) — AKB never deletes bucket objects, so a
 #   # compromise of the primary S3 key can't erase the audit trail.
+#   # In platform_hard, access_key/secret_key must stay blank. The uploader uses
+#   # the workload session; its role must authorize PutObject on the audit bucket.
 #   endpoint_url: ""
 #   access_key: ""
 #   secret_key: ""

--- a/config/secret.yaml.example
+++ b/config/secret.yaml.example
@@ -52,21 +52,23 @@ sso_session_epoch: null
 sso_browser_session_encryption_key: ""
 
 # === Embedding API key (required) ===
-# Provider key for `embed_base_url` in app.yaml. In platform_hard mode this is
-# the workload's platform gateway credential, not the upstream provider key.
+# Provider key for `embed_base_url` in app.yaml. Forbidden in platform_hard;
+# managed workloads authenticate with the projected Gateway token instead.
 embed_api_key: ""
 
 # === LLM API key (optional) ===
-# Only needed if `llm_base_url` in app.yaml is set. In platform_hard mode this
-# is the workload's platform gateway credential.
+# Only needed if `llm_base_url` requires a provider key. Forbidden in
+# platform_hard, which uses platform_gateway_token_file.
 llm_api_key: ""
 
 # === Reranker API key (optional) ===
 # Only needed if `rerank_enabled: true`. Blank → falls back to llm_api_key.
+# Forbidden in platform_hard.
 rerank_api_key: ""
 
 # === S3 credentials (optional) ===
-# Only needed if `s3_endpoint_url` in app.yaml is set.
+# Only used with s3_auth_mode: static. Remove both values for default_chain
+# (including every platform_hard deployment); static fallback is rejected.
 # Local Compose MinIO credentials only; replace for any external object store.
 s3_access_key: "akb-local"
 s3_secret_key: "akb-local-secret" # pragma: allowlist secret -- public local Compose default only

--- a/deploy/helm/akb/templates/config.yaml
+++ b/deploy/helm/akb/templates/config.yaml
@@ -22,8 +22,11 @@ data:
     rerank_provider: {{ .Values.app.rerank.provider }}
     rerank_model: {{ .Values.app.rerank.model }}
     rerank_prefetch: {{ .Values.app.rerank.prefetch }}
+    s3_auth_mode: {{ .Values.app.objectStorage.authMode | quote }}
     s3_endpoint_url: {{ .Values.app.objectStorage.endpointUrl | quote }}
+    s3_public_url: {{ .Values.app.objectStorage.publicUrl | quote }}
     s3_bucket: {{ .Values.app.objectStorage.bucket }}
+    s3_region: {{ .Values.app.objectStorage.region | quote }}
     auth_mode: {{ ternary "sso" "local" .Values.sso.enabled }}
     jwt_algorithm: RS256
     {{- if .Values.sso.enabled }}

--- a/deploy/helm/akb/values.yaml
+++ b/deploy/helm/akb/values.yaml
@@ -36,8 +36,11 @@ app:
     model: cohere/rerank-v3.5
     prefetch: 30
   objectStorage:
+    authMode: static # static | default_chain; default_chain must omit static keys
     endpointUrl: ""
+    publicUrl: ""
     bucket: akb-files
+    region: ""
   vectorStore:
     driver: pgvector
     dsn: ""

--- a/docs/managed-workload-identity.md
+++ b/docs/managed-workload-identity.md
@@ -1,0 +1,98 @@
+# Workload identity for Gateway and object storage
+
+AKB supports two deployment profiles. Standalone `external_metering` keeps
+direct model-provider credentials and either static S3 credentials or the
+native AWS credential chain. `platform_hard` requires projected workload
+tokens for both the model Gateway and S3 STS; it rejects static model, S3,
+and audit-storage credentials at startup.
+
+## Managed configuration
+
+The control plane provisions the bucket and role before starting AKB. It
+mounts two projected ServiceAccount tokens with distinct audiences and writes
+the following non-secret settings to `app.yaml`:
+
+```yaml
+model_api_governance_mode: platform_hard
+platform_gateway_base_url: https://gateway.example/v1
+platform_gateway_token_file: /var/run/akb-identity/gateway/token
+embed_base_url: https://gateway.example/v1
+embed_model: text-embedding-3-small
+embed_dimensions: 1536
+
+s3_auth_mode: default_chain
+s3_endpoint_url: https://storage.example
+s3_public_url: https://files.example
+s3_bucket: tenant-files
+s3_region: us-east-1
+s3_sts_endpoint_url: https://storage.example
+s3_role_arn: arn:aws:iam:::role/tenant-files
+s3_web_identity_token_file: /var/run/akb-identity/rgw/token
+```
+
+Every enabled embedding, chat, and rerank route must use the declared Gateway
+base URL. A blank embedding or chat URL disables that route. Each logical
+request reopens the Gateway token path and sends its current contents as the
+Bearer token. Transport retries retain that request's idempotency key. Missing,
+empty, or invalid token files prevent the outbound request.
+
+Despite the `default_chain` selection, the managed profile installs only the
+configured WebIdentity provider. It never selects AWS environment credentials,
+shared profiles, instance metadata, or a different STS endpoint. AKB exchanges
+the RGW token using unsigned `AssumeRoleWithWebIdentity`, caches the resulting
+temporary session in memory, and reopens the token file when refreshing it.
+Both S3 endpoint clients share this session. The token path may use Kubernetes
+projection symlinks; no file handle is retained between reads.
+
+S3 clients use SigV4 and custom endpoints use path-style addressing. Browser
+upload/download URLs contain the temporary session token. Each URL is signed
+with a fixed credential snapshot and its lifetime is capped at that snapshot's
+remaining lifetime minus 60 seconds. API `expires_in` reports the actual cap.
+Expired sessions and sessions with less than that safety margin cannot produce
+a URL. See the [S3 presigned URL lifetime contract](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html).
+
+Managed startup performs `HeadBucket` and fails if identity exchange or bucket
+access fails. It never creates a bucket. The role must authorize the required
+object operations and `HeadBucket` on the provisioned bucket. RGW OIDC trust,
+audience, role policy, and STS support are control-plane responsibilities; see
+the [Ceph STS documentation](https://docs.ceph.com/en/latest/radosgw/STS/).
+
+Remove `embed_api_key`, `llm_api_key`, `rerank_api_key`, `s3_access_key`, and
+`s3_secret_key` from managed configuration, including `secret.yaml`. Dedicated
+`audit.access_key` and `audit.secret_key` are also forbidden. An enabled audit
+uploader uses the workload session, so the role must separately grant
+`PutObject` on its pre-provisioned audit bucket. Leave `audit.bucket` blank for
+file-only audit collection.
+
+The process needs no Kubernetes API permissions. Token audiences, ServiceAccount
+binding, projections, role/bucket policy, and the public endpoint's support for
+temporary-session presigned GET/PUT must be configured by the deployment owner.
+Ordinary AKB database and application secrets remain separate from these
+upstream identity settings.
+
+## Standalone compatibility
+
+Existing MinIO/static configurations keep `s3_auth_mode: static` (the default)
+with `s3_access_key` and `s3_secret_key` in `secret.yaml`. This profile retains
+bucket creation on a missing bucket. Static mode never substitutes ambient AWS
+credentials for empty configured keys.
+
+For native cloud credentials, set `s3_auth_mode: default_chain` and remove both
+static key fields. Leave all three explicit WebIdentity fields blank to use
+the [native Boto3 credential providers](https://docs.aws.amazon.com/boto3/latest/guide/credentials.html),
+including cloud roles and AWS WebIdentity configuration. `s3_endpoint_url` and
+`s3_public_url` may both be blank for AWS S3; set `s3_region` to the bucket's
+region. This explicitly enables storage and cleanup workers without requiring
+a custom endpoint. Buckets must already exist. Temporary credentials with a
+known expiration receive the same presign cap; externally supplied session
+tokens whose provider does not expose an expiration remain subject to the
+provider's actual expiry.
+
+A standalone RGW installation can also select `default_chain` and supply the
+complete `s3_web_identity_token_file`, `s3_role_arn`, `s3_sts_endpoint_url` tuple.
+That selects the explicit RGW provider without requiring a model Gateway.
+
+The standalone Helm chart exposes `app.objectStorage.authMode`, `endpointUrl`,
+`publicUrl`, `bucket`, and `region`. Native AWS role projection follows the
+cluster's normal ServiceAccount configuration. Managed control planes provide
+the complete `app.yaml` and the two audience-specific token projections.


### PR DESCRIPTION
## Change

Managed deployments can authenticate model requests with rotating projected tokens and access object storage through STS web identity. Static upstream credentials are rejected in the managed profile. Server requests and public presigning share refreshable credentials; signed URL expiration is bounded by the exact credential generation used to sign it.

Standalone static credentials and native cloud credential providers remain supported. Managed storage verifies provisioned buckets without granting bucket creation. The backend version is 0.14.3.

## Validation

- Repository check completed, including backend static analysis, frontend tests, SDK checks and publication checks.
- Backend suite: 2,653 passed; 664 skipped in the configured suite; 63 relevant PostgreSQL tests separately passed on a real database.
- After rebasing onto the latest audit change: 46 affected audit, credential-provider and managed configuration tests passed.
- Actual RGW STS exchange and public browser PUT/GET passed; incorrect origins were denied by CORS. Presigned lifetime was clamped to the temporary session. An expired 900-second session was denied by the storage service.
- Reviewed credential fallback, concurrent refresh, token rotation, startup validation and standalone compatibility.
