### PR TITLE
Protect document edits with OCC and recoverable drafts

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -6393,7 +6393,7 @@
         "filename": "frontend/src/pages/__tests__/document-view-toggle.test.tsx",
         "hashed_secret": "6c688927eafd673c7d9194b46b2b88e096e6c9f7",
         "is_verified": false,
-        "line_number": 92,
+        "line_number": 97,
         "is_secret": false
       }
     ],

--- a/frontend/e2e/document-edit-recovery.spec.ts
+++ b/frontend/e2e/document-edit-recovery.spec.ts
@@ -207,19 +207,64 @@ test.describe("document edit recovery mock contract", () => {
     page,
     request,
   }) => {
+    const draftTitle = "AC7-TITLE-248";
+    const markerOne = "AC7-ORIGINAL-ONE-248";
+    const markerTwo = "AC7-ORIGINAL-TWO-248";
+    const draftBody = `${markerOne}\n\n${markerTwo}\n`;
     const recovery = await fixture(request);
     await page.goto(recovery.identity!.start_url!);
-    await page.getByRole("textbox", { name: "Document body (markdown)" }).fill("Draft that will expire");
+    await page.getByRole("textbox", { name: "Document title" }).fill(draftTitle);
+    const editor = page.getByRole("textbox", { name: "Document body (markdown)" });
+    await editor.fill(draftBody);
+    await expect(page.getByText("Draft saved locally")).toBeVisible();
     await operate(request, recovery.operations!.expire_draft);
+    await page.waitForTimeout(500);
+    let beforeUnloadAccepted = false;
+    page.once("dialog", async (dialog) => {
+      expect(dialog.type()).toBe("beforeunload");
+      beforeUnloadAccepted = true;
+      await dialog.accept();
+    });
     await page.reload();
+    expect(beforeUnloadAccepted).toBe(true);
+    await page.waitForTimeout(3_000);
+    await expect(page.getByRole("textbox", { name: "Document title" })).toHaveValue(draftTitle);
+    await expect(editor).toContainText(markerOne);
+    await expect(editor).toContainText(markerTwo);
+    await expect(page.getByText("Local draft restored")).toHaveCount(0);
     await expect(page.getByText("This draft has expired")).toBeVisible();
+    await expect(page.getByText(/attached images are not guaranteed/)).toBeVisible();
     const expiredCopy = page.getByRole("button", { name: "Copy expired Markdown" });
     await expect(expiredCopy).toBeVisible();
     await expectInstantKeyboardFocus(expiredCopy);
+    await page.context().grantPermissions(["clipboard-read", "clipboard-write"], {
+      origin: new URL(page.url()).origin,
+    });
+    await expiredCopy.click();
+    await expect
+      .poll(async () => page.evaluate(() => navigator.clipboard.readText()))
+      .toBe(draftBody);
+    await page.evaluate(() => {
+      const target = document.createElement("textarea");
+      target.dataset.clipboardPasteTarget = "true";
+      target.style.cssText = "position:fixed;left:0;top:0;width:240px;height:40px;";
+      document.body.append(target);
+    });
+    const pasteTarget = page.locator("[data-clipboard-paste-target]");
+    await pasteTarget.focus();
+    await pasteTarget.press(process.platform === "darwin" ? "Meta+V" : "Control+V");
+    await expect(pasteTarget).toHaveValue(draftBody);
 
     await page.getByRole("button", { name: "Cancel" }).click();
     await page.getByRole("button", { name: "Discard changes" }).click();
     await expect(page.locator("#doc-title")).toHaveText("Recovery document");
+    await page.getByRole("button", { name: "Edit" }).click();
+    await expect(page.getByRole("textbox", { name: "Document title" })).toHaveValue("Recovery document");
+    const reopenedEditor = page.getByRole("textbox", { name: "Document body (markdown)" });
+    await expect(reopenedEditor).toContainText("The original body is safe to edit.");
+    await expect(reopenedEditor).not.toContainText(markerOne);
+    await expect(reopenedEditor).not.toContainText(markerTwo);
+    await expect(page.getByText("This draft has expired")).toHaveCount(0);
     const state = await operate(request, recovery.operations!.state);
     expect(state.scenario).toBe("document-edit-recovery");
   });

--- a/frontend/e2e/document-edit-recovery.spec.ts
+++ b/frontend/e2e/document-edit-recovery.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type APIRequestContext } from "@playwright/test";
+import { expect, test, type APIRequestContext, type Locator } from "@playwright/test";
 
 type MockOperation = {
   method: "GET" | "POST";
@@ -34,6 +34,31 @@ test.describe("document edit recovery mock contract", () => {
     return recovery!;
   }
 
+  async function expectInstantKeyboardFocus(button: Locator) {
+    await button.evaluate((element) => {
+      const sentinel = document.createElement("span");
+      sentinel.tabIndex = 0;
+      sentinel.dataset.focusTestSentinel = "true";
+      sentinel.style.cssText = "position:fixed;width:1px;height:1px;opacity:0;";
+      element.before(sentinel);
+    });
+    await button.page().locator("[data-focus-test-sentinel]").last().focus();
+    await button.page().keyboard.press("Tab");
+    await expect(button).toBeFocused();
+    await expect(button).toHaveClass(/focus-ring-instant/);
+    const focusStyle = await button.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return {
+        focusVisible: element.matches(":focus-visible"),
+        transitionDuration: style.transitionDuration,
+        transitionProperty: style.transitionProperty,
+      };
+    });
+    expect(focusStyle.focusVisible).toBe(true);
+    expect(focusStyle.transitionDuration).toBe("0s");
+    expect(focusStyle.transitionProperty).toBe("none");
+  }
+
   async function reset(request: APIRequestContext) {
     const response = await request.post("/__akb_mock__/reset", {
       data: { scenario: "document-edit-recovery" },
@@ -63,6 +88,11 @@ test.describe("document edit recovery mock contract", () => {
     page,
     request,
   }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.addInitScript(() => {
+      localStorage.setItem("akb.vaultRailWidth.v2", "320");
+      localStorage.setItem("akb.treeWidth.v2", "270");
+    });
     const recovery = await fixture(request);
     await page.goto(recovery.identity!.start_url!);
     const editor = page.getByRole("textbox", { name: "Document body (markdown)" });
@@ -78,10 +108,50 @@ test.describe("document edit recovery mock contract", () => {
     await expect(editor).toContainText("Local draft before another editor saves");
 
     await page.getByRole("button", { name: "Save" }).click();
-    await expect(page.getByText("This document changed on the server")).toBeVisible();
-    await expect(page.getByText("Original base", { exact: true })).toBeVisible();
-    await expect(page.getByText("Your draft", { exact: true })).toBeVisible();
-    await expect(page.getByText("Latest server version", { exact: true })).toBeVisible();
+    const conflict = page
+      .getByRole("alert")
+      .filter({ hasText: "This document changed on the server" });
+    await expect(conflict).toBeVisible();
+    const snapshots = conflict.locator("[data-conflict-snapshot]");
+    await expect(snapshots).toHaveCount(3);
+    const snapshotWidths = await snapshots.evaluateAll((elements) =>
+      elements.map((element) => Math.round(element.getBoundingClientRect().width)),
+    );
+    expect(Math.min(...snapshotWidths)).toBeGreaterThanOrEqual(240);
+    const metadata = await conflict.locator("[data-conflict-metadata]").evaluateAll((elements) =>
+      elements.map((element) => {
+        const style = getComputedStyle(element);
+        return {
+          textOverflow: style.textOverflow,
+          whiteSpace: style.whiteSpace,
+        };
+      }),
+    );
+    expect(metadata).toHaveLength(9);
+    expect(
+      metadata.every(
+        ({ textOverflow, whiteSpace }) =>
+          textOverflow !== "ellipsis" && whiteSpace !== "nowrap",
+      ),
+    ).toBe(true);
+    const actionStyles = await conflict.getByRole("button").evaluateAll((buttons) =>
+      buttons.map((button) => getComputedStyle(button).whiteSpace),
+    );
+    expect(actionStyles.every((whiteSpace) => whiteSpace === "nowrap")).toBe(true);
+    for (const width of [320, 634, 1920]) {
+      await page.setViewportSize({ width, height: 900 });
+      await expect
+        .poll(async () =>
+          page.evaluate(
+            () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+          ),
+        )
+        .toBe(true);
+    }
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await expectInstantKeyboardFocus(
+      conflict.getByRole("button", { name: "Apply draft to latest" }),
+    );
 
     await page.getByRole("button", { name: "Apply draft to latest" }).click();
     await page.getByRole("button", { name: "Save" }).click();
@@ -143,7 +213,9 @@ test.describe("document edit recovery mock contract", () => {
     await operate(request, recovery.operations!.expire_draft);
     await page.reload();
     await expect(page.getByText("This draft has expired")).toBeVisible();
-    await expect(page.getByRole("button", { name: "Copy expired Markdown" })).toBeVisible();
+    const expiredCopy = page.getByRole("button", { name: "Copy expired Markdown" });
+    await expect(expiredCopy).toBeVisible();
+    await expectInstantKeyboardFocus(expiredCopy);
 
     await page.getByRole("button", { name: "Cancel" }).click();
     await page.getByRole("button", { name: "Discard changes" }).click();

--- a/frontend/e2e/document-edit-recovery.spec.ts
+++ b/frontend/e2e/document-edit-recovery.spec.ts
@@ -1,0 +1,154 @@
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+type MockOperation = {
+  method: "GET" | "POST";
+  url: string;
+  body?: Record<string, unknown>;
+};
+
+type MockDescriptor = {
+  scenario?: string;
+  mock?: {
+    fixture?: {
+      identity?: { start_url?: string };
+      operations?: Record<string, MockOperation>;
+    } | null;
+  };
+};
+
+test.describe("document edit recovery mock contract", () => {
+  test.skip(
+    process.env.CRABBOX_RUNTIME_SCENARIO !== "document-edit-recovery",
+    "The recovery fixture is selected by CRABBOX_RUNTIME_SCENARIO",
+  );
+  test.describe.configure({ mode: "serial" });
+
+  async function fixture(request: APIRequestContext) {
+    const response = await request.get("/__akb_mock__/discover");
+    expect(response.ok()).toBeTruthy();
+    const descriptor = (await response.json()) as MockDescriptor;
+    expect(descriptor.scenario).toBe("document-edit-recovery");
+    const recovery = descriptor.mock?.fixture;
+    expect(recovery?.identity?.start_url).toBeTruthy();
+    expect(recovery?.operations).toBeTruthy();
+    return recovery!;
+  }
+
+  async function reset(request: APIRequestContext) {
+    const response = await request.post("/__akb_mock__/reset", {
+      data: { scenario: "document-edit-recovery" },
+    });
+    expect(response.ok()).toBeTruthy();
+  }
+
+  async function operate(
+    request: APIRequestContext,
+    operation: MockOperation,
+    body: Record<string, unknown> = {},
+  ) {
+    const response = operation.method === "GET"
+      ? await request.get(operation.url)
+      : await request.post(operation.url, {
+          data: { ...(operation.body || {}), ...body },
+        });
+    expect(response.ok()).toBeTruthy();
+    return response.json();
+  }
+
+  test.beforeEach(async ({ request }) => {
+    await reset(request);
+  });
+
+  test("keeps a dirty body through refetch and exposes a three-way OCC conflict", async ({
+    page,
+    request,
+  }) => {
+    const recovery = await fixture(request);
+    await page.goto(recovery.identity!.start_url!);
+    const editor = page.getByRole("textbox", { name: "Document body (markdown)" });
+    await expect(editor).toBeVisible();
+    await editor.fill("Local draft before another editor saves");
+
+    await operate(request, recovery.operations!.remote_revision, {
+      actor: "editor-b",
+      title: "Remote revision",
+      content: "Remote editor body",
+    });
+    await operate(request, recovery.operations!.refetch);
+    await expect(editor).toContainText("Local draft before another editor saves");
+
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(page.getByText("This document changed on the server")).toBeVisible();
+    await expect(page.getByText("Original base", { exact: true })).toBeVisible();
+    await expect(page.getByText("Your draft", { exact: true })).toBeVisible();
+    await expect(page.getByText("Latest server version", { exact: true })).toBeVisible();
+
+    await page.getByRole("button", { name: "Apply draft to latest" }).click();
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(page.getByRole("button", { name: "Save" })).toHaveCount(0);
+    await expect(page.getByText("This document changed on the server")).toHaveCount(0);
+  });
+
+  test("keeps a failed save draft across reload, retries an image, and claims it on success", async ({
+    page,
+    request,
+  }) => {
+    const recovery = await fixture(request);
+    await page.goto(recovery.identity!.start_url!);
+    const editor = page.getByRole("textbox", { name: "Document body (markdown)" });
+    await editor.fill("Draft retained after a retryable server failure");
+    await expect(page.getByText("Draft saved locally")).toBeVisible();
+    await operate(request, recovery.operations!.retryable_save_failure);
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(page.getByText("The server hit an error while saving. Please retry.")).toBeVisible();
+
+    await page.reload();
+    await expect(page.getByText("Local draft restored")).toBeVisible();
+    await expect(editor).toContainText("Draft retained after a retryable server failure");
+
+    const input = page.locator('input[type="file"]');
+    await operate(request, recovery.operations!.retryable_upload_failure);
+    await input.setInputFiles({
+      name: "recovery.png",
+      mimeType: "image/png",
+      buffer: Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+        "base64",
+      ),
+    });
+    await expect(page.getByText("Image upload failed")).toBeVisible();
+    await page.getByRole("button", { name: "Retry" }).click();
+    await expect(page.getByRole("button", { name: /Remove image: recovery/ })).toBeVisible();
+
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(page.getByText("This document changed on the server")).toHaveCount(0);
+    await expect
+      .poll(
+        async () => {
+          const state = await operate(request, recovery.operations!.state);
+          return state.assets.some((asset: { status: string }) => asset.status === "claimed");
+        },
+        { timeout: 5_000 },
+      )
+      .toBe(true);
+  });
+
+  test("makes expiry and explicit draft discard observable without storage access", async ({
+    page,
+    request,
+  }) => {
+    const recovery = await fixture(request);
+    await page.goto(recovery.identity!.start_url!);
+    await page.getByRole("textbox", { name: "Document body (markdown)" }).fill("Draft that will expire");
+    await operate(request, recovery.operations!.expire_draft);
+    await page.reload();
+    await expect(page.getByText("This draft has expired")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Copy expired Markdown" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await page.getByRole("button", { name: "Discard changes" }).click();
+    await expect(page.locator("#doc-title")).toHaveText("Recovery document");
+    const state = await operate(request, recovery.operations!.state);
+    expect(state.scenario).toBe("document-edit-recovery");
+  });
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -12,6 +12,7 @@ if (!mockMode && !process.env.AKB_FRONTEND_URL) {
 const baseURL = mockMode
   ? "http://127.0.0.1:4173"
   : process.env.AKB_FRONTEND_URL!;
+const recoveryScenario = process.env.CRABBOX_RUNTIME_SCENARIO === "document-edit-recovery";
 
 // Mock mode owns its Vite webServer and browser MSW worker. Real mode consumes
 // the already-ready frontend origin from the repository runtime descriptor.
@@ -22,6 +23,7 @@ const baseURL = mockMode
 // browser end-to-end" — not exhaustive UX coverage.
 export default defineConfig({
   testDir: "./e2e",
+  ...(recoveryScenario ? { testMatch: /document-edit-recovery\.spec\.ts/ } : {}),
   fullyParallel: false,                  // single backend, serialize
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,

--- a/frontend/src/components/document-conflict-notice.tsx
+++ b/frontend/src/components/document-conflict-notice.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+import { Check, Copy, GitCompareArrows } from "lucide-react";
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export interface DocumentConflictSnapshot {
+  label: string;
+  commit: string | null;
+  title: string;
+  body: string;
+}
+
+interface DocumentConflictNoticeProps {
+  base: DocumentConflictSnapshot;
+  local: DocumentConflictSnapshot;
+  latest: DocumentConflictSnapshot | null;
+  latestError?: string;
+  rebasing: boolean;
+  onRebase: () => void;
+  onRetryLatest: () => void;
+}
+
+function Snapshot({ snapshot }: { snapshot: DocumentConflictSnapshot }) {
+  const [copied, setCopied] = useState(false);
+
+  async function copySnapshot() {
+    try {
+      await navigator.clipboard?.writeText(snapshot.body);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2_000);
+    } catch {
+      // The visible pre remains selectable when clipboard access is blocked.
+    }
+  }
+
+  return (
+    <div className="min-w-0 rounded-[var(--radius-md)] border border-border bg-surface p-3">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="truncate text-xs font-semibold text-foreground">{snapshot.label}</p>
+          <p className="mt-0.5 truncate text-xs text-foreground-muted">
+            Title: <span className="text-foreground">{snapshot.title || "(untitled)"}</span>
+          </p>
+          <p className="truncate text-xs text-foreground-muted">
+            Revision: <code className="font-mono text-foreground">{snapshot.commit || "unavailable"}</code>
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="shrink-0"
+          onClick={() => void copySnapshot()}
+          aria-label={`Copy ${snapshot.label} markdown`}
+        >
+          {copied ? <Check className="h-3.5 w-3.5 text-success" aria-hidden /> : <Copy className="h-3.5 w-3.5" aria-hidden />}
+          {copied ? "Copied" : "Copy"}
+        </Button>
+      </div>
+      <pre className="mt-2 max-h-32 overflow-auto whitespace-pre-wrap break-words rounded-[var(--radius-sm)] bg-surface-2 p-2 font-mono text-xs leading-relaxed text-foreground">
+        {snapshot.body || "(empty)"}
+      </pre>
+    </div>
+  );
+}
+
+export function DocumentConflictNotice({
+  base,
+  local,
+  latest,
+  latestError,
+  rebasing,
+  onRebase,
+  onRetryLatest,
+}: DocumentConflictNoticeProps) {
+  return (
+    <Alert variant="warning" title="This document changed on the server" className="mt-4">
+      <p>
+        Your draft is still protected. Review the original base, your local draft, and the latest server version before choosing a new base.
+      </p>
+      <div className="mt-3 grid gap-3 xl:grid-cols-3">
+        <Snapshot snapshot={base} />
+        <Snapshot snapshot={local} />
+        {latest ? (
+          <Snapshot snapshot={latest} />
+        ) : (
+          <div className="min-w-0 rounded-[var(--radius-md)] border border-border bg-surface p-3">
+            <p className="flex items-center gap-2 text-xs font-semibold text-foreground">
+              <GitCompareArrows className="h-3.5 w-3.5 text-warning" aria-hidden />
+              Latest server version
+            </p>
+            <p className="mt-2 text-xs text-foreground-muted">
+              {latestError || "The latest version could not be loaded. Your draft remains available."}
+            </p>
+          </div>
+        )}
+      </div>
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <Button
+          type="button"
+          variant="default"
+          size="sm"
+          onClick={onRebase}
+          disabled={!latest?.commit || rebasing}
+          loading={rebasing}
+        >
+          Apply draft to latest
+        </Button>
+        {!latest && (
+          <Button type="button" variant="outline" size="sm" onClick={onRetryLatest} disabled={rebasing}>
+            Try loading latest
+          </Button>
+        )}
+      </div>
+      <p className={cn("mt-2 text-xs text-warning-soft-foreground", !latest && "font-medium")}>
+        Applying the draft to latest is explicit; saving will still be rejected if the server changes again.
+      </p>
+    </Alert>
+  );
+}

--- a/frontend/src/components/document-conflict-notice.tsx
+++ b/frontend/src/components/document-conflict-notice.tsx
@@ -35,22 +35,32 @@ function Snapshot({ snapshot }: { snapshot: DocumentConflictSnapshot }) {
   }
 
   return (
-    <div className="min-w-0 rounded-[var(--radius-md)] border border-border bg-surface p-3">
+    <div
+      data-conflict-snapshot
+      className="min-w-0 rounded-[var(--radius-md)] border border-border bg-surface p-3"
+    >
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
-          <p className="truncate text-xs font-semibold text-foreground">{snapshot.label}</p>
-          <p className="mt-0.5 truncate text-xs text-foreground-muted">
+          <p
+            data-conflict-metadata="label"
+            className="text-xs font-semibold text-foreground"
+          >
+            {snapshot.label}
+          </p>
+          <p data-conflict-metadata="title" className="mt-0.5 text-xs text-foreground-muted">
             Title: <span className="text-foreground">{snapshot.title || "(untitled)"}</span>
           </p>
-          <p className="truncate text-xs text-foreground-muted">
-            Revision: <code className="font-mono text-foreground">{snapshot.commit || "unavailable"}</code>
+          <p data-conflict-metadata="revision" className="text-xs text-foreground-muted">
+            Revision: <code className="break-all font-mono text-foreground">
+              {snapshot.commit || "unavailable"}
+            </code>
           </p>
         </div>
         <Button
           type="button"
           variant="ghost"
           size="sm"
-          className="shrink-0"
+          className="shrink-0 focus-ring-instant"
           onClick={() => void copySnapshot()}
           aria-label={`Copy ${snapshot.label} markdown`}
         >
@@ -79,28 +89,37 @@ export function DocumentConflictNotice({
       <p>
         Your draft is still protected. Review the original base, your local draft, and the latest server version before choosing a new base.
       </p>
-      <div className="mt-3 grid gap-3 xl:grid-cols-3">
-        <Snapshot snapshot={base} />
-        <Snapshot snapshot={local} />
-        {latest ? (
-          <Snapshot snapshot={latest} />
-        ) : (
-          <div className="min-w-0 rounded-[var(--radius-md)] border border-border bg-surface p-3">
-            <p className="flex items-center gap-2 text-xs font-semibold text-foreground">
-              <GitCompareArrows className="h-3.5 w-3.5 text-warning" aria-hidden />
-              Latest server version
-            </p>
-            <p className="mt-2 text-xs text-foreground-muted">
-              {latestError || "The latest version could not be loaded. Your draft remains available."}
-            </p>
-          </div>
-        )}
+      <div className="mt-3 @container">
+        <div className="grid gap-3 @lg:grid-cols-2 @2xl:grid-cols-3">
+          <Snapshot snapshot={base} />
+          <Snapshot snapshot={local} />
+          {latest ? (
+            <Snapshot snapshot={latest} />
+          ) : (
+            <div
+              data-conflict-snapshot
+              className="min-w-0 rounded-[var(--radius-md)] border border-border bg-surface p-3"
+            >
+              <p
+                data-conflict-metadata="label"
+                className="flex items-center gap-2 text-xs font-semibold text-foreground"
+              >
+                <GitCompareArrows className="h-3.5 w-3.5 text-warning" aria-hidden />
+                Latest server version
+              </p>
+              <p className="mt-2 text-xs text-foreground-muted">
+                {latestError || "The latest version could not be loaded. Your draft remains available."}
+              </p>
+            </div>
+          )}
+        </div>
       </div>
       <div className="mt-3 flex flex-wrap items-center gap-2">
         <Button
           type="button"
           variant="default"
           size="sm"
+          className="shrink-0 focus-ring-instant"
           onClick={onRebase}
           disabled={!latest?.commit || rebasing}
           loading={rebasing}
@@ -108,7 +127,14 @@ export function DocumentConflictNotice({
           Apply draft to latest
         </Button>
         {!latest && (
-          <Button type="button" variant="outline" size="sm" onClick={onRetryLatest} disabled={rebasing}>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="shrink-0 focus-ring-instant"
+            onClick={onRetryLatest}
+            disabled={rebasing}
+          >
             Try loading latest
           </Button>
         )}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -631,6 +631,11 @@ body::before {
     box-shadow var(--duration-fast) var(--ease-in-out);
 }
 
+/* Opt into an immediate keyboard focus ring for recovery actions. The ring
+   itself uses the Button primitive's box-shadow, so it must not wait on the
+   shared color/shadow transition. */
+.focus-ring-instant:focus-visible { transition: none; }
+
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
     animation-duration: 1ms !important;

--- a/frontend/src/lib/__tests__/document-edit-draft.test.ts
+++ b/frontend/src/lib/__tests__/document-edit-draft.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearDocumentEditDraft,
+  documentEditDraftStorageKey,
+  loadDocumentEditDraft,
+  saveDocumentEditDraft,
+  type DocumentEditDraftInput,
+} from "@/lib/document-draft";
+
+const USER = "user-1";
+const VAULT = "team";
+const DOCUMENT = "akb://team/coll/notes/doc/hello.md";
+
+function draft(overrides: Partial<DocumentEditDraftInput> = {}): DocumentEditDraftInput {
+  return {
+    draftId: "draft-1",
+    tabId: "tab-1",
+    userId: USER,
+    vault: VAULT,
+    document: DOCUMENT,
+    baseCommit: "base-commit",
+    baseTitle: "Original title",
+    baseBody: "Original body",
+    title: "Local title",
+    body: "Local body",
+    assetIds: ["asset-1"],
+    editorVersion: "0.1.0",
+    markdownProfile: "preserve",
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  window.localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("existing-document draft storage", () => {
+  it("isolates drafts by user, vault, document, and tab without overwriting another tab", () => {
+    expect(saveDocumentEditDraft(draft())).toBe(true);
+    expect(
+      saveDocumentEditDraft(
+        draft({ draftId: "draft-2", tabId: "tab-2", title: "Other tab" }),
+      ),
+    ).toBe(true);
+
+    expect(loadDocumentEditDraft(USER, VAULT, DOCUMENT, "tab-1")).toMatchObject({
+      status: "restored",
+      draft: { draftId: "draft-1", title: "Local title" },
+    });
+    expect(loadDocumentEditDraft(USER, VAULT, DOCUMENT, "tab-2")).toMatchObject({
+      status: "restored",
+      draft: { draftId: "draft-2", title: "Other tab" },
+    });
+    expect(window.localStorage.length).toBe(2);
+  });
+
+  it("does not mix a document draft across user, vault, or document identity", () => {
+    expect(saveDocumentEditDraft(draft())).toBe(true);
+
+    expect(loadDocumentEditDraft("other-user", VAULT, DOCUMENT, "tab-1").status).toBe("none");
+    expect(loadDocumentEditDraft(USER, "other-vault", DOCUMENT, "tab-1").status).toBe("none");
+    expect(loadDocumentEditDraft(USER, VAULT, "akb://team/doc/other.md", "tab-1").status).toBe("none");
+  });
+
+  it("returns an expired draft for recovery without deleting its original text", () => {
+    const stored = {
+      ...draft(),
+      version: 1,
+      kind: "document-edit",
+      updatedAt: "2026-09-01T00:00:00.000Z",
+      expiresAt: "2026-09-01T01:00:00.000Z",
+    };
+    window.localStorage.setItem(
+      documentEditDraftStorageKey(USER, VAULT, DOCUMENT, "tab-1", "draft-1"),
+      JSON.stringify(stored),
+    );
+
+    const result = loadDocumentEditDraft(
+      USER,
+      VAULT,
+      DOCUMENT,
+      "tab-1",
+      new Date("2026-09-02T00:00:00.000Z"),
+    );
+    expect(result).toMatchObject({ status: "expired", draft: { body: "Local body" } });
+    expect(window.localStorage.getItem(documentEditDraftStorageKey(USER, VAULT, DOCUMENT, "tab-1", "draft-1"))).toContain("Local body");
+  });
+
+  it("preserves incompatible records for copying instead of migrating or discarding them", () => {
+    const key = documentEditDraftStorageKey(USER, VAULT, DOCUMENT, "tab-1", "old-draft");
+    window.localStorage.setItem(
+      key,
+      JSON.stringify({ version: 99, title: "Old title", body: "Old body" }),
+    );
+
+    expect(loadDocumentEditDraft(USER, VAULT, DOCUMENT, "tab-1")).toMatchObject({
+      status: "incompatible",
+      draft: { copyTitle: "Old title", copyBody: "Old body" },
+    });
+    expect(window.localStorage.getItem(key)).toContain("Old body");
+  });
+
+  it("reports local-storage write failure instead of claiming persistence", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementationOnce(() => {
+      throw new Error("quota exceeded");
+    });
+
+    expect(saveDocumentEditDraft(draft())).toBe(false);
+    expect(window.localStorage.length).toBe(0);
+  });
+
+  it("clears only the selected draft record", () => {
+    const first = draft();
+    const second = draft({ draftId: "draft-2", tabId: "tab-2" });
+    saveDocumentEditDraft(first);
+    saveDocumentEditDraft(second);
+
+    clearDocumentEditDraft(first);
+
+    expect(window.localStorage.getItem(documentEditDraftStorageKey(USER, VAULT, DOCUMENT, "tab-1", "draft-1"))).toBeNull();
+    expect(window.localStorage.getItem(documentEditDraftStorageKey(USER, VAULT, DOCUMENT, "tab-2", "draft-2"))).not.toBeNull();
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1326,8 +1326,34 @@ export function getDocumentDiff(
   );
 }
 
-export const updateDocument = (vault: string, id: string, data: any) =>
-  api<any>(`/documents/${vault}/${encodeURIComponent(id)}`, { method: "PATCH", body: JSON.stringify(data) });
+export interface DocumentUpdateInput {
+  content?: string;
+  title?: string;
+  type?: string;
+  status?: "draft" | "active" | "archived";
+  tags?: string[];
+  domain?: string | null;
+  summary?: string | null;
+  depends_on?: string[];
+  related_to?: string[];
+  message?: string;
+  expected_commit?: string;
+  expected_content_hash?: string;
+  title_conflict_policy?: "allow" | "reject";
+}
+
+export interface DocumentUpdateResult {
+  path?: string;
+  current_commit?: string | null;
+  commit_hash?: string | null;
+  [key: string]: unknown;
+}
+
+export const updateDocument = (vault: string, id: string, data: DocumentUpdateInput) =>
+  api<DocumentUpdateResult>(
+    `/documents/${vault}/${encodeURIComponent(id)}`,
+    { method: "PATCH", body: JSON.stringify(data) },
+  );
 
 export interface DocumentMoveInput {
   collection?: string;

--- a/frontend/src/lib/document-draft.ts
+++ b/frontend/src/lib/document-draft.ts
@@ -3,6 +3,22 @@ import { DOC_TYPES, type DocType } from "@/lib/doc-constants";
 const DRAFT_VERSION = 1;
 const DRAFT_PREFIX = "akb:document-draft:";
 
+/**
+ * Existing-document drafts are a separate record from the new-document
+ * composer.  A draft is deliberately pinned to the public markdown contract
+ * rather than a private Plate schema: package semver + MarkdownProfile are
+ * the durable compatibility boundary owned by the shared editor package.
+ */
+const DOCUMENT_EDIT_DRAFT_VERSION = 1;
+const DOCUMENT_EDIT_DRAFT_KIND = "document-edit";
+const DOCUMENT_EDIT_DRAFT_PREFIX = "akb:document-edit-draft:";
+const DOCUMENT_EDIT_TAB_ID_KEY = "akb:document-edit-tab-id";
+export const DOCUMENT_EDIT_DRAFT_EDITOR_VERSION = "0.1.0";
+export const DOCUMENT_EDIT_DRAFT_MARKDOWN_PROFILE = "preserve" as const;
+export const DOCUMENT_EDIT_DRAFT_RETENTION_HOURS = 24;
+const DOCUMENT_EDIT_DRAFT_RETENTION_MS =
+  DOCUMENT_EDIT_DRAFT_RETENTION_HOURS * 60 * 60 * 1000;
+
 export interface StoredDocumentDraft {
   version: typeof DRAFT_VERSION;
   vault: string;
@@ -15,6 +31,294 @@ export interface StoredDocumentDraft {
   body: string;
   assetIds: string[];
   updatedAt: string;
+}
+
+export interface StoredDocumentEditDraft {
+  version: typeof DOCUMENT_EDIT_DRAFT_VERSION;
+  kind: typeof DOCUMENT_EDIT_DRAFT_KIND;
+  draftId: string;
+  tabId: string;
+  userId: string;
+  vault: string;
+  document: string;
+  baseCommit: string;
+  baseTitle: string;
+  baseBody: string;
+  title: string;
+  body: string;
+  assetIds: string[];
+  editorVersion: typeof DOCUMENT_EDIT_DRAFT_EDITOR_VERSION;
+  markdownProfile: typeof DOCUMENT_EDIT_DRAFT_MARKDOWN_PROFILE;
+  updatedAt: string;
+  expiresAt: string;
+}
+
+export interface IncompatibleDocumentEditDraft {
+  userId: string;
+  vault: string;
+  document: string;
+  raw: unknown;
+  copyTitle: string;
+  copyBody: string;
+}
+
+export type DocumentEditDraftLoadResult =
+  | { status: "none" }
+  | { status: "storage-unavailable" }
+  | { status: "restored"; draft: StoredDocumentEditDraft }
+  | { status: "expired"; draft: StoredDocumentEditDraft }
+  | { status: "incompatible"; draft: IncompatibleDocumentEditDraft };
+
+export type DocumentEditDraftInput = Omit<
+  StoredDocumentEditDraft,
+  "version" | "kind" | "updatedAt" | "expiresAt"
+>;
+
+let fallbackTabId: string | null = null;
+
+function encodeKeyPart(value: string): string {
+  return encodeURIComponent(value);
+}
+
+function randomId(): string {
+  try {
+    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+      return crypto.randomUUID();
+    }
+  } catch {
+    // Hardened browsers can expose crypto without randomUUID. Fall through to
+    // the non-secret, collision-resistant enough tab-local fallback.
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function createDocumentEditDraftId(): string {
+  return randomId();
+}
+
+export function documentEditDraftTabId(): string {
+  if (fallbackTabId) return fallbackTabId;
+  try {
+    const existing = window.sessionStorage.getItem(DOCUMENT_EDIT_TAB_ID_KEY);
+    if (existing) {
+      fallbackTabId = existing;
+      return existing;
+    }
+    const created = randomId();
+    window.sessionStorage.setItem(DOCUMENT_EDIT_TAB_ID_KEY, created);
+    fallbackTabId = created;
+    return created;
+  } catch {
+    fallbackTabId = randomId();
+    return fallbackTabId;
+  }
+}
+
+function documentEditDraftPrefix(
+  userId: string,
+  vault: string,
+  document: string,
+): string {
+  return [
+    DOCUMENT_EDIT_DRAFT_PREFIX,
+    encodeKeyPart(userId),
+    encodeKeyPart(vault),
+    encodeKeyPart(document),
+  ].join(":");
+}
+
+export function documentEditDraftStorageKey(
+  userId: string,
+  vault: string,
+  document: string,
+  tabId: string,
+  draftId: string,
+): string {
+  return [
+    documentEditDraftPrefix(userId, vault, document),
+    encodeKeyPart(tabId),
+    encodeKeyPart(draftId),
+  ].join(":");
+}
+
+function recordLooksLikeEditDraft(value: unknown): value is StoredDocumentEditDraft {
+  if (!value || typeof value !== "object") return false;
+  const draft = value as Partial<StoredDocumentEditDraft>;
+  return (
+    draft.version === DOCUMENT_EDIT_DRAFT_VERSION &&
+    draft.kind === DOCUMENT_EDIT_DRAFT_KIND &&
+    draft.editorVersion === DOCUMENT_EDIT_DRAFT_EDITOR_VERSION &&
+    draft.markdownProfile === DOCUMENT_EDIT_DRAFT_MARKDOWN_PROFILE &&
+    typeof draft.draftId === "string" &&
+    typeof draft.tabId === "string" &&
+    typeof draft.userId === "string" &&
+    typeof draft.vault === "string" &&
+    typeof draft.document === "string" &&
+    typeof draft.baseCommit === "string" &&
+    typeof draft.baseTitle === "string" &&
+    typeof draft.baseBody === "string" &&
+    typeof draft.title === "string" &&
+    typeof draft.body === "string" &&
+    Array.isArray(draft.assetIds) &&
+    draft.assetIds.every((assetId) => typeof assetId === "string") &&
+    typeof draft.updatedAt === "string" &&
+    typeof draft.expiresAt === "string"
+  );
+}
+
+function copyableIncompatibleDraft(
+  raw: unknown,
+  userId: string,
+  vault: string,
+  document: string,
+): IncompatibleDocumentEditDraft {
+  const candidate = raw && typeof raw === "object"
+    ? raw as Record<string, unknown>
+    : {};
+  const title = typeof candidate.title === "string"
+    ? candidate.title
+    : typeof candidate.localTitle === "string"
+      ? candidate.localTitle
+      : "";
+  const body = typeof candidate.body === "string"
+    ? candidate.body
+    : typeof candidate.localBody === "string"
+      ? candidate.localBody
+      : typeof candidate.content === "string"
+        ? candidate.content
+        : JSON.stringify(raw, null, 2);
+  return { userId, vault, document, raw, copyTitle: title, copyBody: body };
+}
+
+function parseStoredEditDraft(
+  raw: string,
+  userId: string,
+  vault: string,
+  document: string,
+): StoredDocumentEditDraft | IncompatibleDocumentEditDraft | null {
+  try {
+    const value = JSON.parse(raw) as unknown;
+    if (recordLooksLikeEditDraft(value)) {
+      if (
+        value.userId !== userId ||
+        value.vault !== vault ||
+        value.document !== document ||
+        Number.isNaN(Date.parse(value.updatedAt)) ||
+        Number.isNaN(Date.parse(value.expiresAt))
+      ) {
+        return null;
+      }
+      return value;
+    }
+    return copyableIncompatibleDraft(value, userId, vault, document);
+  } catch {
+    return copyableIncompatibleDraft(raw, userId, vault, document);
+  }
+}
+
+function readDocumentEditDraftEntries(
+  userId: string,
+  vault: string,
+  document: string,
+): { active: StoredDocumentEditDraft[]; incompatible: IncompatibleDocumentEditDraft[] } {
+  const active: StoredDocumentEditDraft[] = [];
+  const incompatible: IncompatibleDocumentEditDraft[] = [];
+  const prefix = `${documentEditDraftPrefix(userId, vault, document)}:`;
+  for (let index = 0; index < window.localStorage.length; index += 1) {
+    const key = window.localStorage.key(index);
+    if (!key?.startsWith(prefix)) continue;
+    const raw = window.localStorage.getItem(key);
+    if (raw === null) continue;
+    const parsed = parseStoredEditDraft(raw, userId, vault, document);
+    if (!parsed) continue;
+    if (recordLooksLikeEditDraft(parsed)) active.push(parsed);
+    else incompatible.push(parsed);
+  }
+  active.sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt));
+  return { active, incompatible };
+}
+
+export function loadDocumentEditDraft(
+  userId: string,
+  vault: string,
+  document: string,
+  tabId = documentEditDraftTabId(),
+  now = new Date(),
+): DocumentEditDraftLoadResult {
+  try {
+    const entries = readDocumentEditDraftEntries(userId, vault, document);
+    const exactTab = entries.active.filter((draft) => draft.tabId === tabId);
+    const candidate = [...exactTab, ...entries.active.filter((draft) => draft.tabId !== tabId)][0];
+    if (candidate) {
+      return Date.parse(candidate.expiresAt) <= now.getTime()
+        ? { status: "expired", draft: candidate }
+        : { status: "restored", draft: candidate };
+    }
+    const incompatible = entries.incompatible[0];
+    return incompatible
+      ? { status: "incompatible", draft: incompatible }
+      : { status: "none" };
+  } catch {
+    return { status: "storage-unavailable" };
+  }
+}
+
+export function listDocumentEditDrafts(
+  userId: string,
+  vault: string,
+  document: string,
+): StoredDocumentEditDraft[] {
+  try {
+    return readDocumentEditDraftEntries(userId, vault, document).active;
+  } catch {
+    return [];
+  }
+}
+
+export function saveDocumentEditDraft(draft: DocumentEditDraftInput): boolean {
+  const updatedAt = new Date();
+  const expiresAt = new Date(
+    updatedAt.getTime() + DOCUMENT_EDIT_DRAFT_RETENTION_MS,
+  );
+  const stored: StoredDocumentEditDraft = {
+    ...draft,
+    version: DOCUMENT_EDIT_DRAFT_VERSION,
+    kind: DOCUMENT_EDIT_DRAFT_KIND,
+    updatedAt: updatedAt.toISOString(),
+    expiresAt: expiresAt.toISOString(),
+  };
+  try {
+    window.localStorage.setItem(
+      documentEditDraftStorageKey(
+        stored.userId,
+        stored.vault,
+        stored.document,
+        stored.tabId,
+        stored.draftId,
+      ),
+      JSON.stringify(stored),
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function clearDocumentEditDraft(draft: Pick<StoredDocumentEditDraft, "userId" | "vault" | "document" | "tabId" | "draftId">): void {
+  try {
+    window.localStorage.removeItem(
+      documentEditDraftStorageKey(
+        draft.userId,
+        draft.vault,
+        draft.document,
+        draft.tabId,
+        draft.draftId,
+      ),
+    );
+  } catch {
+    // A blocked storage area cannot be cleared reliably. The record remains
+    // isolated and the server TTL is still the attachment safety net.
+  }
 }
 
 export function documentDraftStorageKey(vault: string): string {

--- a/frontend/src/mocks/browser.ts
+++ b/frontend/src/mocks/browser.ts
@@ -6,11 +6,9 @@ import {
   vaultHealth,
 } from "@/stories/page-story-fixtures";
 import {
-  DOCUMENT_EDIT_DRAFT_EDITOR_VERSION,
-  DOCUMENT_EDIT_DRAFT_MARKDOWN_PROFILE,
-  createDocumentEditDraftId,
   documentEditDraftStorageKey,
   documentEditDraftTabId,
+  listDocumentEditDrafts,
 } from "@/lib/document-draft";
 
 const API = "/api/v1";
@@ -150,7 +148,7 @@ async function syncFixtureState(): Promise<FixtureState> {
       expireGeneration > appliedExpireDraftGeneration
     ) {
       appliedExpireDraftGeneration = expireGeneration;
-      seedExpiredDraft();
+      expireCurrentDraft();
     }
     return fixtureState;
   } catch {
@@ -158,37 +156,33 @@ async function syncFixtureState(): Promise<FixtureState> {
   }
 }
 
-function seedExpiredDraft() {
+function expireCurrentDraft() {
   if (!isDocumentScenario()) return;
-  const document = documentForState();
+  const drafts = listDocumentEditDrafts(
+    "u-jylkim",
+    "fixture",
+    documentIdentity(),
+  );
   const tabId = documentEditDraftTabId();
-  const draft = {
-    version: 1,
-    kind: "document-edit",
-    draftId: createDocumentEditDraftId(),
-    tabId,
-    userId: fixtureState.identity?.user_id || initialUser.user_id,
-    vault: "fixture",
-    document: documentIdentity(),
-    baseCommit: document.current_commit,
-    baseTitle: document.title,
-    baseBody: document.content,
-    title: document.title,
-    body: `${document.content}\n\nExpired draft recovery text.`,
-    assetIds: [],
-    editorVersion: DOCUMENT_EDIT_DRAFT_EDITOR_VERSION,
-    markdownProfile: DOCUMENT_EDIT_DRAFT_MARKDOWN_PROFILE,
-    updatedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
-    expiresAt: new Date(Date.now() - 60_000).toISOString(),
-  };
+  const draft = drafts.find((candidate) => candidate.tabId === tabId) || drafts[0];
+  if (!draft) return;
   try {
     window.localStorage.setItem(
-      documentEditDraftStorageKey("u-jylkim", "fixture", documentIdentity(), tabId, draft.draftId),
-      JSON.stringify(draft),
+      documentEditDraftStorageKey(
+        draft.userId,
+        draft.vault,
+        draft.document,
+        draft.tabId,
+        draft.draftId,
+      ),
+      JSON.stringify({
+        ...draft,
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+      }),
     );
   } catch {
     // The browser will surface the same local-storage-unavailable state as a
-    // real user when the test fixture cannot write a draft.
+    // real user when the test fixture cannot expire a draft.
   }
 }
 

--- a/frontend/src/mocks/browser.ts
+++ b/frontend/src/mocks/browser.ts
@@ -5,6 +5,13 @@ import {
   localAuthConfig,
   vaultHealth,
 } from "@/stories/page-story-fixtures";
+import {
+  DOCUMENT_EDIT_DRAFT_EDITOR_VERSION,
+  DOCUMENT_EDIT_DRAFT_MARKDOWN_PROFILE,
+  createDocumentEditDraftId,
+  documentEditDraftStorageKey,
+  documentEditDraftTabId,
+} from "@/lib/document-draft";
 
 const API = "/api/v1";
 const MOCK_TOKEN = "akb-mock-browser-token";
@@ -14,28 +21,183 @@ type MockUser = typeof fixtureUser & { auth_method: "local" };
 const initialUser: MockUser = { ...fixtureUser, auth_method: "local" };
 let user: MockUser = { ...initialUser };
 let appliedResetGeneration = 0;
+let activeScenario = "empty";
+let appliedRefetchGeneration = 0;
+let appliedExpireDraftGeneration = 0;
+let fixturePoll: number | null = null;
+
+const documentScenarioAuthConfig = {
+  schema_version: 2 as const,
+  auth_mode: "sso" as const,
+  local_auth: { enabled: false },
+  keycloak: { enabled: true, browser_session_ready: true },
+  providers: [],
+  mcp_oauth: { enabled: false },
+};
+
+type FixtureDocument = {
+  title: string;
+  content: string;
+  current_commit: string;
+  updated_at: string;
+};
+
+type FixtureState = {
+  scenario?: string;
+  identity?: {
+    user_id?: string;
+    vault?: string;
+    document_path?: string;
+    document_uri?: string;
+  };
+  document?: FixtureDocument;
+  refetch_generation?: number;
+  expire_draft_generation?: number;
+  faults?: { save?: number; upload?: number };
+  assets?: Array<{ id: string; filename: string; status: string }>;
+};
+
+let fixtureState: FixtureState = {};
+
+const baseDocument = {
+  kind: "document" as const,
+  uri: "akb://fixture/coll/notes/doc/recovery.md",
+  vault: "fixture",
+  path: "notes/recovery.md",
+  title: "Recovery document",
+  type: "note",
+  status: "active",
+  summary: "A source-neutral document recovery fixture.",
+  domain: null,
+  created_by: "u-jylkim",
+  created_by_name: "JY Kim",
+  created_at: "2026-09-08T00:00:00.000Z",
+  updated_at: "2026-09-08T00:00:00.000Z",
+  current_commit: "fixture-base-0001",
+  content_hash: null,
+  hash_algorithm: "sha256",
+  tags: ["fixture"],
+  content: "# Recovery document\n\nThe original body is safe to edit.",
+  is_public: false,
+  public_slug: null,
+  metadata_is_current: true,
+};
+
+function documentForState(): typeof baseDocument {
+  const remote = fixtureState.document;
+  return remote
+    ? { ...baseDocument, ...remote }
+    : { ...baseDocument };
+}
+
+function isDocumentScenario(): boolean {
+  return activeScenario === "document-edit-recovery";
+}
+
+function documentIdentity(): string {
+  return fixtureState.identity?.document_uri || baseDocument.uri;
+}
+
+async function consumeFixtureFault(operation: "save" | "upload"): Promise<boolean> {
+  try {
+    const response = await fetch("/__akb_mock__/fixture/consume-fault", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ operation }),
+    });
+    if (!response.ok) return false;
+    const body = (await response.json()) as { consumed?: unknown };
+    return body.consumed === true;
+  } catch {
+    return false;
+  }
+}
+
+async function syncFixtureState(): Promise<FixtureState> {
+  try {
+    const response = await fetch("/__akb_mock__/fixture/state", { cache: "no-store" });
+    if (!response.ok) return fixtureState;
+    const next = (await response.json()) as FixtureState & { reset_generation?: unknown };
+    const resetGeneration = next.reset_generation;
+    if (
+      typeof resetGeneration === "number" &&
+      Number.isInteger(resetGeneration) &&
+      resetGeneration > appliedResetGeneration
+    ) {
+      resetState();
+      appliedResetGeneration = resetGeneration;
+      appliedRefetchGeneration = 0;
+      appliedExpireDraftGeneration = 0;
+    }
+    fixtureState = next;
+    const refetchGeneration = next.refetch_generation;
+    if (
+      isDocumentScenario() &&
+      typeof refetchGeneration === "number" &&
+      refetchGeneration > appliedRefetchGeneration
+    ) {
+      appliedRefetchGeneration = refetchGeneration;
+      window.dispatchEvent(
+        new CustomEvent("akb:mock-document-refetch", {
+          detail: { vault: "fixture", document: "notes/recovery.md" },
+        }),
+      );
+    }
+    const expireGeneration = next.expire_draft_generation;
+    if (
+      isDocumentScenario() &&
+      typeof expireGeneration === "number" &&
+      expireGeneration > appliedExpireDraftGeneration
+    ) {
+      appliedExpireDraftGeneration = expireGeneration;
+      seedExpiredDraft();
+    }
+    return fixtureState;
+  } catch {
+    return fixtureState;
+  }
+}
+
+function seedExpiredDraft() {
+  if (!isDocumentScenario()) return;
+  const document = documentForState();
+  const tabId = documentEditDraftTabId();
+  const draft = {
+    version: 1,
+    kind: "document-edit",
+    draftId: createDocumentEditDraftId(),
+    tabId,
+    userId: fixtureState.identity?.user_id || initialUser.user_id,
+    vault: "fixture",
+    document: documentIdentity(),
+    baseCommit: document.current_commit,
+    baseTitle: document.title,
+    baseBody: document.content,
+    title: document.title,
+    body: `${document.content}\n\nExpired draft recovery text.`,
+    assetIds: [],
+    editorVersion: DOCUMENT_EDIT_DRAFT_EDITOR_VERSION,
+    markdownProfile: DOCUMENT_EDIT_DRAFT_MARKDOWN_PROFILE,
+    updatedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+    expiresAt: new Date(Date.now() - 60_000).toISOString(),
+  };
+  try {
+    window.localStorage.setItem(
+      documentEditDraftStorageKey("u-jylkim", "fixture", documentIdentity(), tabId, draft.draftId),
+      JSON.stringify(draft),
+    );
+  } catch {
+    // The browser will surface the same local-storage-unavailable state as a
+    // real user when the test fixture cannot write a draft.
+  }
+}
 
 function resetState() {
   user = { ...initialUser };
 }
 
 async function syncPublicReset() {
-  try {
-    const response = await fetch("/__akb_mock__/health", { cache: "no-store" });
-    if (!response.ok) return;
-    const body = (await response.json()) as { reset_generation?: unknown };
-    const generation = body.reset_generation;
-    if (
-      typeof generation === "number" &&
-      Number.isInteger(generation) &&
-      generation > appliedResetGeneration
-    ) {
-      resetState();
-      appliedResetGeneration = generation;
-    }
-  } catch {
-    // The mock API remains usable if the optional control probe is unavailable.
-  }
+  await syncFixtureState();
 }
 
 async function jsonBody(request: Request): Promise<Record<string, unknown>> {
@@ -43,7 +205,10 @@ async function jsonBody(request: Request): Promise<Record<string, unknown>> {
 }
 
 const handlers = [
-  http.get(`${API}/auth/config`, () => HttpResponse.json(localAuthConfig)),
+  http.get(`${API}/auth/config`, async () => {
+    await syncPublicReset();
+    return HttpResponse.json(isDocumentScenario() ? documentScenarioAuthConfig : localAuthConfig);
+  }),
   http.get(`${API}/auth/me`, async () => {
     await syncPublicReset();
     return HttpResponse.json(user);
@@ -80,7 +245,160 @@ const handlers = [
       email: user.email,
     });
   }),
-  http.get(`${API}/my/vaults`, () => HttpResponse.json({ vaults: [] })),
+  http.get(`${API}/my/vaults`, async () => {
+    await syncPublicReset();
+    return HttpResponse.json({
+      vaults: isDocumentScenario()
+        ? [{ name: "fixture", role: "owner", description: "Document recovery fixture" }]
+        : [],
+    });
+  }),
+  http.get(`${API}/vaults/fixture/info`, async () => {
+    await syncPublicReset();
+    return HttpResponse.json({
+      name: "fixture",
+      description: "Document recovery fixture",
+      role: "owner",
+      member_count: 1,
+      owner_display_name: "JY Kim",
+      collection_count: 1,
+      document_count: 1,
+      table_count: 0,
+      file_count: 0,
+      edge_count: 0,
+      is_archived: false,
+      is_external_git: false,
+      tables: [],
+    });
+  }),
+  http.get(/\/api\/v1\/browse\/fixture(?:\?.*)?$/, async () => {
+    await syncPublicReset();
+    return HttpResponse.json({
+      vault: "fixture",
+      path: "",
+      items: [
+        { type: "collection", name: "notes", path: "notes", doc_count: 1 },
+        { type: "document", name: documentForState().title, path: "notes/recovery.md" },
+      ],
+    });
+  }),
+  http.get(/\/api\/v1\/documents\/fixture\/.+$/, async () => {
+    await syncPublicReset();
+    return HttpResponse.json(documentForState());
+  }),
+  http.patch(/\/api\/v1\/documents\/fixture\/.+$/, async ({ request }) => {
+    await syncPublicReset();
+    if (await consumeFixtureFault("save")) {
+      return HttpResponse.json(
+        { detail: { message: "Temporary fixture server failure", code: "fixture_failure" } },
+        { status: 503 },
+      );
+    }
+    const body = await jsonBody(request);
+    const latest = documentForState();
+    if (
+      typeof body.expected_commit === "string" &&
+      body.expected_commit !== latest.current_commit
+    ) {
+      return HttpResponse.json(
+        { detail: { message: "current_commit moved", code: "conflict" } },
+        { status: 409 },
+      );
+    }
+    const assetIds = typeof body.content === "string"
+      ? [...body.content.matchAll(/\/api\/assets\/([A-Za-z0-9-]+)/g)].map((match) => match[1])
+      : [];
+    try {
+      const commit = await fetch("/__akb_mock__/fixture/commit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...body, asset_ids: assetIds }),
+      });
+      if (!commit.ok) {
+        const error = await commit.json().catch(() => ({ error: "fixture_commit_failed" }));
+        return HttpResponse.json(error, { status: commit.status });
+      }
+      const result = (await commit.json()) as { document?: FixtureDocument };
+      return HttpResponse.json({
+        kind: "document_write",
+        path: "notes/recovery.md",
+        current_commit: result.document?.current_commit,
+        commit_hash: result.document?.current_commit,
+      });
+    } catch {
+      return HttpResponse.json({ error: "fixture_commit_failed" }, { status: 503 });
+    }
+  }),
+  http.get(/\/api\/v1\/history\/fixture\/.+$/, async () => {
+    await syncPublicReset();
+    const document = documentForState();
+    return HttpResponse.json({
+      kind: "document_history",
+      uri: document.uri || baseDocument.uri,
+      history: [
+        {
+          hash: document.current_commit,
+          message: "Fixture document revision",
+          author: "fixture",
+          author_name: "Fixture editor",
+          date: document.updated_at,
+        },
+      ],
+    });
+  }),
+  http.get(`${API}/relations`, async () => {
+    await syncPublicReset();
+    return HttpResponse.json({ uri: baseDocument.uri, relations: [] });
+  }),
+  http.post(`${API}/assets/fixture`, async ({ request }) => {
+    await syncPublicReset();
+    if (await consumeFixtureFault("upload")) {
+      return HttpResponse.json(
+        { detail: { message: "Temporary fixture upload failure", code: "fixture_failure" } },
+        { status: 503 },
+      );
+    }
+    const url = new URL(request.url);
+    const filename = url.searchParams.get("filename") || "fixture.png";
+    const id = `00000000-0000-4000-8000-${String(Date.now() % 1_000_000_000_000).padStart(12, "0")}`;
+    try {
+      await fetch("/__akb_mock__/fixture/upload", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id, filename }),
+      });
+    } catch {
+      return HttpResponse.json({ error: "fixture_upload_failed" }, { status: 503 });
+    }
+    return HttpResponse.json({
+      id,
+      url: `/api/assets/${id}`,
+      name: filename,
+      mime_type: request.headers.get("content-type") || "image/png",
+      size_bytes: Number(request.headers.get("content-length") || 0),
+    });
+  }),
+  http.delete(/\/api\/v1\/assets\/fixture\/.+$/, async ({ request }) => {
+    await syncPublicReset();
+    const id = new URL(request.url).pathname.split("/").at(-1) || "";
+    const response = await fetch("/__akb_mock__/fixture/discard", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id }),
+    });
+    return HttpResponse.json(await response.json());
+  }),
+  http.get(/\/api\/assets\/.+$/, async ({ request }) => {
+    await syncPublicReset();
+    const id = new URL(request.url).pathname.split("/").at(-1) || "";
+    const asset = fixtureState.assets?.find((candidate) => candidate.id === id);
+    if (!asset || asset.status === "discarded") {
+      return new HttpResponse(null, { status: 404 });
+    }
+    return new HttpResponse(new Blob(["fixture-image"], { type: "image/png" }), {
+      headers: { "Content-Type": "image/png" },
+    });
+  }),
   http.get(`${API}/recent`, () => HttpResponse.json({ changes: [] })),
   http.get(`${API}/auth/tokens`, () => HttpResponse.json({ tokens: [] })),
   http.get(`${API}/search`, ({ request }) => {
@@ -122,6 +440,7 @@ const handlers = [
     });
   }),
   http.get("/health", () => HttpResponse.json(vaultHealth)),
+  http.get(/\/health\/vault\/fixture(?:\?.*)?$/, () => HttpResponse.json(vaultHealth)),
   // Mock product APIs never fall through to a real backend.
   http.all(`${API}/*`, () =>
     HttpResponse.json({ error: "unhandled_mock_api_request" }, { status: 501 }),
@@ -133,8 +452,25 @@ const worker = setupWorker(...handlers);
 export async function startMockWorker() {
   resetState();
   appliedResetGeneration = 0;
+  appliedRefetchGeneration = 0;
+  appliedExpireDraftGeneration = 0;
+  fixtureState = {};
+  try {
+    const discovery = await fetch("/__akb_mock__/discover", { cache: "no-store" });
+    if (discovery.ok) {
+      const descriptor = (await discovery.json()) as { scenario?: unknown };
+      activeScenario = typeof descriptor.scenario === "string" ? descriptor.scenario : "empty";
+    }
+  } catch {
+    activeScenario = "empty";
+  }
   await worker.start({
     onUnhandledRequest: "bypass",
     serviceWorker: { url: "/mockServiceWorker.js" },
   });
+  await syncFixtureState();
+  if (fixturePoll !== null) window.clearInterval(fixturePoll);
+  fixturePoll = window.setInterval(() => {
+    void syncFixtureState();
+  }, 250);
 }

--- a/frontend/src/pages/__tests__/document-view-toggle.test.tsx
+++ b/frontend/src/pages/__tests__/document-view-toggle.test.tsx
@@ -8,11 +8,14 @@ import { CurrentUserProvider } from "@/contexts/current-user-context";
 import DocumentPage from "@/pages/document";
 import { readRecentDocumentViews } from "@/lib/recent-document-views";
 
+const editorAssetIds = vi.hoisted(() => ({ value: [] as readonly string[] }));
+
 vi.mock("@/lib/api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/api")>();
   return {
     ...actual,
     getDocument: vi.fn(),
+    discardAsset: vi.fn(),
     getDocumentDiff: vi.fn(),
     getDocumentHistoryWithFallback: vi.fn(),
     getVaultInfo: vi.fn(),
@@ -29,17 +32,17 @@ vi.mock("@/lib/api", async (importOriginal) => {
 vi.mock("@/components/markdown-editor", () => ({
   default: ({
     value,
-    onChange,
-    ariaLabel,
-  }: {
-    value: string;
-    onChange?: (value: string) => void;
-    ariaLabel?: string;
+      onChange,
+      ariaLabel,
+    }: {
+      value: string;
+      onChange?: (value: string, assetIds?: readonly string[]) => void;
+      ariaLabel?: string;
   }) => (
     <textarea
       aria-label={ariaLabel}
       defaultValue={value}
-      onChange={(event) => onChange?.(event.currentTarget.value)}
+      onChange={(event) => onChange?.(event.currentTarget.value, editorAssetIds.value)}
     />
   ),
 }));
@@ -47,6 +50,7 @@ vi.mock("@/components/markdown-editor", () => ({
 import {
   ApiError,
   DocumentRevisionApiError,
+  discardAsset,
   deleteDocument,
   getDocument,
   getDocumentDiff,
@@ -59,6 +63,7 @@ import {
 } from "@/lib/api";
 
 const getDocumentMock = getDocument as unknown as ReturnType<typeof vi.fn>;
+const discardAssetMock = discardAsset as unknown as ReturnType<typeof vi.fn>;
 const deleteDocumentMock = deleteDocument as unknown as ReturnType<typeof vi.fn>;
 const getDocumentDiffMock = getDocumentDiff as unknown as ReturnType<typeof vi.fn>;
 const getDocumentHistoryMock = getDocumentHistoryWithFallback as unknown as ReturnType<typeof vi.fn>;
@@ -179,7 +184,7 @@ function LocationProbe() {
 
 function renderAt(url: string) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(
+  return { ...render(
     <QueryClientProvider client={qc}>
       <MemoryRouter initialEntries={[url]}>
         <CurrentUserProvider user={CURRENT_USER}>
@@ -192,7 +197,7 @@ function renderAt(url: string) {
         <LocationProbe />
       </MemoryRouter>
     </QueryClientProvider>,
-  );
+  ), queryClient: qc };
 }
 
 function renderPreviewAt(url: string) {
@@ -234,11 +239,14 @@ function renderPreviewAt(url: string) {
 beforeEach(() => {
   localStorage.clear();
   getDocumentMock.mockReset();
+  discardAssetMock.mockReset();
+  discardAssetMock.mockResolvedValue(undefined);
   deleteDocumentMock.mockReset();
   getDocumentDiffMock.mockReset();
   getDocumentHistoryMock.mockReset();
   getVaultInfoMock.mockReset();
   getRelationsMock.mockReset();
+  editorAssetIds.value = [];
   updateDocumentMock.mockReset();
   browseVaultMock.mockReset();
   moveDocumentMock.mockReset();
@@ -839,7 +847,7 @@ describe("DocumentPage view toggle", () => {
       expect(updateDocumentMock).toHaveBeenCalledWith(
         "v",
         "notes/hello.md",
-        { content: "Updated from pinned HEAD" },
+        { content: "Updated from pinned HEAD", expected_commit: "abcdef1234567" },
       ),
     );
     await waitFor(() =>
@@ -852,6 +860,112 @@ describe("DocumentPage view toggle", () => {
       () =>
         expect(screen.getByText("Updated from pinned HEAD")).toBeInTheDocument(),
       { timeout: 5_000 },
+    );
+  });
+
+  it("keeps the dirty editor when a newer server read arrives", async () => {
+    const user = userEvent.setup();
+    getVaultInfoMock.mockResolvedValue({ role: "owner" });
+    let serverDoc = makeDoc();
+    getDocumentMock.mockImplementation(async () => serverDoc);
+    const rendered = renderAt("/vault/v/doc/notes%2Fhello.md");
+
+    await user.click(await screen.findByRole("button", { name: "Edit" }));
+    const editor = await screen.findByRole("textbox", {
+      name: "Document body (markdown)",
+    });
+    await user.clear(editor);
+    await user.type(editor, "Local draft that must stay visible");
+
+    serverDoc = makeDoc({
+      content: "New server body",
+      current_commit: "server-commit",
+    });
+    await rendered.queryClient.refetchQueries({
+      queryKey: ["document", "v", "notes/hello.md"],
+    });
+
+    expect(screen.getByRole("textbox", { name: "Document body (markdown)" })).toHaveValue(
+      "Local draft that must stay visible",
+    );
+    expect(screen.getByRole("textbox", { name: "Document title" })).toHaveValue("DocTitle");
+  });
+
+  it("shows a three-way OCC conflict, preserves the image draft, and rebases only explicitly", async () => {
+    const user = userEvent.setup();
+    getVaultInfoMock.mockResolvedValue({ role: "owner" });
+    let serverDoc = makeDoc();
+    getDocumentMock.mockImplementation(async () => serverDoc);
+    updateDocumentMock
+      .mockRejectedValueOnce(new ApiError("revision moved", 409, { code: "conflict" }))
+      .mockResolvedValueOnce({ current_commit: "saved-after-rebase", commit_hash: "saved-after-rebase" });
+    editorAssetIds.value = ["asset-1"];
+    renderAt("/vault/v/doc/notes%2Fhello.md");
+
+    await user.click(await screen.findByRole("button", { name: "Edit" }));
+    const editor = await screen.findByRole("textbox", {
+      name: "Document body (markdown)",
+    });
+    await user.clear(editor);
+    await user.type(editor, "Local image draft");
+
+    serverDoc = makeDoc({
+      title: "Server title",
+      content: "Server changed body",
+      current_commit: "server-commit",
+    });
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByText("This document changed on the server")).toBeInTheDocument();
+    expect(screen.getByText("Original base")).toBeInTheDocument();
+    expect(screen.getByText("Your draft")).toBeInTheDocument();
+    expect(screen.getByText("Latest server version")).toBeInTheDocument();
+    expect(editor).toHaveValue("Local image draft");
+    expect(updateDocumentMock).toHaveBeenNthCalledWith(
+      1,
+      "v",
+      "notes/hello.md",
+      expect.objectContaining({ expected_commit: "abcdef1234567" }),
+    );
+    expect(discardAssetMock).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Apply draft to latest" }));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(updateDocumentMock).toHaveBeenLastCalledWith(
+        "v",
+        "notes/hello.md",
+        expect.objectContaining({ expected_commit: "server-commit" }),
+      ),
+    );
+    expect(discardAssetMock).not.toHaveBeenCalled();
+  });
+
+  it("restores the same valid draft after a failed save and reopening the document", async () => {
+    const user = userEvent.setup();
+    getVaultInfoMock.mockResolvedValue({ role: "owner" });
+    updateDocumentMock.mockRejectedValue(new Error("offline"));
+    const first = renderAt("/vault/v/doc/notes%2Fhello.md");
+
+    await user.click(await screen.findByRole("button", { name: "Edit" }));
+    const editor = await screen.findByRole("textbox", {
+      name: "Document body (markdown)",
+    });
+    await user.clear(editor);
+    await user.type(editor, "Offline draft body");
+    await screen.findByText("Draft saved locally");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(await screen.findByText("Your local draft is preserved. Retry when the server is available.")).toBeInTheDocument();
+
+    first.unmount();
+    expect(window.localStorage.length).toBeGreaterThan(0);
+    renderAt("/vault/v/doc/notes%2Fhello.md");
+    await user.click(await screen.findByRole("button", { name: "Edit" }));
+
+    expect(await screen.findByText("Local draft restored")).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Document body (markdown)" })).toHaveValue(
+      "Offline draft body",
     );
   });
 
@@ -916,6 +1030,7 @@ describe("DocumentPage view toggle", () => {
         "notes/hello.md",
         {
           content: "Updated contract body",
+          expected_commit: "abcdef1234567",
           title: "API contract",
           title_conflict_policy: "reject",
         },
@@ -977,7 +1092,7 @@ describe("DocumentPage view toggle", () => {
       expect(updateDocumentMock).toHaveBeenCalledWith(
         "v",
         "notes/hello.md",
-        { title: "API contract", title_conflict_policy: "allow" },
+        { title: "API contract", expected_commit: "abcdef1234567", title_conflict_policy: "allow" },
       ),
     );
   });
@@ -1022,7 +1137,7 @@ describe("DocumentPage view toggle", () => {
       expect(updateDocumentMock).toHaveBeenLastCalledWith(
         "v",
         "notes/hello.md",
-        { title: "API contract", title_conflict_policy: "allow" },
+        { title: "API contract", expected_commit: "abcdef1234567", title_conflict_policy: "allow" },
       ),
     );
   });

--- a/frontend/src/pages/__tests__/document-view-toggle.test.tsx
+++ b/frontend/src/pages/__tests__/document-view-toggle.test.tsx
@@ -969,6 +969,31 @@ describe("DocumentPage view toggle", () => {
     );
   });
 
+  it("does not resurrect a draft after explicit discard and a later reopen", async () => {
+    const user = userEvent.setup();
+    getVaultInfoMock.mockResolvedValue({ role: "owner" });
+    const first = renderAt("/vault/v/doc/notes%2Fhello.md");
+
+    await user.click(await screen.findByRole("button", { name: "Edit" }));
+    await user.type(
+      await screen.findByRole("textbox", { name: "Document body (markdown)" }),
+      "discard me",
+    );
+    await screen.findByText("Draft saved locally");
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    await user.click(screen.getByRole("button", { name: "Discard changes" }));
+    await screen.findByRole("heading", { level: 2, name: "BodyHeading" });
+
+    first.unmount();
+    renderAt("/vault/v/doc/notes%2Fhello.md");
+    await user.click(await screen.findByRole("button", { name: "Edit" }));
+
+    expect(screen.queryByText("Local draft restored")).not.toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Document body (markdown)" })).toHaveValue(
+      SAMPLE_CONTENT,
+    );
+  });
+
   it("exposes document deletion in the header for writers and leaves the stale route", async () => {
     const user = userEvent.setup();
     getVaultInfoMock.mockResolvedValue({ role: "writer" });

--- a/frontend/src/pages/document.tsx
+++ b/frontend/src/pages/document.tsx
@@ -478,6 +478,17 @@ export default function DocumentPage({
     retry: false,
   });
 
+  useEffect(() => {
+    if (import.meta.env.VITE_AKB_TEST_MODE !== "mock" || !name || !docId) return;
+    const onMockRefetch = (event: Event) => {
+      const detail = (event as CustomEvent<{ vault?: unknown; document?: unknown }>).detail;
+      if (detail?.vault !== name || detail.document !== docId) return;
+      void queryClient.refetchQueries({ queryKey: ["document", name, docId] });
+    };
+    window.addEventListener("akb:mock-document-refetch", onMockRefetch);
+    return () => window.removeEventListener("akb:mock-document-refetch", onMockRefetch);
+  }, [docId, name, queryClient]);
+
   const doc = docOverride ?? docQuery.data ?? null;
   const historyQuery = useQuery({
     queryKey: ["document-history", name, doc?.path],

--- a/frontend/src/pages/document.tsx
+++ b/frontend/src/pages/document.tsx
@@ -93,6 +93,7 @@ import {
   listDocumentEditDrafts,
   saveDocumentEditDraft,
   type DocumentEditDraftLoadResult,
+  type DocumentEditDraftInput,
   type StoredDocumentEditDraft,
 } from "@/lib/document-draft";
 import {
@@ -253,6 +254,7 @@ export default function DocumentPage({
   const latestServerDocumentRef = useRef<any>(null);
   const latestServerErrorRef = useRef("");
   const storageSaveTimerRef = useRef<number | null>(null);
+  const latestDraftInputRef = useRef<DocumentEditDraftInput | null>(null);
   const editingSnapshotRef = useRef({
     title: "",
     content: "",
@@ -343,6 +345,7 @@ export default function DocumentPage({
   function persistEditDraft(overrides: Parameters<typeof currentDraftInput>[0] = {}): boolean {
     const input = currentDraftInput(overrides);
     if (!input) return false;
+    latestDraftInputRef.current = input;
     const saved = saveDocumentEditDraft(input);
     setDraftStatus(saved ? "saved" : "error");
     setDraftNotice(saved ? "Draft saved locally" : "Could not save this draft locally; it remains only in this tab.");
@@ -834,19 +837,24 @@ export default function DocumentPage({
     view,
   ]);
 
-  // Persist the latest snapshot synchronously before a route unmount. The
-  // normal 300ms write above gives localStorage a quiet path; this cleanup is
-  // the guard for a fast tab close, Back navigation, or preview dismissal.
   useEffect(() => {
-    return () => {
-      if (view !== "edit" || !isDirty) return;
-      const input = currentDraftInput();
-      if (input) saveDocumentEditDraft(input);
-    };
+    if (
+      view !== "edit" ||
+      !isDirty ||
+      draftStatus === "expired" ||
+      draftStatus === "incompatible" ||
+      (draftStatus === "restored" &&
+        draftRevisionRef.current === restoredDraftRevisionRef.current)
+    ) {
+      latestDraftInputRef.current = null;
+      return;
+    }
+    latestDraftInputRef.current = currentDraftInput();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     currentUserId,
     doc?.path,
+    draftStatus,
     editingAssetIds,
     editingContent,
     editingTitle,
@@ -856,6 +864,17 @@ export default function DocumentPage({
     originalTitle,
     view,
   ]);
+
+  // Persist the latest snapshot synchronously before a fast tab close, Back
+  // navigation, or preview dismissal. This effect intentionally has no state
+  // dependencies: its cleanup is an actual component-unmount boundary.
+  useEffect(
+    () => () => {
+      const input = latestDraftInputRef.current;
+      if (input) saveDocumentEditDraft(input);
+    },
+    [],
+  );
 
   // Warn before page navigation (close tab, browser back) when dirty.
   useEffect(() => {
@@ -1045,6 +1064,7 @@ export default function DocumentPage({
       } else if (draftSessionRef.current) {
         clearDocumentEditDraft(draftSessionRef.current);
         draftSessionRef.current = null;
+        latestDraftInputRef.current = null;
         setDraftStatus("idle");
         setDraftNotice("");
       }
@@ -1173,6 +1193,7 @@ export default function DocumentPage({
   async function discardEditDraft() {
     const draft = draftSessionRef.current;
     const protectedAssets = protectedDraftAssetIds(draft?.draftId);
+    latestDraftInputRef.current = null;
     const assets = new Set<string>([
       ...(draft?.assetIds || []),
       ...editingAssetIds,

--- a/frontend/src/pages/document.tsx
+++ b/frontend/src/pages/document.tsx
@@ -2224,6 +2224,7 @@ export default function DocumentPage({
           const next = pendingView;
           await discardEditDraft();
           setEditingContent(originalContent);
+          setEditorInitialContent(originalContent);
           setEditingTitle(originalTitle);
           setEditingAssetIds([]);
           setEditorKey((k) => k + 1);

--- a/frontend/src/pages/document.tsx
+++ b/frontend/src/pages/document.tsx
@@ -35,11 +35,13 @@ import {
 import {
   ApiError,
   browseVault,
+  discardAsset,
   deleteDocument,
   getDocument,
   getDocumentHistoryWithFallback,
   getRelations,
   getVaultInfo,
+  type DocumentUpdateInput,
   type DocumentHistoryEntry,
   type RelationRow,
   unpublishDoc,
@@ -78,6 +80,22 @@ import { DocumentMoveDialog } from "@/components/document-move-dialog";
 import { ArchiveVerificationError, changeDocumentArchiveState, checkDocumentArchiveState, documentArchiveDisabledReason } from "@/lib/document-archive";
 import { DocumentTitleConflictNotice } from "@/components/document-title-conflict-notice";
 import {
+  DocumentConflictNotice,
+  type DocumentConflictSnapshot,
+} from "@/components/document-conflict-notice";
+import {
+  clearDocumentEditDraft,
+  createDocumentEditDraftId,
+  DOCUMENT_EDIT_DRAFT_EDITOR_VERSION,
+  DOCUMENT_EDIT_DRAFT_MARKDOWN_PROFILE,
+  documentEditDraftTabId,
+  loadDocumentEditDraft,
+  listDocumentEditDrafts,
+  saveDocumentEditDraft,
+  type DocumentEditDraftLoadResult,
+  type StoredDocumentEditDraft,
+} from "@/lib/document-draft";
+import {
   documentCollection,
   documentTitleConflictFromError,
   documentTitleKey,
@@ -106,6 +124,24 @@ function isBrowsedDocumentTitle(item: unknown): item is BrowsedDocumentTitle {
     candidate.type === "document" &&
     typeof candidate.name === "string" &&
     typeof candidate.path === "string"
+  );
+}
+
+function documentIdentity(vault: string, document: Record<string, any>): string {
+  return typeof document.uri === "string" && document.uri
+    ? document.uri
+    : `${vault}:${String(document.path || "")}`;
+}
+
+function validRevision(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isRevisionConflict(error: unknown): error is ApiError {
+  return (
+    error instanceof ApiError &&
+    error.status === 409 &&
+    (error.detail as { code?: unknown } | null)?.code === "conflict"
   );
 }
 
@@ -186,15 +222,132 @@ export default function DocumentPage({
   const [bodyError, setBodyError] = useState("");
   const [savedAt, setSavedAt] = useState<number | null>(null);
   const [moveNotice, setMoveNotice] = useState<{ collection: string } | null>(null);
+  const [editBaseCommit, setEditBaseCommit] = useState<string | null>(null);
+  const [latestServerDocument, setLatestServerDocument] = useState<any>(null);
+  const [saveConflict, setSaveConflict] = useState<{
+    base: DocumentConflictSnapshot;
+    local: DocumentConflictSnapshot;
+    latest: DocumentConflictSnapshot | null;
+    latestError?: string;
+  } | null>(null);
+  const [rebasing, setRebasing] = useState(false);
+  const [draftStatus, setDraftStatus] = useState<
+    "idle" | "restored" | "saving" | "saved" | "error" | "expired" | "incompatible" | "unavailable"
+  >("idle");
+  const [draftNotice, setDraftNotice] = useState("");
+  const [draftRecovery, setDraftRecovery] = useState<DocumentEditDraftLoadResult | null>(null);
+  const [editorInitialContent, setEditorInitialContent] = useState("");
   // Plate's markdown roundtrip is not byte-identity: adopt the first
   // post-hydration emission as the new `originalContent` baseline so the
   // editor doesn't flash "UNSAVED" the moment it mounts.
   const hydratedKey = useRef<number | null>(null);
+  const editorHydrationModeRef = useRef<"server" | "draft">("server");
+  const documentIdentityRef = useRef<string | null>(null);
+  const editBaseCommitRef = useRef<string | null>(null);
+  const draftHydratedForRef = useRef<string | null>(null);
+  const draftSessionRef = useRef<StoredDocumentEditDraft | null>(null);
+  const draftTabIdRef = useRef<string | null>(null);
+  const skipNextDraftSaveRef = useRef(false);
+  const restoredDraftRevisionRef = useRef<number | null>(null);
+  const draftRevisionRef = useRef(0);
+  const latestServerDocumentRef = useRef<any>(null);
+  const latestServerErrorRef = useRef("");
+  const storageSaveTimerRef = useRef<number | null>(null);
+  const editingSnapshotRef = useRef({
+    title: "",
+    content: "",
+    assetIds: [] as readonly string[],
+  });
   const contentChanged = editingContent !== originalContent;
   const normalizedEditingTitle = documentTitleKey(editingTitle);
   const titleChanged = normalizedEditingTitle !== documentTitleKey(originalTitle);
   const isDirty = contentChanged || titleChanged;
   const hasUnsavedWork = isDirty || uploadingImage;
+
+  useEffect(() => {
+    editingSnapshotRef.current = {
+      title: editingTitle,
+      content: editingContent,
+      assetIds: editingAssetIds,
+    };
+  }, [editingAssetIds, editingContent, editingTitle]);
+
+  useEffect(() => {
+    // A real editor can emit one canonicalization event while mounting. The
+    // page state already owns the server/draft baseline, so user input from
+    // the mounted editor must not be mistaken for that first emission (the
+    // mock editor has no mount event and otherwise makes clear() rewrite the
+    // OCC base to an empty string).
+    hydratedKey.current = editorKey;
+  }, [editorKey]);
+
+  function setBaseCommit(commit: string | null) {
+    editBaseCommitRef.current = commit;
+    setEditBaseCommit(commit);
+  }
+
+  function setLatestServer(document: any, error = "") {
+    latestServerDocumentRef.current = document;
+    latestServerErrorRef.current = error;
+    setLatestServerDocument(document);
+  }
+
+  function currentDraftInput(
+    overrides: Partial<{
+      baseCommit: string;
+      baseTitle: string;
+      baseBody: string;
+      title: string;
+      body: string;
+      assetIds: readonly string[];
+    }> = {},
+  ) {
+    if (!currentUserId || !name || !doc?.path || !editBaseCommitRef.current) return null;
+    if (!draftSessionRef.current) {
+      draftSessionRef.current = {
+        version: 1,
+        kind: "document-edit",
+        draftId: createDocumentEditDraftId(),
+        tabId: draftTabIdRef.current || documentEditDraftTabId(),
+        userId: currentUserId,
+        vault: name,
+        document: documentIdentity(name, doc),
+        baseCommit: editBaseCommitRef.current,
+        baseTitle: originalTitle,
+        baseBody: originalContent,
+        title: editingTitle,
+        body: editingContent,
+        assetIds: [...editingAssetIds],
+        editorVersion: DOCUMENT_EDIT_DRAFT_EDITOR_VERSION,
+        markdownProfile: DOCUMENT_EDIT_DRAFT_MARKDOWN_PROFILE,
+        updatedAt: new Date().toISOString(),
+        expiresAt: new Date().toISOString(),
+      };
+    }
+    const session = draftSessionRef.current;
+    return {
+      ...session,
+      userId: currentUserId,
+      vault: name,
+      document: documentIdentity(name, doc),
+      baseCommit: overrides.baseCommit ?? editBaseCommitRef.current,
+      baseTitle: overrides.baseTitle ?? originalTitle,
+      baseBody: overrides.baseBody ?? originalContent,
+      title: overrides.title ?? editingTitle,
+      body: overrides.body ?? editingContent,
+      assetIds: [...(overrides.assetIds ?? editingAssetIds)],
+      tabId: draftTabIdRef.current || session.tabId,
+    };
+  }
+
+  function persistEditDraft(overrides: Parameters<typeof currentDraftInput>[0] = {}): boolean {
+    const input = currentDraftInput(overrides);
+    if (!input) return false;
+    const saved = saveDocumentEditDraft(input);
+    setDraftStatus(saved ? "saved" : "error");
+    setDraftNotice(saved ? "Draft saved locally" : "Could not save this draft locally; it remains only in this tab.");
+    return saved;
+  }
 
   useEffect(() => {
     if (!moveNotice) return;
@@ -465,41 +618,244 @@ export default function DocumentPage({
 
   useEffect(() => {
     const d = docQuery.data;
-    setDocOverride(null);
-    setRelations([]);
-    setRelationsError(false);
-    setBodyError("");
-    setTitleTouched(false);
-    setServerTitleConflict(null);
-    setClaimedAssetIds(null);
-    if (!d) return;
-    const body = d.content || "";
-    const title = d.title || "";
-    setOriginalContent(body);
-    setEditingContent(body);
-    setOriginalTitle(title);
-    setEditingTitle(title);
-    // Bump the key so the Plate editor remounts with the new value —
-    // it's uncontrolled internally and won't pick up `value` prop
-    // changes after mount.
-    setEditorKey((k) => k + 1);
+    if (!d?.path || !name) return;
+
+    const identity = documentIdentity(name, d);
+    const identityChanged = documentIdentityRef.current !== identity;
+    const preserveEditState =
+      view === "edit" &&
+      (isDirty ||
+        draftStatus === "restored" ||
+        draftStatus === "saving" ||
+        draftStatus === "saved" ||
+        draftStatus === "error" ||
+        saveConflict !== null);
+
+    if (identityChanged) {
+      documentIdentityRef.current = identity;
+      draftHydratedForRef.current = null;
+      draftSessionRef.current = null;
+      draftTabIdRef.current = currentUserId ? documentEditDraftTabId() : null;
+      setDocOverride(null);
+      setRelations([]);
+      setRelationsError(false);
+      setBodyError("");
+      setTitleTouched(false);
+      setServerTitleConflict(null);
+      setSaveConflict(null);
+      setLatestServer(null);
+      setDraftRecovery(null);
+      setDraftStatus("idle");
+      setDraftNotice("");
+      setClaimedAssetIds(null);
+      setOriginalContent(d.content || "");
+      setEditingContent(d.content || "");
+      setOriginalTitle(d.title || "");
+      setEditingTitle(d.title || "");
+      setEditingAssetIds([]);
+      setEditorInitialContent(d.content || "");
+      editorHydrationModeRef.current = "server";
+      hydratedKey.current = null;
+      setBaseCommit(validRevision(d.current_commit) ? d.current_commit : null);
+      setEditorKey((k) => k + 1);
+    } else if (preserveEditState) {
+      if (
+        validRevision(d.current_commit) &&
+        d.current_commit !== editBaseCommitRef.current
+      ) {
+        setLatestServer(d);
+      }
+    } else {
+      // A clean editor can follow an external refresh. Once the user has a
+      // dirty draft, this branch is never used, so the base revision remains
+      // pinned until the user explicitly reapplies it to the latest version.
+      setOriginalContent(d.content || "");
+      setEditingContent(d.content || "");
+      setOriginalTitle(d.title || "");
+      setEditingTitle(d.title || "");
+      setEditorInitialContent(d.content || "");
+      editorHydrationModeRef.current = "server";
+      hydratedKey.current = null;
+      setBaseCommit(validRevision(d.current_commit) ? d.current_commit : null);
+      setEditorKey((k) => k + 1);
+    }
+
     if (d.path && d.path !== docId) {
       navigate(`/vault/${name}/doc/${encodeURIComponent(d.path)}`, {
         replace: true,
         state: routeLocation.state,
       });
     }
-    if (d.path) {
-      // getRelations builds the canonical akb:// URI from the vault-relative
-      // *path* (docUri). The GET response exposes no internal `id` — `uri`/
-      // `path` is the sole identifier — so keying this off `d.id` (always
-      // undefined) meant relations never loaded on the document page.
-      getRelations(name!, d.path)
-        .then((r) => setRelations(r.relations || []))
-        .catch(() => setRelationsError(true));
-    }
+    // getRelations builds the canonical akb:// URI from the vault-relative
+    // path. The GET response exposes no internal `id`; `uri`/`path` is the
+    // sole document identifier.
+    getRelations(name, d.path)
+      .then((r) => setRelations(r.relations || []))
+      .catch(() => setRelationsError(true));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [docQuery.data]);
+
+  useEffect(() => {
+    const d = docQuery.data;
+    if (view !== "edit" || !d?.path || !name || !currentUserId) return;
+    const identity = documentIdentity(name, d);
+    const hydrationKey = `${currentUserId}\u0000${identity}`;
+    if (draftHydratedForRef.current === hydrationKey) return;
+    draftHydratedForRef.current = hydrationKey;
+    draftTabIdRef.current ||= documentEditDraftTabId();
+    const result = loadDocumentEditDraft(
+      currentUserId,
+      name,
+      identity,
+      draftTabIdRef.current,
+    );
+    setDraftRecovery(
+      result.status === "expired" || result.status === "incompatible" ? result : null,
+    );
+
+    if (result.status === "restored" || result.status === "expired") {
+      const stored = result.draft;
+      const sameTab = stored.tabId === draftTabIdRef.current;
+      draftSessionRef.current = sameTab
+        ? stored
+        : {
+            ...stored,
+            draftId: createDocumentEditDraftId(),
+            tabId: draftTabIdRef.current,
+          };
+      skipNextDraftSaveRef.current = true;
+      restoredDraftRevisionRef.current = draftRevisionRef.current;
+      setOriginalContent(stored.baseBody);
+      setOriginalTitle(stored.baseTitle);
+      setEditingContent(stored.body);
+      setEditingTitle(stored.title);
+      setEditingAssetIds(stored.assetIds);
+      setEditorInitialContent(stored.body);
+      editorHydrationModeRef.current = "draft";
+      hydratedKey.current = null;
+      setBaseCommit(validRevision(stored.baseCommit) ? stored.baseCommit : null);
+      setEditorKey((k) => k + 1);
+      setDraftStatus(result.status === "expired" ? "expired" : "restored");
+      setDraftNotice(
+        result.status === "expired"
+          ? "This draft has expired. Its text is kept for copying; attached images may no longer be available."
+          : "Local draft restored",
+      );
+      if (result.status === "expired") {
+        const protectedAssetIds = new Set(
+          listDocumentEditDrafts(currentUserId, name, identity)
+            .filter(
+              (draft) =>
+                draft.draftId !== stored.draftId &&
+                Date.parse(draft.expiresAt) > Date.now(),
+            )
+            .flatMap((draft) => draft.assetIds),
+        );
+        void Promise.allSettled(
+          stored.assetIds
+            .filter((assetId) => !protectedAssetIds.has(assetId))
+            .map((assetId) => discardAsset(name, assetId)),
+        );
+      }
+    } else if (result.status === "incompatible") {
+      setDraftStatus("incompatible");
+      setDraftNotice(
+        "This draft uses an incompatible editor profile. Its original text remains available to copy.",
+      );
+    } else if (result.status === "storage-unavailable") {
+      setDraftStatus("unavailable");
+      setDraftNotice("Local draft storage is unavailable; edits remain only in this tab.");
+    }
+  }, [currentUserId, docQuery.data, name, view]);
+
+  useEffect(() => {
+    if (view !== "edit" || !currentUserId || !name || !doc?.path) return;
+    if (draftStatus === "expired" || draftStatus === "incompatible" || draftStatus === "unavailable") {
+      return;
+    }
+    if (
+      skipNextDraftSaveRef.current ||
+      (draftStatus === "restored" &&
+        draftRevisionRef.current === restoredDraftRevisionRef.current)
+    ) {
+      skipNextDraftSaveRef.current = false;
+      return;
+    }
+    if (!isDirty) {
+      const existing = draftSessionRef.current;
+      if (existing) {
+        clearDocumentEditDraft(existing);
+        const currentAssets = new Set(editingAssetIds);
+        const protectedAssets = protectedDraftAssetIds(existing.draftId);
+        void Promise.allSettled(
+          existing.assetIds
+            .filter(
+              (assetId) =>
+                !currentAssets.has(assetId) && !protectedAssets.has(assetId),
+            )
+            .map((assetId) => discardAsset(name, assetId)),
+        );
+      }
+      draftSessionRef.current = null;
+      setDraftStatus("idle");
+      setDraftNotice("");
+      return;
+    }
+
+    if (storageSaveTimerRef.current !== null) {
+      window.clearTimeout(storageSaveTimerRef.current);
+    }
+    setDraftStatus("saving");
+    setDraftNotice("Saving draft locally…");
+    storageSaveTimerRef.current = window.setTimeout(() => {
+      storageSaveTimerRef.current = null;
+      persistEditDraft();
+    }, 300);
+    return () => {
+      if (storageSaveTimerRef.current !== null) {
+        window.clearTimeout(storageSaveTimerRef.current);
+        storageSaveTimerRef.current = null;
+      }
+    };
+    // `draftStatus` is intentionally read from the render that scheduled this
+    // write. Including it here would restart the debounce after every status
+    // update and could mark an expired draft active again.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    currentUserId,
+    doc?.path,
+    editingAssetIds,
+    editingContent,
+    editingTitle,
+    isDirty,
+    name,
+    originalContent,
+    originalTitle,
+    view,
+  ]);
+
+  // Persist the latest snapshot synchronously before a route unmount. The
+  // normal 300ms write above gives localStorage a quiet path; this cleanup is
+  // the guard for a fast tab close, Back navigation, or preview dismissal.
+  useEffect(() => {
+    return () => {
+      if (view !== "edit" || !isDirty) return;
+      const input = currentDraftInput();
+      if (input) saveDocumentEditDraft(input);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    currentUserId,
+    doc?.path,
+    editingAssetIds,
+    editingContent,
+    editingTitle,
+    isDirty,
+    name,
+    originalContent,
+    originalTitle,
+    view,
+  ]);
 
   // Warn before page navigation (close tab, browser back) when dirty.
   useEffect(() => {
@@ -540,6 +896,69 @@ export default function DocumentPage({
     window.requestAnimationFrame(() => titleConflictRef.current?.focus());
   }
 
+  function makeConflictSnapshot(
+    label: string,
+    commit: string | null,
+    title: string,
+    body: string,
+  ): DocumentConflictSnapshot {
+    return { label, commit, title, body };
+  }
+
+  async function readLatestForConflict(): Promise<any | null> {
+    try {
+      const latest = await getDocument(name!, docId);
+      setLatestServer(latest);
+      return latest;
+    } catch {
+      setLatestServer(
+        null,
+        "The latest version could not be loaded. Your draft remains available.",
+      );
+      return null;
+    }
+  }
+
+  async function applyDraftToLatest() {
+    const latest = latestServerDocument || (await readLatestForConflict());
+    if (!latest || !validRevision(latest.current_commit)) return;
+    setRebasing(true);
+    try {
+      const baseBody = typeof latest.content === "string" ? latest.content : "";
+      const baseTitle = typeof latest.title === "string" ? latest.title : "";
+      setOriginalContent(baseBody);
+      setOriginalTitle(baseTitle);
+      setBaseCommit(latest.current_commit);
+      setDocOverride(latest);
+      queryClient.setQueryData(
+        ["document", name, docId, undefined],
+        latest,
+      );
+      setLatestServer(null);
+      setSaveConflict(null);
+      setBodyError("");
+      persistEditDraft({
+        baseCommit: latest.current_commit,
+        baseTitle,
+        baseBody,
+        title: editingTitle,
+        body: editingContent,
+        assetIds: editingAssetIds,
+      });
+    } finally {
+      setRebasing(false);
+    }
+  }
+
+  async function copyDraftText(text: string, message: string) {
+    try {
+      await navigator.clipboard?.writeText(text);
+      setDraftNotice(message);
+    } catch {
+      setDraftNotice("Clipboard access is unavailable; select the preserved text manually.");
+    }
+  }
+
   async function handleSaveDocument(
     titleConflictPolicy: "allow" | "reject" = "reject",
   ) {
@@ -557,7 +976,7 @@ export default function DocumentPage({
 
     const contentToSave = editingContent;
     const assetIdsToClaim = editingAssetIds;
-    const payload: Record<string, unknown> = {};
+    const payload: DocumentUpdateInput = {};
     if (contentChanged) payload.content = contentToSave;
     if (titleChanged) {
       payload.title = normalizedEditingTitle;
@@ -565,11 +984,26 @@ export default function DocumentPage({
     }
     if (Object.keys(payload).length === 0) return;
 
+    const baseCommit = editBaseCommitRef.current;
+    if (!validRevision(baseCommit)) {
+      setBodyError("This document has no valid revision. Reload it before saving.");
+      return;
+    }
+    payload.expected_commit = baseCommit;
+
+    const saveRevision = draftRevisionRef.current;
     setSavingBody(true);
     setBodyError("");
     try {
       const saved = await updateDocument(name, docId, payload);
+      const savedCommit = saved.current_commit ?? saved.commit_hash ?? null;
+      if (!validRevision(savedCommit)) {
+        throw new Error("The server did not return a document revision after saving.");
+      }
       const now = new Date().toISOString();
+      const titleToSave = titleChanged ? normalizedEditingTitle : originalTitle;
+      const hasFollowupEdits = draftRevisionRef.current !== saveRevision;
+      const followup = editingSnapshotRef.current;
       // Optimistically advance content + updated_at so the byline reads
       // "last changed just now" without waiting for a refetch. DocumentView
       // consumes the same query key independently, so update that cache too;
@@ -577,10 +1011,11 @@ export default function DocumentPage({
       const nextDoc = {
         ...(doc || {}),
         content: contentToSave,
-        title: titleChanged ? normalizedEditingTitle : doc?.title,
+        title: titleToSave,
         updated_at: now,
-        current_commit: saved.current_commit ?? saved.commit_hash ?? doc?.current_commit,
+        current_commit: savedCommit,
       };
+      setBaseCommit(savedCommit);
       setDocOverride(nextDoc);
       queryClient.setQueryData(
         ["document", name, docId, undefined],
@@ -590,10 +1025,29 @@ export default function DocumentPage({
         }),
       );
       setOriginalContent(contentToSave);
-      setOriginalTitle(titleChanged ? normalizedEditingTitle : originalTitle);
-      setEditingTitle(titleChanged ? normalizedEditingTitle : originalTitle);
+      setOriginalTitle(titleToSave);
+      if (!hasFollowupEdits) setEditingTitle(titleToSave);
       setTitleTouched(false);
       setServerTitleConflict(null);
+      setSaveConflict(null);
+      setLatestServer(null);
+      if (hasFollowupEdits) {
+        // Keep later edits in a new draft whose base is the commit that just
+        // succeeded. The accepted snapshot alone is the one being claimed.
+        persistEditDraft({
+          baseCommit: savedCommit,
+          baseTitle: titleToSave,
+          baseBody: contentToSave,
+          title: followup.title,
+          body: followup.content,
+          assetIds: followup.assetIds,
+        });
+      } else if (draftSessionRef.current) {
+        clearDocumentEditDraft(draftSessionRef.current);
+        draftSessionRef.current = null;
+        setDraftStatus("idle");
+        setDraftNotice("");
+      }
       // Sidebar refresh is best-effort — its failure must not leave the
       // user looking at a "still dirty" editor after a successful save.
       try {
@@ -627,6 +1081,34 @@ export default function DocumentPage({
         await showTitleConflict(conflict);
         return;
       }
+      if (isRevisionConflict(e)) {
+        const latest = await readLatestForConflict();
+        setSaveConflict({
+          base: makeConflictSnapshot(
+            "Original base",
+            baseCommit,
+            originalTitle,
+            originalContent,
+          ),
+          local: makeConflictSnapshot(
+            "Your draft",
+            baseCommit,
+            normalizedEditingTitle,
+            contentToSave,
+          ),
+          latest: latest
+            ? makeConflictSnapshot(
+                "Latest server version",
+                validRevision(latest.current_commit) ? latest.current_commit : null,
+                latest.title || "",
+                latest.content || "",
+              )
+            : null,
+          latestError: latest ? undefined : latestServerErrorRef.current,
+        });
+        setDraftNotice("Your local draft is preserved after the conflict.");
+        return;
+      }
       const status = e instanceof ApiError ? e.status : 0;
       // 5xx responses can carry stack traces or SQL fragments — never
       // surface those verbatim. 4xx are intentional API errors so the
@@ -638,6 +1120,7 @@ export default function DocumentPage({
             ? e.message
             : "Save failed.";
       setBodyError(safe);
+      setDraftNotice("Your local draft is preserved. Retry when the server is available.");
     } finally {
       // Always clear the spinner — a post-await setState throwing must not
       // leave the editor stuck on "Saving…".
@@ -670,6 +1153,46 @@ export default function DocumentPage({
     setView("rendered");
   }
 
+  function protectedDraftAssetIds(excludeDraftId?: string): Set<string> {
+    if (!currentUserId || !name || !doc?.path) return new Set();
+    return new Set(
+      listDocumentEditDrafts(
+        currentUserId,
+        name,
+        documentIdentity(name, doc),
+      )
+        .filter(
+          (draft) =>
+            draft.draftId !== excludeDraftId &&
+            Date.parse(draft.expiresAt) > Date.now(),
+        )
+        .flatMap((draft) => draft.assetIds),
+    );
+  }
+
+  async function discardEditDraft() {
+    const draft = draftSessionRef.current;
+    const protectedAssets = protectedDraftAssetIds(draft?.draftId);
+    const assets = new Set<string>([
+      ...(draft?.assetIds || []),
+      ...editingAssetIds,
+    ]);
+    if (draft) clearDocumentEditDraft(draft);
+    if (draftRecovery?.status === "expired") {
+      clearDocumentEditDraft(draftRecovery.draft);
+    }
+    await Promise.allSettled(
+      [...assets]
+        .filter((assetId) => !protectedAssets.has(assetId))
+        .map((assetId) => discardAsset(name!, assetId)),
+    );
+    draftSessionRef.current = null;
+    setDraftRecovery(null);
+    setDraftStatus("idle");
+    setDraftNotice("");
+    setSaveConflict(null);
+  }
+
   // The vault guide is system-managed: its only editing surface is the guide
   // section in vault settings, so the plain full-page viewer bounces there.
   // Search preview is exempt so every document result keeps the same modal
@@ -688,7 +1211,7 @@ export default function DocumentPage({
     return <Navigate to={`/vault/${name}/settings#skill`} replace />;
   }
 
-  if (docQuery.isError) {
+  if (docQuery.isError && !doc) {
     const errorMsg = (docQuery.error as Error)?.message ?? "Unknown error";
     return (
       <div className="py-8 fade-up">
@@ -973,6 +1496,15 @@ export default function DocumentPage({
             <Alert variant="destructive">{publishError}</Alert>
           </div>
         )}
+        {docQuery.isRefetchError && (
+          <div className="shrink-0 border-b border-border bg-surface px-4 py-3 sm:px-6">
+            <Alert variant="warning" title="Couldn’t refresh the document">
+              {isDirty
+                ? "Your local draft is still open. The latest server version will be loaded before any conflict resolution."
+                : "The current document remains visible. Try again when the server is available."}
+            </Alert>
+          </div>
+        )}
 
         <div className="relative min-h-0 flex-1 overflow-hidden">
           <main
@@ -1066,7 +1598,15 @@ export default function DocumentPage({
                       Editing document
                     </span>
                     <span role="status" aria-live="polite" className="ml-auto text-xs text-foreground-muted">
-                      {uploadingImage ? "Uploading image…" : isDirty ? "Unsaved changes" : "No changes"}
+                      {uploadingImage
+                        ? "Uploading image…"
+                        : isDirty
+                          ? "Unsaved changes"
+                          : draftStatus === "saving"
+                            ? "Saving draft locally…"
+                            : draftStatus === "saved"
+                              ? "Draft saved locally"
+                              : "No changes"}
                     </span>
                   </div>
                   <div
@@ -1080,6 +1620,7 @@ export default function DocumentPage({
                         value={editingTitle}
                         onChange={(event) => {
                           setEditingTitle(event.currentTarget.value);
+                          draftRevisionRef.current += 1;
                           setServerTitleConflict(null);
                           setBodyError("");
                         }}
@@ -1129,15 +1670,24 @@ export default function DocumentPage({
                     <Suspense fallback={<MarkdownEditorFallback />}>
                       <MarkdownEditor
                         key={editorKey}
-                        value={originalContent}
+                        value={editorInitialContent}
                         onChange={(markdown, assetIds) => {
-                          setEditingAssetIds(assetIds);
+                          const nextAssetIds = assetIds || [];
+                          draftRevisionRef.current += 1;
+                          editingSnapshotRef.current = {
+                            title: editingTitle,
+                            content: markdown,
+                            assetIds: nextAssetIds,
+                          };
+                          setEditingAssetIds(nextAssetIds);
                           setServerTitleConflict((current) =>
                             current ? { ...current, exactContent: false } : null,
                           );
                           if (hydratedKey.current !== editorKey) {
                             hydratedKey.current = editorKey;
-                            setOriginalContent(markdown);
+                            if (editorHydrationModeRef.current === "server") {
+                              setOriginalContent(markdown);
+                            }
                             setEditingContent(markdown);
                             return;
                           }
@@ -1148,16 +1698,69 @@ export default function DocumentPage({
                         readOnly={savingBody}
                         vault={name!}
                         document={doc?.path}
-                        commit={doc?.current_commit ?? undefined}
+                        commit={editBaseCommit ?? undefined}
                         appearance="workspace"
                         onUploadingChange={(uploading) => {
                           setUploadingImage(uploading);
                           if (uploading) setClaimedAssetIds(null);
                         }}
-                        preserveUploadsOnUnmount={savingBody}
+                        preserveUploadsOnUnmount={
+                          savingBody ||
+                          draftStatus === "saving" ||
+                          draftStatus === "saved" ||
+                          draftStatus === "restored" ||
+                          draftStatus === "expired"
+                        }
                         claimedAssetIds={claimedAssetIds}
+                        initialUnclaimedAssetIds={editingAssetIds}
                       />
                     </Suspense>
+                    {draftNotice && (draftStatus === "restored" || draftStatus === "saved" || draftStatus === "error" || draftStatus === "unavailable") && (
+                      <p className="mt-3 text-xs text-foreground-muted" role="status" aria-live="polite">
+                        {draftNotice}
+                      </p>
+                    )}
+                    {draftRecovery?.status === "expired" && (
+                      <Alert variant="warning" title="This draft has expired" className="mt-4">
+                        <p>{draftRecovery.draft.body ? "The preserved text can still be copied, but attached images are not guaranteed to be recoverable." : "The draft record is expired."}</p>
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={() => void copyDraftText(draftRecovery.draft.body, "Expired draft Markdown copied")}
+                          >
+                            Copy expired Markdown
+                          </Button>
+                        </div>
+                      </Alert>
+                    )}
+                    {draftRecovery?.status === "incompatible" && (
+                      <Alert variant="warning" title="Draft editor profile is not supported here" className="mt-4">
+                        <p>The original draft was kept without conversion or deletion. Copy its text before choosing a new draft.</p>
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={() => void copyDraftText(draftRecovery.draft.copyBody, "Incompatible draft Markdown copied")}
+                          >
+                            Copy preserved Markdown
+                          </Button>
+                        </div>
+                      </Alert>
+                    )}
+                    {saveConflict && (
+                      <DocumentConflictNotice
+                        base={saveConflict.base}
+                        local={saveConflict.local}
+                        latest={saveConflict.latest}
+                        latestError={saveConflict.latestError}
+                        rebasing={rebasing}
+                        onRebase={() => void applyDraftToLatest()}
+                        onRetryLatest={() => void readLatestForConflict()}
+                      />
+                    )}
                     {bodyError && <Alert variant="destructive" className="mt-4">{bodyError}</Alert>}
                   </div>
                 </section>
@@ -1559,8 +2162,9 @@ export default function DocumentPage({
         cancelLabel="Keep editing"
         variant="destructive"
         returnFocusRef={editTitleRef}
-        onConfirm={() => {
+        onConfirm={async () => {
           const existingPath = pendingExistingPath;
+          await discardEditDraft();
           setEditingContent(originalContent);
           setEditingTitle(originalTitle);
           setEditingAssetIds([]);
@@ -1582,8 +2186,9 @@ export default function DocumentPage({
         confirmLabel="Discard changes"
         variant="destructive"
         returnFocusRef={cancelEditButtonRef}
-        onConfirm={() => {
+        onConfirm={async () => {
           const next = pendingView;
+          await discardEditDraft();
           setEditingContent(originalContent);
           setEditingTitle(originalTitle);
           setEditingAssetIds([]);

--- a/frontend/src/pages/document.tsx
+++ b/frontend/src/pages/document.tsx
@@ -1760,6 +1760,7 @@ export default function DocumentPage({
                             type="button"
                             variant="outline"
                             size="sm"
+                            className="shrink-0 focus-ring-instant"
                             onClick={() => void copyDraftText(draftRecovery.draft.body, "Expired draft Markdown copied")}
                           >
                             Copy expired Markdown
@@ -1775,6 +1776,7 @@ export default function DocumentPage({
                             type="button"
                             variant="outline"
                             size="sm"
+                            className="shrink-0 focus-ring-instant"
                             onClick={() => void copyDraftText(draftRecovery.draft.copyBody, "Incompatible draft Markdown copied")}
                           >
                             Copy preserved Markdown

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,14 +9,159 @@ import path from "path";
 const target = process.env.AKB_FRONTEND_BACKEND_URL || "http://localhost:8000";
 const cacheDir = process.env.AKB_FRONTEND_CACHE_DIR;
 const isHttps = false;
+const requestedMockScenario = process.env.CRABBOX_RUNTIME_SCENARIO || "empty";
+const mockScenario = requestedMockScenario === "document-edit-recovery"
+  ? requestedMockScenario
+  : "empty";
 let mockResetGeneration = 0;
 
+type MockFixtureDocument = {
+  title: string;
+  content: string;
+  current_commit: string;
+  updated_at: string;
+};
+
+type MockFixtureAsset = {
+  id: string;
+  filename: string;
+  status: "unclaimed" | "claimed" | "discarded";
+};
+
+type MockFixtureState = {
+  remote_document: MockFixtureDocument | null;
+  refetch_generation: number;
+  expire_draft_generation: number;
+  faults: { save: number; upload: number };
+  assets: MockFixtureAsset[];
+  asset_sequence: number;
+  commit_sequence: number;
+};
+
+const BASE_FIXTURE_DOCUMENT: MockFixtureDocument = {
+  title: "Recovery document",
+  content: "# Recovery document\n\nThe original body is safe to edit.",
+  current_commit: "fixture-base-0001",
+  updated_at: "2026-09-08T00:00:00.000Z",
+};
+
+let mockFixtureState: MockFixtureState = createMockFixtureState();
+
+function createMockFixtureState(): MockFixtureState {
+  return {
+    remote_document: null,
+    refetch_generation: 0,
+    expire_draft_generation: 0,
+    faults: { save: 0, upload: 0 },
+    assets: [],
+    asset_sequence: 0,
+    commit_sequence: 1,
+  };
+}
+
+function resetMockFixtureState() {
+  mockFixtureState = createMockFixtureState();
+}
+
+function currentFixtureDocument(): MockFixtureDocument {
+  return mockFixtureState.remote_document || BASE_FIXTURE_DOCUMENT;
+}
+
+function fixtureStateSnapshot() {
+  const document = currentFixtureDocument();
+  return {
+    scenario: mockScenario,
+    reset_generation: mockResetGeneration,
+    identity: {
+      user_id: "u-jylkim",
+      vault: "fixture",
+      document_path: "notes/recovery.md",
+      document_uri: "akb://fixture/coll/notes/doc/recovery.md",
+      start_url: "/vault/fixture/doc/notes%2Frecovery.md?view=edit",
+      actors: ["editor-a", "editor-b"],
+    },
+    document,
+    refetch_generation: mockFixtureState.refetch_generation,
+    expire_draft_generation: mockFixtureState.expire_draft_generation,
+    faults: mockFixtureState.faults,
+    assets: mockFixtureState.assets,
+  };
+}
+
+function readJsonBody(request: NodeJS.ReadableStream): Promise<Record<string, unknown>> {
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = [];
+    request.on("data", (chunk: Buffer | string) => chunks.push(Buffer.from(chunk)));
+    request.on("end", () => {
+      if (chunks.length === 0) {
+        resolve({});
+        return;
+      }
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>);
+      } catch {
+        resolve({});
+      }
+    });
+  });
+}
+
+function mockDocumentFromBody(body: Record<string, unknown>): MockFixtureDocument {
+  mockFixtureState.commit_sequence += 1;
+  return {
+    title: typeof body.title === "string" ? body.title : currentFixtureDocument().title,
+    content: typeof body.content === "string" ? body.content : currentFixtureDocument().content,
+    current_commit: `fixture-commit-${String(mockFixtureState.commit_sequence).padStart(4, "0")}`,
+    updated_at: new Date().toISOString(),
+  };
+}
+
 function mockDescriptor(origin: string) {
+  const fixture = mockScenario === "document-edit-recovery"
+    ? {
+        identity: {
+          user_id: "u-jylkim",
+          vault: "fixture",
+          document_path: "notes/recovery.md",
+          document_uri: "akb://fixture/coll/notes/doc/recovery.md",
+          start_url: `${origin}/vault/fixture/doc/notes%2Frecovery.md?view=edit`,
+          actors: ["editor-a", "editor-b"],
+        },
+        operations: {
+          state: { method: "GET", url: `${origin}/__akb_mock__/fixture/state` },
+          remote_revision: {
+            method: "POST",
+            url: `${origin}/__akb_mock__/fixture/remote-revision`,
+            body: { actor: "editor-b", title: "Remote revision", content: "Remote body" },
+          },
+          refetch: {
+            method: "POST",
+            url: `${origin}/__akb_mock__/fixture/refetch`,
+            body: {},
+          },
+          retryable_save_failure: {
+            method: "POST",
+            url: `${origin}/__akb_mock__/fixture/failure`,
+            body: { operation: "save", times: 1, status: 503 },
+          },
+          retryable_upload_failure: {
+            method: "POST",
+            url: `${origin}/__akb_mock__/fixture/failure`,
+            body: { operation: "upload", times: 1, status: 503 },
+          },
+          expire_draft: {
+            method: "POST",
+            url: `${origin}/__akb_mock__/fixture/expire-draft`,
+            body: {},
+          },
+        },
+      }
+    : null;
   return {
     schema_version: 2,
     status: "ready",
     mode: "mock",
-    scenario: "empty",
+    scenario: mockScenario,
     services: {
       web: {
         origin,
@@ -25,7 +170,7 @@ function mockDescriptor(origin: string) {
         reset: {
           method: "POST",
           url: `${origin}/__akb_mock__/reset`,
-          body: { scenario: "empty" },
+          body: { scenario: mockScenario },
         },
       },
     },
@@ -33,6 +178,7 @@ function mockDescriptor(origin: string) {
     mock: {
       worker_url: `${origin}/mockServiceWorker.js`,
       unhandled_api: "error",
+      fixture,
     },
   };
 }
@@ -79,6 +225,7 @@ function mockControlPlugin(): Plugin {
             JSON.stringify({
               status: "ready",
               mode: "mock",
+              scenario: mockScenario,
               reset_generation: mockResetGeneration,
             }),
           );
@@ -90,14 +237,97 @@ function mockControlPlugin(): Plugin {
         }
         if (pathname === "/__akb_mock__/reset" && request.method === "POST") {
           mockResetGeneration += 1;
+          resetMockFixtureState();
           response.end(
             JSON.stringify({
               status: "ready",
               mode: "mock",
-              scenario: "empty",
+              scenario: mockScenario,
               reset_generation: mockResetGeneration,
             }),
           );
+          return;
+        }
+        if (pathname === "/__akb_mock__/fixture/state" && request.method === "GET") {
+          response.end(JSON.stringify(fixtureStateSnapshot()));
+          return;
+        }
+        if (pathname === "/__akb_mock__/fixture/remote-revision" && request.method === "POST") {
+          void readJsonBody(request).then((body) => {
+            mockFixtureState.remote_document = mockDocumentFromBody(body);
+            response.end(JSON.stringify({ status: "ready", action: "remote-revision", document: currentFixtureDocument() }));
+          });
+          return;
+        }
+        if (pathname === "/__akb_mock__/fixture/refetch" && request.method === "POST") {
+          mockFixtureState.refetch_generation += 1;
+          response.end(JSON.stringify({ status: "ready", refetch_generation: mockFixtureState.refetch_generation }));
+          return;
+        }
+        if (pathname === "/__akb_mock__/fixture/failure" && request.method === "POST") {
+          void readJsonBody(request).then((body) => {
+            const operation = body.operation === "upload" ? "upload" : "save";
+            const times = typeof body.times === "number" && Number.isInteger(body.times)
+              ? Math.max(0, Math.min(body.times, 5))
+              : 1;
+            mockFixtureState.faults[operation] = times;
+            response.end(JSON.stringify({ status: "ready", operation, times }));
+          });
+          return;
+        }
+        if (pathname === "/__akb_mock__/fixture/expire-draft" && request.method === "POST") {
+          mockFixtureState.expire_draft_generation += 1;
+          response.end(JSON.stringify({ status: "ready", expire_draft_generation: mockFixtureState.expire_draft_generation }));
+          return;
+        }
+        if (pathname === "/__akb_mock__/fixture/consume-fault" && request.method === "POST") {
+          void readJsonBody(request).then((body) => {
+            const operation = body.operation === "upload" ? "upload" : "save";
+            const consumed = mockFixtureState.faults[operation] > 0;
+            if (consumed) mockFixtureState.faults[operation] -= 1;
+            response.end(JSON.stringify({ status: "ready", consumed, operation }));
+          });
+          return;
+        }
+        if (pathname === "/__akb_mock__/fixture/upload" && request.method === "POST") {
+          void readJsonBody(request).then((body) => {
+            mockFixtureState.asset_sequence += 1;
+            const id = typeof body.id === "string" ? body.id : `fixture-asset-${mockFixtureState.asset_sequence}`;
+            mockFixtureState.assets.push({
+              id,
+              filename: typeof body.filename === "string" ? body.filename : "fixture.png",
+              status: "unclaimed",
+            });
+            response.end(JSON.stringify({ status: "ready", id }));
+          });
+          return;
+        }
+        if (pathname === "/__akb_mock__/fixture/commit" && request.method === "POST") {
+          void readJsonBody(request).then((body) => {
+            const expected = typeof body.expected_commit === "string" ? body.expected_commit : "";
+            if (expected && expected !== currentFixtureDocument().current_commit) {
+              response.statusCode = 409;
+              response.end(JSON.stringify({ error: "current_commit moved", code: "conflict" }));
+              return;
+            }
+            mockFixtureState.remote_document = mockDocumentFromBody(body);
+            const assetIds = Array.isArray(body.asset_ids)
+              ? body.asset_ids.filter((assetId): assetId is string => typeof assetId === "string")
+              : [];
+            for (const asset of mockFixtureState.assets) {
+              if (asset.status === "unclaimed") asset.status = "claimed";
+            }
+            response.end(JSON.stringify({ status: "ready", document: currentFixtureDocument() }));
+          });
+          return;
+        }
+        if (pathname === "/__akb_mock__/fixture/discard" && request.method === "POST") {
+          void readJsonBody(request).then((body) => {
+            const id = typeof body.id === "string" ? body.id : "";
+            const asset = mockFixtureState.assets.find((candidate) => candidate.id === id);
+            if (asset && asset.status === "unclaimed") asset.status = "discarded";
+            response.end(JSON.stringify({ status: "ready", id, discarded: asset?.status === "discarded" }));
+          });
           return;
         }
         response.statusCode = 404;


### PR DESCRIPTION
## Summary
- pin document edits to the loaded commit and preserve dirty editor state across refetches
- persist per-user, vault, document, and tab drafts with explicit conflict recovery and expiry handling
- preserve unclaimed attachments through recoverable failures and clean only the accepted draft snapshot
- expose a repository-owned document recovery mock scenario for independent browser validation

## Validation
- frontend design check, typecheck, lint, and 773 unit tests
- document recovery mock E2E: 3/3; default mock E2E: 6/6
- GitHub CI: static analysis, backend unit, pgvector live DB, shell runtime E2E, frontend mock E2E
- correctness review: no P0/P1 findings
- complexity review: no material findings
- source-blind document recovery behavior validation: pass
- corrective source-blind expiry fidelity, copy, and discard validation: pass

## Behavior proof

OCC conflict preserves the local draft and presents readable original-base, local-draft, and latest-server snapshots before explicit reapply. The comparison reflows with its content width instead of compressing metadata into unreadable columns:

![Responsive OCC conflict comparison panel](https://github.com/user-attachments/assets/dc72e86c-c487-4cce-bf5d-e52461326a1a)

Expired drafts preserve the user-entered Markdown, state attachment recovery limits, remain copyable, and can be explicitly discarded without reappearing:

![Expired draft recovery panel with preserved Markdown copy action](https://github.com/user-attachments/assets/3a7d841b-bc0f-45db-8935-ade0d37fb1eb)

Tracks AKB-248.
