### PR TITLE
feat(eval): accuracy gate, cost readout, and the project-akb seed evalset

### DIFF
--- a/eval/agentic-bench/README.md
+++ b/eval/agentic-bench/README.md
@@ -53,6 +53,7 @@ src/
   prep_judge_v3.py     Pre/post processing for the offline judge step
   judge.py             Aggregator: per-arm pass%, provenance%, accuracy gate,
                        tokens per correct answer, payload per call, tradeoff
+  paths.py             EVALSET_DIR / RUNS_DIR — one resolution for all stages
 scripts/
   run_v4_multiproc.sh  Multi-process driver — N processes × M queries each
 evalset-project-akb/   Tracked seed questions over the `project-akb` vault —
@@ -88,8 +89,10 @@ RUNS_DIR=runs_v1 python -m src.judge --aggregate
 
 `RUNS_DIR` is required for any version other than the default
 `runs/`. `EVALSET_DIR` selects the question set (default `evalset/`; the
-tracked seed set is `evalset-project-akb/`). The aggregator emits
-`metrics.json` next to the raw runs.
+tracked seed set is `evalset-project-akb/`) and is read by the runner, the
+judge prep and the aggregator through one helper (`src/paths.py`), so a
+run cannot be produced against one question set and scored against
+another. The aggregator emits `metrics.json` next to the raw runs.
 
 ## The accuracy gate and the cost tradeoff
 
@@ -112,6 +115,13 @@ RUNS_DIR=runs_v1 python -m src.judge --aggregate \
   question is `(1 − p) × D`.
 - `--saving-per-call` — tokens the change under test saves per tool call,
   scaled by the measured calls per question to compare like with like.
+- `--fail-on-gate` — exit 1 when any arm is below the floor. Off by
+  default, so reading a run never fails a shell; turn it on to use the
+  bench as a gate.
+
+The two cost options go together. Given one alone the aggregator refuses
+the run rather than treating the other as zero, which would report a net
+that always favours the change.
 
 `net/q` is the saving less the expected redirect cost: positive means the
 change pays for the answers it is expected to break. `break-even p` is the
@@ -125,7 +135,10 @@ divided by answers that survived the rubric, not by questions asked) and a
 **payload per call** section (mean response characters the agent had to
 read, per call and per question). Both are the units a payload change
 moves. The harness counts characters, not tokens: a tokenizer would pin a
-model the bench does not otherwise depend on.
+model the bench does not otherwise depend on. Payload is read from the run
+summaries, so `--aggregate` reports it for runs judged before this readout
+existed; a run whose summaries carry no size at all is reported as
+`unknown`, never as zero.
 
 Neither cost input has a default. Without them the readout is pass/fail
 only — what a redirect costs is a property of the deployment, and the

--- a/eval/agentic-bench/README.md
+++ b/eval/agentic-bench/README.md
@@ -51,9 +51,15 @@ src/
   react_agent.py       Per-arm ARM_TOOLS / ARM_HINTS + ReAct loop
   runner.py            Chunk runner: 1 session, sequential queries, auto-reconnect
   prep_judge_v3.py     Pre/post processing for the offline judge step
-  judge.py             Aggregator: per-arm pass%, provenance%, per-category breakdown
+  judge.py             Aggregator: per-arm pass%, provenance%, accuracy gate,
+                       tokens per correct answer, payload per call, tradeoff
 scripts/
   run_v4_multiproc.sh  Multi-process driver — N processes × M queries each
+evalset-project-akb/   Tracked seed questions over the `project-akb` vault —
+                       the only worked examples of the schema in this repo
+                       (`evalset/` itself stays private, see below)
+tests/                 Unit tests for the gate/tradeoff arithmetic and the
+                       seed evalset schema
 ```
 
 ## How to run
@@ -81,7 +87,49 @@ RUNS_DIR=runs_v1 python -m src.judge --aggregate
 ```
 
 `RUNS_DIR` is required for any version other than the default
-`runs/`. The aggregator emits `metrics.json` next to the raw runs.
+`runs/`. `EVALSET_DIR` selects the question set (default `evalset/`; the
+tracked seed set is `evalset-project-akb/`). The aggregator emits
+`metrics.json` next to the raw runs.
+
+## The accuracy gate and the cost tradeoff
+
+A change that makes responses cheaper is only worth having if the answers
+are still right, so the aggregator states the gate rather than leaving it
+to be read off the table:
+
+```bash
+RUNS_DIR=runs_v1 python -m src.judge --aggregate \
+  --accuracy-floor 0.95 \
+  --redirect-cost 8000 \
+  --saving-per-call 250
+```
+
+- `--accuracy-floor` (default **0.95**) — an arm below it is `FAIL`. The
+  readout repeats each arm at 0.90 and 0.80 so a near miss can be read
+  against the thresholds a reviewer asks about next.
+- `--redirect-cost` **D** — tokens it costs to redirect one wrong answer
+  (the re-prompt plus the retry it triggers). The expected cost per
+  question is `(1 − p) × D`.
+- `--saving-per-call` — tokens the change under test saves per tool call,
+  scaled by the measured calls per question to compare like with like.
+
+`net/q` is the saving less the expected redirect cost: positive means the
+change pays for the answers it is expected to break. `break-even p` is the
+accuracy at which the two are equal, `p* = 1 − saving / D` — the number
+the decision actually turns on. Both are levels, not deltas: the harness
+does not know how much accuracy a change cost, only what accuracy the run
+measured, so a before/after comparison is still two runs.
+
+The aggregate table also carries **tokens per correct answer** (spend
+divided by answers that survived the rubric, not by questions asked) and a
+**payload per call** section (mean response characters the agent had to
+read, per call and per question). Both are the units a payload change
+moves. The harness counts characters, not tokens: a tokenizer would pin a
+model the bench does not otherwise depend on.
+
+Neither cost input has a default. Without them the readout is pass/fail
+only — what a redirect costs is a property of the deployment, and the
+harness will not invent it.
 
 ## Required tools
 
@@ -152,6 +200,17 @@ live in a sister repo. They aren't checked in here because:
 
 If you fork this for your own domain, you'll write your own
 `evalset/`. The schema is intentionally tiny.
+
+`evalset-project-akb/` is the exception that is checked in: three seed
+questions over the `project-akb` vault (the AKB family's own
+design/decision record), written so this repository carries at least one
+worked example of the schema. Point the harness at them with
+`EVALSET_DIR=evalset-project-akb`. They cover a cross-repository seam
+(the Product-API contract in `product/pipeline/modules/collector.md`), a
+single decision with a client-visible consequence (`ADR-016`, write-lane
+admission), and a two-sided module contract (`product/akb-oss/modules/backend.md`).
+Each answer lives in one section of one document, so an arm that retrieves
+the right document and stops has not answered the question.
 
 ## License
 

--- a/eval/agentic-bench/evalset-project-akb/q001.yaml
+++ b/eval/agentic-bench/evalset-project-akb/q001.yaml
@@ -1,0 +1,18 @@
+# Seed question: the seam between two repositories. The answer lives in one
+# module document, but only in its "Agent contract" section — an arm that
+# retrieves the document and stops has not answered it.
+id: q001
+category: cross-repo-seam
+query: >-
+  How is akb-platform allowed to call Seahorse Pipeline? Name the constraints
+  the Product-API seam puts on every mutating call.
+ground_truth:
+  must_mention:
+    - "Idempotency-Key"
+    - "Product API allowlist"
+    - "credential references"
+  forbidden:
+    - "akb-platform may call any Pipeline endpoint it needs"
+    - "raw secrets are sent in the request payload"
+  source_docs:
+    - "akb://project-akb/coll/product/pipeline/modules/doc/collector.md"

--- a/eval/agentic-bench/evalset-project-akb/q002.yaml
+++ b/eval/agentic-bench/evalset-project-akb/q002.yaml
@@ -1,0 +1,18 @@
+# Seed question: a specific decision, with a specific client-visible
+# consequence. Tests whether an arm can find one ADR among many and read the
+# clause rather than the title.
+id: q002
+category: decision-lookup
+query: >-
+  What does ADR-016 decide about write admission in akb-oss, and what does a
+  client see when the write lane stays saturated?
+ground_truth:
+  must_mention:
+    - "coroutine waiting before any resource is acquired"
+    - "429"
+    - "Retry-After"
+  forbidden:
+    - "the write is rejected immediately without waiting"
+    - "the request holds a database connection while it waits"
+  source_docs:
+    - "akb://project-akb/coll/decisions/adr/doc/adr-016-write-admission-write-lane-429-backpressure.md"

--- a/eval/agentic-bench/evalset-project-akb/q002.yaml
+++ b/eval/agentic-bench/evalset-project-akb/q002.yaml
@@ -1,6 +1,10 @@
 # Seed question: a specific decision, with a specific client-visible
 # consequence. Tests whether an arm can find one ADR among many and read the
 # clause rather than the title.
+#
+# `must_mention` items are matched two ways — an LLM judge for meaning and a
+# normalized substring pass for provenance — so they are the shortest form
+# that still pins the fact, spelled as the source document spells it.
 id: q002
 category: decision-lookup
 query: >-
@@ -8,7 +12,7 @@ query: >-
   client see when the write lane stays saturated?
 ground_truth:
   must_mention:
-    - "coroutine waiting before any resource is acquired"
+    - "coroutine"
     - "429"
     - "Retry-After"
   forbidden:

--- a/eval/agentic-bench/evalset-project-akb/q003.yaml
+++ b/eval/agentic-bench/evalset-project-akb/q003.yaml
@@ -1,6 +1,10 @@
 # Seed question: a two-sided contract. A complete answer carries both the
 # MUST clauses and the NEVER clauses; an arm that summarises the module
 # document's opening paragraphs gets half of it.
+#
+# `must_mention` items are matched two ways — an LLM judge for meaning and a
+# normalized substring pass for provenance — so they are the shortest form
+# that still pins the fact, spelled as the source document spells it.
 id: q003
 category: module-contract
 query: >-
@@ -8,10 +12,10 @@ query: >-
   it forbid outright?
 ground_truth:
   must_mention:
-    - "MUST route every write through the write-lane admission gate"
-    - "MUST keep local-filesystem behaviour in the stdio proxy, not the backend"
-    - "NEVER add a pgvector or embedding column to the main DB schema"
-    - "NEVER read an environment variable from backend/app/config.py"
+    - "MUST"
+    - "NEVER"
+    - "write-lane"
+    - "pgvector"
   forbidden:
     - "the backend implements the local file tools"
     - "configuration is read from environment variables in app/config.py"

--- a/eval/agentic-bench/evalset-project-akb/q003.yaml
+++ b/eval/agentic-bench/evalset-project-akb/q003.yaml
@@ -1,0 +1,19 @@
+# Seed question: a two-sided contract. A complete answer carries both the
+# MUST clauses and the NEVER clauses; an arm that summarises the module
+# document's opening paragraphs gets half of it.
+id: q003
+category: module-contract
+query: >-
+  What does the akb-oss backend module's Agent contract require, and what does
+  it forbid outright?
+ground_truth:
+  must_mention:
+    - "MUST route every write through the write-lane admission gate"
+    - "MUST keep local-filesystem behaviour in the stdio proxy, not the backend"
+    - "NEVER add a pgvector or embedding column to the main DB schema"
+    - "NEVER read an environment variable from backend/app/config.py"
+  forbidden:
+    - "the backend implements the local file tools"
+    - "configuration is read from environment variables in app/config.py"
+  source_docs:
+    - "akb://project-akb/coll/product/akb-oss/modules/doc/backend.md"

--- a/eval/agentic-bench/src/judge.py
+++ b/eval/agentic-bench/src/judge.py
@@ -13,20 +13,21 @@ import os
 import re
 import statistics
 import sys
-from pathlib import Path
 from typing import Any
 
 import yaml
 
 from .llm_client import LLM, LLMError
+from .paths import evalset_dir, runs_dir
 
 
-ROOT = Path(__file__).resolve().parent.parent
 # `evalset/` is the private Korean-law set the harness shipped against;
 # `EVALSET_DIR` points the same code at another one — e.g. the tracked
-# `evalset-project-akb/` seed questions.
-EVALSET = Path(os.environ.get("EVALSET_DIR", ROOT / "evalset"))
-RUNS = Path(os.environ.get("RUNS_DIR", ROOT / "runs"))
+# `evalset-project-akb/` seed questions. Resolved in `paths` so the runner,
+# the judge prep and this aggregator cannot disagree about which questions
+# a run is about.
+EVALSET = evalset_dir()
+RUNS = runs_dir("runs")
 
 # The accuracy the batch is gated on. A payload change that makes answers
 # cheaper is only worth having if the answers are still right, so the gate
@@ -239,12 +240,21 @@ def tokens_per_correct_answer(total_tokens: float, passes: int) -> float:
     return total_tokens / passes
 
 
-def payload_per_call(result_chars: list[int], questions: int) -> dict[str, float]:
+def payload_per_call(
+    result_chars: list[int] | None, questions: int
+) -> dict[str, float] | None:
     """Aggregate the per-tool-call response sizes an agent had to read.
+
+    `None` in means the runs carried no measurable size at all, and `None`
+    comes back out — reporting that as `0` would read as "this arm sent
+    nothing", which is the opposite of "nobody wrote it down". An empty list
+    is different: the arm ran and made no tool calls, and zero is the answer.
 
     Characters, not tokens: the runner stores what the tool returned, and the
     token count depends on a tokenizer the harness deliberately does not pin.
     """
+    if result_chars is None:
+        return None
     calls = len(result_chars)
     total = float(sum(result_chars))
     return {
@@ -300,15 +310,22 @@ def tradeoff_row(
     }
 
 
-def arm_result_chars(arm: str, qids: list[str]) -> list[int]:
+def arm_result_chars(arm: str, qids: list[str]) -> list[int] | None:
     """Per-call response sizes for one arm, read from the run summaries.
 
     The judge file carries the *count* of tool calls; the sizes live in the
     run summary's `tool_calls_clean`, which is where the runner already wrote
     `result_chars`. Reading them here means `--aggregate` reports payload for
-    runs that were judged before this readout existed.
+    runs that were judged before this readout existed — those summaries carry
+    `result_text` instead, and its length is used.
+
+    Returns `None` when nothing could be measured: no readable summary, or
+    calls that carry neither field. An arm that genuinely made no tool calls
+    returns `[]`, which is a measured zero and not the same thing.
     """
     chars: list[int] = []
+    calls_seen = 0
+    summaries_read = 0
     for qid in qids:
         summary_path = RUNS / arm / f"{qid}.summary.json"
         if not summary_path.exists():
@@ -317,13 +334,19 @@ def arm_result_chars(arm: str, qids: list[str]) -> list[int]:
             summary = json.loads(summary_path.read_text())
         except (OSError, json.JSONDecodeError):
             continue
+        summaries_read += 1
         for call in summary.get("tool_calls_clean") or []:
+            calls_seen += 1
             size = call.get("result_chars")
             if isinstance(size, int):
                 chars.append(size)
             elif isinstance(call.get("result_text"), str):
                 chars.append(len(call["result_text"]))
-    return chars
+    if chars:
+        return chars
+    if summaries_read and not calls_seen:
+        return []
+    return None
 
 
 def _infer_verdict(d: dict[str, Any]) -> str:
@@ -351,9 +374,15 @@ def _infer_verdict(d: dict[str, Any]) -> str:
 def aggregate(
     *,
     accuracy_floor: float = DEFAULT_ACCURACY_FLOOR,
-    redirect_cost: float = 0.0,
-    saving_per_call: float = 0.0,
+    redirect_cost: float | None = None,
+    saving_per_call: float | None = None,
 ) -> dict[str, Any]:
+    """Print the run's readout and return the per-arm metrics.
+
+    The tradeoff needs both cost inputs. With neither, the readout is the
+    accuracy gate alone — which is the honest output, because the harness
+    does not know what a redirect costs in a given deployment.
+    """
     print("\n=== AGGREGATE ===\n")
     rows = []
     for arm in ARMS:
@@ -415,36 +444,49 @@ def aggregate(
     # A payload change is worth having when what it saves per question is
     # more than what the answers it breaks cost to redirect. `D` and the
     # per-call saving are operator inputs — the harness does not know what a
-    # re-prompt costs in this deployment, and refuses to invent it.
-    print(
-        f"\n--- accuracy floor {accuracy_floor:.2f} "
-        f"(D={redirect_cost:.0f} tok/redirect, saving={saving_per_call:.0f} tok/call) ---"
-    )
-    if redirect_cost <= 0 and saving_per_call <= 0:
-        print("  no cost inputs given — pass/fail only "
-              "(pass --redirect-cost and --saving-per-call for the tradeoff)")
-    print(f"  {'arm':<18}{'floor':<8}{'p':<8}{'verdict':<9}{'(1-p)xD':<12}{'saving/q':<12}{'net/q':<12}{'break-even p':<13}")
+    # re-prompt costs in this deployment, and refuses to invent it, so
+    # without both the readout stops at the gate.
+    have_costs = redirect_cost is not None and saving_per_call is not None
     floors = [accuracy_floor, *TRADEOFF_FLOORS]
-    for arm, _ in rows:
-        m = metrics[arm]
-        arm_rows = []
-        for floor in floors:
-            row = tradeoff_row(
-                pass_rate=m["pass_rate"],
-                floor=floor,
-                redirect_cost=redirect_cost,
-                saving_per_call=saving_per_call,
-                calls_per_question=m["mean_tools"],
-            )
-            arm_rows.append(row)
-            break_even = row["break_even_accuracy"]
-            break_even_text = "-" if break_even is None else f"{break_even:.3f}"
-            print(
-                f"  {arm:<18}{floor:<8.2f}{row['pass_rate']:<8.3f}{row['verdict']:<9}"
-                f"{row['expected_redirect_tokens']:<12.0f}{row['saving_tokens']:<12.0f}"
-                f"{row['net_tokens']:<12.0f}{break_even_text:<13}"
-            )
-        metrics[arm]["tradeoff"] = arm_rows
+    if have_costs:
+        print(
+            f"\n--- accuracy floor {accuracy_floor:.2f} "
+            f"(D={redirect_cost:.0f} tok/redirect, saving={saving_per_call:.0f} tok/call) ---"
+        )
+        print(f"  {'arm':<18}{'floor':<8}{'p':<8}{'verdict':<9}{'(1-p)xD':<12}{'saving/q':<12}{'net/q':<12}{'break-even p':<13}")
+        for arm, _ in rows:
+            m = metrics[arm]
+            arm_rows = []
+            for floor in floors:
+                row = tradeoff_row(
+                    pass_rate=m["pass_rate"],
+                    floor=floor,
+                    redirect_cost=redirect_cost,
+                    saving_per_call=saving_per_call,
+                    calls_per_question=m["mean_tools"],
+                )
+                arm_rows.append(row)
+                break_even = row["break_even_accuracy"]
+                break_even_text = "-" if break_even is None else f"{break_even:.3f}"
+                print(
+                    f"  {arm:<18}{floor:<8.2f}{row['pass_rate']:<8.3f}{row['verdict']:<9}"
+                    f"{row['expected_redirect_tokens']:<12.0f}{row['saving_tokens']:<12.0f}"
+                    f"{row['net_tokens']:<12.0f}{break_even_text:<13}"
+                )
+            metrics[arm]["tradeoff"] = arm_rows
+    else:
+        print(f"\n--- accuracy floor {accuracy_floor:.2f} ---")
+        print("  pass/fail only — give both --redirect-cost and "
+              "--saving-per-call for the cost tradeoff")
+        print(f"  {'arm':<18}{'floor':<8}{'p':<8}{'verdict':<9}")
+        for arm, _ in rows:
+            m = metrics[arm]
+            for floor in floors:
+                print(
+                    f"  {arm:<18}{floor:<8.2f}{m['pass_rate']:<8.3f}"
+                    f"{gate_verdict(m['pass_rate'], floor):<9}"
+                )
+            metrics[arm]["tradeoff"] = None
 
     # Per-category breakdown.
     print("\n--- per category ---")
@@ -460,11 +502,16 @@ def aggregate(
             if v:
                 print(f"    {arm}: {sum(v)}/{len(v)} PASS")
 
-    # Payload per call — what the agent had to read to get there.
+    # Payload per call — what the agent had to read to get there. A run whose
+    # summaries carry neither `result_chars` nor `result_text` is reported as
+    # unknown, never as zero.
     print("\n--- payload per call ---")
     print(f"  {'arm':<18}{'calls':<8}{'chars/call':<13}{'chars/q':<12}")
     for arm, _ in rows:
         pay = metrics[arm]["payload"]
+        if pay is None:
+            print(f"  {arm:<18}{'unknown':<8}{'unknown':<13}{'unknown':<12}")
+            continue
         print(
             f"  {arm:<18}{pay['calls']:<8}{pay['chars_per_call']:<13.0f}"
             f"{pay['chars_per_question']:<12.0f}"
@@ -495,31 +542,57 @@ def main():
     p.add_argument(
         "--redirect-cost",
         type=float,
-        default=0.0,
+        default=None,
         help=(
             "D: tokens it costs to redirect one wrong answer (re-prompt plus "
-            "the retry it triggers). Used for the (1-p)xD readout."
+            "the retry it triggers). Required together with "
+            "--saving-per-call; without both, the readout is the gate only."
         ),
     )
     p.add_argument(
         "--saving-per-call",
         type=float,
-        default=0.0,
+        default=None,
         help=(
             "Tokens saved per tool call by the change under test. Scaled by "
-            "the measured calls per question to compare against (1-p)xD."
+            "the measured calls per question to compare against (1-p)xD. "
+            "Required together with --redirect-cost."
+        ),
+    )
+    p.add_argument(
+        "--fail-on-gate",
+        action="store_true",
+        help=(
+            "Exit 1 when any arm's accuracy is below --accuracy-floor. Off by "
+            "default so reading a run never fails a shell; turn it on to use "
+            "the bench as a gate."
         ),
     )
     args = p.parse_args()
     if not (0.0 <= args.accuracy_floor <= 1.0):
         p.error("--accuracy-floor is a fraction in [0, 1]")
+    # Half the tradeoff is not a cheaper tradeoff, it is a wrong one: with
+    # only one of the two the readout would silently treat the other as zero
+    # and report a net that always favours the change.
+    if (args.redirect_cost is None) != (args.saving_per_call is None):
+        p.error(
+            "--redirect-cost and --saving-per-call go together; give both for "
+            "the cost tradeoff, or neither for the accuracy gate alone"
+        )
     if not args.aggregate:
         asyncio.run(judge_all_async(args))
-    aggregate(
+    metrics = aggregate(
         accuracy_floor=args.accuracy_floor,
         redirect_cost=args.redirect_cost,
         saving_per_call=args.saving_per_call,
     )
+    below = sorted(arm for arm, m in metrics.items() if m["gate"] == "FAIL")
+    if args.fail_on_gate and below:
+        print(
+            f"\ngate FAILED at {args.accuracy_floor:.2f}: {', '.join(below)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/eval/agentic-bench/src/judge.py
+++ b/eval/agentic-bench/src/judge.py
@@ -22,8 +22,19 @@ from .llm_client import LLM, LLMError
 
 
 ROOT = Path(__file__).resolve().parent.parent
-EVALSET = ROOT / "evalset"
+# `evalset/` is the private Korean-law set the harness shipped against;
+# `EVALSET_DIR` points the same code at another one — e.g. the tracked
+# `evalset-project-akb/` seed questions.
+EVALSET = Path(os.environ.get("EVALSET_DIR", ROOT / "evalset"))
 RUNS = Path(os.environ.get("RUNS_DIR", ROOT / "runs"))
+
+# The accuracy the batch is gated on. A payload change that makes answers
+# cheaper is only worth having if the answers are still right, so the gate
+# is stated up front rather than read off the table afterwards.
+DEFAULT_ACCURACY_FLOOR = 0.95
+# Reported alongside the configured floor so a near miss can be read against
+# the two thresholds a reviewer is likely to ask about next.
+TRADEOFF_FLOORS = (0.90, 0.80)
 _V4_STYLE = any(s in str(RUNS) for s in ("v4", "v5", "v6", "v7", "v8", "v9"))
 ARMS = ["A1_search_only", "A2_grep_only", "A3_tree", "A4_all"] if _V4_STYLE else ["A1_search_only", "A2_grep", "A3_drill"]
 
@@ -199,6 +210,122 @@ async def judge_all_async(args: argparse.Namespace) -> None:
     return None
 
 
+# ── gate + payload arithmetic ────────────────────────────────────────
+#
+# All pure, all unit-tested. The bench exists to answer one question — is a
+# cheaper response still a correct one — and that answer is arithmetic over
+# two measured numbers (accuracy, payload) and two the operator supplies
+# (what a wrong answer costs to redirect, what the change saves per call).
+
+
+def gate_verdict(pass_rate: float, floor: float) -> str:
+    """PASS when measured accuracy is at or above the floor.
+
+    `pass_rate` and `floor` are both fractions in [0, 1]. Equality passes: a
+    floor of 0.95 means "95 % is acceptable", not "better than 95 %".
+    """
+    return "PASS" if pass_rate >= floor else "FAIL"
+
+
+def tokens_per_correct_answer(total_tokens: float, passes: int) -> float:
+    """Tokens spent per answer that was actually right.
+
+    Mean tokens per question flatters an arm that answers cheaply and wrongly;
+    this divides the same spend by the answers that survived the rubric. An
+    arm with no passing answer has no finite cost per correct answer.
+    """
+    if passes <= 0:
+        return float("inf")
+    return total_tokens / passes
+
+
+def payload_per_call(result_chars: list[int], questions: int) -> dict[str, float]:
+    """Aggregate the per-tool-call response sizes an agent had to read.
+
+    Characters, not tokens: the runner stores what the tool returned, and the
+    token count depends on a tokenizer the harness deliberately does not pin.
+    """
+    calls = len(result_chars)
+    total = float(sum(result_chars))
+    return {
+        "calls": calls,
+        "total_chars": total,
+        "chars_per_call": (total / calls) if calls else 0.0,
+        "chars_per_question": (total / questions) if questions else 0.0,
+    }
+
+
+def break_even_accuracy(*, redirect_cost: float, saving: float) -> float | None:
+    """The accuracy at which a payload saving exactly pays for the redirects
+    it costs: `(1 - p) * D == saving`, so `p = 1 - saving / D`.
+
+    This is the number the tradeoff actually turns on. Below it the expected
+    cost of re-asking outweighs what was saved per question; above it the
+    saving wins. `None` when no redirect cost was supplied — without `D` there
+    is nothing to trade the saving against.
+    """
+    if redirect_cost <= 0:
+        return None
+    return 1.0 - (saving / redirect_cost)
+
+
+def tradeoff_row(
+    *,
+    pass_rate: float,
+    floor: float,
+    redirect_cost: float,
+    saving_per_call: float,
+    calls_per_question: float,
+) -> dict[str, Any]:
+    """One row of the accuracy/cost readout at a single floor.
+
+    `expected_redirect_tokens` is `(1 - p) * D`: the share of questions the
+    agent gets wrong, times what it costs to redirect one of them.
+    `saving_tokens` is the payload saving over the calls one question
+    actually makes. `net_tokens` is what is left — positive means the change
+    pays for the redirects it is expected to cause.
+    """
+    saving = saving_per_call * calls_per_question
+    expected_redirect = (1.0 - pass_rate) * redirect_cost
+    return {
+        "floor": floor,
+        "pass_rate": pass_rate,
+        "verdict": gate_verdict(pass_rate, floor),
+        "expected_redirect_tokens": expected_redirect,
+        "saving_tokens": saving,
+        "net_tokens": saving - expected_redirect,
+        "break_even_accuracy": break_even_accuracy(
+            redirect_cost=redirect_cost, saving=saving
+        ),
+    }
+
+
+def arm_result_chars(arm: str, qids: list[str]) -> list[int]:
+    """Per-call response sizes for one arm, read from the run summaries.
+
+    The judge file carries the *count* of tool calls; the sizes live in the
+    run summary's `tool_calls_clean`, which is where the runner already wrote
+    `result_chars`. Reading them here means `--aggregate` reports payload for
+    runs that were judged before this readout existed.
+    """
+    chars: list[int] = []
+    for qid in qids:
+        summary_path = RUNS / arm / f"{qid}.summary.json"
+        if not summary_path.exists():
+            continue
+        try:
+            summary = json.loads(summary_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        for call in summary.get("tool_calls_clean") or []:
+            size = call.get("result_chars")
+            if isinstance(size, int):
+                chars.append(size)
+            elif isinstance(call.get("result_text"), str):
+                chars.append(len(call["result_text"]))
+    return chars
+
+
 def _infer_verdict(d: dict[str, Any]) -> str:
     """Fallback when the judge model forgot to emit `verdict`.
     Apply the rubric to must_mention / forbidden / faithfulness."""
@@ -221,7 +348,12 @@ def _infer_verdict(d: dict[str, Any]) -> str:
     return "FAIL"
 
 
-def aggregate() -> None:
+def aggregate(
+    *,
+    accuracy_floor: float = DEFAULT_ACCURACY_FLOOR,
+    redirect_cost: float = 0.0,
+    saving_per_call: float = 0.0,
+) -> dict[str, Any]:
     print("\n=== AGGREGATE ===\n")
     rows = []
     for arm in ARMS:
@@ -232,11 +364,12 @@ def aggregate() -> None:
         for jp in sorted(adir.glob("q*.judge.json")):
             d = json.loads(jp.read_text())
             d["verdict"] = _infer_verdict(d)
+            d["_qid"] = d.get("_qid") or jp.name.split(".")[0]
             per_q.append(d)
         rows.append((arm, per_q))
 
-    print(f"{'arm':<18}{'n':<5}{'PASS':<6}{'PART':<6}{'FAIL':<6}{'pass%':<8}{'prov%':<8}{'tools/q':<10}{'tok/q':<10}{'wall/q':<9}{'tok/pass':<10}")
-    metrics = {}
+    print(f"{'arm':<18}{'n':<5}{'PASS':<6}{'PART':<6}{'FAIL':<6}{'pass%':<8}{'prov%':<8}{'tools/q':<10}{'tok/q':<10}{'wall/q':<9}{'tok/correct':<13}{'gate':<6}")
+    metrics: dict[str, Any] = {}
     for arm, per_q in rows:
         n = len(per_q)
         p = sum(1 for d in per_q if d.get("verdict") == "PASS")
@@ -253,18 +386,65 @@ def aggregate() -> None:
             if d.get("_provenance", {}).get("retrieved_rate") is not None
         ]
         prov_pct = 100 * statistics.mean(prov_rates) if prov_rates else 0
-        tokens_per_pass = (sum(toks) / p) if p else float("inf")
-        pct = 100 * p / n if n else 0
-        print(f"{arm:<18}{n:<5}{p:<6}{pa:<6}{f:<6}{pct:<8.1f}{prov_pct:<8.1f}{statistics.mean(tools):<10.2f}{statistics.mean(toks):<10.0f}{statistics.mean(walls):<9.1f}{tokens_per_pass:<10.0f}")
+        tok_per_correct = tokens_per_correct_answer(sum(toks), p)
+        pass_rate = (p / n) if n else 0.0
+        pct = 100 * pass_rate
+        verdict = gate_verdict(pass_rate, accuracy_floor)
+        payload = payload_per_call(
+            arm_result_chars(arm, [d["_qid"] for d in per_q]), n
+        )
+        print(f"{arm:<18}{n:<5}{p:<6}{pa:<6}{f:<6}{pct:<8.1f}{prov_pct:<8.1f}{statistics.mean(tools):<10.2f}{statistics.mean(toks):<10.0f}{statistics.mean(walls):<9.1f}{tok_per_correct:<13.0f}{verdict:<6}")
         metrics[arm] = {
             "n": n, "pass": p, "partial": pa, "fail": f,
             "pass_pct": pct,
+            "pass_rate": pass_rate,
             "provenance_pct": prov_pct,
             "mean_tools": statistics.mean(tools),
             "mean_tokens": statistics.mean(toks),
             "mean_wall_s": statistics.mean(walls),
-            "tokens_per_pass": tokens_per_pass if p else None,
+            # Kept under its original name for anything already reading it.
+            "tokens_per_pass": tok_per_correct if p else None,
+            "tokens_per_correct_answer": tok_per_correct if p else None,
+            "payload": payload,
+            "accuracy_floor": accuracy_floor,
+            "gate": verdict,
         }
+
+    # Accuracy floor + the cost tradeoff behind it.
+    #
+    # A payload change is worth having when what it saves per question is
+    # more than what the answers it breaks cost to redirect. `D` and the
+    # per-call saving are operator inputs — the harness does not know what a
+    # re-prompt costs in this deployment, and refuses to invent it.
+    print(
+        f"\n--- accuracy floor {accuracy_floor:.2f} "
+        f"(D={redirect_cost:.0f} tok/redirect, saving={saving_per_call:.0f} tok/call) ---"
+    )
+    if redirect_cost <= 0 and saving_per_call <= 0:
+        print("  no cost inputs given — pass/fail only "
+              "(pass --redirect-cost and --saving-per-call for the tradeoff)")
+    print(f"  {'arm':<18}{'floor':<8}{'p':<8}{'verdict':<9}{'(1-p)xD':<12}{'saving/q':<12}{'net/q':<12}{'break-even p':<13}")
+    floors = [accuracy_floor, *TRADEOFF_FLOORS]
+    for arm, _ in rows:
+        m = metrics[arm]
+        arm_rows = []
+        for floor in floors:
+            row = tradeoff_row(
+                pass_rate=m["pass_rate"],
+                floor=floor,
+                redirect_cost=redirect_cost,
+                saving_per_call=saving_per_call,
+                calls_per_question=m["mean_tools"],
+            )
+            arm_rows.append(row)
+            break_even = row["break_even_accuracy"]
+            break_even_text = "-" if break_even is None else f"{break_even:.3f}"
+            print(
+                f"  {arm:<18}{floor:<8.2f}{row['pass_rate']:<8.3f}{row['verdict']:<9}"
+                f"{row['expected_redirect_tokens']:<12.0f}{row['saving_tokens']:<12.0f}"
+                f"{row['net_tokens']:<12.0f}{break_even_text:<13}"
+            )
+        metrics[arm]["tradeoff"] = arm_rows
 
     # Per-category breakdown.
     print("\n--- per category ---")
@@ -280,9 +460,20 @@ def aggregate() -> None:
             if v:
                 print(f"    {arm}: {sum(v)}/{len(v)} PASS")
 
+    # Payload per call — what the agent had to read to get there.
+    print("\n--- payload per call ---")
+    print(f"  {'arm':<18}{'calls':<8}{'chars/call':<13}{'chars/q':<12}")
+    for arm, _ in rows:
+        pay = metrics[arm]["payload"]
+        print(
+            f"  {arm:<18}{pay['calls']:<8}{pay['chars_per_call']:<13.0f}"
+            f"{pay['chars_per_question']:<12.0f}"
+        )
+
     # Save metrics.
     (RUNS / "metrics.json").write_text(json.dumps(metrics, ensure_ascii=False, indent=2))
     print(f"\nsaved {RUNS / 'metrics.json'}")
+    return metrics
 
 
 def main():
@@ -292,10 +483,43 @@ def main():
     p.add_argument("--parallel", type=int, default=4)
     p.add_argument("--force", action="store_true")
     p.add_argument("--aggregate", action="store_true")
+    p.add_argument(
+        "--accuracy-floor",
+        type=float,
+        default=DEFAULT_ACCURACY_FLOOR,
+        help=(
+            "Accuracy the batch is gated on, as a fraction "
+            f"(default {DEFAULT_ACCURACY_FLOOR}). An arm below it is FAIL."
+        ),
+    )
+    p.add_argument(
+        "--redirect-cost",
+        type=float,
+        default=0.0,
+        help=(
+            "D: tokens it costs to redirect one wrong answer (re-prompt plus "
+            "the retry it triggers). Used for the (1-p)xD readout."
+        ),
+    )
+    p.add_argument(
+        "--saving-per-call",
+        type=float,
+        default=0.0,
+        help=(
+            "Tokens saved per tool call by the change under test. Scaled by "
+            "the measured calls per question to compare against (1-p)xD."
+        ),
+    )
     args = p.parse_args()
+    if not (0.0 <= args.accuracy_floor <= 1.0):
+        p.error("--accuracy-floor is a fraction in [0, 1]")
     if not args.aggregate:
         asyncio.run(judge_all_async(args))
-    aggregate()
+    aggregate(
+        accuracy_floor=args.accuracy_floor,
+        redirect_cost=args.redirect_cost,
+        saving_per_call=args.saving_per_call,
+    )
 
 
 if __name__ == "__main__":

--- a/eval/agentic-bench/src/paths.py
+++ b/eval/agentic-bench/src/paths.py
@@ -1,0 +1,43 @@
+"""Where the bench reads its questions and writes its runs.
+
+One definition, three consumers. `runner.py`, `prep_judge_v3.py` and
+`judge.py` each used to resolve these on their own, so `EVALSET_DIR` could
+select the seed question set for one stage of a run and not the next —
+the runner would answer `evalset-project-akb/q001` and the judge would
+score it against a `evalset/q001` that means something else entirely, with
+nothing in the output saying so.
+
+Both are read from the environment at import, which is when a module-level
+constant is built; a test that changes them reloads the module.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+#: Selects the question set. Default `evalset/` is the private hand-authored
+#: one the harness shipped against; `evalset-project-akb/` is the tracked
+#: seed set in this repository.
+EVALSET_DIR_ENV = "EVALSET_DIR"
+#: Selects the run directory. Required for any version other than `runs/`.
+RUNS_DIR_ENV = "RUNS_DIR"
+
+
+def evalset_dir() -> Path:
+    """The question set this process scores against."""
+    configured = os.environ.get(EVALSET_DIR_ENV)
+    return Path(configured) if configured else ROOT / "evalset"
+
+
+def runs_dir(default: str = "runs") -> Path:
+    """The run directory this process reads or writes.
+
+    `default` differs per entry point for historical reasons — the runner
+    writes `runs/`, the v3 judge prep reads `runs_v3/` — so the fallback
+    stays the caller's, while `RUNS_DIR` overrides all of them alike.
+    """
+    configured = os.environ.get(RUNS_DIR_ENV)
+    return Path(configured) if configured else ROOT / default

--- a/eval/agentic-bench/src/prep_judge_v3.py
+++ b/eval/agentic-bench/src/prep_judge_v3.py
@@ -13,14 +13,13 @@ from __future__ import annotations
 import json
 import re
 import sys
-from pathlib import Path
 
 import yaml
 
-import os
-ROOT = Path(__file__).resolve().parent.parent
-EVALSET = ROOT / "evalset"
-RUNS = Path(os.environ.get("RUNS_DIR", ROOT / "runs_v3"))
+from .paths import evalset_dir, runs_dir
+
+EVALSET = evalset_dir()
+RUNS = runs_dir("runs_v3")
 BATCHES = RUNS / "batches"
 VERDICTS = RUNS / "verdicts"
 _V4_STYLE = any(s in str(RUNS) for s in ("v4", "v5", "v6", "v7", "v8", "v9"))

--- a/eval/agentic-bench/src/runner.py
+++ b/eval/agentic-bench/src/runner.py
@@ -13,19 +13,18 @@ import os
 import sys
 import time
 from dataclasses import asdict
-from pathlib import Path
 from typing import Any
 
 import yaml
 
 from .llm_client import LLM
 from .mcp_client import mcp_session
+from .paths import evalset_dir, runs_dir
 from .react_agent import ARM_TOOLS, run_agent_with_session
 
 
-ROOT = Path(__file__).resolve().parent.parent
-EVALSET = ROOT / "evalset"
-RUNS = Path(os.environ.get("RUNS_DIR", ROOT / "runs"))
+EVALSET = evalset_dir()
+RUNS = runs_dir("runs")
 
 
 def load_query(qid: str) -> dict[str, Any]:

--- a/eval/agentic-bench/tests/conftest.py
+++ b/eval/agentic-bench/tests/conftest.py
@@ -1,0 +1,15 @@
+"""Make `src` importable as a package when pytest is run from anywhere.
+
+The bench is normally driven as `python -m src.judge` from
+`eval/agentic-bench/`, so the package root is that directory rather than the
+repository root.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+BENCH_ROOT = Path(__file__).resolve().parents[1]
+if str(BENCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(BENCH_ROOT))

--- a/eval/agentic-bench/tests/test_evalset_project_akb.py
+++ b/eval/agentic-bench/tests/test_evalset_project_akb.py
@@ -1,0 +1,59 @@
+"""The tracked seed evalset must match the schema the harness reads.
+
+`evalset/` itself is private (hand-authored Korean-law ground truth), so
+these three project-akb questions are the only worked examples of the
+schema in the repository. If they drift from what `judge.py` reads, the
+schema documentation in the README drifts with them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+EVALSET = Path(__file__).resolve().parents[1] / "evalset-project-akb"
+QUESTIONS = sorted(EVALSET.glob("q*.yaml"))
+
+
+def test_the_seed_set_has_its_three_questions():
+    assert [p.stem for p in QUESTIONS] == ["q001", "q002", "q003"]
+
+
+@pytest.mark.parametrize("path", QUESTIONS, ids=lambda p: p.stem)
+def test_question_matches_the_readme_schema(path):
+    spec = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+    assert set(spec) == {"id", "category", "query", "ground_truth"}
+    assert spec["id"] == path.stem
+    assert isinstance(spec["category"], str) and spec["category"]
+    assert isinstance(spec["query"], str) and spec["query"].strip()
+
+    truth = spec["ground_truth"]
+    assert set(truth) == {"must_mention", "forbidden", "source_docs"}
+    for key in truth:
+        assert isinstance(truth[key], list), key
+        assert all(isinstance(item, str) and item for item in truth[key]), key
+
+    assert truth["must_mention"], "a question with nothing to assert scores nothing"
+    assert truth["source_docs"], "every question must name where its answer lives"
+    for uri in truth["source_docs"]:
+        assert uri.startswith("akb://project-akb/"), uri
+
+
+def test_the_judge_can_load_the_seed_set_through_evalset_dir(monkeypatch):
+    # `judge.py` resolves EVALSET at import time from EVALSET_DIR, which is
+    # how the seed set is selected without moving files around.
+    monkeypatch.setenv("EVALSET_DIR", str(EVALSET))
+    import importlib
+
+    import src.judge as judge
+
+    reloaded = importlib.reload(judge)
+    try:
+        assert reloaded.EVALSET == EVALSET
+        assert reloaded.list_query_ids() == ["q001", "q002", "q003"]
+    finally:
+        monkeypatch.delenv("EVALSET_DIR", raising=False)
+        importlib.reload(judge)

--- a/eval/agentic-bench/tests/test_judge_cli.py
+++ b/eval/agentic-bench/tests/test_judge_cli.py
@@ -1,0 +1,231 @@
+"""The aggregator's command-line contract, and what it does with runs that
+predate the readout.
+
+Two things are easy to get wrong here and expensive to notice late: half a
+cost tradeoff silently reads as a free win, and a run nobody measured reads
+as a run that sent nothing.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+BENCH_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_cli(args: list[str], runs_dir: Path, **env_extra) -> subprocess.CompletedProcess:
+    import os
+
+    env = {**os.environ, "RUNS_DIR": str(runs_dir), **env_extra}
+    return subprocess.run(
+        [sys.executable, "-m", "src.judge", "--aggregate", *args],
+        cwd=BENCH_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _seed_run(
+    runs_dir: Path,
+    arm: str = "A1_search_only",
+    verdicts: tuple[str, ...] = ("PASS", "PASS", "FAIL"),
+    calls: list[dict] | None = None,
+) -> None:
+    arm_dir = runs_dir / arm
+    arm_dir.mkdir(parents=True, exist_ok=True)
+    if calls is None:
+        calls = [
+            {"name": "akb_search", "result_chars": 1800, "result_text": "x"},
+            {"name": "akb_drill_down", "result_chars": 5200, "result_text": "y"},
+        ]
+    for index, verdict in enumerate(verdicts, start=1):
+        qid = f"q{index:03d}"
+        (arm_dir / f"{qid}.judge.json").write_text(json.dumps({
+            "verdict": verdict,
+            "must_mention_matched": ["a"] if verdict == "PASS" else [],
+            "must_mention_missing": [] if verdict == "PASS" else ["a"],
+            "forbidden_found": [],
+            "faithfulness": "high",
+            "_qid": qid,
+            "_arm": arm,
+            "_provenance": {"retrieved": ["a"], "retrieved_rate": 1.0},
+            "_summary_stats": {
+                "tool_calls": len(calls), "tokens": 12000, "wall_seconds": 40.0,
+                "iterations": 3, "category": "decision-lookup", "abort_reason": None,
+            },
+        }))
+        (arm_dir / f"{qid}.summary.json").write_text(json.dumps({
+            "tool_calls_clean": calls,
+            "usage_total": {"total_tokens": 12000},
+            "wall_seconds": 40.0,
+        }))
+
+
+@pytest.fixture
+def runs(tmp_path):
+    # The arm list is chosen from the runs-dir name, so keep the v4 marker.
+    directory = tmp_path / "runs_v4_test"
+    directory.mkdir()
+    return directory
+
+
+# ── the cost inputs go together ─────────────────────────────────────
+
+
+def test_no_cost_inputs_reports_the_gate_only(runs):
+    _seed_run(runs)
+    result = _run_cli([], runs)
+
+    assert result.returncode == 0, result.stderr
+    assert "pass/fail only" in result.stdout
+    assert "break-even p" not in result.stdout
+    metrics = json.loads((runs / "metrics.json").read_text())
+    assert metrics["A1_search_only"]["tradeoff"] is None
+    assert metrics["A1_search_only"]["gate"] == "FAIL"
+
+
+def test_both_cost_inputs_produce_the_tradeoff(runs):
+    _seed_run(runs)
+    result = _run_cli(["--redirect-cost", "8000", "--saving-per-call", "250"], runs)
+
+    assert result.returncode == 0, result.stderr
+    assert "break-even p" in result.stdout
+    metrics = json.loads((runs / "metrics.json").read_text())
+    tradeoff = metrics["A1_search_only"]["tradeoff"]
+    assert [row["floor"] for row in tradeoff] == [0.95, 0.90, 0.80]
+
+
+@pytest.mark.parametrize(
+    "args",
+    [["--redirect-cost", "8000"], ["--saving-per-call", "250"]],
+)
+def test_one_cost_input_alone_is_refused(runs, args):
+    _seed_run(runs)
+    result = _run_cli(args, runs)
+
+    assert result.returncode != 0
+    assert "go together" in result.stderr
+
+
+# ── the gate as an exit code ────────────────────────────────────────
+
+
+def test_reading_a_failing_run_does_not_fail_the_shell(runs):
+    _seed_run(runs, verdicts=("FAIL", "FAIL", "FAIL"))
+    assert _run_cli([], runs).returncode == 0
+
+
+def test_fail_on_gate_exits_non_zero_below_the_floor(runs):
+    _seed_run(runs, verdicts=("PASS", "PASS", "FAIL"))
+    result = _run_cli(["--fail-on-gate"], runs)
+
+    assert result.returncode == 1
+    assert "gate FAILED" in result.stderr
+    assert "A1_search_only" in result.stderr
+
+
+def test_fail_on_gate_passes_when_every_arm_clears_the_floor(runs):
+    _seed_run(runs, verdicts=("PASS", "PASS", "PASS"))
+    assert _run_cli(["--fail-on-gate"], runs).returncode == 0
+
+
+def test_a_lower_floor_can_clear_the_same_run(runs):
+    _seed_run(runs, verdicts=("PASS", "PASS", "FAIL"))
+    assert _run_cli(["--fail-on-gate", "--accuracy-floor", "0.6"], runs).returncode == 0
+
+
+# ── payload from older runs ─────────────────────────────────────────
+
+
+def test_a_summary_with_only_result_text_is_still_measured(runs):
+    _seed_run(runs, calls=[{"name": "akb_search", "result_text": "y" * 1234}])
+    _run_cli([], runs)
+
+    payload = json.loads((runs / "metrics.json").read_text())["A1_search_only"]["payload"]
+    assert payload["calls"] == 3
+    assert payload["chars_per_call"] == 1234
+
+
+def test_an_unmeasurable_run_reports_unknown_not_zero(runs):
+    _seed_run(runs, calls=[{"name": "akb_search"}])
+    result = _run_cli([], runs)
+
+    assert "unknown" in result.stdout
+    payload = json.loads((runs / "metrics.json").read_text())["A1_search_only"]["payload"]
+    assert payload is None
+
+
+def test_an_arm_that_made_no_call_reports_a_measured_zero(runs):
+    _seed_run(runs, calls=[])
+    _run_cli([], runs)
+
+    payload = json.loads((runs / "metrics.json").read_text())["A1_search_only"]["payload"]
+    assert payload is not None
+    assert payload["calls"] == 0
+    assert payload["chars_per_call"] == 0.0
+
+
+# ── one evalset for the whole pipeline ──────────────────────────────
+
+
+@pytest.fixture
+def stubbed_mcp_client(monkeypatch):
+    """`src.runner` reaches the MCP SDK through `src.mcp_client`, whose SDK
+    pin is the bench's own and need not match whatever interpreter runs these
+    tests. The path resolution under test has nothing to do with it, so the
+    module is stubbed rather than imported."""
+    import types
+
+    stub = types.ModuleType("src.mcp_client")
+    stub.mcp_session = None
+    stub.call_tool = None
+    stub.list_tools_full = None
+    stub.MCPCallError = RuntimeError
+    monkeypatch.setitem(sys.modules, "src.mcp_client", stub)
+    return stub
+
+
+def test_every_stage_resolves_the_same_evalset(monkeypatch, stubbed_mcp_client):
+    seed = BENCH_ROOT / "evalset-project-akb"
+    monkeypatch.setenv("EVALSET_DIR", str(seed))
+
+    import src.judge
+    import src.paths
+    import src.prep_judge_v3
+    import src.react_agent
+    import src.runner
+
+    importlib.reload(src.paths)
+    importlib.reload(src.react_agent)
+    judge = importlib.reload(src.judge)
+    runner = importlib.reload(src.runner)
+    prep = importlib.reload(src.prep_judge_v3)
+    try:
+        # One helper, one answer — a run whose questions changed between the
+        # runner and the judge would score answers against other questions.
+        assert {judge.EVALSET, runner.EVALSET, prep.EVALSET} == {seed}
+        assert judge.list_query_ids() == ["q001", "q002", "q003"]
+        assert runner.list_queries() == ["q001", "q002", "q003"]
+    finally:
+        monkeypatch.delenv("EVALSET_DIR", raising=False)
+        for module in (src.paths, src.judge, src.runner, src.prep_judge_v3):
+            importlib.reload(module)
+
+
+def test_the_default_evalset_is_unchanged_without_the_variable(monkeypatch, stubbed_mcp_client):
+    monkeypatch.delenv("EVALSET_DIR", raising=False)
+
+    import src.judge
+    import src.paths
+
+    importlib.reload(src.paths)
+    judge = importlib.reload(src.judge)
+
+    assert judge.EVALSET == BENCH_ROOT / "evalset"

--- a/eval/agentic-bench/tests/test_judge_gate.py
+++ b/eval/agentic-bench/tests/test_judge_gate.py
@@ -1,0 +1,190 @@
+"""The gate and the cost tradeoff are arithmetic, so they are tested as
+arithmetic.
+
+The bench exists to answer one question — is a cheaper response still a
+correct one — and the aggregator turns that into a pass/fail against an
+accuracy floor plus a readout of what the change saves against what its
+wrong answers cost to redirect. Getting the sign or the scaling wrong there
+would make a payload regression look like a win, so each piece is pinned.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from src.judge import (
+    DEFAULT_ACCURACY_FLOOR,
+    TRADEOFF_FLOORS,
+    break_even_accuracy,
+    gate_verdict,
+    payload_per_call,
+    tokens_per_correct_answer,
+    tradeoff_row,
+)
+
+
+# ── the gate ────────────────────────────────────────────────────────
+
+
+def test_the_default_floor_is_ninety_five_percent():
+    assert DEFAULT_ACCURACY_FLOOR == 0.95
+    assert TRADEOFF_FLOORS == (0.90, 0.80)
+
+
+@pytest.mark.parametrize(
+    "pass_rate,floor,expected",
+    [
+        (0.96, 0.95, "PASS"),
+        (0.95, 0.95, "PASS"),   # the floor is acceptable, not a strict minimum
+        (0.9499, 0.95, "FAIL"),
+        (0.94, 0.90, "PASS"),
+        (0.79, 0.80, "FAIL"),
+        (0.0, 0.95, "FAIL"),
+        (1.0, 0.95, "PASS"),
+    ],
+)
+def test_gate_verdict(pass_rate, floor, expected):
+    assert gate_verdict(pass_rate, floor) == expected
+
+
+# ── tokens per correct answer ───────────────────────────────────────
+
+
+def test_tokens_per_correct_answer_divides_by_passes_not_questions():
+    # 40 questions, 400_000 tokens, 20 of them right: the mean per question
+    # (10_000) flatters an arm that answers cheaply and wrongly.
+    assert tokens_per_correct_answer(400_000, 20) == 20_000
+
+
+def test_an_arm_with_no_correct_answer_has_no_finite_cost():
+    assert math.isinf(tokens_per_correct_answer(400_000, 0))
+
+
+# ── payload per call ────────────────────────────────────────────────
+
+
+def test_payload_per_call_reports_calls_and_both_denominators():
+    stats = payload_per_call([1000, 2000, 3000, 6000], questions=2)
+
+    assert stats["calls"] == 4
+    assert stats["total_chars"] == 12_000
+    assert stats["chars_per_call"] == 3000
+    assert stats["chars_per_question"] == 6000
+
+
+def test_payload_per_call_survives_an_arm_that_made_no_call():
+    stats = payload_per_call([], questions=0)
+
+    assert stats["calls"] == 0
+    assert stats["chars_per_call"] == 0.0
+    assert stats["chars_per_question"] == 0.0
+
+
+# ── the tradeoff ────────────────────────────────────────────────────
+
+
+def test_expected_redirect_cost_is_one_minus_p_times_d():
+    row = tradeoff_row(
+        pass_rate=0.90,
+        floor=0.95,
+        redirect_cost=8000,
+        saving_per_call=0,
+        calls_per_question=0,
+    )
+
+    assert row["expected_redirect_tokens"] == pytest.approx(800.0)
+    assert row["verdict"] == "FAIL"
+
+
+def test_the_saving_is_scaled_by_the_calls_a_question_actually_makes():
+    row = tradeoff_row(
+        pass_rate=0.96,
+        floor=0.95,
+        redirect_cost=0,
+        saving_per_call=250,
+        calls_per_question=3.2,
+    )
+
+    assert row["saving_tokens"] == pytest.approx(800.0)
+    assert row["verdict"] == "PASS"
+
+
+def test_net_is_the_saving_less_the_expected_redirect():
+    row = tradeoff_row(
+        pass_rate=0.90,
+        floor=0.90,
+        redirect_cost=8000,
+        saving_per_call=250,
+        calls_per_question=4,
+    )
+
+    # saving 1000/question, expected redirect 800/question
+    assert row["saving_tokens"] == pytest.approx(1000.0)
+    assert row["expected_redirect_tokens"] == pytest.approx(800.0)
+    assert row["net_tokens"] == pytest.approx(200.0)
+
+
+def test_a_change_that_saves_less_than_it_costs_shows_a_negative_net():
+    row = tradeoff_row(
+        pass_rate=0.80,
+        floor=0.95,
+        redirect_cost=8000,
+        saving_per_call=100,
+        calls_per_question=3,
+    )
+
+    assert row["expected_redirect_tokens"] == pytest.approx(1600.0)
+    assert row["saving_tokens"] == pytest.approx(300.0)
+    assert row["net_tokens"] == pytest.approx(-1300.0)
+    assert row["verdict"] == "FAIL"
+
+
+def test_the_same_measurement_reads_differently_at_each_floor():
+    verdicts = {
+        floor: tradeoff_row(
+            pass_rate=0.88,
+            floor=floor,
+            redirect_cost=8000,
+            saving_per_call=250,
+            calls_per_question=3.2,
+        )["verdict"]
+        for floor in (0.95, 0.90, 0.80)
+    }
+
+    assert verdicts == {0.95: "FAIL", 0.90: "FAIL", 0.80: "PASS"}
+
+
+# ── break-even ──────────────────────────────────────────────────────
+
+
+def test_break_even_is_the_accuracy_at_which_the_saving_pays_for_itself():
+    # saving 800/question against D = 8000 → p* = 1 - 0.1 = 0.90
+    assert break_even_accuracy(redirect_cost=8000, saving=800) == pytest.approx(0.90)
+
+
+def test_at_break_even_the_net_is_zero():
+    p_star = break_even_accuracy(redirect_cost=8000, saving=800)
+    row = tradeoff_row(
+        pass_rate=p_star,
+        floor=0.95,
+        redirect_cost=8000,
+        saving_per_call=800,
+        calls_per_question=1,
+    )
+
+    assert row["net_tokens"] == pytest.approx(0.0)
+
+
+def test_without_a_redirect_cost_there_is_nothing_to_trade_against():
+    assert break_even_accuracy(redirect_cost=0, saving=800) is None
+    row = tradeoff_row(
+        pass_rate=0.9,
+        floor=0.95,
+        redirect_cost=0,
+        saving_per_call=800,
+        calls_per_question=1,
+    )
+    assert row["break_even_accuracy"] is None
+    assert row["expected_redirect_tokens"] == 0.0


### PR DESCRIPTION
## Summary

`eval/agentic-bench` gains the accuracy gate and the cost readout that project-akb DEC-029 defines for agent-facing payload changes, plus the seed of the project-akb question set.

- `--accuracy-floor` (default 0.95): every arm is judged PASS/FAIL against the configured floor and also reported at 0.90 and 0.80; `--fail-on-gate` (default off) makes `--aggregate` exit non-zero when an arm misses the floor.
- Cost readout, only when both `--redirect-cost D` and `--saving-per-call` are given (neither has a default; one without the other is an error): expected re-derivation cost `(1 − p) × D`, saving per call × mean tool calls, and the break-even accuracy `p* = 1 − saving/D`.
- New aggregate metrics: tokens per correct answer (PASS only) and payload per call (`None` when a run recorded neither `result_chars` nor `result_text`, instead of a silent 0).
- `EVALSET_DIR` / `RUNS_DIR` are resolved in one helper (`src/paths.py`) and honoured by runner, prep and judge alike; per-caller default run dirs are unchanged.
- Seed question set `evalset-project-akb/` (3 questions: the Product-API seam, ADR-016 write-lane admission, the akb-oss backend Agent contract) in the README schema; `must_mention` kept to short key terms present in the source documents.

## Tests

`pytest eval/agentic-bench/tests` rc=0 — 38 passed (gate arithmetic incl. `p == floor` and zero passes, CLI argument handling for omitted/half-specified costs, `EVALSET_DIR` seen identically by the three modules, aggregate compatibility with pre-existing summary fields, evalset schema).

Reviewed in the main loop plus a codex `gpt-5.6-luna` review axis; the review fixes are the later commit on this branch. Pre-existing ruff findings in `eval/` (outside `scripts/check.sh`) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8P1poam9hTGNB57KJixYk
