### PR TITLE
feat: add document archive discovery and recovery

### DIFF
--- a/backend/app/api/routes/collections.py
+++ b/backend/app/api/routes/collections.py
@@ -17,6 +17,7 @@ from app.services.collection_service import (
     InvalidPathError,
 )
 from app.services.revision_backend import get_document_service
+from app.services.search_filters import ArchiveScope
 
 router = APIRouter()
 doc_service = get_document_service()
@@ -72,12 +73,14 @@ async def browse_vault(
     ),
     include_hashes: bool = Query(False, description="Include content hash/version metadata for documents and files."),
     include_archived: bool = Query(False, description="Include archived documents (hidden from browse by default)."),
+    archive_scope: ArchiveScope | None = Query(None, description="Document archive scope; overrides include_archived."),
     user: AuthenticatedUser = Depends(get_current_user),
 ):
     await check_vault_access(user.user_id, vault, required_role="reader")
     return await doc_service.browse(
         vault, collection=collection, depth=depth, include_hashes=include_hashes,
         include_archived=include_archived,
+        archive_scope=archive_scope,
     )
 
 

--- a/backend/app/api/routes/search.py
+++ b/backend/app/api/routes/search.py
@@ -9,6 +9,7 @@ from app.models.document import DrillDownResponse, GrepResponse, SearchResponse
 from app.services.access_service import check_vault_access
 from app.services.auth_service import AuthenticatedUser
 from app.services.search_service import SearchService
+from app.services.search_filters import ArchiveScope, resolve_archive_scope
 from app.services.uri_service import parse_uri
 
 router = APIRouter()
@@ -39,20 +40,24 @@ async def search_documents(
     source_type: Literal["document", "file", "table"] | None = Query(None),
     limit: int = Query(10, ge=1, le=100),
     include_archived: bool = Query(False, description="Include archived documents (hidden from search by default)."),
+    archive_scope: ArchiveScope | None = Query(None, description="Document archive scope; overrides include_archived. Archived scope excludes files and tables."),
     source_uris: list[str] | None = Query(
         None,
         description="Restrict search to this set of resource akb:// URIs (intersected with the other filters + ACL).",
     ),
     user: AuthenticatedUser = Depends(get_current_user),
 ):
-    return await search_service.search(
+    response = await search_service.search(
         query=q, vault=vault, collection=collection,
         mode=mode, rerank=rerank,
         doc_type=type, tags=tags, limit=limit,
         user_id=user.user_id, include_archived=include_archived,
         source_uris=source_uris,
         doc_types=doc_types, source_type=source_type,
+        archive_scope=archive_scope,
     )
+    response.archive_scope = resolve_archive_scope(archive_scope, include_archived)
+    return response
 
 
 @router.get(
@@ -94,6 +99,7 @@ async def grep_documents(
     doc_types: list[str] | None = Query(None),
     tags: list[str] | None = Query(None),
     include_archived: bool = Query(True, description="Legacy default includes archived documents; the search UI explicitly excludes them."),
+    archive_scope: ArchiveScope | None = Query(None, description="Document archive scope; overrides include_archived."),
     limit: int = Query(20, ge=1, le=100),
     count_only: bool = Query(False, description="grep -c — per-doc counts + total"),
     files_with_matches: bool = Query(False, description="grep -l — URIs with matches"),
@@ -110,6 +116,8 @@ async def grep_documents(
         measurement_include_text_files=measurement_include_text_files,
         user_id=user.user_id,
         doc_types=doc_types, tags=tags, include_archived=include_archived,
+        archive_scope=archive_scope,
     )
     response.setdefault("regex", regex)
+    response["archive_scope"] = resolve_archive_scope(archive_scope, include_archived)
     return {"kind": "grep", **response}

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -239,6 +239,7 @@ class BrowseResponse(BaseModel):
 
     kind: Literal["document"] = "document"
     vault: str
+    archive_scope: Literal["unarchived", "archived", "all"] | None = None
     path: str
     context: BrowseContext | None = None
     items: list[BrowseItem]
@@ -258,6 +259,7 @@ class SearchResult(BaseModel):
     vault: str
     path: str
     title: str
+    status: str | None = None
     collection: str | None = None                     # containing collection (null at vault root)
     collection_summary: str | None = None             # parent collection intent; not part of search scoring
     vault_description: str | None = None              # containing vault intent; not part of search scoring
@@ -292,6 +294,7 @@ class SearchResponse(BaseModel):
     """
 
     kind: Literal["search"] = "search"
+    archive_scope: Literal["unarchived", "archived", "all"] | None = None
     query: str
     total: int
     returned: int = 0
@@ -337,6 +340,7 @@ class GrepResult(BaseModel):
     vault: str
     path: str
     title: str
+    status: str | None = None
     # Additive native measurement identity. Legacy Document grep leaves these
     # unset, preserving its frozen response; W3b needs them to distinguish an
     # admitted searchable text File and bind the result to its current Head.
@@ -389,6 +393,7 @@ class GrepResponse(BaseModel):
     """
 
     kind: Literal["grep"] = "grep"
+    archive_scope: Literal["unarchived", "archived", "all"] | None = None
     pattern: str
     regex: bool
     error: str | None = None

--- a/backend/app/openapi_contract.py
+++ b/backend/app/openapi_contract.py
@@ -956,6 +956,7 @@ def _success_envelope_schemas() -> dict[str, dict[str, Any]]:
         "AkbDocumentEnvelope": _kind_schema(
             "document",
             {
+                "archive_scope": {"type": "string", "enum": ["unarchived", "archived", "all"]},
                 "uri": {"type": "string"},
                 "vault": {"type": "string"},
                 "path": {"type": "string"},
@@ -1007,6 +1008,7 @@ def _success_envelope_schemas() -> dict[str, dict[str, Any]]:
         "AkbSearchEnvelope": _kind_schema(
             "search",
             {
+                "archive_scope": {"type": "string", "enum": ["unarchived", "archived", "all"]},
                 "query": {"type": "string"},
                 "total": {"type": "integer"},
                 "returned": {"type": "integer"},
@@ -1047,6 +1049,7 @@ def _success_envelope_schemas() -> dict[str, dict[str, Any]]:
         "AkbGrepEnvelope": _kind_schema(
             "grep",
             {
+                "archive_scope": {"type": "string", "enum": ["unarchived", "archived", "all"]},
                 "pattern": {"type": "string"},
                 "regex": {"type": "boolean"},
                 "error": _nullable_string(),

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -1829,6 +1829,7 @@ class DocumentService:
         content_type: str = "all",
         include_hashes: bool = False,
         include_archived: bool = False,
+        archive_scope: str | None = None,
     ) -> BrowseResponse:
         """Unified vault browse.
 
@@ -1852,13 +1853,17 @@ class DocumentService:
         ``collection`` is provided. ``doc`` / ``table`` / ``file`` rows
         are the ones gated by depth.
         """
+        from app.services.search_filters import resolve_archive_scope, status_matches
+
+        scope = resolve_archive_scope(archive_scope, include_archived)
+        include_archived = scope != "unarchived"
         vault_repo, doc_repo, coll_repo = await self._repos()
 
         browse_path = collection or ""
         vault_row = await vault_repo.get_by_name(vault)
 
         if not vault_row:
-            return BrowseResponse(vault=vault, path=browse_path, items=[])
+            return BrowseResponse(vault=vault, path=browse_path, items=[], archive_scope=scope)
         vault_id = vault_row["id"]
 
         if collection:
@@ -1880,8 +1885,8 @@ class DocumentService:
             )
 
         show_docs = content_type in ("all", "documents")
-        show_tables = content_type in ("all", "tables")
-        show_files = content_type in ("all", "files")
+        show_tables = scope != "archived" and content_type in ("all", "tables")
+        show_files = scope != "archived" and content_type in ("all", "files")
 
         items: list[BrowseItem] = []
         prefix = collection or ""
@@ -1908,9 +1913,11 @@ class DocumentService:
                 include_hashes=include_hashes,
             ))
 
+        items = [item for item in items if item.type != "document" or status_matches(item.status, scope)]
         hint = self._browse_hint(vault, collection, items)
         return BrowseResponse(
             vault=vault,
+            archive_scope=scope,
             path=browse_path,
             context=context,
             items=items,

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -13,6 +13,7 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
+from app.services.search_filters import ArchiveScope
 
 if TYPE_CHECKING:
     from app.services.external_git_validation import ValidatedRemote
@@ -1829,7 +1830,7 @@ class DocumentService:
         content_type: str = "all",
         include_hashes: bool = False,
         include_archived: bool = False,
-        archive_scope: str | None = None,
+        archive_scope: ArchiveScope | None = None,
     ) -> BrowseResponse:
         """Unified vault browse.
 

--- a/backend/app/services/m1_native_grep_service.py
+++ b/backend/app/services/m1_native_grep_service.py
@@ -19,6 +19,7 @@ import time
 import uuid
 from dataclasses import dataclass
 from typing import Any, Literal
+from app.services.search_filters import ArchiveScope
 
 import asyncpg
 
@@ -652,7 +653,7 @@ class M1NativeGrepService:
         doc_types: list[str] | None = None,
         tags: list[str] | None = None,
         include_archived: bool = True,
-        archive_scope: str | None = None,
+        archive_scope: ArchiveScope | None = None,
     ) -> dict[str, Any]:
         from app.services.search_filters import metadata_matches, resolve_archive_scope
 

--- a/backend/app/services/m1_native_grep_service.py
+++ b/backend/app/services/m1_native_grep_service.py
@@ -652,7 +652,11 @@ class M1NativeGrepService:
         doc_types: list[str] | None = None,
         tags: list[str] | None = None,
         include_archived: bool = True,
+        archive_scope: str | None = None,
     ) -> dict[str, Any]:
+        from app.services.search_filters import metadata_matches, resolve_archive_scope
+
+        scope = resolve_archive_scope(archive_scope, include_archived)
         if pattern == "":
             raise ValidationError("grep pattern must not be empty")
         if count_only and files_with_matches:
@@ -693,13 +697,11 @@ class M1NativeGrepService:
             resource_id=resource_id,
             surfaces=self._selected_surfaces(include_text_files=include_text_files),
         )
-        if doc_types or tags or not include_archived:
-            from app.services.search_filters import metadata_matches
-
+        if doc_types or tags or scope != "all":
             bodies = [body for body in bodies if (
                 body.surface == "document"
-                and metadata_matches(_parse_markdown(body.text)[0], doc_types, tags, include_archived)
-            ) or (body.surface != "document" and not (doc_types or tags))]
+                and metadata_matches(_parse_markdown(body.text)[0], doc_types, tags, include_archived, scope)
+            ) or (body.surface != "document" and scope != "archived" and not (doc_types or tags))]
         searched_bytes = sum(body.byte_size for body in bodies)
         if searched_bytes > NATIVE_GREP_MAX_SEARCH_BYTES:
             raise ValidationError(
@@ -743,6 +745,8 @@ class M1NativeGrepService:
         matched = scanned["items"]
         for item in matched:
             item["_body"] = bodies[item.pop("_body_index")]
+            if item["_body"].surface == "document":
+                item["status"] = _parse_markdown(item["_body"].text)[0].get("status") or "draft"
 
         base = {
             "pattern": pattern,
@@ -921,6 +925,7 @@ class M1NativeGrepService:
                 "vault": row["vault"],
                 "path": row["path"],
                 "title": row["title"],
+                **({"status": row["status"]} if row.get("status") is not None else {}),
                 "matches": [
                     {"section": None, "text": match["text"]}
                     for match in row["matches"]

--- a/backend/app/services/native_document_service.py
+++ b/backend/app/services/native_document_service.py
@@ -1272,8 +1272,13 @@ class NativeDocumentService(DocumentService):
         content_type: str = "all",
         include_hashes: bool = False,
         include_archived: bool = False,
+        archive_scope: str | None = None,
     ) -> BrowseResponse:
         """Return the legacy browse envelope with Native document Heads."""
+        from app.services.search_filters import resolve_archive_scope, status_matches
+
+        scope = resolve_archive_scope(archive_scope, include_archived)
+        include_archived = scope != "unarchived"
         prefix = normalize_collection_path(collection) if collection is not None else ""
         pool = await self._pool()
         vault_row = await VaultRepository(pool).get_by_name(vault)
@@ -1299,8 +1304,8 @@ class NativeDocumentService(DocumentService):
                 description=vault_row.get("description"),
             )
         show_docs = content_type in ("all", "documents")
-        show_tables = content_type in ("all", "tables")
-        show_files = content_type in ("all", "files")
+        show_tables = scope != "archived" and content_type in ("all", "tables")
+        show_files = scope != "archived" and content_type in ("all", "files")
 
         items: list[BrowseItem] = []
         if show_docs:
@@ -1346,9 +1351,11 @@ class NativeDocumentService(DocumentService):
             )
 
         browse_path = prefix
+        items = [item for item in items if item.type != "document" or status_matches(item.status, scope)]
         hint = self._browse_hint(vault, prefix or None, items)
         return BrowseResponse(
             vault=vault,
+            archive_scope=scope,
             path=browse_path,
             context=context,
             items=items,

--- a/backend/app/services/native_document_service.py
+++ b/backend/app/services/native_document_service.py
@@ -16,6 +16,7 @@ import uuid
 from dataclasses import replace
 from datetime import UTC, datetime
 from typing import NoReturn
+from app.services.search_filters import ArchiveScope
 
 import asyncpg
 
@@ -1272,7 +1273,7 @@ class NativeDocumentService(DocumentService):
         content_type: str = "all",
         include_hashes: bool = False,
         include_archived: bool = False,
-        archive_scope: str | None = None,
+        archive_scope: ArchiveScope | None = None,
     ) -> BrowseResponse:
         """Return the legacy browse envelope with Native document Heads."""
         from app.services.search_filters import resolve_archive_scope, status_matches

--- a/backend/app/services/search_filters.py
+++ b/backend/app/services/search_filters.py
@@ -1,5 +1,23 @@
 """Small shared predicates for search scope; values always remain bound parameters."""
 
+from typing import Literal
+
+ArchiveScope = Literal["unarchived", "archived", "all"]
+
+
+def resolve_archive_scope(scope: ArchiveScope | None, include_archived: bool) -> ArchiveScope:
+    """Explicit scope wins; absent scope preserves each caller's legacy default."""
+    if scope is not None:
+        if scope not in ("unarchived", "archived", "all"):
+            from app.exceptions import ValidationError
+            raise ValidationError("Invalid archive scope")
+        return scope
+    return "all" if include_archived else "unarchived"
+
+
+def status_matches(status: str | None, scope: ArchiveScope) -> bool:
+    return scope == "all" or (status == "archived") == (scope == "archived")
+
 
 def escape_like(value: str) -> str:
     return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
@@ -16,9 +34,10 @@ def collection_predicate(column: str, collection: str, params: list) -> str:
 
 
 def metadata_matches(metadata: dict, doc_types: list[str] | None,
-                     tags: list[str] | None, include_archived: bool) -> bool:
+                     tags: list[str] | None, include_archived: bool,
+                     archive_scope: ArchiveScope | None = None) -> bool:
     return (
         (not doc_types or (metadata.get("type") or "note") in doc_types)
         and (not tags or bool(set(metadata.get("tags") or []).intersection(tags)))
-        and (include_archived or metadata.get("status", "draft") != "archived")
+        and status_matches(metadata.get("status"), resolve_archive_scope(archive_scope, include_archived))
     )

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -20,7 +20,7 @@ from typing import Literal
 from app.config import settings
 from app.db.postgres import get_pool
 from app.exceptions import ValidationError
-from app.services.search_filters import collection_predicate, escape_like, metadata_matches
+from app.services.search_filters import ArchiveScope, collection_predicate, escape_like, metadata_matches, resolve_archive_scope
 from app.models.document import SearchResponse, SearchResult
 from app.repositories.vault_files_repo import confirmed_file_predicate
 from app.services import sparse_encoder
@@ -237,6 +237,7 @@ class SearchService:
         doc_type: str | None,
         tags: list[str] | None,
         include_archived: bool,
+        archive_scope: ArchiveScope | None = None,
         source_uris: list[str] | None,
         doc_types: list[str] | None = None,
     ) -> list[str]:
@@ -326,7 +327,7 @@ class SearchService:
             metadata = await asyncio.to_thread(_verified_native_metadata, row)
             if doc_type and (metadata.get("type") or "note") != doc_type:
                 continue
-            if not metadata_matches(metadata, doc_types, tags, include_archived):
+            if not metadata_matches(metadata, doc_types, tags, include_archived, archive_scope):
                 continue
             candidates.append(str(row["resource_id"]))
         return candidates
@@ -343,6 +344,7 @@ class SearchService:
         limit: int = 10,
         user_id: str | None = None,
         include_archived: bool = False,
+        archive_scope: ArchiveScope | None = None,
         source_uris: list[str] | None = None,
         doc_types: list[str] | None = None,
         source_type: Literal["document", "file", "table"] | None = None,
@@ -354,6 +356,8 @@ class SearchService:
         intersected with the other filters, so retrieval runs only inside that
         set. An empty/omitted list means no restriction (default behaviour).
         """
+        scope = resolve_archive_scope(archive_scope, include_archived)
+        include_archived = scope != "unarchived"
         if mode != "hybrid":
             raise ValidationError("unsupported search mode")
         if source_uris and len(source_uris) > NATIVE_SEARCH_MAX_SOURCE_URIS:
@@ -418,7 +422,7 @@ class SearchService:
         # pre-upgrade pgvector point carries its vault_id, fall back to the
         # source-id path so a user can't miss their own un-backfilled docs.
         from app.services import vault_backfill
-        use_vault_path = not (doc_types or source_type or not include_archived) and vault_path_eligible(
+        use_vault_path = not (doc_types or source_type or scope != "all") and vault_path_eligible(
             collection=collection, doc_type=doc_type, tags=tags, source_uris=source_uris,
         ) and vault_backfill.is_ready()
 
@@ -437,7 +441,7 @@ class SearchService:
             # []    → the named vaults are all unreadable → no results.
             if candidate_vault_ids is not None and not candidate_vault_ids:
                 return SearchResponse(
-                    query=query, total=0, returned=0, total_matches=0, results=[],
+                    query=query, total=0, returned=0, total_matches=0, results=[], archive_scope=scope,
                 )
         elif has_filters:
             async with pool.acquire() as conn:
@@ -509,6 +513,8 @@ class SearchService:
                 # only the document candidate query carries doc status.)
                 if not include_archived:
                     conditions.append("d.status != 'archived'")
+                elif scope == "archived":
+                    conditions.append("d.status = 'archived'")
 
                 where_sql = " AND ".join(conditions) if conditions else "TRUE"
                 if source_type in {"file", "table"}:
@@ -523,6 +529,7 @@ class SearchService:
                         doc_type=doc_type,
                         tags=tags,
                         include_archived=include_archived,
+                        archive_scope=scope,
                         source_uris=source_uris,
                         doc_types=doc_types,
                     )
@@ -538,7 +545,7 @@ class SearchService:
                     candidate_source_ids = [str(r["id"]) for r in rows]
 
                 # Document metadata filters never admit unrelated files/tables.
-                if (not doc_type or doc_type == "table") and not (doc_types or tags) and source_type in {None, "table"}:
+                if scope != "archived" and (not doc_type or doc_type == "table") and not (doc_types or tags) and source_type in {None, "table"}:
                     t_params: list = []
                     t_conds: list[str] = []
                     if vaults:
@@ -559,7 +566,7 @@ class SearchService:
                     trows = await conn.fetch(q, *t_params)
                     candidate_source_ids.extend(str(r["id"]) for r in trows)
 
-                if (not doc_type or doc_type == "file") and not (doc_types or tags) and source_type in {None, "file"}:
+                if scope != "archived" and (not doc_type or doc_type == "file") and not (doc_types or tags) and source_type in {None, "file"}:
                     f_params: list = []
                     # Editor attachments are storage implementation details,
                     # never standalone searchable File resources.
@@ -591,7 +598,7 @@ class SearchService:
                     candidate_source_ids.extend(str(r["id"]) for r in frows)
 
                 if not candidate_source_ids:
-                    return SearchResponse(query=query, total=0, returned=0, total_matches=0, results=[])
+                    return SearchResponse(query=query, total=0, returned=0, total_matches=0, results=[], archive_scope=scope)
 
         target_unique = resolve_first_stage_unique_limit(
             limit=limit,
@@ -612,6 +619,7 @@ class SearchService:
 
         if not hits:
             return SearchResponse(
+                archive_scope=scope,
                 query=query, total=0, returned=0, total_matches=0, results=[],
                 degraded=degraded_reason is not None,
                 degradation_reason=degraded_reason,
@@ -663,6 +671,7 @@ class SearchService:
             "exhaustively enumerated."
         ) if prefetch_capped else None
         return SearchResponse(
+            archive_scope=scope,
             query=query,
             total=returned,  # deprecated alias of `returned`
             returned=returned,
@@ -805,7 +814,7 @@ class SearchService:
                     """
                     SELECT d.id, v.name AS vault_name, d.path, d.title,
                            c.path AS collection,
-                           d.doc_type, d.summary, d.tags
+                           d.doc_type, d.summary, d.tags, d.status
                       FROM documents d
                       JOIN vaults v ON d.vault_id = v.id
                       LEFT JOIN collections c ON c.id = d.collection_id
@@ -817,6 +826,7 @@ class SearchService:
                     meta[("document", str(r["id"]))] = {
                         "vault": r["vault_name"], "path": r["path"],
                         "title": r["title"], "doc_type": r["doc_type"],
+                        "status": r.get("status") or "draft",
                         "summary": r["summary"],
                         "tags": list(r["tags"]) if r["tags"] else [],
                         "collection": r["collection"],
@@ -892,6 +902,7 @@ class SearchService:
                         "vault": r["vault_name"],
                         "path": path,
                         "title": metadata.get("title") or path.rsplit("/", 1)[-1],
+                        "status": metadata.get("status") or "draft",
                         "doc_type": metadata.get("type") or "note",
                         "summary": metadata.get("summary"),
                         "tags": list(metadata.get("tags") or []),
@@ -1120,6 +1131,7 @@ class SearchService:
                     collection_summary=m.get("collection_summary"),
                     vault_description=m.get("vault_description"),
                     doc_type=m["doc_type"], summary=m["summary"],
+                    status=m.get("status"),
                     tags=m["tags"], score=h.score,
                     matched_section=(strip_chunk_metadata_header(h.content) or "")[:500] or None,
                 )
@@ -1248,6 +1260,7 @@ class SearchService:
         doc_types: list[str] | None = None,
         tags: list[str] | None = None,
         include_archived: bool = True,
+        archive_scope: ArchiveScope | None = None,
     ) -> dict:
         """Exact text / regex search across document content.
 
@@ -1264,6 +1277,9 @@ class SearchService:
         valid with the default response shape).
         """
         import re as _re
+
+        scope = resolve_archive_scope(archive_scope, include_archived)
+        include_archived = scope != "unarchived"
 
         if pattern == "":
             raise ValidationError("grep pattern must not be empty")
@@ -1329,6 +1345,7 @@ class SearchService:
                 files_with_matches=files_with_matches,
                 include_text_files=measurement_include_text_files,
                 doc_types=doc_types, tags=tags, include_archived=include_archived,
+                archive_scope=scope,
             )
 
         if replace is not None and doc_service is None:
@@ -1383,6 +1400,8 @@ class SearchService:
                 params.append(tags)
             if not include_archived:
                 conditions.append("d.status != 'archived'")
+            elif scope == "archived":
+                conditions.append("d.status = 'archived'")
 
             where_sql = " AND ".join(conditions)
             # No prefetch cap. The old `LIMIT (limit * 5)` cap was inherited
@@ -1405,7 +1424,7 @@ class SearchService:
             rows = await conn.fetch(
                 f"""
                 SELECT d.id::text as doc_id, v.name as vault, d.path, d.title,
-                       d.metadata,
+                       d.metadata, d.status,
                        c.section_path, c.content, c.chunk_index
                 FROM chunks c
                 JOIN documents d ON c.source_id = d.id AND c.source_type = 'document'
@@ -1431,6 +1450,7 @@ class SearchService:
                     "path": r["path"],
                     "title": r["title"],
                     "metadata": r["metadata"],
+                    **({"status": r["status"]} if r.get("status") is not None else {}),
                     "matches": [],
                 }
 

--- a/backend/tests/test_document_archive_scope_unit.py
+++ b/backend/tests/test_document_archive_scope_unit.py
@@ -1,0 +1,83 @@
+"""Archive discovery is authoritative metadata filtering, not a new ACL."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+import uuid
+
+import pytest
+
+from app.models.document import BrowseItem
+from app.services.document_service import DocumentService
+from app.services import native_document_service as native
+
+
+@pytest.mark.parametrize("native_backend", [False, True])
+@pytest.mark.parametrize("scope,statuses", [
+    ("unarchived", ["draft", "active"]),
+    ("archived", ["archived"]),
+    ("all", ["draft", "active", "archived"]),
+])
+async def test_browse_archive_scope_retains_navigation_and_filters_before_pagination(monkeypatch, native_backend, scope, statuses):
+    vault_id = uuid.UUID(int=1)
+    vault_repo = SimpleNamespace(get_by_name=AsyncMock(return_value={"id": vault_id}))
+    coll_repo = SimpleNamespace(list_by_vault=AsyncMock(return_value=[{
+        "path": "notes", "name": "notes", "summary": None, "doc_count": 3, "last_updated": None,
+    }]))
+    docs = [BrowseItem(name=status, path=f"notes/{status}.md", type="document", status=status,
+                       uri=f"akb://mine/coll/notes/doc/{status}.md") for status in ["draft", "active", "archived"]]
+    files = [BrowseItem(name="file", path="file", type="file", uri="akb://mine/file/f")]
+    tables = [BrowseItem(name="table", path="table", type="table", uri="akb://mine/table/t")]
+    if native_backend:
+        service = native.NativeDocumentService(pool=object())
+        monkeypatch.setattr(native, "VaultRepository", lambda _: vault_repo)
+        monkeypatch.setattr(native, "CollectionRepository", lambda _: coll_repo)
+        doc_list, file_list, table_list = "_browse_native_documents", "_browse_legacy_files", "_browse_legacy_tables"
+    else:
+        service = DocumentService(git=object())
+        monkeypatch.setattr(service, "_repos", AsyncMock(return_value=(vault_repo, object(), coll_repo)))
+        doc_list, file_list, table_list = "_browse_docs", "_browse_files_by_depth", "_browse_tables_by_depth"
+    monkeypatch.setattr(service, doc_list, AsyncMock(return_value=docs))
+    monkeypatch.setattr(service, file_list, AsyncMock(return_value=files))
+    monkeypatch.setattr(service, table_list, AsyncMock(return_value=tables))
+    response = await service.browse("mine", depth=-1, archive_scope=scope, include_archived=scope == "unarchived")
+    assert response.archive_scope == scope
+    assert [item.status for item in response.items if item.type == "document"] == statuses
+    assert any(item.type == "collection" for item in response.items)
+    assert any(item.type == "file" for item in response.items) is (scope != "archived")
+    assert any(item.type == "table" for item in response.items) is (scope != "archived")
+    assert getattr(service, doc_list).call_args.kwargs["include_archived"] is (scope != "unarchived")
+
+
+async def test_browse_empty_result_echoes_scope(monkeypatch):
+    service = DocumentService(git=object())
+    vault_repo = SimpleNamespace(get_by_name=AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_repos", AsyncMock(return_value=(vault_repo, object(), object())))
+    response = await service.browse("missing", archive_scope="archived")
+    assert response.items == []
+    assert response.archive_scope == "archived"
+
+
+@pytest.mark.parametrize("can_write", [False, True])
+async def test_restore_uses_existing_writer_gate_and_patch(monkeypatch, can_write, tmp_path):
+    from app.config import settings
+    monkeypatch.setattr(settings, "git_storage_path", str(tmp_path))
+    from app.api.routes import documents
+    from app.exceptions import ForbiddenError
+    from app.models.document import DocumentUpdateRequest
+
+    access = AsyncMock(side_effect=None if can_write else ForbiddenError("Read only"))
+    update = AsyncMock(return_value=object())
+    monkeypatch.setattr(documents, "check_vault_access", access)
+    monkeypatch.setattr(documents.doc_service, "get", AsyncMock(return_value=SimpleNamespace(path="notes/old.md")))
+    monkeypatch.setattr(documents.doc_service, "update", update)
+    request = DocumentUpdateRequest(status="active", expected_commit="head")
+    user = SimpleNamespace(user_id="reader-or-writer", username="tester")
+    if can_write:
+        await documents.update_document("mine", "notes/old.md", request, user)
+        assert update.call_args.args[2].status == "active"
+        assert update.call_args.args[2].expected_commit == "head"
+    else:
+        with pytest.raises(ForbiddenError):
+            await documents.update_document("mine", "notes/old.md", request, user)
+        update.assert_not_awaited()
+    access.assert_awaited_once_with(user.user_id, "mine", required_role="writer")

--- a/backend/tests/test_native_search_selection_unit.py
+++ b/backend/tests/test_native_search_selection_unit.py
@@ -266,6 +266,21 @@ async def test_native_search_collection_is_exact_descendant_boundary_and_escaped
 
 
 @pytest.mark.asyncio
+async def test_native_archived_candidates_use_current_metadata_before_ranking(monkeypatch):
+    from app.services import search_service as module
+
+    conn = _CandidateConn()
+    conn.rows = [{"resource_id": uuid.UUID(int=i + 1), "status": status}
+                 for i, status in enumerate(["draft", "active", "archived"])]
+    monkeypatch.setattr(module, "_verified_native_metadata", lambda row: {"status": row["status"]})
+    candidates = await SearchService()._native_document_candidates(
+        conn, user_uuid=None, is_admin=True, vaults=["mine"], collection=None,
+        doc_type=None, tags=None, include_archived=False, archive_scope="archived", source_uris=None,
+    )
+    assert candidates == [str(uuid.UUID(int=3))]
+
+
+@pytest.mark.asyncio
 async def test_native_search_pushes_source_uri_into_bounded_sql_scope():
     conn = _CandidateConn()
     await SearchService()._native_document_candidates(

--- a/backend/tests/test_search_filter_contract_unit.py
+++ b/backend/tests/test_search_filter_contract_unit.py
@@ -17,6 +17,68 @@ from app.services.search_filters import collection_predicate, escape_like, metad
 from app.services.m1_native_grep_service import HeadBody, M1NativeGrepService
 
 
+@pytest.mark.parametrize("scope,expected", [("unarchived", ["draft", "active"]), ("archived", ["archived"]), ("all", ["draft", "active", "archived"])])
+@pytest.mark.parametrize("legacy", [False, True])
+def test_archive_scope_overrides_legacy_flag(scope, expected, legacy):
+    assert [status for status in ["draft", "active", "archived"]
+            if metadata_matches({"status": status}, None, None, legacy, scope)] == expected
+
+
+async def test_rest_archive_scope_echo_even_with_no_results(monkeypatch):
+    app = FastAPI()
+    app.include_router(routes.router)
+    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(user_id="user")
+    search = AsyncMock(return_value=SearchResponse(query="x", total=0, results=[]))
+    grep = AsyncMock(return_value={"pattern": "x", "results": []})
+    monkeypatch.setattr(routes.search_service, "search", search)
+    monkeypatch.setattr(routes.search_service, "grep", grep)
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        for endpoint, handler in [("search", search), ("grep", grep)]:
+            response = await client.get(f"/{endpoint}?q=x&archive_scope=archived&include_archived=false")
+            assert response.status_code == 200
+            assert response.json()["archive_scope"] == "archived"
+            assert handler.call_args.kwargs["archive_scope"] == "archived"
+            assert (await client.get(f"/{endpoint}?q=x&archive_scope=deleted")).status_code == 422
+
+
+async def test_archived_search_filters_before_top_k_and_excludes_other_resources(monkeypatch):
+    conn = CandidateConnection()
+    monkeypatch.setattr(ss, "get_pool", AsyncMock(return_value=Pool(conn)))
+    monkeypatch.setattr(ss, "generate_embeddings", AsyncMock(return_value=[[0.1]]))
+    monkeypatch.setattr(ss, "_configured_document_source_type", lambda: ss.LEGACY_DOCUMENT_SOURCE)
+    service = ss.SearchService()
+    vector = AsyncMock(return_value=([], None))
+    monkeypatch.setattr(service, "_run_vector_search", vector)
+    result = await service.search("x", vault="mine", archive_scope="archived", include_archived=False, limit=1)
+    assert result.archive_scope == "archived"
+    assert len(conn.queries) == 1
+    assert "d.status = 'archived'" in conn.queries[0][0]
+    assert vector.call_args.kwargs["candidate_source_ids"] == [str(uuid.UUID(int=30))]
+
+
+@pytest.mark.parametrize("mode", [{}, {"count_only": True}, {"files_with_matches": True}])
+async def test_native_archived_only_precedes_limit_and_counts(monkeypatch, mode):
+    bodies = [HeadBody(namespace_id=uuid.UUID(int=1), vault="mine", resource_id=uuid.UUID(int=i + 1),
+                       surface="document", path=f"{i}.md", revision_id="r", digest="d", byte_size=100,
+                       canonical_bytes=(f"---\nstatus: {'archived' if i >= 28 else 'draft'}\n---\nneedle\n").encode())
+              for i in range(30)]
+    bodies.append(HeadBody(namespace_id=uuid.UUID(int=1), vault="mine", resource_id=uuid.UUID(int=99),
+                           surface="file", path="sample.txt", revision_id="r", digest="d", byte_size=7,
+                           canonical_bytes=b"needle\n"))
+    service = M1NativeGrepService(None)
+    monkeypatch.setattr(service, "_head_bodies", AsyncMock(return_value=bodies))
+    response = await service.grep_public("needle", user_id=uuid.UUID(int=1), archive_scope="archived",
+                                         include_archived=False, include_text_files=True, limit=1, **mode)
+    if mode.get("files_with_matches"):
+        assert response["n_files"] == 2
+    else:
+        assert response["total_docs"] == 2
+    if not mode:
+        assert response["returned_docs"] == 1
+        assert response["results"][0]["status"] == "archived"
+        assert response["results"][0]["path"] == "28.md"
+
+
 def test_collection_boundary_and_literal_metacharacters():
     params = ["existing"]
     sql = collection_predicate("c.path", "/guide_%/", params)

--- a/docs/designs/document-archive-recovery.md
+++ b/docs/designs/document-archive-recovery.md
@@ -1,0 +1,73 @@
+# Document archive discovery and recovery (AKB-222)
+
+## Purpose
+
+An archived document remains the same resource. Archive changes default discovery;
+it does not delete content, revoke access, disable published links, or create a
+second archive store. Users must be able to find and restore it without knowing
+its technical URI.
+
+## API contract
+
+REST browse, semantic search, and literal grep accept the optional
+`archive_scope` parameter:
+
+| Value | Documents | Files and tables |
+| --- | --- | --- |
+| `unarchived` | Draft and active | Included where supported |
+| `archived` | Archived only | Excluded |
+| `all` | All states | Included where supported |
+
+An explicit scope overrides `include_archived`. Without it, existing defaults
+remain unchanged: browse/search exclude archives, grep includes them. Existing
+MCP callers retain their boolean contract. Responses echo the effective scope,
+including empty responses, so a client can distinguish a supported empty result
+from a server that silently ignores a new parameter. Document search/grep rows
+also expose status; non-document resources have no document status.
+
+Both legacy and Native storage paths apply scope before search candidates or
+grep counts/limits. Browse retains Collections for navigation and filters the
+document inventory before returning it. Semantic counts still describe the
+bounded retrieval candidate window, not an exhaustive corpus count.
+
+Restore reuses the existing document PATCH with `status: active` and the loaded
+`expected_commit` when available. It preserves identity, path, content, history,
+and links. No new table, endpoint, or archive index is required. Restoring a
+previous draft explicitly produces an active document; the system does not
+invent a remembered prior state.
+
+## Interaction
+
+- Collections and advanced Search expose Current / Archived / All documents.
+  Current includes drafts. Search keeps the scope in its URL, including support
+  for old `include_archived` links.
+- The reader overflow offers Archive or Restore. An archived reader also has a
+  compact restore notice. Both full-page and Search-preview readers use the same
+  operation. Confirmation explains discovery versus access and the restore
+  destination. Search preview remains open and its background results refresh.
+- Archive/restore requires Writer or higher; changing the reserved Vault guide
+  requires Owner. Historical/diff views and read-only Vaults cannot mutate state.
+  Unavailable actions show the reason instead of disappearing.
+- A PATCH alone is not considered proof of state change: the reader reloads the
+  current document and verifies its status before notifying other views. Errors
+  remain in the confirmation dialog without closing it or claiming success.
+- Unsupported explicit filters suppress untrusted results and offer a return to
+  current documents. No misleading zero-archive count is shown.
+- The archived-only tree does not expose recursive Collection deletion, because
+  that filtered inventory does not show all resources that deletion would affect.
+
+## Boundaries
+
+Native search uses a derived index and may lag a restored Head briefly. Browse
+reads authoritative document state and provides a recovery path during that lag.
+Existing links and public access remain governed by their existing policies.
+The sidebar still uses the existing full subtree browse; DOM progressive
+disclosure is not server-side pagination.
+
+## Verification
+
+Tests cover scope precedence and legacy defaults; legacy/Native parity;
+document-only archives; filtering before counts/limits; empty response echoes;
+permission and concurrency guards; older-server handling; stale UI responses;
+and reader archive/restore with unchanged path and preview state. The browser
+contract uses isolated HTTP fixtures and is distinct from a live-server E2E.

--- a/docs/designs/document-archive-recovery.md
+++ b/docs/designs/document-archive-recovery.md
@@ -49,8 +49,12 @@ invent a remembered prior state.
   requires Owner. Historical/diff views and read-only Vaults cannot mutate state.
   Unavailable actions show the reason instead of disappearing.
 - A PATCH alone is not considered proof of state change: the reader reloads the
-  current document and verifies its status before notifying other views. Errors
-  remain in the confirmation dialog without closing it or claiming success.
+  current document, refreshes other views with the observed state, and verifies
+  its status before claiming success. If that verification fails after an
+  accepted write, the dialog offers **Check current state**. This retries only
+  the read, including after closing and reopening the dialog, rather than
+  repeating the mutation with an outdated concurrency token. A different
+  observed state is reported without overwriting it or claiming success.
 - Unsupported explicit filters suppress untrusted results and offer a return to
   current documents. No misleading zero-archive count is shown.
 - The archived-only tree does not expose recursive Collection deletion, because

--- a/frontend/DESIGN_SYSTEM.md
+++ b/frontend/DESIGN_SYSTEM.md
@@ -341,7 +341,12 @@ an `sr-only` summary, never the only signal.
   Collection vocabulary, with the target Collection preselected in each modal.
   Collection rows keep the human name and one overflow trigger only—never a
   second line of icon counts or sibling action icons that squeeze the name.
-  Document rows also remain title-first. When two documents in the same
+  Document rows also remain title-first. For archive recovery, the rail's compact document-state selector
+  exposes Current (draft and active), Archived, and All. Archived rows pair a
+  quiet archive glyph with an accessible label. The reader owns Archive/Restore
+  in its overflow and a compact archived-state restore notice; archive never
+  implies deletion or revoked access. Unsupported server filters show a recovery
+  notice rather than a false empty inventory. When two documents in the same
   Collection have the same title, and only then, both rows add one quiet
   monospace filename discriminator; generated UUID suffixes collapse to four
   characters. This is ambiguity recovery, not permanent technical metadata.

--- a/frontend/e2e/document-archive-contract.spec.ts
+++ b/frontend/e2e/document-archive-contract.spec.ts
@@ -35,7 +35,7 @@ test(`archived search result restores inside the reader at ${width}px (${dark ? 
         writes.push(body);
         status = body.status;
       }
-      return route.fulfill({ json: { path: "example.md", title: "Archive recovery example", content: "# Recovery\n\nOriginal document body.", status, current_commit: "abcdef1234567", tags: [] } });
+      return route.fulfill({ json: { path: "example.md", title: "Archive recovery example", content: "# Recovery\n\nOriginal document body.", status, current_commit: "aaaaaaaaaaaaa", tags: [] } });
     }
     return route.fulfill({ json: { items: [], history: [], relations: [], vaults: [] } });
   });
@@ -49,7 +49,7 @@ test(`archived search result restores inside the reader at ${width}px (${dark ? 
   const confirm = page.getByRole("dialog", { name: "Restore this document?" });
   await confirm.getByRole("button", { name: "Restore document" }).click();
   await expect(page.getByText("Restored to Vault root.")).toBeVisible();
-  expect(writes).toEqual([{ status: "active", expected_commit: "abcdef1234567" }]);
+  expect(writes).toEqual([{ status: "active", expected_commit: "aaaaaaaaaaaaa" }]);
   await page.keyboard.press("Escape");
   await expect(page).toHaveURL(/\/search\?q=example&archive_scope=archived/);
   await expect(page.getByRole("link", { name: /Archive recovery example/ })).toHaveCount(0);

--- a/frontend/e2e/document-archive-contract.spec.ts
+++ b/frontend/e2e/document-archive-contract.spec.ts
@@ -1,0 +1,58 @@
+// Real browser, isolated HTTP fixtures: never changes a user's Vault.
+import { test, expect } from "@playwright/test";
+
+for (const width of [1440, 390]) {
+for (const dark of [false, true]) {
+test(`archived search result restores inside the reader at ${width}px (${dark ? "dark" : "light"})`, async ({ page }, testInfo) => {
+  test.skip(process.env.AKB_FE_E2E_MODE === "mock", "This contract owns its HTTP fixtures, not MSW.");
+  let status = "archived";
+  await page.setViewportSize({ width, height: 900 });
+  const writes: unknown[] = [];
+  await page.route("**/health/**", route => route.fulfill({ json: {} }));
+  await page.addInitScript(() => localStorage.setItem("akb_token", "archive-browser-fixture"));
+  await page.route("**/api/v1/**", async (route) => {
+    const url = new URL(route.request().url());
+    const path = url.pathname;
+    if (path.endsWith("/auth/config")) return route.fulfill({ json: {
+      schema_version: 2, auth_mode: "local", local_auth: { enabled: true },
+      keycloak: { enabled: false, browser_session_ready: false }, providers: [], mcp_oauth: { enabled: false },
+    } });
+    if (path.endsWith("/auth/me")) return route.fulfill({ json: {
+      user_id: "archive-fixture", username: "fixture", display_name: "Fixture writer", email: "fixture@example.invalid", is_admin: false, auth_method: "local",
+    } });
+    if (path.endsWith("/vaults")) return route.fulfill({ json: { vaults: [{ name: "fixture", role: "writer" }] } });
+    if (path.endsWith("/vaults/fixture/info")) return route.fulfill({ json: { name: "fixture", role: "writer", is_archived: false, is_external_git: false } });
+    if (path.endsWith("/search")) {
+      const scope = url.searchParams.get("archive_scope") || "unarchived";
+      const results = scope === "archived" && status !== "archived" ? [] : [{
+        title: "Archive recovery example", uri: "akb://fixture/doc/example.md", vault: "fixture", path: "example.md", source_type: "document", status, score: 1,
+      }];
+      return route.fulfill({ json: { query: "example", archive_scope: scope, total: results.length, returned: results.length, total_matches: results.length, results } });
+    }
+    if (path.includes("/documents/fixture/") && !path.endsWith("/history")) {
+      if (route.request().method() === "PATCH") {
+        const body = route.request().postDataJSON();
+        writes.push(body);
+        status = body.status;
+      }
+      return route.fulfill({ json: { path: "example.md", title: "Archive recovery example", content: "# Recovery\n\nOriginal document body.", status, current_commit: "abcdef1234567", tags: [] } });
+    }
+    return route.fulfill({ json: { items: [], history: [], relations: [], vaults: [] } });
+  });
+  await page.goto("/search?q=example&archive_scope=archived&source=document");
+  await page.evaluate(value => document.documentElement.classList.toggle("dark", value), dark);
+  await page.getByRole("link", { name: /Archive recovery example/ }).click();
+  const reader = page.getByRole("dialog").filter({ has: page.getByRole("heading", { name: "Archive recovery example" }) });
+  await expect(reader).toBeVisible();
+  await page.screenshot({ path: testInfo.outputPath("archived-reader.png") });
+  await reader.getByRole("button", { name: "Restore document" }).click();
+  const confirm = page.getByRole("dialog", { name: "Restore this document?" });
+  await confirm.getByRole("button", { name: "Restore document" }).click();
+  await expect(page.getByText("Restored to Vault root.")).toBeVisible();
+  expect(writes).toEqual([{ status: "active", expected_commit: "abcdef1234567" }]);
+  await page.keyboard.press("Escape");
+  await expect(page).toHaveURL(/\/search\?q=example&archive_scope=archived/);
+  await expect(page.getByRole("link", { name: /Archive recovery example/ })).toHaveCount(0);
+});
+}
+}

--- a/frontend/e2e/search-contract.spec.ts
+++ b/frontend/e2e/search-contract.spec.ts
@@ -51,6 +51,7 @@ for (const viewport of [
             return route.fulfill({
               json: {
                 query: "deployment",
+                archive_scope: url.searchParams.get("archive_scope") || "unarchived",
                 total: 1,
                 returned: 1,
                 total_matches: 30,
@@ -74,6 +75,7 @@ for (const viewport of [
             return route.fulfill({
               json: {
                 pattern: "deployment",
+                archive_scope: url.searchParams.get("archive_scope") || "unarchived",
                 regex: url.searchParams.get("regex") === "true",
                 total_docs: 0,
                 total_matches: 0,
@@ -117,14 +119,16 @@ for (const viewport of [
       for (const label of [
         "Regular expression",
         "Case sensitive",
-        "Include archived documents",
       ]) {
         await page.getByLabel(label).click();
         await expect(page.getByLabel(label)).toBeChecked();
       }
+      await page.getByRole("button", { name: "Document state", exact: true }).click();
+      await page.getByRole("menuitemradio", { name: "All documents", exact: true }).click();
+      await expect(page.getByRole("button", { name: "Document state", exact: true })).toHaveText("All documents");
       await expect
-        .poll(() => requests.at(-1)?.searchParams.get("include_archived"))
-        .toBe("true");
+        .poll(() => requests.at(-1)?.searchParams.get("archive_scope"))
+        .toBe("all");
       expect(requests.at(-1)?.searchParams.get("regex")).toBe("true");
       expect(requests.at(-1)?.searchParams.get("case_sensitive")).toBe("true");
       expect(requests.at(-1)?.searchParams.getAll("doc_types")).toEqual([
@@ -132,8 +136,8 @@ for (const viewport of [
       ]);
       await page.goBack();
       await expect(
-        page.getByLabel("Include archived documents"),
-      ).not.toBeChecked();
+        page.getByRole("button", { name: "Document state", exact: true }),
+      ).toHaveText("Current documents");
       expect(
         await page.evaluate(
           () => document.documentElement.scrollWidth <= innerWidth,

--- a/frontend/e2e/search-live.spec.ts
+++ b/frontend/e2e/search-live.spec.ts
@@ -74,7 +74,8 @@ test("real login, search filters, reload and exact-search options", async ({
       page.getByText("Live active report", { exact: true }),
     ).toBeVisible();
     await expect(page.getByText("Live note", { exact: true })).toHaveCount(0);
-    await page.getByLabel("Include archived documents").click();
+    await page.getByRole("button", { name: "Document state", exact: true }).click();
+    await page.getByRole("menuitemradio", { name: "All documents", exact: true }).click();
     await expect(
       page.getByText("Live archived report", { exact: true }),
     ).toBeVisible();

--- a/frontend/src/components/__tests__/vault-explorer.test.tsx
+++ b/frontend/src/components/__tests__/vault-explorer.test.tsx
@@ -88,6 +88,38 @@ beforeEach(() => {
 
 afterEach(() => cleanup());
 
+describe("archive document navigation", () => {
+  it("keeps the scope selector available in an empty Vault and gives compatibility recovery", async () => {
+    browseMock.mockResolvedValue({ vault: "v", path: "", items: [] });
+    renderAt("/vault/v");
+    const user = userEvent.setup();
+    await screen.findByText(/No collections yet/);
+    await user.click(screen.getByRole("button", { name: "Collection document state" }));
+    await user.click(screen.getByRole("menuitemradio", { name: /Archived documents/ }));
+    await screen.findByText(/This server does not support/);
+    expect(screen.queryByText("No archived documents in this Vault.")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "show current documents" }));
+    await screen.findByText(/No collections yet/);
+  });
+
+  it("shows confirmed archives at their Collection path with a readable state marker", async () => {
+    vaultInfoMock.mockResolvedValue({ role: "owner" });
+    browseMock.mockImplementation(async (_v: string, _c: unknown, _d: number, options: { archive_scope?: string } = {}) => ({
+      vault: "v", path: "", archive_scope: options.archive_scope ?? "unarchived",
+      items: options.archive_scope === "archived" ? [{ type: "document", name: "Old guide", path: "guides/old.md", status: "archived" }] : [],
+    }));
+    renderAt("/vault/v");
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Collection document state" }));
+    await user.click(screen.getByRole("menuitemradio", { name: /Archived documents/ }));
+    await user.click(await screen.findByRole("button", { name: "guides" }));
+    expect(screen.getByRole("treeitem", { name: /Document:\s*Old guide\s*Archived/ })).toHaveAttribute("href", "/vault/v/doc/guides%2Fold.md");
+    expect(screen.getByRole("button", { name: "Resource type" })).toBeDisabled();
+    await user.click(screen.getByRole("button", { name: "Collection actions for guides" }));
+    expect(screen.queryByRole("menuitem", { name: /Delete collection/ })).not.toBeInTheDocument();
+  });
+});
+
 describe("VaultExplorer — rendering", () => {
   it("renders collections from browse response", async () => {
     renderAt("/vault/v");

--- a/frontend/src/components/frontmatter-edit-dialog.tsx
+++ b/frontend/src/components/frontmatter-edit-dialog.tsx
@@ -24,6 +24,7 @@ interface DocLike {
   title?: string;
   type?: string;
   status?: string;
+  current_commit?: string;
   domain?: string;
   summary?: string;
   tags?: string[];
@@ -127,6 +128,7 @@ export function FrontmatterEditDialog({
         tags,
       };
       if (contentChanged) payload.content = content;
+      if (doc.current_commit) payload.expected_commit = doc.current_commit;
       const result = await updateDocument(vault, docId, payload);
       onSaved({
         ...doc,
@@ -137,6 +139,7 @@ export function FrontmatterEditDialog({
         tags,
         content: contentChanged ? content : doc.content,
         path: result?.path || doc.path,
+        current_commit: result?.current_commit ?? result?.commit_hash ?? doc.current_commit,
       });
       onOpenChange(false);
     } catch (e: any) {

--- a/frontend/src/components/resource-actions-menu.tsx
+++ b/frontend/src/components/resource-actions-menu.tsx
@@ -1,5 +1,5 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
-import { FolderInput, MoreHorizontal, Share2, Trash2 } from "lucide-react";
+import { Archive, ArchiveRestore, FolderInput, MoreHorizontal, Share2, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -12,6 +12,9 @@ interface ResourceActionsMenuProps {
   publishLabel?: string;
   onPublish?: () => void;
   moveDisabledReason?: string;
+  archiveAction?: "archive" | "restore";
+  onArchiveAction?: () => void;
+  archiveDisabledReason?: string;
   className?: string;
   side?: "top" | "right" | "bottom" | "left";
   align?: "start" | "center" | "end";
@@ -32,6 +35,9 @@ export function ResourceActionsMenu({
   publishLabel,
   onPublish,
   moveDisabledReason,
+  archiveAction,
+  onArchiveAction,
+  archiveDisabledReason,
   className,
   side = "bottom",
   align = "end",
@@ -39,7 +45,7 @@ export function ResourceActionsMenu({
   const showMoveAction = Boolean(moveLabel && (onMove || moveDisabledReason));
   const showPublishAction = Boolean(publishLabel && onPublish);
   const showDeleteAction = Boolean(deleteLabel && onDelete);
-  if (!showMoveAction && !showPublishAction && !showDeleteAction) return null;
+  if (!showMoveAction && !showPublishAction && !showDeleteAction && !archiveAction) return null;
 
   return (
     <DropdownMenu.Root>
@@ -88,6 +94,22 @@ export function ResourceActionsMenu({
               </span>
             </DropdownMenu.Item>
           )}
+          {archiveAction && (
+            <DropdownMenu.Item
+              aria-disabled={archiveDisabledReason ? true : undefined}
+              onSelect={(event) => {
+                if (archiveDisabledReason || !onArchiveAction) event.preventDefault();
+                else onArchiveAction();
+              }}
+              className={cn("flex cursor-pointer select-none items-start gap-2 rounded-[var(--radius-sm)] px-2.5 py-2 text-sm text-foreground outline-none data-[highlighted]:bg-surface-hover", archiveDisabledReason && "cursor-not-allowed opacity-50")}
+            >
+              {archiveAction === "restore" ? <ArchiveRestore className="mt-0.5 h-4 w-4 shrink-0 text-link" aria-hidden /> : <Archive className="mt-0.5 h-4 w-4 shrink-0 text-foreground-muted" aria-hidden />}
+              <span>
+                <span className="block font-medium">{archiveAction === "restore" ? "Restore document" : "Archive document"}</span>
+                {archiveDisabledReason && <span className="mt-0.5 block max-w-64 text-xs leading-snug text-foreground-muted">{archiveDisabledReason}</span>}
+              </span>
+            </DropdownMenu.Item>
+          )}
           {showPublishAction && (
             <DropdownMenu.Item
               onSelect={onPublish}
@@ -97,7 +119,7 @@ export function ResourceActionsMenu({
               {publishLabel}
             </DropdownMenu.Item>
           )}
-          {(showMoveAction || showPublishAction) && showDeleteAction && (
+          {(showMoveAction || showPublishAction || archiveAction) && showDeleteAction && (
             <DropdownMenu.Separator className="my-1 h-px bg-border" />
           )}
           {showDeleteAction && (

--- a/frontend/src/components/vault-explorer.tsx
+++ b/frontend/src/components/vault-explorer.tsx
@@ -3,6 +3,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import {
   ChevronDown,
+  Archive,
   ChevronRight,
   FilePlus,
   FileText,
@@ -45,6 +46,7 @@ import {
   deleteVaultFile,
   deleteVaultTable,
   getVaultInfo,
+  type ArchiveScope,
 } from "@/lib/api";
 import { recentTone } from "@/lib/recent";
 import { isReservedCollection } from "@/lib/skill";
@@ -107,7 +109,9 @@ export function VaultExplorer({
   onRefetchReady,
   onCollapse,
 }: VaultExplorerProps) {
-  const { tree, loading, refreshing, error, refetch } = useVaultTree(vault);
+  const [scopeSelection, setScopeSelection] = useState<{ vault: string; scope: ArchiveScope }>({ vault, scope: "unarchived" });
+  const archiveScope = scopeSelection.vault === vault ? scopeSelection.scope : "unarchived";
+  const { tree, loading, refreshing, showingPreviousScope, unsupported, error, refetch } = useVaultTree(vault, archiveScope);
   const openCreateDocument = useOpenDocumentCreateDialog();
   const refreshCtx = useVaultRefresh();
   // Prefer the explicit prop; otherwise fall back to context. This lets
@@ -127,6 +131,11 @@ export function VaultExplorer({
   const navigate = useNavigate();
   const [filter, setFilter] = useState("");
   const [kindFilter, setKindFilter] = useState<ResourceKind | "all">("all");
+  function changeArchiveScope(value: string) {
+    setScopeSelection({ vault, scope: value as ArchiveScope });
+    setKindFilter("all");
+    setFilter("");
+  }
   const [collapsedKindGroups, setCollapsedKindGroups] = useState<Set<string>>(
     () => new Set(),
   );
@@ -232,8 +241,8 @@ export function VaultExplorer({
 
   const kindFiltered = useMemo(() => {
     if (!tree) return tree;
-    return filterTreeByKind(tree, kindFilter);
-  }, [tree, kindFilter]);
+    return filterTreeByKind(tree, archiveScope === "archived" ? "document" : kindFilter);
+  }, [tree, kindFilter, archiveScope]);
 
   const filtered = useMemo(() => {
     if (!kindFiltered) return kindFiltered;
@@ -452,7 +461,21 @@ export function VaultExplorer({
         </div>
       </div>
 
-      {total > 0 && (
+      <div className="shrink-0 border-b border-border px-2 py-1.5">
+        <SelectMenu
+          value={archiveScope}
+          onValueChange={changeArchiveScope}
+          aria-label="Collection document state"
+          className="h-8 bg-background px-2 text-xs"
+          options={[
+            { value: "unarchived", label: "Current documents", hint: "Includes drafts; files and tables remain visible" },
+            { value: "archived", label: "Archived documents", hint: "Documents only, in their original Collections" },
+            { value: "all", label: "All documents", hint: "Includes archived documents, files, and tables" },
+          ]}
+        />
+      </div>
+
+      {total > 0 && !unsupported && (
         <div className="shrink-0 border-b border-border px-2 py-1.5">
           <div className="grid grid-cols-[minmax(0,1fr)_6.5rem] gap-1.5">
             <div className="relative min-w-0">
@@ -470,12 +493,13 @@ export function VaultExplorer({
               />
             </div>
             <SelectMenu
-              value={kindFilter}
+              value={archiveScope === "archived" ? "document" : kindFilter}
               onValueChange={(value) =>
                 setKindFilter(value as ResourceKind | "all")
               }
               options={kindOptions}
               aria-label="Resource type"
+              disabled={archiveScope === "archived"}
               className="h-8 bg-background px-2 text-xs"
             />
           </div>
@@ -491,19 +515,28 @@ export function VaultExplorer({
         className="flex-1 overflow-y-auto"
       >
         {loading && <VaultExplorerLoading />}
+        {showingPreviousScope && (
+          <p role="status" className="px-3 py-2 text-xs text-foreground-muted">Previous document state view shown{refreshing ? " while updating…" : ". Refresh to try again."}</p>
+        )}
         {error && <Alert variant="destructive" className="m-2">{error}</Alert>}
-        {!loading && total === 0 && (
+        {unsupported && (
+          <Alert variant="warning" className="m-2">
+            This server does not support this document state view yet. Update the server or{" "}
+            <button type="button" onClick={() => changeArchiveScope("unarchived")} className="underline focus-visible:ring-2 focus-visible:ring-ring">show current documents</button>.
+          </Alert>
+        )}
+        {!loading && !refreshing && !error && !unsupported && (total === 0 || (archiveScope === "archived" && resourceCounts.document === 0)) && (
           <div className="px-3 py-4 text-xs leading-relaxed text-foreground-muted" role="status">
-            No collections yet — the tree fills in with your first document.
+            {archiveScope === "archived" ? "No archived documents in this Vault." : "No collections yet — the tree fills in with your first document."}
           </div>
         )}
-        {!loading && total > 0 && visibleRows.length === 0 && (
+        {!loading && !refreshing && !unsupported && total > 0 && visibleRows.length === 0 && !(archiveScope === "archived" && resourceCounts.document === 0) && (
           <div className="coord px-3 py-2" role="status">
             No resources match these filters.
           </div>
         )}
 
-        {!loading &&
+        {!loading && !unsupported &&
           visibleRows.map((row) => {
             if (row.type === "kind-group") {
               return (
@@ -551,7 +584,7 @@ export function VaultExplorer({
                     editable: canWrite && !isReservedCollection(node.path),
                   });
                 }}
-                onDeleteCollection={(node) => {
+                onDeleteCollection={archiveScope === "archived" || showingPreviousScope ? undefined : (node) => {
                   const counts = countCollectionResources(node);
                   setDeleteTarget({
                     path: node.path,
@@ -906,6 +939,12 @@ const TreeRow = memo(function TreeRow({
           )}
         </span>
         {isSkill && <SkillBadge defined className="ml-auto shrink-0" />}
+        {node.kind === "document" && node.raw?.status === "archived" && (
+          <span title="Archived" className="shrink-0 text-foreground-muted">
+            <Archive className="h-3 w-3" aria-hidden />
+            <span className="sr-only">Archived</span>
+          </span>
+        )}
       </Link>
       {canDeleteResource && (
         <ResourceActionsMenu

--- a/frontend/src/hooks/__tests__/use-vault-tree-archive.test.ts
+++ b/frontend/src/hooks/__tests__/use-vault-tree-archive.test.ts
@@ -1,0 +1,47 @@
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { browseVault, type ArchiveScope } from "@/lib/api";
+import { useVaultTree } from "../use-vault-tree";
+
+vi.mock("@/lib/api", () => ({ browseVault: vi.fn() }));
+const browse = vi.mocked(browseVault);
+const response = (scope?: ArchiveScope) => ({
+  vault: "v", path: "", archive_scope: scope,
+  items: [{ type: "document", name: scope ?? "Current", path: "guides/doc.md", status: scope === "archived" ? "archived" : "active" }],
+});
+beforeEach(() => { vi.clearAllMocks(); browse.mockResolvedValue(response()); });
+afterEach(cleanup);
+
+describe("archive-aware Vault tree", () => {
+  it("keeps the old browse call for default consumers and refetches on a status change", async () => {
+    const { result } = renderHook(() => useVaultTree("v"));
+    await waitFor(() => expect(result.current.tree).not.toBeNull());
+    expect(browse).toHaveBeenCalledWith("v", undefined, -1);
+    act(() => window.dispatchEvent(new CustomEvent("akb:document-status-changed", { detail: { vault: "other" } })));
+    expect(browse).toHaveBeenCalledTimes(1);
+    act(() => window.dispatchEvent(new CustomEvent("akb:document-status-changed", { detail: { vault: "v" } })));
+    await waitFor(() => expect(browse).toHaveBeenCalledTimes(2));
+  });
+
+  it("retains the prior snapshot during scope loading, then replaces it with confirmed archives", async () => {
+    const { result, rerender } = renderHook(({ scope }: { scope: ArchiveScope }) => useVaultTree("v", scope), { initialProps: { scope: "unarchived" as ArchiveScope } });
+    await waitFor(() => expect(result.current.tree).not.toBeNull());
+    let resolve!: (value: ReturnType<typeof response>) => void;
+    browse.mockReturnValueOnce(new Promise((done) => { resolve = done; }));
+    rerender({ scope: "archived" });
+    expect(result.current.tree?.[0].children?.[0].name).toBe("Current");
+    expect(result.current.showingPreviousScope).toBe(true);
+    expect(result.current.refreshing).toBe(true);
+    await act(async () => resolve(response("archived")));
+    expect(result.current.showingPreviousScope).toBe(false);
+    expect(result.current.tree?.[0].children?.[0].raw.status).toBe("archived");
+    expect(browse).toHaveBeenLastCalledWith("v", undefined, -1, { archive_scope: "archived" });
+  });
+
+  it("does not expose an ignored scope as a valid tree", async () => {
+    const { result } = renderHook(() => useVaultTree("v", "archived"));
+    await waitFor(() => expect(result.current.unsupported).toBe(true));
+    expect(result.current.tree).toEqual([]);
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/frontend/src/hooks/use-vault-tree.ts
+++ b/frontend/src/hooks/use-vault-tree.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { browseVault } from "@/lib/api";
+import { browseVault, type ArchiveScope } from "@/lib/api";
 import { isReservedCollection } from "@/lib/skill";
 import { parseFileUri } from "@/lib/uri";
 
@@ -46,9 +46,16 @@ interface BrowseItem {
  * kind disclosures and progressive pages. True network/memory scaling will
  * require a future browse contract with collection + kind + cursor inputs.
  */
-export function useVaultTree(vault: string | undefined) {
-  const [snapshot, setSnapshot] = useState<{ vault: string; items: BrowseItem[] } | null>(null);
-  const snapshotRef = useRef<{ vault: string; items: BrowseItem[] } | null>(null);
+interface TreeSnapshot {
+  vault: string;
+  scope: ArchiveScope;
+  items: BrowseItem[];
+  unsupported: boolean;
+}
+
+export function useVaultTree(vault: string | undefined, archiveScope: ArchiveScope = "unarchived") {
+  const [snapshot, setSnapshot] = useState<TreeSnapshot | null>(null);
+  const snapshotRef = useRef<TreeSnapshot | null>(null);
   const [error, setError] = useState<string>("");
   const [refreshing, setRefreshing] = useState(false);
   // Counter bumped on every refetch invocation so the underlying
@@ -59,6 +66,14 @@ export function useVaultTree(vault: string | undefined) {
   const refetch = useCallback(() => {
     setRefetchTick((n) => n + 1);
   }, []);
+
+  useEffect(() => {
+    const refresh = (event: Event) => {
+      if ((event as CustomEvent<{ vault?: string }>).detail?.vault === vault) refetch();
+    };
+    window.addEventListener("akb:document-status-changed", refresh);
+    return () => window.removeEventListener("akb:document-status-changed", refresh);
+  }, [vault, refetch]);
 
   // `alive` guard still matters: if `vault` changes mid-flight (or the
   // user fires refetch twice before the first resolves), we don't want
@@ -75,10 +90,14 @@ export function useVaultTree(vault: string | undefined) {
     const hasCurrentSnapshot = snapshotRef.current?.vault === vault;
     setRefreshing(hasCurrentSnapshot);
     setError("");
-    browseVault(vault, undefined, -1)
+    const request = archiveScope === "unarchived"
+      ? browseVault(vault, undefined, -1)
+      : browseVault(vault, undefined, -1, { archive_scope: archiveScope });
+    request
       .then((d) => {
         if (!alive) return;
-        const next = { vault, items: d.items as BrowseItem[] };
+        const unsupported = archiveScope !== "unarchived" && d.archive_scope !== archiveScope;
+        const next = { vault, scope: archiveScope, unsupported, items: unsupported ? [] : d.items as BrowseItem[] };
         snapshotRef.current = next;
         setSnapshot(next);
       })
@@ -89,16 +108,19 @@ export function useVaultTree(vault: string | undefined) {
         if (alive) setRefreshing(false);
       });
     return () => { alive = false; };
-  }, [vault, refetchTick]);
+  }, [vault, archiveScope, refetchTick]);
 
   const items = snapshot && snapshot.vault === vault ? snapshot.items : null;
+  const scopePending = Boolean(snapshot && snapshot.vault === vault && snapshot.scope !== archiveScope && !error);
+  const unsupported = Boolean(snapshot && snapshot.vault === vault && snapshot.scope === archiveScope && snapshot.unsupported);
+  const showingPreviousScope = Boolean(snapshot && snapshot.vault === vault && snapshot.scope !== archiveScope);
 
   const tree = useMemo<TreeNode[] | null>(() => {
     if (!items) return null;
     return buildTree(items);
   }, [items]);
 
-  return { tree, loading: items === null && !error, refreshing, error, refetch };
+  return { tree, loading: items === null && !error, refreshing: refreshing || scopePending, showingPreviousScope, unsupported, error, refetch };
 }
 
 export function buildTree(items: BrowseItem[]): TreeNode[] {

--- a/frontend/src/lib/__tests__/api-search-contract.test.ts
+++ b/frontend/src/lib/__tests__/api-search-contract.test.ts
@@ -84,7 +84,7 @@ describe("grep response contract — total_matches + total_docs", () => {
       return HttpResponse.json({ results: [] });
     }));
     const options = { collection: "guide_%", doc_types: ["report", "note"], tags: ["ops", "한글"],
-      source_type: "document" as const, include_archived: false, regex: true, case_sensitive: true };
+      source_type: "document" as const, include_archived: false, archive_scope: "archived" as const, regex: true, case_sensitive: true };
     await searchDocs("x", ["a", "b"], 25, options);
     await grepDocs("A.*B", ["a", "b"], 20, options);
     for (const url of requests) {
@@ -93,6 +93,7 @@ describe("grep response contract — total_matches + total_docs", () => {
       expect(url.searchParams.getAll("doc_types")).toEqual(["report", "note"]);
       expect(url.searchParams.getAll("tags")).toEqual(["ops", "한글"]);
       expect(url.searchParams.get("include_archived")).toBe("false");
+      expect(url.searchParams.get("archive_scope")).toBe("archived");
     }
     expect(requests[0].searchParams.has("regex")).toBe(false);
     expect(requests[0].searchParams.get("source_type")).toBe("document");

--- a/frontend/src/lib/__tests__/document-archive.test.ts
+++ b/frontend/src/lib/__tests__/document-archive.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { changeDocumentArchiveState, documentArchiveDisabledReason } from "@/lib/document-archive";
+import { ArchiveVerificationError, changeDocumentArchiveState, checkDocumentArchiveState, documentArchiveDisabledReason } from "@/lib/document-archive";
 import { getDocument, updateDocument } from "@/lib/api";
 
 vi.mock("@/lib/api", () => ({ getDocument: vi.fn(), updateDocument: vi.fn() }));
@@ -24,6 +24,14 @@ describe("document archive permissions", () => {
 });
 
 describe("verified archive mutations", () => {
+  it("recovers an accepted mutation by reading, never repeating the PATCH", async () => {
+    vi.mocked(updateDocument).mockResolvedValue({ current_commit: "new" } as never);
+    vi.mocked(getDocument).mockRejectedValueOnce(new Error("503"))
+      .mockResolvedValueOnce({ status: "active", path: "a.md", current_commit: "new" } as never);
+    await expect(changeDocumentArchiveState("team", "a.md", "active", "old")).rejects.toBeInstanceOf(ArchiveVerificationError);
+    expect(await checkDocumentArchiveState("team", "a.md")).toMatchObject({ status: "active", current_commit: "new" });
+    expect(updateDocument).toHaveBeenCalledOnce();
+  });
   it.each(["active", "archived"] as const)("patches only status and concurrency token for %s", async (status) => {
     vi.mocked(updateDocument).mockResolvedValue({} as never);
     vi.mocked(getDocument).mockResolvedValue({ status, path: "research/a.md", title: "A" } as never);

--- a/frontend/src/lib/__tests__/document-archive.test.ts
+++ b/frontend/src/lib/__tests__/document-archive.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { changeDocumentArchiveState, documentArchiveDisabledReason } from "@/lib/document-archive";
+import { getDocument, updateDocument } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({ getDocument: vi.fn(), updateDocument: vi.fn() }));
+afterEach(() => vi.resetAllMocks());
+
+describe("document archive permissions", () => {
+  const allowed = { role: "writer", readOnly: false, historical: false, guide: false };
+  it("allows writers on ordinary current documents", () => {
+    expect(documentArchiveDisabledReason(allowed)).toBeUndefined();
+  });
+  it.each([
+    [{ role: "reader" }, "Writer"],
+    [{ readOnly: true }, "read-only"],
+    [{ historical: true }, "latest version"],
+    [{ guide: true }, "owner"],
+  ])("explains unavailable actions: %j", (overrides, reason) => {
+    expect(documentArchiveDisabledReason({ ...allowed, ...overrides })).toContain(reason);
+  });
+  it("lets only an owner change a guide", () => {
+    expect(documentArchiveDisabledReason({ ...allowed, role: "owner", guide: true })).toBeUndefined();
+  });
+});
+
+describe("verified archive mutations", () => {
+  it.each(["active", "archived"] as const)("patches only status and concurrency token for %s", async (status) => {
+    vi.mocked(updateDocument).mockResolvedValue({} as never);
+    vi.mocked(getDocument).mockResolvedValue({ status, path: "research/a.md", title: "A" } as never);
+    const listener = vi.fn();
+    window.addEventListener("akb:document-status-changed", listener);
+    try {
+      const result = await changeDocumentArchiveState("team", "research/a.md", status, "commit1");
+      expect(updateDocument).toHaveBeenCalledWith("team", "research/a.md", { status, expected_commit: "commit1" });
+      expect(result.path).toBe("research/a.md");
+      expect(listener).toHaveBeenCalledOnce();
+    } finally {
+      window.removeEventListener("akb:document-status-changed", listener);
+    }
+  });
+  it("does not claim success when an older server ignores status", async () => {
+    vi.mocked(updateDocument).mockResolvedValue({} as never);
+    vi.mocked(getDocument).mockResolvedValue({ status: "active" } as never);
+    await expect(changeDocumentArchiveState("team", "a.md", "archived")).rejects.toThrow("could not be verified");
+  });
+  it("preserves conflict failure without retrying or reading a false success", async () => {
+    vi.mocked(updateDocument).mockRejectedValue(new Error("Document changed. Reload before trying again."));
+    await expect(changeDocumentArchiveState("team", "a.md", "archived", "old")).rejects.toThrow("Reload");
+    expect(updateDocument).toHaveBeenCalledOnce();
+    expect(getDocument).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1788,10 +1788,14 @@ export const deleteVaultTable = (vault: string, tableName: string) =>
   );
 
 // ── Browse ──
-export const browseVault = (vault: string, collection?: string, depth = 1) => {
+export type ArchiveScope = "unarchived" | "archived" | "all";
+
+export const browseVault = (vault: string, collection?: string, depth = 1, options: { archive_scope?: ArchiveScope } = {}) => {
   const p = new URLSearchParams({ depth: String(depth) });
   if (collection) p.set("collection", collection);
+  if (options.archive_scope) p.set("archive_scope", options.archive_scope);
   return api<{
+    archive_scope?: ArchiveScope;
     vault: string;
     path: string;
     context?: {
@@ -1843,6 +1847,7 @@ export async function importKnowledgeBundle(
 //   - truncated / hint: set when the prefetch pool filled, meaning the
 //     corpus may contain more hits than the response surfaces (#77 / 0.2.5).
 export interface SearchResponse {
+  archive_scope?: ArchiveScope;
   query: string;
   total: number;
   returned: number;
@@ -1862,6 +1867,7 @@ const vaultScopeParams = (vaults?: string[] | string): string[] =>
   (Array.isArray(vaults) ? vaults : vaults ? [vaults] : []).filter(Boolean);
 
 export interface SearchOptions {
+  archive_scope?: ArchiveScope;
   collection?: string;
   source_type?: "document" | "file" | "table";
   doc_types?: string[];
@@ -1872,6 +1878,7 @@ export interface SearchOptions {
 }
 
 function appendSearchOptions(p: URLSearchParams, options: SearchOptions, literal: boolean) {
+  if (options.archive_scope) p.set("archive_scope", options.archive_scope);
   if (options.collection) p.set("collection", options.collection);
   for (const type of options.doc_types || []) p.append("doc_types", type);
   for (const tag of options.tags || []) p.append("tags", tag);
@@ -1894,6 +1901,7 @@ export interface GrepMatch {
   text: string;
 }
 export interface GrepDoc {
+  status?: string | null;
   uri: string;
   vault: string;
   path: string;
@@ -1906,6 +1914,7 @@ export interface GrepDoc {
 // matches than the response surfaces — switch to count_only or
 // files_with_matches at the agent / caller level (backend #76 / 0.2.4).
 export interface GrepResponse {
+  archive_scope?: ArchiveScope;
   pattern: string;
   regex: boolean;
   returned_docs?: number;

--- a/frontend/src/lib/document-archive.ts
+++ b/frontend/src/lib/document-archive.ts
@@ -13,6 +13,20 @@ export function documentArchiveDisabledReason(options: {
   if (options.guide && options.role !== "owner") return "Only the Vault owner can change the Vault guide.";
 }
 
+export class ArchiveVerificationError extends Error {
+  constructor() {
+    super("The change was accepted, but its current state could not be verified. Check current state before making another change.");
+    this.name = "ArchiveVerificationError";
+  }
+}
+
+/** Reconcile a previously accepted write without sending it again. */
+export async function checkDocumentArchiveState(vault: string, ref: string) {
+  const current = await getDocument(vault, ref);
+  window.dispatchEvent(new CustomEvent("akb:document-status-changed", { detail: { vault, path: current.path, status: current.status } }));
+  return current;
+}
+
 export async function changeDocumentArchiveState(vault: string, ref: string, status: "active" | "archived", expectedCommit?: string) {
   await updateDocument(vault, ref, {
     status,
@@ -20,10 +34,11 @@ export async function changeDocumentArchiveState(vault: string, ref: string, sta
   });
   // A successful HTTP response alone cannot prove older servers applied status.
   // Do not overwrite title/body locally with an optimistic metadata snapshot.
-  const current = await getDocument(vault, ref);
-  if (current.status !== status) {
-    throw new Error("The document state could not be verified. Reload the document before trying again; the server may not support this action or another edit may have changed it.");
+  try {
+    const current = await checkDocumentArchiveState(vault, ref);
+    if (current.status !== status) throw new ArchiveVerificationError();
+    return current;
+  } catch {
+    throw new ArchiveVerificationError();
   }
-  window.dispatchEvent(new CustomEvent("akb:document-status-changed", { detail: { vault, path: current.path, status } }));
-  return current;
 }

--- a/frontend/src/lib/document-archive.ts
+++ b/frontend/src/lib/document-archive.ts
@@ -1,0 +1,29 @@
+import { getDocument, updateDocument } from "@/lib/api";
+
+/** Archive changes discovery, never document identity or access permissions. */
+export function documentArchiveDisabledReason(options: {
+  role: string | null;
+  readOnly: boolean;
+  historical: boolean;
+  guide: boolean;
+}): string | undefined {
+  if (options.historical) return "Open the latest version to change document state.";
+  if (options.readOnly) return "This Vault is read-only or its write access could not be verified.";
+  if (!["writer", "admin", "owner"].includes(options.role || "")) return "Writer access or higher is required.";
+  if (options.guide && options.role !== "owner") return "Only the Vault owner can change the Vault guide.";
+}
+
+export async function changeDocumentArchiveState(vault: string, ref: string, status: "active" | "archived", expectedCommit?: string) {
+  await updateDocument(vault, ref, {
+    status,
+    ...(expectedCommit ? { expected_commit: expectedCommit } : {}),
+  });
+  // A successful HTTP response alone cannot prove older servers applied status.
+  // Do not overwrite title/body locally with an optimistic metadata snapshot.
+  const current = await getDocument(vault, ref);
+  if (current.status !== status) {
+    throw new Error("The document state could not be verified. Reload the document before trying again; the server may not support this action or another edit may have changed it.");
+  }
+  window.dispatchEvent(new CustomEvent("akb:document-status-changed", { detail: { vault, path: current.path, status } }));
+  return current;
+}

--- a/frontend/src/lib/search-state.ts
+++ b/frontend/src/lib/search-state.ts
@@ -6,12 +6,14 @@ export const SEARCH_FILTER_KEYS = [
   "tag",
   "collection",
   "include_archived",
+  "archive_scope",
   "regex",
   "case_sensitive",
 ] as const;
 
 export function readSearchOptions(params: URLSearchParams): SearchOptions {
   const source = params.get("source");
+  const archiveScope = params.get("archive_scope");
   return {
     collection: params.get("collection") || undefined,
     source_type:
@@ -21,6 +23,11 @@ export function readSearchOptions(params: URLSearchParams): SearchOptions {
     doc_types: [...new Set(params.getAll("doc_type").filter(Boolean))],
     tags: [...new Set(params.getAll("tag").filter(Boolean))],
     include_archived: params.get("include_archived") === "true",
+    ...(archiveScope === "unarchived" ||
+    archiveScope === "archived" ||
+    archiveScope === "all"
+      ? { archive_scope: archiveScope }
+      : {}),
     regex: params.get("regex") === "true",
     case_sensitive: params.get("case_sensitive") === "true",
   };

--- a/frontend/src/mocks/browser.ts
+++ b/frontend/src/mocks/browser.ts
@@ -90,6 +90,7 @@ const handlers = [
       : "Initial result";
     return HttpResponse.json({
       query: "deployment",
+      archive_scope: url.searchParams.get("archive_scope") || "unarchived",
       total: 1,
       returned: 1,
       total_matches: 30,
@@ -111,6 +112,7 @@ const handlers = [
     const url = new URL(request.url);
     return HttpResponse.json({
       pattern: "deployment",
+      archive_scope: url.searchParams.get("archive_scope") || "unarchived",
       regex: url.searchParams.get("regex") === "true",
       total_docs: 0,
       total_matches: 0,

--- a/frontend/src/pages/__tests__/document-view-toggle.test.tsx
+++ b/frontend/src/pages/__tests__/document-view-toggle.test.tsx
@@ -102,6 +102,34 @@ function makeDoc(overrides: Record<string, unknown> = {}) {
 }
 
 describe("document archive and restore", () => {
+  it("offers read-only recovery after an accepted restore cannot be verified", async () => {
+    const user = userEvent.setup();
+    let current = { ...makeDoc(), status: "archived" };
+    let failNextRead = false;
+    getVaultInfoMock.mockResolvedValue({ role: "writer" });
+    getDocumentMock.mockImplementation(async () => {
+      if (failNextRead) { failNextRead = false; throw new Error("503 temporary read failure"); }
+      return current;
+    });
+    updateDocumentMock.mockImplementation(async () => {
+      current = { ...current, status: "active", current_commit: UPDATED_COMMIT };
+      failNextRead = true;
+      return { current_commit: UPDATED_COMMIT };
+    });
+    renderPreviewAt("/vault/v/doc/notes%2Fhello.md");
+    await screen.findByRole("button", { name: "Edit" });
+    await user.click(screen.getByRole("button", { name: "Restore document" }));
+    await user.click(within(await screen.findByRole("dialog", { name: "Restore this document?" })).getByRole("button", { name: "Restore document" }));
+    const recovery = await screen.findByRole("dialog", { name: "Check document state" });
+    expect(within(recovery).getByRole("alert")).toHaveTextContent("change was accepted");
+    await user.click(within(recovery).getByRole("button", { name: "Cancel" }));
+    await user.click(screen.getByRole("button", { name: "Restore document" }));
+    await user.click(within(await screen.findByRole("dialog", { name: "Check document state" })).getByRole("button", { name: "Check current state" }));
+    await screen.findByText("Restored to notes.");
+    expect(updateDocumentMock).toHaveBeenCalledOnce();
+    expect(screen.getByTestId("location-state")).toHaveTextContent('"documentPreview":true');
+  });
+
   it("archives through overflow and restores in the preview without moving the document", async () => {
     const user = userEvent.setup();
     let current = makeDoc({ status: "active" });

--- a/frontend/src/pages/__tests__/document-view-toggle.test.tsx
+++ b/frontend/src/pages/__tests__/document-view-toggle.test.tsx
@@ -101,6 +101,43 @@ function makeDoc(overrides: Record<string, unknown> = {}) {
   };
 }
 
+describe("document archive and restore", () => {
+  it("archives through overflow and restores in the preview without moving the document", async () => {
+    const user = userEvent.setup();
+    let current = makeDoc({ status: "active" });
+    getDocumentMock.mockImplementation(async () => current);
+    getVaultInfoMock.mockResolvedValue({ role: "writer" });
+    updateDocumentMock.mockImplementation(async (_vault, _ref, patch) => {
+      current = { ...current, status: patch.status, current_commit: UPDATED_COMMIT };
+      return { current_commit: UPDATED_COMMIT };
+    });
+    renderPreviewAt("/vault/v/doc/notes%2Fhello.md");
+    await screen.findByRole("button", { name: "Edit" });
+    await user.click(screen.getByRole("button", { name: "Actions for DocTitle" }));
+    await user.click(screen.getByRole("menuitem", { name: "Archive document" }));
+    const archiveDialog = await screen.findByRole("dialog", { name: "Archive this document?" });
+    expect(within(archiveDialog).getByText(/does not delete it, revoke access/)).toBeInTheDocument();
+    await user.click(within(archiveDialog).getByRole("button", { name: "Archive document" }));
+    await screen.findByText(/Archived · Hidden from current documents/);
+    expect(updateDocumentMock).toHaveBeenCalledWith("v", "notes/hello.md", { status: "archived", expected_commit: "abcdef1234567" });
+    await user.click(screen.getByRole("button", { name: "Restore document" }));
+    const restoreDialog = await screen.findByRole("dialog", { name: "Restore this document?" });
+    await user.click(within(restoreDialog).getByRole("button", { name: "Restore document" }));
+    await screen.findByText("Restored to notes.");
+    expect(updateDocumentMock).toHaveBeenLastCalledWith("v", "notes/hello.md", { status: "active", expected_commit: UPDATED_COMMIT });
+    expect(screen.getByTestId("location-pathname")).toHaveTextContent("/vault/v/doc/notes%2Fhello.md");
+    expect(screen.getByTestId("location-state")).toHaveTextContent('"documentPreview":true');
+  });
+
+  it("keeps reader restore visible with an explicit permission reason", async () => {
+    getDocumentMock.mockResolvedValue(makeDoc({ status: "archived" }));
+    renderAt("/vault/v/doc/notes%2Fhello.md");
+    expect(await screen.findByRole("button", { name: "Restore document" })).toBeDisabled();
+    await screen.findByText("Writer access or higher is required.");
+    expect(updateDocumentMock).not.toHaveBeenCalled();
+  });
+});
+
 function LocationProbe() {
   const loc = useLocation();
   return (

--- a/frontend/src/pages/__tests__/search-filter-chips.test.tsx
+++ b/frontend/src/pages/__tests__/search-filter-chips.test.tsx
@@ -63,6 +63,48 @@ const openFilters = async (user: ReturnType<typeof userEvent.setup>) =>
   user.click(screen.getByRole("button", { name: "Filter by document type" }));
 
 describe("server search filters", () => {
+  it("requests archived documents on the server, displays status, and preserves scope across modes and Back", async () => {
+    search.mockImplementation(async (_q, _v, _l, options) => ({
+      ...response(options?.archive_scope === "archived" ? [{ ...hit("Old guide"), status: "archived" }] : []),
+      archive_scope: options?.archive_scope ?? "unarchived",
+    }));
+    grep.mockResolvedValue({ pattern: "x", regex: false, total_docs: 1, total_matches: 1, archive_scope: "archived", results: [{ ...hit("Old literal guide"), status: "archived", matches: [{ section: null, text: "x" }] }] });
+    renderAt();
+    const user = userEvent.setup();
+    await openFilters(user);
+    await user.click(screen.getByLabelText("Document state"));
+    await user.click(screen.getByRole("menuitemradio", { name: "Archived documents" }));
+    await screen.findByText("Old guide");
+    expect(screen.getByText("Archived")).toBeInTheDocument();
+    expect(search).toHaveBeenLastCalledWith("x", [], 25, expect.objectContaining({ archive_scope: "archived", source_type: "document" }));
+    expect(screen.getByTestId("url")).toHaveTextContent("archive_scope=archived");
+    await user.click(screen.getByRole("button", { name: "Literal", pressed: false }));
+    await screen.findByText("Old literal guide");
+    expect(screen.getByText("Archived")).toBeInTheDocument();
+    expect(grep).toHaveBeenLastCalledWith("x", [], 20, expect.objectContaining({ archive_scope: "archived" }));
+    await user.click(screen.getByRole("button", { name: "Back" }));
+    await screen.findByText("Old guide");
+    expect(screen.getByLabelText("Document state")).toHaveTextContent("Archived documents");
+  });
+
+  it("does not claim no archives when an older server ignores the scope and offers recovery", async () => {
+    renderAt("/search?q=x&archive_scope=archived");
+    await screen.findByText(/This server could not confirm/);
+    expect(screen.queryByRole("heading", { name: /No results/ })).not.toBeInTheDocument();
+    expect(screen.queryByText("0 top results loaded")).not.toBeInTheDocument();
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "search current documents" }));
+    await screen.findByRole("heading", { name: /No results/ });
+    expect(screen.getByTestId("url")).not.toHaveTextContent("archive_scope");
+  });
+
+  it("hides wrong-scope hits from an older server instead of client-filtering them", async () => {
+    search.mockResolvedValue(response([hit("Current guide")]));
+    renderAt("/search?q=x&archive_scope=archived");
+    await screen.findByText(/This server could not confirm/);
+    expect(screen.queryByText("Current guide")).not.toBeInTheDocument();
+  });
+
   it("keeps filters available before results and after a zero-match response", async () => {
     renderAt();
     const user = userEvent.setup();
@@ -127,7 +169,8 @@ describe("server search filters", () => {
       screen.getByLabelText("Tags (match any)"),
       "rare-tag{Enter}",
     );
-    await user.click(screen.getByLabelText("Include archived documents"));
+    await user.click(screen.getByLabelText("Document state"));
+    await user.click(screen.getByRole("menuitemradio", { name: "All documents" }));
     await waitFor(() =>
       expect(search).toHaveBeenLastCalledWith(
         "x",
@@ -137,7 +180,7 @@ describe("server search filters", () => {
           collection: "guides/api",
           tags: ["rare-tag"],
           source_type: "document",
-          include_archived: true,
+          archive_scope: "all",
         }),
       ),
     );

--- a/frontend/src/pages/document.tsx
+++ b/frontend/src/pages/document.tsx
@@ -75,6 +75,7 @@ import { recordRecentDocumentView } from "@/lib/recent-document-views";
 import { ResourceActionsMenu } from "@/components/resource-actions-menu";
 import { ResourceDeleteDialog } from "@/components/resource-delete-dialog";
 import { DocumentMoveDialog } from "@/components/document-move-dialog";
+import { changeDocumentArchiveState, documentArchiveDisabledReason } from "@/lib/document-archive";
 import { DocumentTitleConflictNotice } from "@/components/document-title-conflict-notice";
 import {
   documentCollection,
@@ -154,6 +155,8 @@ export default function DocumentPage({
   const [editOpen, setEditOpen] = useState(false);
   const [moveOpen, setMoveOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const [archiveOpen, setArchiveOpen] = useState(false);
+  const [archiveNotice, setArchiveNotice] = useState("");
   const [publishOpen, setPublishOpen] = useState(false);
   const [detailsOpen, setDetailsOpen] = useState(false);
   const [detailsTab, setDetailsTab] = useState<"info" | "outline" | "relations" | "history">("info");
@@ -405,6 +408,8 @@ export default function DocumentPage({
   // is still loading — so a real older version is never briefly editable.
   const isHistorical = !!commitHash && !sameCommitRef(commitHash, headCommit);
   const canEdit =
+    !vaultReadOnly &&
+    (doc?.path !== VAULT_SKILL_PATH || vaultRole === "owner") &&
     !isHistorical &&
     !isDiffMode &&
     (vaultRole === "writer" || vaultRole === "admin" || vaultRole === "owner");
@@ -753,6 +758,11 @@ export default function DocumentPage({
     !isHistorical &&
     !isDiffMode &&
     doc.path !== VAULT_SKILL_PATH;
+  const archiveDisabledReason = documentArchiveDisabledReason({
+    role: vaultRole, readOnly: vaultReadOnly,
+    historical: isHistorical || isDiffMode,
+    guide: doc.path === VAULT_SKILL_PATH,
+  });
 
   const openVersion = (hash?: string, options: { replace?: boolean } = {}) => {
     const params = new URLSearchParams(searchParams);
@@ -887,6 +897,9 @@ export default function DocumentPage({
                 )}
                 <ResourceActionsMenu
                   resourceName={doc.title || fileName}
+                  archiveAction={doc.status === "archived" ? "restore" : "archive"}
+                  archiveDisabledReason={archiveDisabledReason}
+                  onArchiveAction={() => setArchiveOpen(true)}
                   moveLabel="Move document"
                   onMove={moveDisabledReason ? undefined : () => setMoveOpen(true)}
                   moveDisabledReason={moveDisabledReason || undefined}
@@ -897,6 +910,15 @@ export default function DocumentPage({
             )}
           </div>
         </header>
+
+        {archiveNotice && <Alert variant="success" className="shrink-0">{archiveNotice}<Button variant="ghost" size="sm" onClick={() => setArchiveNotice("")}>Dismiss</Button></Alert>}
+        {doc.status === "archived" && !isHistorical && !isDiffMode && view !== "edit" && (
+          <div className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-border bg-surface-2 px-4 py-2 text-xs text-foreground-muted">
+            <span>Archived · Hidden from current documents. Existing links and access remain unchanged.</span>
+            <Button variant="outline" size="sm" disabled={!!archiveDisabledReason} title={archiveDisabledReason} onClick={() => setArchiveOpen(true)}>Restore document</Button>
+            {archiveDisabledReason && <span>{archiveDisabledReason}</span>}
+          </div>
+        )}
 
         {isDiffMode ? (
           <div
@@ -1239,7 +1261,7 @@ export default function DocumentPage({
                     <Info className="h-4 w-4 text-link" aria-hidden />
                     Properties
                   </h3>
-                  {canWrite && !isHistorical && (
+                  {canEdit && (
                     <Button type="button" variant="ghost" size="sm" onClick={() => setEditOpen(true)}>
                       <Pencil className="h-3.5 w-3.5" aria-hidden />
                       Edit
@@ -1420,6 +1442,8 @@ export default function DocumentPage({
         doc={doc}
         onSaved={(next) => {
           setDocOverride({ ...doc, ...next });
+          void queryClient.invalidateQueries({ queryKey: ["document", name] });
+          if (next.status !== doc.status) window.dispatchEvent(new CustomEvent("akb:document-status-changed", { detail: { vault: name, path: next.path, status: next.status } }));
           refetchTree();
         }}
       />
@@ -1489,6 +1513,27 @@ export default function DocumentPage({
           await deleteDocument(name!, docId);
           refetchTree();
           navigate(`/vault/${name}`);
+        }}
+      />
+
+      <ConfirmDialog
+        open={archiveOpen}
+        onOpenChange={setArchiveOpen}
+        title={doc.status === "archived" ? "Restore this document?" : "Archive this document?"}
+        description={doc.status === "archived"
+          ? `Restore as an active document in ${collectionPath || "Vault root"}. Its identity, links, and history stay unchanged. Search may take a moment to catch up.`
+          : "Hide this document from current documents and default search. You can find it with the Archived documents filter and restore it later. This does not delete it, revoke access, or disable public links."}
+        confirmLabel={doc.status === "archived" ? "Restore document" : "Archive document"}
+        onConfirm={async () => {
+          if (archiveDisabledReason) throw new Error(archiveDisabledReason);
+          const status = doc.status === "archived" ? "active" : "archived";
+          const next = await changeDocumentArchiveState(name!, docId, status, doc.current_commit);
+          setDocOverride(next);
+          await queryClient.invalidateQueries({ queryKey: ["document", name] });
+          void queryClient.invalidateQueries({ queryKey: ["document-history", name] });
+          refetchTree();
+          setArchiveNotice(status === "active" ? `Restored to ${collectionPath || "Vault root"}.` : "Document archived. Find it using the Archived documents filter.");
+          if (commitHash) openVersion(undefined, { replace: true });
         }}
       />
 

--- a/frontend/src/pages/document.tsx
+++ b/frontend/src/pages/document.tsx
@@ -75,7 +75,7 @@ import { recordRecentDocumentView } from "@/lib/recent-document-views";
 import { ResourceActionsMenu } from "@/components/resource-actions-menu";
 import { ResourceDeleteDialog } from "@/components/resource-delete-dialog";
 import { DocumentMoveDialog } from "@/components/document-move-dialog";
-import { changeDocumentArchiveState, documentArchiveDisabledReason } from "@/lib/document-archive";
+import { ArchiveVerificationError, changeDocumentArchiveState, checkDocumentArchiveState, documentArchiveDisabledReason } from "@/lib/document-archive";
 import { DocumentTitleConflictNotice } from "@/components/document-title-conflict-notice";
 import {
   documentCollection,
@@ -157,6 +157,7 @@ export default function DocumentPage({
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [archiveOpen, setArchiveOpen] = useState(false);
   const [archiveNotice, setArchiveNotice] = useState("");
+  const [archivePending, setArchivePending] = useState<{ vault: string; ref: string; status: "active" | "archived" } | null>(null);
   const [publishOpen, setPublishOpen] = useState(false);
   const [detailsOpen, setDetailsOpen] = useState(false);
   const [detailsTab, setDetailsTab] = useState<"info" | "outline" | "relations" | "history">("info");
@@ -763,6 +764,7 @@ export default function DocumentPage({
     historical: isHistorical || isDiffMode,
     guide: doc.path === VAULT_SKILL_PATH,
   });
+  const pendingArchiveCheck = archivePending && archivePending.vault === name && archivePending.ref === docId ? archivePending : null;
 
   const openVersion = (hash?: string, options: { replace?: boolean } = {}) => {
     const params = new URLSearchParams(searchParams);
@@ -1519,20 +1521,31 @@ export default function DocumentPage({
       <ConfirmDialog
         open={archiveOpen}
         onOpenChange={setArchiveOpen}
-        title={doc.status === "archived" ? "Restore this document?" : "Archive this document?"}
-        description={doc.status === "archived"
+        title={pendingArchiveCheck ? "Check document state" : doc.status === "archived" ? "Restore this document?" : "Archive this document?"}
+        description={pendingArchiveCheck ? "The change was accepted. Only the current document will be fetched; the change will not be sent again." : doc.status === "archived"
           ? `Restore as an active document in ${collectionPath || "Vault root"}. Its identity, links, and history stay unchanged. Search may take a moment to catch up.`
           : "Hide this document from current documents and default search. You can find it with the Archived documents filter and restore it later. This does not delete it, revoke access, or disable public links."}
-        confirmLabel={doc.status === "archived" ? "Restore document" : "Archive document"}
+        confirmLabel={pendingArchiveCheck ? "Check current state" : doc.status === "archived" ? "Restore document" : "Archive document"}
         onConfirm={async () => {
-          if (archiveDisabledReason) throw new Error(archiveDisabledReason);
-          const status = doc.status === "archived" ? "active" : "archived";
-          const next = await changeDocumentArchiveState(name!, docId, status, doc.current_commit);
+          if (!pendingArchiveCheck && archiveDisabledReason) throw new Error(archiveDisabledReason);
+          const status = pendingArchiveCheck?.status ?? (doc.status === "archived" ? "active" : "archived");
+          let next;
+          try {
+            next = pendingArchiveCheck
+              ? await checkDocumentArchiveState(name!, docId)
+              : await changeDocumentArchiveState(name!, docId, status, doc.current_commit);
+          } catch (error) {
+            if (error instanceof ArchiveVerificationError) setArchivePending({ vault: name!, ref: docId, status });
+            throw error;
+          }
+          setArchivePending(null);
           setDocOverride(next);
           await queryClient.invalidateQueries({ queryKey: ["document", name] });
           void queryClient.invalidateQueries({ queryKey: ["document-history", name] });
           refetchTree();
-          setArchiveNotice(status === "active" ? `Restored to ${collectionPath || "Vault root"}.` : "Document archived. Find it using the Archived documents filter.");
+          setArchiveNotice(next.status !== status
+            ? "Current state loaded. The requested state is not present; review the document before making another change."
+            : status === "active" ? `Restored to ${collectionPath || "Vault root"}.` : "Document archived. Find it using the Archived documents filter.");
           if (commitHash) openVersion(undefined, { replace: true });
         }}
       />

--- a/frontend/src/pages/search.tsx
+++ b/frontend/src/pages/search.tsx
@@ -50,6 +50,7 @@ import { parseUri } from "@/lib/uri";
 import { cn } from "@/lib/utils";
 import { documentPreviewState } from "@/lib/document-preview-navigation";
 import { Input } from "@/components/ui/input";
+import { SelectMenu } from "@/components/ui/select-menu";
 import { TagInput } from "@/components/ui/tag-input";
 import { InlineLoadingState } from "@/components/ui/loading-state";
 import {
@@ -82,6 +83,7 @@ const SUGGESTED_QUERIES = [
 ] as const;
 
 interface DenseResult {
+  status?: string;
   source_type?: SourceType;
   uri: string;
   vault: string;
@@ -167,6 +169,9 @@ export default function SearchPage() {
   const [returnedMatches, setReturnedMatches] = useState(0);
   const [truncated, setTruncated] = useState(false);
   const [degraded, setDegraded] = useState(false);
+  const [archiveUnsupported, setArchiveUnsupported] = useState(false);
+  const archiveScope =
+    options.archive_scope ?? (options.include_archived ? "all" : "unarchived");
   const [loading, setLoading] = useState(false);
   const [searched, setSearched] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -205,6 +210,7 @@ export default function SearchPage() {
             options,
           );
           if (id !== reqId.current) return;
+          setArchiveUnsupported(Boolean(options.archive_scope && response.archive_scope !== options.archive_scope));
           setDenseResults(response.results);
           setLiteralResults([]);
           setTotal(response.total ?? response.results.length);
@@ -222,6 +228,7 @@ export default function SearchPage() {
             options,
           );
           if (id !== reqId.current) return;
+          setArchiveUnsupported(Boolean(options.archive_scope && response.archive_scope !== options.archive_scope));
           setLiteralResults(response.results);
           setDenseResults([]);
           setTotal(response.total_docs ?? response.results.length);
@@ -271,6 +278,14 @@ export default function SearchPage() {
   }, [currentUserId]);
 
   useEffect(() => {
+    const refresh = () => {
+      if (q.trim()) void doSearch(q, mode, scopeVaults);
+    };
+    window.addEventListener("akb:document-status-changed", refresh);
+    return () => window.removeEventListener("akb:document-status-changed", refresh);
+  }, [q, mode, scopeVaults, doSearch]);
+
+  useEffect(() => {
     setDraft(q);
   }, [q]);
 
@@ -294,6 +309,7 @@ export default function SearchPage() {
       void doSearch(q, mode, scopeVaults);
     } else {
       reqId.current += 1;
+      setArchiveUnsupported(false);
       setDenseResults([]);
       setLiteralResults([]);
       setTotal(0);
@@ -350,11 +366,16 @@ export default function SearchPage() {
 
   function setFilter(key: string, values: string[]) {
     const next = setSearchValues(searchParams, key, values);
+    if (key === "archive_scope") {
+      next.delete("include_archived");
+      if (values[0] === "archived") next.set("source", "document");
+    }
     if ((key === "doc_type" || key === "tag") && values.length)
       next.set("source", "document");
     if (key === "source" && values[0] !== "document") {
       next.delete("doc_type");
       next.delete("tag");
+      if (archiveScope === "archived") next.delete("archive_scope");
     }
     setSearchParams(next);
   }
@@ -434,7 +455,7 @@ export default function SearchPage() {
     (allTypesActive ? 0 : 1) +
     (activeTags.size === 0 ? 0 : 1) +
     Number(Boolean(options.collection)) +
-    Number(options.include_archived) +
+    Number(archiveScope !== "unarchived") +
     Number(options.regex) +
     Number(options.case_sensitive);
   const accessibleVaultNames = new Set(
@@ -450,6 +471,8 @@ export default function SearchPage() {
     ? "Searching…"
     : error
       ? "Search unavailable"
+      : archiveUnsupported
+        ? "Document state filter unavailable"
       : !searched
         ? "Ready to search"
         : degraded
@@ -788,20 +811,30 @@ export default function SearchPage() {
                   </p>
                 </form>
                 <div className="flex flex-col gap-3 text-sm">
-                  <label className="flex min-h-9 items-center gap-2">
-                    <input
-                      type="checkbox"
-                      className="accent-primary focus-visible:outline-ring"
-                      checked={Boolean(options.include_archived)}
-                      onChange={(event) =>
-                        setFilter(
-                          "include_archived",
-                          event.target.checked ? ["true"] : [],
-                        )
+                  <div>
+                    <label
+                      htmlFor="search-document-state"
+                      className="mb-2 block text-xs font-semibold"
+                    >
+                      Document state
+                    </label>
+                    <SelectMenu
+                      id="search-document-state"
+                      aria-label="Document state"
+                      value={archiveScope}
+                      onValueChange={(value) =>
+                        setFilter("archive_scope", [value])
                       }
+                      options={[
+                        { value: "unarchived", label: "Current documents" },
+                        { value: "archived", label: "Archived documents" },
+                        { value: "all", label: "All documents" },
+                      ]}
                     />
-                    Include archived documents
-                  </label>
+                    <p className="mt-1 text-xs text-foreground-muted">
+                      Current includes drafts. Archived searches documents only.
+                    </p>
+                  </div>
                   {mode === "literal" && (
                     <>
                       <label className="flex min-h-9 items-center gap-2">
@@ -931,6 +964,13 @@ export default function SearchPage() {
             </Alert>
           )}
 
+          {archiveUnsupported && !loading && !error && (
+            <Alert variant="warning" title="Document state filter unavailable" className="rounded-none border-x-0 border-t-0">
+              This server could not confirm the selected document state filter. Results are hidden to avoid showing the wrong scope. Update the server or{" "}
+              <button type="button" className={inlineActionClass} onClick={() => setFilter("archive_scope", [])}>search current documents</button>.
+            </Alert>
+          )}
+
           {!searched && (
             <SearchStartState
               mode={mode}
@@ -942,7 +982,7 @@ export default function SearchPage() {
             />
           )}
 
-          {searched && !loading && !error && !degraded && !hasResults && (
+          {searched && !loading && !error && !degraded && !archiveUnsupported && !hasResults && (
             <section aria-labelledby="no-search-results-heading">
               <div className="border-b border-border bg-surface-2/60 px-4 py-3 sm:px-5">
                 <h2
@@ -980,7 +1020,7 @@ export default function SearchPage() {
             </section>
           )}
 
-          {truncated && !loading && !error && (
+          {truncated && !loading && !error && !archiveUnsupported && (
             <Alert
               variant="info"
               title={
@@ -996,7 +1036,7 @@ export default function SearchPage() {
             </Alert>
           )}
 
-          {hasResults && (
+          {hasResults && !archiveUnsupported && (
             <section aria-labelledby="search-results-heading">
               <h2 id="search-results-heading" className="sr-only">
                 Results for {q}
@@ -1296,6 +1336,7 @@ function DenseResultList({ items }: { items: DenseResult[] }) {
                   {result.doc_type && (
                     <Badge variant="outline">{result.doc_type}</Badge>
                   )}
+                  {result.status === "archived" && <Badge variant="outline">Archived</Badge>}
                   {tags.slice(0, 2).map((tag) => (
                     <Badge key={tag} variant="secondary">
                       {tag}
@@ -1372,6 +1413,7 @@ function LiteralResultList({ items }: { items: GrepDoc[] }) {
                 <span className="text-sm font-semibold text-foreground transition-colors group-hover:text-link">
                   {result.title}
                 </span>
+                {result.status === "archived" && <Badge variant="outline">Archived</Badge>}
                 <span className="ml-auto text-xs font-semibold tabular-nums text-foreground sm:hidden">
                   {result.matches.length}
                 </span>


### PR DESCRIPTION
## Summary

Make archived documents discoverable and restorable from the Collections explorer and advanced Search, using the existing document reader and status update contract.

Previously, the default explorer hid archived documents and Search only offered an inclusive archive toggle. Users could not directly browse an archived-only inventory or discover a clear restore action.

## Changes

- Add Current / Archived / All document-state filters to Collections and Search, with URL-backed Search state and archived document indicators.
- Add Archive / Restore actions to the reader, including Search previews. Confirmation explains the effect, restoration keeps the original location, and successful changes refresh surrounding discovery views.
- Add optional `archive_scope=unarchived|archived|all` to REST browse, search, and grep. Apply filtering before search candidate selection and grep counts/limits in both legacy and Native storage paths.
- Echo the effective scope in responses, including empty results, and expose document status in search/grep results.
- Preserve permission and concurrency checks, explain unavailable actions, and verify the resulting document status before reporting success.
- Document the behavior and add API, UI, and isolated browser contract coverage.

## Compatibility and behavior

- Explicit `archive_scope` overrides `include_archived`. Omitting it preserves existing defaults and the existing MCP boolean contract.
- Current documents includes both drafts and active documents. Archived-only results exclude files and tables; browse retains Collections for navigation.
- Older servers that do not confirm an explicit scope show an unsupported-filter notice and a recovery action instead of misleading empty results.
- Restore reuses the existing PATCH endpoint and restores the document as `active`, preserving identity, content, path, and history. No database migration or separate archive store is introduced.
- **Archiving is a discovery feature, not access revocation.** Existing document URLs and public links retain their existing access policies.
- Writer or higher access is required; the reserved Vault guide requires Owner. Read-only Vaults and historical/diff views cannot change document state.
- Native search may briefly lag a restored document; authoritative browse remains available during index catch-up.

## Test coverage

- Scope precedence, legacy defaults, empty-response echoes, and legacy/Native parity.
- Archived-only resource selection and filtering before counts and limits.
- Permission reasons, optimistic concurrency, and ignored-status handling.
- Explorer refresh, stale responses, older-server recovery, and Search URL compatibility.
- Archive/restore inside the reader without changing document location or preview context.
- Isolated browser contracts for Search-preview restoration at desktop/mobile widths in light/dark themes. These use HTTP fixtures and are not live-server E2E tests.

## Scope boundaries

No changes to document identity, publication authorization, or MCP tool schemas. Existing explorer subtree loading and semantic top-K count semantics remain unchanged.
