### PR TITLE
feat(proxy): akb-mcp 2.3.2 — opt-in per-call usage record

### DIFF
--- a/packages/akb-mcp-client/CHANGELOG.md
+++ b/packages/akb-mcp-client/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 2.3.2 — opt-in per-call usage record
+
+Setting `AKB_MCP_USAGE_LOG=<path>` makes the proxy append one JSON line per
+`tools/call` — `{ts, tool, result_bytes, text_chars, latency_ms}`. Unset, which
+is the default, nothing is opened, formatted or written, and the proxy behaves
+exactly as it did in 2.3.1.
+
+It exists because response size is what a tool call actually costs the agent
+reading it, and until now that number could only be recovered by instrumenting
+the client. The record is taken where every `tools/call` result passes, so the
+proxy-local file tools — which never reach the backend — are measured on the
+same footing as forwarded calls.
+
+Characters, not tokens: a tokenizer in the proxy would pin a model the proxy
+does not otherwise depend on. A call that raised is not recorded, and a path
+that cannot be written warns once and then stays quiet rather than failing
+calls.
+
 ## 2.3.1 — negotiate the legacy protocol version instead of hard-rejecting
 
 The legacy `initialize` path no longer returns `-32602 "Unsupported protocol

--- a/packages/akb-mcp-client/CHANGELOG.md
+++ b/packages/akb-mcp-client/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## 2.3.2 — opt-in per-call usage record
 
 Setting `AKB_MCP_USAGE_LOG=<path>` makes the proxy append one JSON line per
-`tools/call` — `{ts, tool, result_bytes, text_chars, latency_ms}`. Unset, which
-is the default, nothing is opened, formatted or written, and the proxy behaves
-exactly as it did in 2.3.1.
+`tools/call` — `{ts, tool, result_bytes, text_chars, latency_ms, error}`.
+Unset, which is the default, nothing is opened, formatted or written — not even
+a clock read — and the proxy behaves exactly as it did in 2.3.1.
 
 It exists because response size is what a tool call actually costs the agent
 reading it, and until now that number could only be recovered by instrumenting
@@ -13,10 +13,17 @@ the client. The record is taken where every `tools/call` result passes, so the
 proxy-local file tools — which never reach the backend — are measured on the
 same footing as forwarded calls.
 
+Failures are measured too and carry `error: true`: a call that fails still
+consumed a round trip, and a session whose failures are invisible reads as
+cheaper than it was. A call that threw before producing a response records
+`result_bytes: 0`.
+
+**Arguments are never written.** The record covers size and timing only —
+a call's arguments carry vault content and, on the file tools, local paths.
+
 Characters, not tokens: a tokenizer in the proxy would pin a model the proxy
-does not otherwise depend on. A call that raised is not recorded, and a path
-that cannot be written warns once and then stays quiet rather than failing
-calls.
+does not otherwise depend on. A path that cannot be written warns once and then
+stays quiet rather than failing calls.
 
 ## 2.3.1 — negotiate the legacy protocol version instead of hard-rejecting
 

--- a/packages/akb-mcp-client/lib/proxy.mjs
+++ b/packages/akb-mcp-client/lib/proxy.mjs
@@ -381,7 +381,7 @@ const UNSUPPORTED_PROTOCOL_VERSION = -32022;
 // local `initialize` response, so it must not silently drift on a proxy
 // behaviour change. There is no import of package.json here to keep lib/
 // zero-dependency and load-safe across Node versions.
-const PROXY_VERSION = "2.3.1";
+const PROXY_VERSION = "2.3.2";
 const VAULT_SKILL_PREFLIGHT_CAPABILITY =
   "io.dnotitia.akb/vault-skill-preflight";
 const PROXY_INSTRUCTIONS =

--- a/packages/akb-mcp-client/lib/proxy.mjs
+++ b/packages/akb-mcp-client/lib/proxy.mjs
@@ -13,7 +13,7 @@
 import { request as httpsRequest, Agent as httpsAgent } from "node:https";
 import { request as httpRequest, Agent as httpAgent } from "node:http";
 import { createInterface } from "node:readline";
-import { createReadStream, createWriteStream, readFileSync, statSync } from "node:fs";
+import { appendFileSync, createReadStream, createWriteStream, readFileSync, statSync } from "node:fs";
 import { mkdir, stat as fsStat } from "node:fs/promises";
 import { basename, dirname, extname, join } from "node:path";
 import { createHash, randomBytes } from "node:crypto";
@@ -466,6 +466,9 @@ export class AKBProxy {
     // Local file/image tools bypass backend call_tool. Keep their vault-level
     // challenge pending until an exact retry carries its opaque token.
     this._localVaultSkillPending = new Map();
+    // Set once if AKB_MCP_USAGE_LOG cannot be written, so a bad path costs
+    // one warning rather than one failed write per tool call.
+    this._usageLogBroken = false;
   }
 
   _sleep(ms) {
@@ -596,12 +599,62 @@ export class AKBProxy {
     const callKey = method === "tools/call" ? this._vaultSkillCallKey(msg.params) : null;
     if (callKey) msg = this._withVaultSkillAcknowledgement(msg, callKey);
 
+    const startedAt = Date.now();
     const response =
       method === "tools/call" && FILE_TOOL_NAMES.has(msg.params?.name)
         ? await this._handleFileTool(id, msg.params)
         : await this._forward(msg);
     if (callKey) this._recordVaultSkillOutcome(callKey, msg, response);
+    if (method === "tools/call") {
+      this._recordUsage(msg.params?.name, response, Date.now() - startedAt);
+    }
     return response;
+  }
+
+  // ── Opt-in usage record ────────────────────────────────────
+  //
+  // With `AKB_MCP_USAGE_LOG=<path>` set, append one JSON line per
+  // `tools/call` — `{ts, tool, result_bytes, text_chars, latency_ms}`.
+  // Unset (the default) this does nothing at all: no file handle, no
+  // formatting, no behaviour change.
+  //
+  // It sits here rather than in `_forward` so the proxy-local file tools,
+  // which never reach the backend, are measured on the same footing as
+  // forwarded calls — this is the only place that sees every tools/call
+  // result. A call that threw is not recorded: there is no payload to
+  // size, and the error already surfaces to the client.
+  //
+  // Characters, not tokens. A tokenizer would be a dependency, a model
+  // choice and a version to keep in step with whatever model the agent
+  // actually runs; `result_bytes` and `text_chars` are exact, and the
+  // token estimate belongs wherever the model is known.
+  _recordUsage(tool, response, latencyMs) {
+    const path = process.env.AKB_MCP_USAGE_LOG;
+    if (!path || this._usageLogBroken) return;
+    try {
+      const result = response?.result;
+      let textChars = 0;
+      const content = Array.isArray(result?.content) ? result.content : [];
+      for (const part of content) {
+        if (typeof part?.text === "string") textChars += part.text.length;
+      }
+      const record = {
+        ts: new Date().toISOString(),
+        tool: typeof tool === "string" ? tool : null,
+        result_bytes: Buffer.byteLength(JSON.stringify(result ?? null), "utf8"),
+        text_chars: textChars,
+        latency_ms: latencyMs,
+      };
+      // Synchronous on purpose: one short line per call, and an interleaved
+      // partial write would corrupt the JSONL this is meant to produce.
+      appendFileSync(path, `${JSON.stringify(record)}\n`);
+    } catch (err) {
+      this._usageLogBroken = true;
+      process.stderr.write(
+        `[akb-mcp] AKB_MCP_USAGE_LOG write failed (${err.message}); ` +
+          `usage records disabled for this session\n`,
+      );
+    }
   }
 
   _protocolError(id, code, message, data = undefined) {

--- a/packages/akb-mcp-client/lib/proxy.mjs
+++ b/packages/akb-mcp-client/lib/proxy.mjs
@@ -466,9 +466,11 @@ export class AKBProxy {
     // Local file/image tools bypass backend call_tool. Keep their vault-level
     // challenge pending until an exact retry carries its opaque token.
     this._localVaultSkillPending = new Map();
-    // Set once if AKB_MCP_USAGE_LOG cannot be written, so a bad path costs
-    // one warning rather than one failed write per tool call.
-    this._usageLogBroken = false;
+    // Opt-in usage record. Read once, here, so the disabled path costs
+    // nothing per call — not even a clock read. Set to null when the
+    // variable is unset or the sink turns out to be unwritable, so a bad
+    // path costs one warning rather than one failed write per tool call.
+    this._usageLogPath = process.env.AKB_MCP_USAGE_LOG || null;
   }
 
   _sleep(ms) {
@@ -599,57 +601,80 @@ export class AKBProxy {
     const callKey = method === "tools/call" ? this._vaultSkillCallKey(msg.params) : null;
     if (callKey) msg = this._withVaultSkillAcknowledgement(msg, callKey);
 
-    const startedAt = Date.now();
-    const response =
-      method === "tools/call" && FILE_TOOL_NAMES.has(msg.params?.name)
-        ? await this._handleFileTool(id, msg.params)
-        : await this._forward(msg);
-    if (callKey) this._recordVaultSkillOutcome(callKey, msg, response);
-    if (method === "tools/call") {
-      this._recordUsage(msg.params?.name, response, Date.now() - startedAt);
+    // Only measured calls read the clock.
+    const measuring = method === "tools/call" && this._usageLogPath !== null;
+    const startedAt = measuring ? Date.now() : 0;
+    let response;
+    let threw = false;
+    try {
+      response =
+        method === "tools/call" && FILE_TOOL_NAMES.has(msg.params?.name)
+          ? await this._handleFileTool(id, msg.params)
+          : await this._forward(msg);
+      if (callKey) this._recordVaultSkillOutcome(callKey, msg, response);
+      return response;
+    } catch (err) {
+      threw = true;
+      throw err;
+    } finally {
+      if (measuring) {
+        this._recordUsage(msg.params?.name, response, Date.now() - startedAt, threw);
+      }
     }
-    return response;
   }
 
   // ── Opt-in usage record ────────────────────────────────────
   //
   // With `AKB_MCP_USAGE_LOG=<path>` set, append one JSON line per
-  // `tools/call` — `{ts, tool, result_bytes, text_chars, latency_ms}`.
+  // `tools/call` — `{ts, tool, result_bytes, text_chars, latency_ms, error}`.
   // Unset (the default) this does nothing at all: no file handle, no
-  // formatting, no behaviour change.
+  // formatting, not even a clock read.
   //
-  // It sits here rather than in `_forward` so the proxy-local file tools,
-  // which never reach the backend, are measured on the same footing as
-  // forwarded calls — this is the only place that sees every tools/call
-  // result. A call that threw is not recorded: there is no payload to
-  // size, and the error already surfaces to the client.
+  // It sits on the dispatch rather than in `_forward` so the proxy-local
+  // file tools, which never reach the backend, are measured on the same
+  // footing as forwarded calls — this is the only place that sees every
+  // tools/call result. Failures are measured too, and marked `error: true`:
+  // a call that fails still consumed a round trip, and a run where the
+  // failures are invisible reads as cheaper than it was. A call that threw
+  // before producing a response records `result_bytes: 0`.
+  //
+  // ARGUMENTS ARE NEVER WRITTEN. The record is about size and timing; a
+  // tool call's arguments carry vault content, paths and, on the file
+  // tools, local filesystem paths, none of which belong in a file the user
+  // enabled to count bytes.
   //
   // Characters, not tokens. A tokenizer would be a dependency, a model
   // choice and a version to keep in step with whatever model the agent
   // actually runs; `result_bytes` and `text_chars` are exact, and the
   // token estimate belongs wherever the model is known.
-  _recordUsage(tool, response, latencyMs) {
-    const path = process.env.AKB_MCP_USAGE_LOG;
-    if (!path || this._usageLogBroken) return;
+  _recordUsage(tool, response, latencyMs, threw = false) {
+    const path = this._usageLogPath;
+    if (!path) return;
     try {
-      const result = response?.result;
+      const payload = response?.result ?? response?.error;
       let textChars = 0;
-      const content = Array.isArray(result?.content) ? result.content : [];
+      const content = Array.isArray(response?.result?.content)
+        ? response.result.content
+        : [];
       for (const part of content) {
         if (typeof part?.text === "string") textChars += part.text.length;
       }
       const record = {
         ts: new Date().toISOString(),
         tool: typeof tool === "string" ? tool : null,
-        result_bytes: Buffer.byteLength(JSON.stringify(result ?? null), "utf8"),
+        result_bytes:
+          payload === undefined
+            ? 0
+            : Buffer.byteLength(JSON.stringify(payload ?? null), "utf8"),
         text_chars: textChars,
         latency_ms: latencyMs,
+        error: threw || response?.error !== undefined || response?.result?.isError === true,
       };
       // Synchronous on purpose: one short line per call, and an interleaved
       // partial write would corrupt the JSONL this is meant to produce.
       appendFileSync(path, `${JSON.stringify(record)}\n`);
     } catch (err) {
-      this._usageLogBroken = true;
+      this._usageLogPath = null;
       process.stderr.write(
         `[akb-mcp] AKB_MCP_USAGE_LOG write failed (${err.message}); ` +
           `usage records disabled for this session\n`,

--- a/packages/akb-mcp-client/package.json
+++ b/packages/akb-mcp-client/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "inspect": "node scripts/mcp-inspector-smoke.mjs",
-    "test": "node test/contract.test.mjs && node test/reconnect.test.mjs && node test/protocol.test.mjs && node --test test/mcp-inspector-smoke.test.mjs"
+    "test": "node test/contract.test.mjs && node test/reconnect.test.mjs && node test/protocol.test.mjs && node test/usage-log.test.mjs && node --test test/mcp-inspector-smoke.test.mjs"
   },
   "type": "module",
   "devDependencies": {

--- a/packages/akb-mcp-client/package.json
+++ b/packages/akb-mcp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akb-mcp",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "mcpName": "io.github.dnotitia/akb",
   "description": "AKB MCP stdio client — connect any AI agent to AKB knowledge base. Zero dependencies, auto-reconnect.",
   "bin": {

--- a/packages/akb-mcp-client/test/usage-log.test.mjs
+++ b/packages/akb-mcp-client/test/usage-log.test.mjs
@@ -1,0 +1,209 @@
+// Opt-in usage record: `AKB_MCP_USAGE_LOG=<path>` appends one JSON line
+// per tools/call. Unset, the proxy must behave exactly as before — no
+// file, no throw, nothing to notice.
+//
+// Run with: node packages/akb-mcp-client/test/usage-log.test.mjs
+
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AKBProxy } from "../lib/proxy.mjs";
+
+let pass = 0;
+let fail = 0;
+// Sequential on purpose: these cases set and unset AKB_MCP_USAGE_LOG, which
+// is process-global. Running them concurrently would have one test's env
+// decide another test's outcome.
+const tests = [];
+function itAsync(name, fn) {
+  tests.push([name, fn]);
+}
+
+const ORIGINAL_LOG = process.env.AKB_MCP_USAGE_LOG;
+
+function backedBy(text) {
+  const proxy = new AKBProxy({ url: "http://akb.test/mcp", pat: "test" });
+  proxy._ensureBackend = async () => true;
+  proxy._rpc = async () => ({ content: [{ type: "text", text }] });
+  return proxy;
+}
+
+function searchCall(id) {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method: "tools/call",
+    params: { name: "akb_search", arguments: { query: "product-api seam" } },
+  };
+}
+
+async function withLogPath(fn) {
+  const directory = await mkdtemp(join(tmpdir(), "akb-mcp-usage-"));
+  const path = join(directory, "usage.jsonl");
+  process.env.AKB_MCP_USAGE_LOG = path;
+  try {
+    return await fn(path);
+  } finally {
+    if (ORIGINAL_LOG === undefined) delete process.env.AKB_MCP_USAGE_LOG;
+    else process.env.AKB_MCP_USAGE_LOG = ORIGINAL_LOG;
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+async function readLines(path) {
+  const raw = await readFile(path, "utf8");
+  return raw.split("\n").filter((line) => line.length > 0).map((line) => JSON.parse(line));
+}
+
+// ── off by default ───────────────────────────────────────────────
+
+itAsync("writes nothing when AKB_MCP_USAGE_LOG is unset", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "akb-mcp-usage-off-"));
+  const path = join(directory, "usage.jsonl");
+  const previous = process.env.AKB_MCP_USAGE_LOG;
+  delete process.env.AKB_MCP_USAGE_LOG;
+  try {
+    const proxy = backedBy(JSON.stringify({ kind: "search", results: [] }));
+    const response = await proxy._handle(searchCall(1));
+
+    assert.equal(response.result.content[0].type, "text");
+    assert.equal(existsSync(path), false, "no usage file may be created");
+  } finally {
+    if (previous !== undefined) process.env.AKB_MCP_USAGE_LOG = previous;
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+// ── one line per call when on ────────────────────────────────────
+
+itAsync("appends one record per tools/call with the documented fields", async () => {
+  await withLogPath(async (path) => {
+    const body = JSON.stringify({ kind: "search", results: [{ uri: "akb://v/doc/a.md" }] });
+    const proxy = backedBy(body);
+
+    const response = await proxy._handle(searchCall(1));
+    const [record] = await readLines(path);
+
+    assert.deepEqual(
+      Object.keys(record).sort(),
+      ["latency_ms", "result_bytes", "text_chars", "tool", "ts"],
+    );
+    assert.equal(record.tool, "akb_search");
+    assert.equal(record.text_chars, body.length);
+    assert.equal(
+      record.result_bytes,
+      Buffer.byteLength(JSON.stringify(response.result), "utf8"),
+    );
+    assert.ok(record.latency_ms >= 0);
+    assert.ok(!Number.isNaN(Date.parse(record.ts)), "ts must be a timestamp");
+  });
+});
+
+itAsync("appends one line per call, not one per session", async () => {
+  await withLogPath(async (path) => {
+    const proxy = backedBy(JSON.stringify({ kind: "search", results: [] }));
+
+    await proxy._handle(searchCall(1));
+    await proxy._handle(searchCall(2));
+    await proxy._handle(searchCall(3));
+
+    const records = await readLines(path);
+    assert.equal(records.length, 3);
+    assert.ok(records.every((r) => r.tool === "akb_search"));
+  });
+});
+
+itAsync("records a bigger payload as more bytes", async () => {
+  await withLogPath(async (path) => {
+    const small = backedBy(JSON.stringify({ sections: ["a"] }));
+    const large = backedBy(JSON.stringify({ sections: Array(50).fill("a".repeat(200)) }));
+
+    await small._handle(searchCall(1));
+    await large._handle(searchCall(2));
+
+    const [first, second] = await readLines(path);
+    assert.ok(second.result_bytes > first.result_bytes * 10);
+    assert.ok(second.text_chars > first.text_chars);
+  });
+});
+
+itAsync("measures a proxy-local file tool too", async () => {
+  await withLogPath(async (path) => {
+    const proxy = new AKBProxy({ url: "http://akb.test/mcp", pat: "test" });
+    proxy._fileToolSkillPreflight = async () => null;
+    proxy._getFile = async () => ({ kind: "file", save_to: "/tmp/a.bin" });
+
+    await proxy._handle({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: {
+        name: "akb_get_file",
+        arguments: {
+          uri: "akb://myvault/file/11111111-2222-3333-4444-555555555555",
+          save_to: "/tmp/a.bin",
+        },
+      },
+    });
+
+    const [record] = await readLines(path);
+    assert.equal(record.tool, "akb_get_file");
+    assert.ok(record.result_bytes > 0);
+  });
+});
+
+itAsync("does not record a non-tools/call request", async () => {
+  await withLogPath(async (path) => {
+    const proxy = backedBy("{}");
+
+    await proxy._handle({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+
+    assert.equal(existsSync(path), false, "only tools/call is measured");
+  });
+});
+
+// ── never in the way ─────────────────────────────────────────────
+
+itAsync("an unwritable path warns once and never fails the call", async () => {
+  const previous = process.env.AKB_MCP_USAGE_LOG;
+  process.env.AKB_MCP_USAGE_LOG = join(tmpdir(), "akb-mcp-usage-missing-dir", "x.jsonl");
+  const written = [];
+  const originalWrite = process.stderr.write.bind(process.stderr);
+  process.stderr.write = (chunk) => { written.push(String(chunk)); return true; };
+  try {
+    const proxy = backedBy(JSON.stringify({ kind: "search", results: [] }));
+
+    const first = await proxy._handle(searchCall(1));
+    const second = await proxy._handle(searchCall(2));
+
+    assert.equal(first.result.content[0].type, "text");
+    assert.equal(second.result.content[0].type, "text");
+    assert.equal(
+      written.filter((line) => line.includes("AKB_MCP_USAGE_LOG")).length,
+      1,
+      "a broken sink warns once, not once per call",
+    );
+  } finally {
+    process.stderr.write = originalWrite;
+    if (previous === undefined) delete process.env.AKB_MCP_USAGE_LOG;
+    else process.env.AKB_MCP_USAGE_LOG = previous;
+  }
+});
+
+// ── Summary ──────────────────────────────────────────────────────
+
+for (const [name, fn] of tests) {
+  try {
+    await fn();
+    pass++;
+    console.log(`  ✓ ${name}`);
+  } catch (e) {
+    fail++;
+    console.log(`  ✗ ${name}: ${e.message}`);
+  }
+}
+console.log("");
+console.log(`  Passed: ${pass}   Failed: ${fail}`);
+process.exit(fail > 0 ? 1 : 0);

--- a/packages/akb-mcp-client/test/usage-log.test.mjs
+++ b/packages/akb-mcp-client/test/usage-log.test.mjs
@@ -88,16 +88,119 @@ itAsync("appends one record per tools/call with the documented fields", async ()
 
     assert.deepEqual(
       Object.keys(record).sort(),
-      ["latency_ms", "result_bytes", "text_chars", "tool", "ts"],
+      ["error", "latency_ms", "result_bytes", "text_chars", "tool", "ts"],
     );
     assert.equal(record.tool, "akb_search");
     assert.equal(record.text_chars, body.length);
+    assert.equal(record.error, false);
     assert.equal(
       record.result_bytes,
       Buffer.byteLength(JSON.stringify(response.result), "utf8"),
     );
     assert.ok(record.latency_ms >= 0);
     assert.ok(!Number.isNaN(Date.parse(record.ts)), "ts must be a timestamp");
+  });
+});
+
+itAsync("sums text_chars across every text block, in characters", async () => {
+  await withLogPath(async (path) => {
+    const parts = ["첫 번째 블록입니다.", "second block", "세 번째 블록"];
+    const proxy = new AKBProxy({ url: "http://akb.test/mcp", pat: "test" });
+    proxy._ensureBackend = async () => true;
+    proxy._rpc = async () => ({
+      content: [
+        { type: "text", text: parts[0] },
+        { type: "image", data: "ignored-non-text-block" },
+        { type: "text", text: parts[1] },
+        { type: "text", text: parts[2] },
+      ],
+    });
+
+    await proxy._handle(searchCall(1));
+
+    const [record] = await readLines(path);
+    assert.equal(record.text_chars, parts.join("").length);
+    // Bytes and characters part company on Korean text, which is the point
+    // of carrying both.
+    assert.ok(record.result_bytes > record.text_chars);
+  });
+});
+
+itAsync("records concurrent calls as whole lines, one per call", async () => {
+  await withLogPath(async (path) => {
+    const proxy = new AKBProxy({ url: "http://akb.test/mcp", pat: "test" });
+    proxy._ensureBackend = async () => true;
+    proxy._rpc = async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      return { content: [{ type: "text", text: "x".repeat(500) }] };
+    };
+
+    await Promise.all(
+      Array.from({ length: 12 }, (_, i) => proxy._handle(searchCall(i + 1))),
+    );
+
+    const records = await readLines(path);
+    assert.equal(records.length, 12, "one line per call, none interleaved");
+    assert.ok(records.every((r) => r.tool === "akb_search" && r.text_chars === 500));
+  });
+});
+
+// ── failures are measured too ────────────────────────────────────
+
+itAsync("records a call that threw, with error true and no payload", async () => {
+  await withLogPath(async (path) => {
+    const proxy = new AKBProxy({ url: "http://akb.test/mcp", pat: "test" });
+    proxy._forward = async () => {
+      throw new Error("backend unreachable");
+    };
+
+    await assert.rejects(() => proxy._handle(searchCall(1)), /backend unreachable/);
+
+    const [record] = await readLines(path);
+    assert.equal(record.tool, "akb_search");
+    assert.equal(record.error, true);
+    assert.equal(record.result_bytes, 0);
+    assert.ok(record.latency_ms >= 0);
+  });
+});
+
+itAsync("marks an isError result as an error without losing its size", async () => {
+  await withLogPath(async (path) => {
+    const body = JSON.stringify({ error: "vault not found", code: "not_found" });
+    const proxy = new AKBProxy({ url: "http://akb.test/mcp", pat: "test" });
+    proxy._ensureBackend = async () => true;
+    proxy._rpc = async () => ({ content: [{ type: "text", text: body }], isError: true });
+
+    await proxy._handle(searchCall(1));
+
+    const [record] = await readLines(path);
+    assert.equal(record.error, true);
+    assert.equal(record.text_chars, body.length);
+    assert.ok(record.result_bytes > 0);
+  });
+});
+
+// ── what the record must not contain ─────────────────────────────
+
+itAsync("never writes the call arguments", async () => {
+  await withLogPath(async (path) => {
+    const secret = "canary-8f3a1c-not-for-the-log";
+    const proxy = backedBy(JSON.stringify({ kind: "search", results: [] }));
+
+    await proxy._handle({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: {
+        name: "akb_search",
+        arguments: { query: secret, vault: secret, file_path: `/tmp/${secret}` },
+      },
+    });
+
+    const raw = await readFile(path, "utf8");
+    assert.ok(!raw.includes(secret), "arguments must never reach the usage log");
+    const [record] = await readLines(path);
+    assert.equal(record.tool, "akb_search");
   });
 });
 

--- a/packages/akb-mcp-client/test/usage-log.test.mjs
+++ b/packages/akb-mcp-client/test/usage-log.test.mjs
@@ -184,7 +184,7 @@ itAsync("marks an isError result as an error without losing its size", async () 
 
 itAsync("never writes the call arguments", async () => {
   await withLogPath(async (path) => {
-    const secret = "canary-8f3a1c-not-for-the-log";
+    const secret = "canary-8f3a1c-not-for-the-log"; // pragma: allowlist secret
     const proxy = backedBy(JSON.stringify({ kind: "search", results: [] }));
 
     await proxy._handle({


### PR DESCRIPTION
## Summary

`akb-mcp` 2.3.2 — an opt-in per-call usage record, the proxy-side half of the measurement that project-akb DEC-029 asks for before any further payload change.

- With `AKB_MCP_USAGE_LOG=<path>` set, the proxy appends one JSON line per `tools/call`: `{ts, tool, result_bytes, text_chars, latency_ms, error}`. Sizes and timing only — never arguments or result content. Failed calls (error envelopes and thrown calls) are recorded too, with `error: true`.
- Unset (the default): no file handle, no timer, no behaviour change. The path is read once at construction; a write failure disables the record for the session after one stderr warning, and never fails the tool call.
- Characters, not tokens: `text_chars` is the length of `result.content[*].text`; the token estimate belongs wherever the model is known.
- CHANGELOG entry and version bump to 2.3.2 (publish/tag left to the release).

## Tests

`npm test` rc=0 — contract 18 / reconnect 13 / **usage-log 12** (unset path does nothing, append format, parallel calls produce N valid lines, error path recorded, a unique token in the arguments never reaches the log, multi-block and Korean `text_chars`, unwritable path disables cleanly) / inspector 5.

Reviewed in the main loop plus a codex `gpt-5.6-luna` review axis; the review fixes are the later commits on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8P1poam9hTGNB57KJixYk
