### PR TITLE
feat: add canonical Markdown resource adapters

### DIFF
--- a/backend/app/api/routes/assets.py
+++ b/backend/app/api/routes/assets.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timedelta, timezone
 import logging
 import uuid
 
@@ -81,6 +82,106 @@ async def upload_document_image(
     finally:
         if body_slot_acquired:
             _asset_body_slots.release()
+
+
+@router.get("/assets/{vault}/policy", summary="Get document attachment retention policy")
+async def document_attachment_policy(
+    vault: str,
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    """Expose the active server retention boundary to draft adapters.
+
+    The values are policy metadata, not an authorization capability. Upload
+    responses also carry the individual unclaimed expiry so a recovered draft
+    can use the earliest real resource expiry rather than a client constant.
+    """
+    await check_vault_access(user.user_id, vault, required_role="reader")
+    now = datetime.now(timezone.utc).isoformat()
+    return {
+        "kind": "attachment_policy",
+        "vault": vault,
+        "server_time": now,
+        "unclaimed_ttl_hours": settings.document_asset_unclaimed_ttl_hours,
+        "revision_retention_days": settings.document_asset_revision_retention_days,
+    }
+
+
+@router.post(
+    "/assets/{vault}/from-file/{file_id}",
+    status_code=201,
+    summary="Copy a standalone image File into a document attachment",
+)
+async def copy_file_attachment(
+    request: Request,
+    vault: str,
+    file_id: str,
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    access, actor_id, _delegated_actor = await resolve_file_write_context(
+        request, vault, user,
+    )
+    return await asset_service.copy_file_to_attachment(
+        vault_id=access["vault_id"],
+        vault_name=vault,
+        file_id=file_id,
+        actor_id=actor_id,
+    )
+
+
+@router.get(
+    "/assets/{vault}/{file_id}/metadata",
+    summary="Read authorized document attachment metadata",
+)
+async def document_attachment_metadata(
+    request: Request,
+    vault: str,
+    file_id: str,
+    document: str | None = Query(None, min_length=1, max_length=1024),
+    commit: str | None = Query(None, min_length=7, max_length=64, pattern=r"^[0-9a-fA-F]+$"),
+    user: AuthenticatedUser = Depends(get_current_user),
+):
+    """Return lifecycle metadata without probing an unscoped asset id.
+
+    The query uses the same reachability predicate as byte delivery. Missing,
+    cross-vault, and unauthorized ids share one 404 so the adapter cannot use
+    metadata as an existence oracle.
+    """
+    try:
+        access = await check_vault_access(user.user_id, vault, required_role="reader")
+        actor_id = user.username
+    except (ForbiddenError, NotFoundError) as exc:
+        raise NotFoundError("Asset", file_id) from exc
+    try:
+        fid = uuid.UUID(file_id)
+    except (ValueError, AttributeError) as exc:
+        raise NotFoundError("Asset", file_id) from exc
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        row = await vault_files_repo.find_authorized_attachment(
+            conn,
+            vault_id=access["vault_id"],
+            file_id=fid,
+            created_by=actor_id,
+            document_path=document,
+            commit_prefix=commit,
+        )
+    if row is None:
+        raise NotFoundError("Asset", file_id)
+
+    target = f"{asset_service.ASSET_URL_PREFIX}{fid}"
+    expiry = None
+    if row.get("attachment_claimed_at") is None and row.get("created_at") is not None:
+        expiry = (
+            row["created_at"]
+            + timedelta(hours=settings.document_asset_unclaimed_ttl_hours)
+        ).isoformat()
+    return {
+        "kind": "attachment",
+        "target": target,
+        "status": "claimed" if row.get("attachment_claimed_at") is not None else "unclaimed",
+        "unclaimed_expires_at": expiry,
+    }
 
 
 async def load_asset_row(file_id: str, vault_id: uuid.UUID) -> dict:

--- a/backend/app/repositories/vault_files_repo.py
+++ b/backend/app/repositories/vault_files_repo.py
@@ -13,8 +13,9 @@ from __future__ import annotations
 
 import re
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 
+from app.config import settings
 
 # The measurement File reads resolve the placement of the body a confirmed
 # native-text row is pinned to. The join is on the row's own Head identity
@@ -142,7 +143,7 @@ def confirmed_attachment_predicate(alias: str = "vf") -> str:
 _ATTACHMENT_SELECT = """
         SELECT vf.id, vf.vault_id, v.name AS vault_name, vf.kind, vf.name,
                vf.s3_key, vf.mime_type, vf.size_bytes, vf.content_hash,
-               vf.hash_verified_at
+               vf.hash_verified_at, vf.created_at, vf.attachment_claimed_at
           FROM vault_files vf
           JOIN vaults v ON v.id = vf.vault_id
 """
@@ -220,7 +221,7 @@ async def insert_pending_attachment(
     size_bytes: int,
     content_hash: str,
     created_by: str,
-) -> None:
+) -> datetime | None:
     """Record a validated editor image before its object-store PUT.
 
     The row remains unreadable while ``hash_verified_at`` is NULL. Persisting
@@ -229,7 +230,7 @@ async def insert_pending_attachment(
     collection: document images are authorized through explicit live/revision
     reference tables.
     """
-    await conn.execute(
+    row = await conn.fetchrow(
         """
         INSERT INTO vault_files (
             id, vault_id, collection_id, kind, upload_state, name, s3_key, mime_type,
@@ -238,10 +239,12 @@ async def insert_pending_attachment(
         )
         VALUES ($1, $2, NULL, 'attachment', 'pending', $3, $4, $5, $6, $7,
                 'sha256', 'Document image', $8)
+        RETURNING created_at
         """,
         file_id, vault_id, name, s3_key, mime_type, size_bytes,
         content_hash, created_by,
     )
+    return row["created_at"] if row else None
 
 
 async def finalize_attachment(
@@ -471,7 +474,9 @@ async def find_authorized_attachment(
            AND vf.vault_id = $2
            AND {confirmed_attachment_predicate("vf")}
            AND (
-                (vf.attachment_claimed_at IS NULL AND vf.created_by = $3)
+                (vf.attachment_claimed_at IS NULL
+                 AND vf.created_by = $3
+                 AND vf.created_at > NOW() - $6::interval)
                 OR EXISTS (
                     SELECT 1
                       FROM document_asset_refs live
@@ -494,6 +499,7 @@ async def find_authorized_attachment(
            )
         """,
         file_id, vault_id, created_by, document_path, commit_prefix,
+        timedelta(hours=settings.document_asset_unclaimed_ttl_hours),
     )
     return dict(row) if row else None
 

--- a/backend/app/services/asset_service.py
+++ b/backend/app/services/asset_service.py
@@ -17,12 +17,13 @@ from PIL import Image, ImageSequence, UnidentifiedImageError
 
 from app.config import settings
 from app.db.postgres import get_pool
-from app.exceptions import AKBError, ValidationError
+from app.exceptions import AKBError, NotFoundError, ValidationError
 from app.repositories import vault_files_repo
 from app.repositories.vault_repo import lock_vault_for_child_write
 from app.services.adapters import s3_adapter
 from app.services.m1_file_measurement import measurement_enabled
 from app.services.s3_delete_worker import enqueue_delete
+from app.services.uri_service import file_uri
 
 
 ASSET_URL_PREFIX = "/api/assets/"
@@ -341,6 +342,7 @@ async def create_image_asset(
 
     await asyncio.to_thread(s3_adapter.ensure_bucket, settings.s3_bucket)
     pool = await get_pool()
+    pending_created_at: datetime | None = None
     async with pool.acquire() as conn:
         async with conn.transaction():
             # Revalidate the vault under the same lock used by the transfer
@@ -352,7 +354,7 @@ async def create_image_asset(
                     "Vault was deleted while the image upload was queued",
                     status_code=409,
                 )
-            await vault_files_repo.insert_pending_attachment(
+            pending_created_at = await vault_files_repo.insert_pending_attachment(
                 conn,
                 file_id=file_id,
                 vault_id=vault_id,
@@ -424,12 +426,82 @@ async def create_image_asset(
             )
         raise
 
+    target = f"{ASSET_URL_PREFIX}{file_id}"
+    expires_from = pending_created_at or datetime.now(timezone.utc)
+    unclaimed_expires_at = expires_from + timedelta(
+        hours=settings.document_asset_unclaimed_ttl_hours,
+    )
     return {
+        "kind": "attachment",
         "id": str(file_id),
-        "url": f"{ASSET_URL_PREFIX}{file_id}",
+        # `target` is the only durable Markdown value. `url` remains the
+        # transport field used by the existing editor upload surface and is
+        # intentionally the same stable, non-runtime target.
+        "target": target,
+        "url": target,
         "name": safe_name,
         "mime_type": actual_mime,
         "size_bytes": len(body),
         "width": width,
         "height": height,
+        "unclaimed_expires_at": unclaimed_expires_at.isoformat(),
     }
+
+
+async def copy_file_to_attachment(
+    *,
+    vault_id: uuid.UUID,
+    vault_name: str,
+    file_id: str,
+    actor_id: str,
+) -> dict:
+    """Copy one confirmed standalone File into a new immutable Attachment.
+
+    The source row is read through the standalone-file predicate and its bytes
+    are copied into a fresh attachment id/key. The original file is never
+    mutated or used as the attachment's object key, so later File replacement
+    or deletion cannot change an already-authored image.
+    """
+    try:
+        source_id = uuid.UUID(file_id)
+    except (ValueError, AttributeError) as exc:
+        raise NotFoundError("File", file_id) from exc
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        row = await vault_files_repo.find_by_id(conn, vault_id, source_id)
+    if (
+        row is None
+        or row.get("kind") != "file"
+        or row.get("upload_state") != "confirmed"
+    ):
+        raise NotFoundError("File", file_id)
+
+    try:
+        metadata = await asyncio.to_thread(s3_adapter.head, row["s3_key"])
+        size = metadata.get("ContentLength")
+        if not isinstance(size, int) or size < 1 or size > IMAGE_ASSET_MAX_BYTES:
+            raise AKBError("Image exceeds the 10 MB limit", status_code=413)
+        body = await asyncio.to_thread(s3_adapter.get_bytes, row["s3_key"])
+    except AKBError:
+        raise
+    except Exception as exc:  # noqa: BLE001 — storage adapters expose varied errors
+        raise AKBError("File content is temporarily unavailable", status_code=502) from exc
+
+    if len(body) != size:
+        raise AKBError("File content is temporarily unavailable", status_code=502)
+    actual_mime, _width, _height = await asyncio.to_thread(inspect_image, body)
+    attachment = await create_image_asset(
+        vault_id=vault_id,
+        vault_name=vault_name,
+        filename=row["name"],
+        declared_mime=actual_mime,
+        body=body,
+        actor_id=actor_id,
+    )
+    attachment["source_file_uri"] = file_uri(
+        vault_name,
+        str(source_id),
+        collection=row.get("collection"),
+    )
+    return attachment

--- a/backend/app/services/kg_service.py
+++ b/backend/app/services/kg_service.py
@@ -20,6 +20,8 @@ import uuid
 from itertools import zip_longest
 from typing import Literal, get_args
 
+from markdown_it import MarkdownIt
+
 from app.exceptions import ValidationError
 from app.db.postgres import get_pool
 from app.repositories.vault_files_repo import confirmed_file_predicate
@@ -91,10 +93,11 @@ def validate_new_structured_relation_refs(
                 "use an ordinary Markdown link for a cross-vault reference."
             )
 
-# Matches markdown links and image destinations. Relative images can represent
+# CommonMark parser handles escaped labels, reference-style links, angle-bracket
+# destinations, and optional link titles. Relative images can represent
 # document-to-document references in imported Markdown; generated editor asset
 # URLs are filtered below because their lifecycle is not a graph edge.
-_MD_LINK_RE = re.compile(r"!?\[([^\]]+)\]\(([^)]+)\)")
+_MARKDOWN_PARSER = MarkdownIt("commonmark")
 # Matches Obsidian-style wikilinks: [[target]] or [[target|alias]]. Only the
 # target (before the first '|') is the link; the rest is display text. The
 # inner run cannot contain '[' or ']'.
@@ -177,9 +180,20 @@ def extract_markdown_links(content: str) -> list[str]:
             targets.append(target)
             seen.add(target)
 
-    # [text](target)
-    for match in _MD_LINK_RE.finditer(content):
-        _add(match.group(2))
+    # Standard inline/reference links and images. Use the parser rather than a
+    # parenthesis regex so a canonical target remains intact when the author
+    # adds a Markdown title or uses an angle-bracket destination.
+    pending = list(reversed(_MARKDOWN_PARSER.parse(content)))
+    while pending:
+        token = pending.pop()
+        if token.children:
+            pending.extend(reversed(token.children))
+        if token.type == "link_open":
+            href = token.attrGet("href")
+            _add(href if isinstance(href, str) else "")
+        elif token.type == "image":
+            source = token.attrGet("src")
+            _add(source if isinstance(source, str) else "")
 
     # [[target]] / [[target|alias]] — the alias after '|' is display text,
     # not part of the link, so keep only the target. Without this the

--- a/backend/tests/test_asset_routes_unit.py
+++ b/backend/tests/test_asset_routes_unit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from datetime import datetime, timezone
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -62,3 +63,106 @@ def test_editor_image_upload_preserves_raw_bytes_and_mime(monkeypatch) -> None:
         "actor_id": "asset-uploader",
     }
     assert response.json()["size_bytes"] == len(image)
+
+
+def test_file_copy_route_uses_writer_scope_and_returns_attachment(monkeypatch) -> None:
+    vault_id = uuid.uuid4()
+    captured: dict[str, object] = {}
+
+    async def _write_context(_request, vault, user):
+        assert vault == "team"
+        assert user.username == "asset-uploader"
+        return {"vault_id": vault_id, "role": "writer"}, user.username, None
+
+    async def _copy(**kwargs):
+        captured.update(kwargs)
+        return {
+            "kind": "attachment",
+            "id": "attachment-id",
+            "target": "/api/assets/attachment-id",
+            "url": "/api/assets/attachment-id",
+        }
+
+    monkeypatch.setattr(assets, "resolve_file_write_context", _write_context)
+    monkeypatch.setattr(assets.asset_service, "copy_file_to_attachment", _copy)
+
+    response = _client().post(
+        "/api/v1/assets/team/from-file/11111111-1111-4111-8111-111111111111",
+    )
+
+    assert response.status_code == 201
+    assert captured == {
+        "vault_id": vault_id,
+        "vault_name": "team",
+        "file_id": "11111111-1111-4111-8111-111111111111",
+        "actor_id": "asset-uploader",
+    }
+
+
+def test_attachment_policy_is_reader_scoped(monkeypatch) -> None:
+    vault_id = uuid.uuid4()
+    captured: dict[str, object] = {}
+
+    async def _access(user_id, vault, required_role):
+        captured.update(user_id=user_id, vault=vault, required_role=required_role)
+        return {"vault_id": vault_id, "role": "reader"}
+
+    monkeypatch.setattr(assets, "check_vault_access", _access)
+    response = _client().get("/api/v1/assets/team/policy")
+
+    assert response.status_code == 200
+    assert response.json()["kind"] == "attachment_policy"
+    assert response.json()["vault"] == "team"
+    assert response.json()["unclaimed_ttl_hours"] >= 1
+    assert captured == {
+        "user_id": "u-asset-upload",
+        "vault": "team",
+        "required_role": "reader",
+    }
+
+
+def test_attachment_metadata_uses_authorized_reachability_and_computes_expiry(monkeypatch) -> None:
+    file_id = uuid.UUID("11111111-2222-4333-8444-555555555555")
+    created_at = datetime(2026, 9, 9, tzinfo=timezone.utc)
+
+    class _Acquire:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, *_args):
+            return None
+
+    class _Pool:
+        def acquire(self):
+            return _Acquire()
+
+    async def _pool():
+        return _Pool()
+
+    async def _find(_conn, **kwargs):
+        assert kwargs["file_id"] == file_id
+        assert kwargs["vault_id"] == vault_id
+        return {
+            "id": file_id,
+            "created_at": created_at,
+            "attachment_claimed_at": None,
+        }
+
+    async def _access(_user_id, _vault, required_role):
+        assert required_role == "reader"
+        return {"vault_id": vault_id}
+
+    vault_id = uuid.uuid4()
+    monkeypatch.setattr(assets, "get_pool", _pool)
+    monkeypatch.setattr(assets, "check_vault_access", _access)
+    monkeypatch.setattr(assets.vault_files_repo, "find_authorized_attachment", _find)
+
+    response = _client().get(f"/api/v1/assets/team/{file_id}/metadata")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "kind": "attachment",
+        "target": f"/api/assets/{file_id}",
+        "status": "unclaimed",
+        "unclaimed_expires_at": "2026-09-10T00:00:00+00:00",
+    }

--- a/backend/tests/test_asset_service.py
+++ b/backend/tests/test_asset_service.py
@@ -6,7 +6,7 @@ import hashlib
 import hmac
 import threading
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -127,6 +127,76 @@ def test_asset_urls_accept_case_variants_and_normalize_to_one_uuid() -> None:
 
 
 @pytest.mark.asyncio
+async def test_copy_file_to_attachment_reads_confirmed_file_bytes_into_new_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.services import asset_service
+
+    vault_id = uuid.uuid4()
+    file_id = uuid.uuid4()
+    body = b"immutable-image-bytes"
+    source = {
+        "id": file_id,
+        "vault_id": vault_id,
+        "kind": "file",
+        "upload_state": "confirmed",
+        "name": "source.png",
+        "collection": "notes",
+        "s3_key": "team/notes/source.png",
+        "mime_type": "image/png",
+    }
+
+    class _Pool:
+        def acquire(self):
+            class _Acquire:
+                async def __aenter__(self):
+                    return object()
+
+                async def __aexit__(self, *_args):
+                    return None
+
+            return _Acquire()
+
+    async def _pool():
+        return _Pool()
+
+    async def _find(_conn, _vault_id, _file_id):
+        return source
+
+    async def _create(**kwargs):
+        assert kwargs["body"] == body
+        assert kwargs["declared_mime"] == "image/png"
+        return {
+            "kind": "attachment",
+            "id": str(uuid.uuid4()),
+            "target": "/api/assets/attachment-id",
+            "url": "/api/assets/attachment-id",
+        }
+
+    monkeypatch.setattr(asset_service, "get_pool", _pool)
+    monkeypatch.setattr(asset_service.vault_files_repo, "find_by_id", _find)
+    monkeypatch.setattr(
+        asset_service.s3_adapter,
+        "head",
+        lambda _key: {"ContentLength": len(body)},
+    )
+    monkeypatch.setattr(asset_service.s3_adapter, "get_bytes", lambda _key: body)
+    monkeypatch.setattr(asset_service, "inspect_image", lambda _body: ("image/png", 1, 1))
+    monkeypatch.setattr(asset_service, "create_image_asset", _create)
+
+    result = await asset_service.copy_file_to_attachment(
+        vault_id=vault_id,
+        vault_name="team",
+        file_id=str(file_id),
+        actor_id="alice",
+    )
+
+    assert result["kind"] == "attachment"
+    assert result["target"] == "/api/assets/attachment-id"
+    assert result["source_file_uri"] == f"akb://team/coll/notes/file/{file_id}"
+
+
+@pytest.mark.asyncio
 async def test_create_asset_decodes_off_loop_and_records_pending_before_s3(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -218,7 +288,10 @@ async def test_create_asset_decodes_off_loop_and_records_pending_before_s3(
         < names.index("finalize")
     )
     assert tx_exit_indexes[0] < names.index("put") < tx_enter_indexes[1]
-    assert result["url"] == f"/api/assets/{result['id']}"
+    assert result["kind"] == "attachment"
+    assert result["target"] == f"/api/assets/{result['id']}"
+    assert result["url"] == result["target"]
+    assert result["unclaimed_expires_at"]
 
 
 @pytest.mark.asyncio
@@ -1278,6 +1351,7 @@ async def test_private_asset_lookup_carries_live_owner_and_revision_scope() -> N
     assert "rev.retain_until > NOW()" in captured["sql"]
     assert captured["args"] == (
         file_id, vault_id, "alice", "notes/weekly.md", "abcdef1",
+        timedelta(hours=vault_files_repo.settings.document_asset_unclaimed_ttl_hours),
     )
 
 

--- a/backend/tests/test_kg_extract_links_unit.py
+++ b/backend/tests/test_kg_extract_links_unit.py
@@ -50,6 +50,17 @@ def test_real_prose_links_are_still_extracted():
     assert "akb://v/coll/notes/doc/intro.md" in out
 
 
+def test_canonical_resource_links_with_titles_are_extracted_without_title_text():
+    out = extract_markdown_links(
+        '[guide](akb://v/coll/notes/doc/guide.md "Guide") and '
+        '[image file](akb://v/file/6d04dc8a-0302-4a85-a314-e7485ff5a610 "PNG")'
+    )
+    assert out == [
+        "akb://v/coll/notes/doc/guide.md",
+        "akb://v/file/6d04dc8a-0302-4a85-a314-e7485ff5a610",
+    ]
+
+
 def test_generated_image_asset_is_not_a_document_relation():
     content = (
         "![diagram](/api/assets/6d04dc8a-0302-4a85-a314-e7485ff5a610)\n\n"

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -99,7 +99,7 @@ Playwright e2e specs live in `e2e/`. Choose `mock` or `real` explicitly:
 - `AKB_FRONTEND_URL=<services.web.origin> pnpm run test:e2e:real` consumes the
   common schema-v2 descriptor. The backend, fixture reset, and process shutdown
   remain owned by the repository runtime.
-- `CRABBOX_RUNTIME_SCENARIO=markdown-reference-adapters` exposes a source-neutral reference
+- `AKB_FE_E2E_SCENARIO=markdown-reference-adapters` exposes a source-neutral reference
   fixture in the schema-v2 descriptor. Its discovered state/expiry/failure controls exercise
   canonical document/file/attachment targets, unavailable resolution, and partial upload
   recovery through the same mock reset path.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -46,6 +46,12 @@ on both the editor and the rendered view — `javascript:`, `data:`,
 `vbscript:`, and protocol-relative `//host` schemes round-trip to
 `#` so a malicious doc can't embed a clickable XSS.
 
+AKB resource links use their canonical `akb://…/doc|file` target in Markdown. The editor and
+viewer resolve those targets only for the current session, showing an unavailable placeholder
+when access or the resource is gone. Signed download URLs and private image blob URLs never
+enter the document body. Editor image uploads return the server's unclaimed expiry metadata so
+recoverable drafts do not promise a longer attachment lifetime than the configured TTL.
+
 ## Architecture quick map
 
 ```
@@ -93,6 +99,10 @@ Playwright e2e specs live in `e2e/`. Choose `mock` or `real` explicitly:
 - `AKB_FRONTEND_URL=<services.web.origin> pnpm run test:e2e:real` consumes the
   common schema-v2 descriptor. The backend, fixture reset, and process shutdown
   remain owned by the repository runtime.
+- `CRABBOX_RUNTIME_SCENARIO=markdown-reference-adapters` exposes a source-neutral reference
+  fixture in the schema-v2 descriptor. Its discovered state/expiry/failure controls exercise
+  canonical document/file/attachment targets, unavailable resolution, and partial upload
+  recovery through the same mock reset path.
 
 For a manual mock session, run `VITE_AKB_TEST_MODE=mock pnpm run dev --host
 127.0.0.1 --port 4173 --strictPort`. The browser worker exposes readiness and

--- a/frontend/e2e/document-edit-recovery.spec.ts
+++ b/frontend/e2e/document-edit-recovery.spec.ts
@@ -18,8 +18,8 @@ type MockDescriptor = {
 
 test.describe("document edit recovery mock contract", () => {
   test.skip(
-    process.env.CRABBOX_RUNTIME_SCENARIO !== "document-edit-recovery",
-    "The recovery fixture is selected by CRABBOX_RUNTIME_SCENARIO",
+    process.env.AKB_FE_E2E_SCENARIO !== "document-edit-recovery",
+    "The recovery fixture is selected by AKB_FE_E2E_SCENARIO",
   );
   test.describe.configure({ mode: "serial" });
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -12,7 +12,8 @@ if (!mockMode && !process.env.AKB_FRONTEND_URL) {
 const baseURL = mockMode
   ? "http://127.0.0.1:4173"
   : process.env.AKB_FRONTEND_URL!;
-const recoveryScenario = process.env.CRABBOX_RUNTIME_SCENARIO === "document-edit-recovery";
+const selectedScenario = process.env.AKB_FE_E2E_SCENARIO || "empty";
+const recoveryScenario = selectedScenario === "document-edit-recovery";
 
 // Mock mode owns its Vite webServer and browser MSW worker. Real mode consumes
 // the already-ready frontend origin from the repository runtime descriptor.

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -12,8 +12,7 @@ if (!mockMode && !process.env.AKB_FRONTEND_URL) {
 const baseURL = mockMode
   ? "http://127.0.0.1:4173"
   : process.env.AKB_FRONTEND_URL!;
-const selectedScenario = process.env.AKB_FE_E2E_SCENARIO || "empty";
-const recoveryScenario = selectedScenario === "document-edit-recovery";
+const recoveryScenario = process.env.AKB_FE_E2E_SCENARIO === "document-edit-recovery";
 
 // Mock mode owns its Vite webServer and browser MSW worker. Real mode consumes
 // the already-ready frontend origin from the repository runtime descriptor.

--- a/frontend/src/components/__tests__/markdown-editor-image.test.tsx
+++ b/frontend/src/components/__tests__/markdown-editor-image.test.tsx
@@ -97,7 +97,14 @@ describe("MarkdownEditor image insertion", () => {
     expect(validateEditorImage(new File(["png"], "ok.png", { type: "image/png" }))).toBeNull();
   });
 
-  it("rejects the whole invalid batch without offering an impossible partial retry", async () => {
+  it("keeps valid images and reports invalid files in a partial batch", async () => {
+    apiMocks.uploadAsset.mockResolvedValue({
+      id: ASSET_ID,
+      url: `/api/assets/${ASSET_ID}`,
+      name: "first.png",
+      mime_type: "image/png",
+      size_bytes: 5,
+    });
     const { container } = render(
       <MarkdownEditor value="Draft" vault="team" onChange={vi.fn()} />,
     );
@@ -109,11 +116,12 @@ describe("MarkdownEditor image insertion", () => {
     });
 
     expect(await screen.findByText(/Choose a PNG/)).toBeVisible();
-    expect(screen.getByText(/No images were uploaded/)).toBeVisible();
+    expect(await screen.findByRole("img", { name: "first" })).toBeVisible();
     expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    expect(apiMocks.uploadAsset).toHaveBeenCalledTimes(1);
     fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
     expect(screen.queryByText(/Choose a PNG/)).toBeNull();
-    expect(apiMocks.uploadAsset).not.toHaveBeenCalled();
+    expect(apiMocks.uploadAsset).toHaveBeenCalledTimes(1);
   });
 
   it("uploads a picked image and serializes its private asset URL", async () => {
@@ -395,8 +403,8 @@ describe("MarkdownEditor image insertion", () => {
     fireEvent.change(container.querySelector('input[type="file"]')!, {
       target: { files },
     });
-    expect(await screen.findByText(/2 images remain/)).toBeVisible();
-    expect(apiMocks.uploadAsset).toHaveBeenCalledTimes(2);
+    expect(await screen.findByText(/1 image remain/)).toBeVisible();
+    expect(apiMocks.uploadAsset).toHaveBeenCalledTimes(3);
 
     expect(screen.getByText("Image upload failed")).toBeVisible();
     expect(screen.getByRole("button", { name: "Choose another" })).toBeVisible();
@@ -406,8 +414,8 @@ describe("MarkdownEditor image insertion", () => {
     expect(apiMocks.uploadAsset.mock.calls.map((call) => call[1])).toEqual([
       files[0],
       files[1],
-      files[1],
       files[2],
+      files[1],
     ]);
   });
 

--- a/frontend/src/components/__tests__/markdown-editor-targets.test.tsx
+++ b/frontend/src/components/__tests__/markdown-editor-targets.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const apiMocks = vi.hoisted(() => ({
+  getAssetBlob: vi.fn(),
+  getAttachmentMetadata: vi.fn(),
+  getDocument: vi.fn(),
+  getVaultFileDownloadUrl: vi.fn(),
+  refreshPublicationViewGrant: vi.fn(),
+  publicationAssetUrl: vi.fn(),
+  uploadAsset: vi.fn(),
+  discardAsset: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => apiMocks);
+
+import { MarkdownEditor } from "@/components/markdown-editor";
+
+const TARGET = "akb://team/coll/notes/doc/guide.md";
+
+describe("MarkdownEditor resource targets", () => {
+  it("keeps the canonical link in the editor model while applying a runtime route", async () => {
+    apiMocks.getDocument.mockResolvedValue({ path: "notes/guide.md" });
+    render(
+      <MarkdownEditor
+        value={`[Guide](${TARGET})`}
+        vault="team"
+        onChange={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      const link = screen.getByRole("link", { name: "Guide" });
+      expect(link).toHaveAttribute("href", "/vault/team/doc/notes%2Fguide.md");
+      expect(link).toHaveAttribute("data-markdown-target", TARGET);
+      expect(link).toHaveAttribute("data-markdown-resolution", "available");
+    });
+  });
+
+  it("turns inaccessible canonical links into non-navigating placeholders", async () => {
+    apiMocks.getDocument.mockRejectedValue(new Error("forbidden"));
+    render(
+      <MarkdownEditor
+        value={`[Private](${TARGET})`}
+        vault="team"
+        onChange={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      const link = screen.getByRole("link", { name: "Private" });
+      expect(link).toHaveAttribute("href", "#");
+      expect(link).toHaveAttribute("aria-disabled", "true");
+      expect(link).toHaveAttribute("data-markdown-target", TARGET);
+    });
+  });
+});

--- a/frontend/src/components/__tests__/markdown-editor-toolbar.test.tsx
+++ b/frontend/src/components/__tests__/markdown-editor-toolbar.test.tsx
@@ -62,6 +62,9 @@ describe("MarkdownEditor formatting toolbar", () => {
     expect(normalizeEditorLinkUrl("mailto:owner@example.com")).toBe(
       "mailto:owner@example.com",
     );
+    expect(
+      normalizeEditorLinkUrl("akb://team/coll/notes/doc/guide.md/"),
+    ).toBe("akb://team/coll/notes/doc/guide.md");
     expect(normalizeEditorLinkUrl("javascript:alert(1)")).toBeNull();
   });
 

--- a/frontend/src/components/__tests__/markdown-render-targets.test.tsx
+++ b/frontend/src/components/__tests__/markdown-render-targets.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const apiMocks = vi.hoisted(() => ({
   getAssetBlob: vi.fn(),
@@ -16,6 +16,19 @@ import { MarkdownRender } from "@/components/markdown-render";
 
 const DOCUMENT = "akb://team/coll/notes/doc/guide.md";
 const FILE = "akb://team/file/123e4567-e89b-42d3-a456-426614174001";
+const ATTACHMENT = "/api/assets/123e4567-e89b-42d3-a456-426614174000";
+
+beforeEach(() => {
+  Object.values(apiMocks).forEach((mock) => mock.mockReset());
+  Object.defineProperty(URL, "createObjectURL", {
+    configurable: true,
+    value: vi.fn(() => "blob:claimed-attachment"),
+  });
+  Object.defineProperty(URL, "revokeObjectURL", {
+    configurable: true,
+    value: vi.fn(),
+  });
+});
 
 describe("MarkdownRender resource targets", () => {
   it("uses a runtime route for an available document while retaining the canonical target", async () => {
@@ -53,5 +66,20 @@ describe("MarkdownRender resource targets", () => {
       expect(link).toHaveAttribute("title", "Reference unavailable");
       expect(link).toHaveAttribute("data-markdown-target", FILE);
     });
+  });
+
+  it("renders a claimed attachment from the authenticated byte path", async () => {
+    apiMocks.getAssetBlob.mockResolvedValue(new Blob(["valid fixture bytes"], { type: "image/png" }));
+
+    render(
+      <MarkdownRender
+        markdown={`![Fixture attachment](${ATTACHMENT})`}
+        assetContext={{ mode: "authenticated", vault: "team" }}
+      />,
+    );
+
+    const image = await screen.findByRole("img", { name: "Fixture attachment" });
+    expect(image).toHaveAttribute("src", "blob:claimed-attachment");
+    expect(image).toHaveAttribute("data-markdown-target", ATTACHMENT);
   });
 });

--- a/frontend/src/components/__tests__/markdown-render-targets.test.tsx
+++ b/frontend/src/components/__tests__/markdown-render-targets.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const apiMocks = vi.hoisted(() => ({
+  getAssetBlob: vi.fn(),
+  getAttachmentMetadata: vi.fn(),
+  getDocument: vi.fn(),
+  getVaultFileDownloadUrl: vi.fn(),
+  refreshPublicationViewGrant: vi.fn(),
+  publicationAssetUrl: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => apiMocks);
+
+import { MarkdownRender } from "@/components/markdown-render";
+
+const DOCUMENT = "akb://team/coll/notes/doc/guide.md";
+const FILE = "akb://team/file/123e4567-e89b-42d3-a456-426614174001";
+
+describe("MarkdownRender resource targets", () => {
+  it("uses a runtime route for an available document while retaining the canonical target", async () => {
+    apiMocks.getDocument.mockResolvedValue({ path: "notes/guide.md" });
+
+    render(
+      <MarkdownRender
+        markdown={`[Guide](${DOCUMENT})`}
+        assetContext={{ mode: "authenticated", vault: "team" }}
+      />,
+    );
+
+    await waitFor(() => {
+      const link = screen.getByRole("link", { name: "Guide" });
+      expect(link).toHaveAttribute("href", "/vault/team/doc/notes%2Fguide.md");
+      expect(link).toHaveAttribute("data-markdown-target", DOCUMENT);
+      expect(link).toHaveAttribute("data-markdown-resolution", "available");
+    });
+  });
+
+  it("renders an unavailable file reference without revealing why it failed", async () => {
+    apiMocks.getVaultFileDownloadUrl.mockRejectedValue(new Error("not found"));
+
+    render(
+      <MarkdownRender
+        markdown={`[Download](${FILE})`}
+        assetContext={{ mode: "authenticated", vault: "team" }}
+      />,
+    );
+
+    await waitFor(() => {
+      const link = screen.getByRole("link", { name: "Download" });
+      expect(link).toHaveAttribute("href", "#");
+      expect(link).toHaveAttribute("aria-disabled", "true");
+      expect(link).toHaveAttribute("title", "Reference unavailable");
+      expect(link).toHaveAttribute("data-markdown-target", FILE);
+    });
+  });
+});

--- a/frontend/src/components/asset-image.tsx
+++ b/frontend/src/components/asset-image.tsx
@@ -36,6 +36,11 @@ function safeExternalImageUrl(src: string): string | null {
 export interface AssetImageProps
   extends Omit<ImgHTMLAttributes<HTMLImageElement>, "src"> {
   src?: string | null;
+  canonicalTarget?: string | null;
+  /** Ephemeral runtime URL for a non-attachment target. Never serialized. */
+  runtimeSrc?: string | null;
+  unavailableLabel?: string;
+  unavailable?: boolean;
   assetContext?: AssetContext;
 }
 
@@ -46,6 +51,10 @@ export interface AssetImageProps
  */
 export function AssetImage({
   src,
+  canonicalTarget,
+  runtimeSrc,
+  unavailableLabel = "Image unavailable",
+  unavailable = false,
   alt = "",
   assetContext,
   className,
@@ -130,18 +139,19 @@ export function AssetImage({
       }
       return null;
     }
-    return src ? safeExternalImageUrl(src) : null;
-  }, [assetId, currentLoadState?.blobUrl, privateVault, publicationRetry, publicationSlug, renderKey, src]);
+    return safeExternalImageUrl(runtimeSrc ?? src ?? "");
+  }, [assetId, currentLoadState?.blobUrl, privateVault, publicationRetry, publicationSlug, renderKey, runtimeSrc, src]);
 
   const frameClass = cn(
     "block my-4 rounded-[var(--radius-lg)] border border-border max-w-full h-auto",
     className,
   );
 
-  if (isPrivateAsset && !currentLoadState?.blobUrl && !currentLoadState?.failed) {
+  if (!unavailable && isPrivateAsset && !currentLoadState?.blobUrl && !currentLoadState?.failed) {
     return (
       <span
         role="status"
+        data-markdown-target={canonicalTarget ?? undefined}
         aria-label={alt ? `Loading image: ${alt}` : "Loading image"}
         className={cn(
           frameClass,
@@ -154,10 +164,11 @@ export function AssetImage({
     );
   }
 
-  if (currentLoadState?.failed || imageFailed || !resolvedSrc) {
+  if (unavailable || currentLoadState?.failed || imageFailed || !resolvedSrc) {
     return (
       <span
         role="img"
+        data-markdown-target={canonicalTarget ?? undefined}
         aria-label={alt ? `Image unavailable: ${alt}` : "Image unavailable"}
         className={cn(
           frameClass,
@@ -165,7 +176,7 @@ export function AssetImage({
         )}
       >
         <ImageOff className="h-4 w-4" aria-hidden />
-        Image unavailable
+        {unavailableLabel}
       </span>
     );
   }
@@ -174,6 +185,7 @@ export function AssetImage({
     <img
       {...imgProps}
       src={resolvedSrc}
+      data-markdown-target={canonicalTarget ?? undefined}
       alt={alt}
       loading={imgProps.loading ?? "lazy"}
       decoding={imgProps.decoding ?? "async"}

--- a/frontend/src/components/document-create-dialog.tsx
+++ b/frontend/src/components/document-create-dialog.tsx
@@ -35,6 +35,7 @@ export function DocumentCreateDialog({
   const [uploading, setUploading] = useState(false);
   const [discardOpen, setDiscardOpen] = useState(false);
   const [draftAssetIds, setDraftAssetIds] = useState<readonly string[]>([]);
+  const [unclaimedAssetIds, setUnclaimedAssetIds] = useState<readonly string[]>([]);
 
   useEffect(() => {
     if (open) return;
@@ -43,6 +44,7 @@ export function DocumentCreateDialog({
     setUploading(false);
     setDiscardOpen(false);
     setDraftAssetIds([]);
+    setUnclaimedAssetIds([]);
   }, [open]);
 
   function requestClose() {
@@ -99,6 +101,7 @@ export function DocumentCreateDialog({
               onCreatingChange={setCreating}
               onUploadingChange={setUploading}
               onAssetIdsChange={setDraftAssetIds}
+              onUnclaimedAssetIdsChange={setUnclaimedAssetIds}
             />
           )}
         </DialogContent>
@@ -120,7 +123,7 @@ export function DocumentCreateDialog({
           // local draft can recover. An explicit discard is the authoritative
           // cleanup path; the server TTL remains the fallback for failures.
           await Promise.allSettled(
-            draftAssetIds.map((assetId) => discardAsset(vault, assetId)),
+            [...new Set([...draftAssetIds, ...unclaimedAssetIds])].map((assetId) => discardAsset(vault, assetId)),
           );
           clearDocumentDraft(vault);
           onOpenChange(false);

--- a/frontend/src/components/document-create-form.tsx
+++ b/frontend/src/components/document-create-form.tsx
@@ -59,6 +59,8 @@ export interface DocumentCreateFormProps {
   onCreatingChange?: (creating: boolean) => void;
   onUploadingChange?: (uploading: boolean) => void;
   onAssetIdsChange?: (assetIds: readonly string[]) => void;
+  onAssetExpirationsChange?: (expirations: Readonly<Record<string, string>>) => void;
+  onUnclaimedAssetIdsChange?: (assetIds: readonly string[]) => void;
 }
 
 /** Depth-first collection paths for the location suggestions. */
@@ -98,8 +100,13 @@ export function DocumentCreateForm({
   onCreatingChange,
   onUploadingChange,
   onAssetIdsChange,
+  onAssetExpirationsChange,
+  onUnclaimedAssetIdsChange,
 }: DocumentCreateFormProps) {
   const restoredDraft = useMemo(() => loadDocumentDraft(vault), [vault]);
+  const restoredDraftExpired = Boolean(
+    restoredDraft?.expiresAt && Date.parse(restoredDraft.expiresAt) <= Date.now(),
+  );
   const { tree } = useVaultTree(vault);
   const { refetchTree, refetchVaults } = useVaultRefresh();
   const collectionOptions = useMemo(
@@ -122,6 +129,12 @@ export function DocumentCreateForm({
   const [bodyAssetIds, setBodyAssetIds] = useState<readonly string[]>(
     restoredDraft?.assetIds ?? [],
   );
+  const [bodyAssetExpirations, setBodyAssetExpirations] = useState<Readonly<Record<string, string>>>(
+    restoredDraft?.assetExpiresAt ?? {},
+  );
+  const [unclaimedAssetIds, setUnclaimedAssetIds] = useState<readonly string[]>(
+    restoredDraft?.assetIds ?? [],
+  );
   const [claimedAssetIds, setClaimedAssetIds] = useState<readonly string[] | null>(null);
   const [error, setError] = useState("");
   const [serverConflict, setServerConflict] = useState<DocumentTitleConflict | null>(null);
@@ -129,8 +142,8 @@ export function DocumentCreateForm({
   const [creating, setCreating] = useState(false);
   const [uploadingImage, setUploadingImage] = useState(false);
   const [draftStatus, setDraftStatus] = useState<
-    "idle" | "restored" | "saving" | "saved" | "error"
-  >(restoredDraft ? "restored" : "idle");
+    "idle" | "restored" | "saving" | "saved" | "error" | "expired"
+  >(restoredDraftExpired ? "expired" : restoredDraft ? "restored" : "idle");
   const skipInitialDraftSaveRef = useRef(Boolean(restoredDraft));
   const [detailsOpen, setDetailsOpen] = useState(() =>
     typeof window === "undefined"
@@ -169,12 +182,16 @@ export function DocumentCreateForm({
     summary.trim() !== "" ||
     tags.length > 0 ||
     hasMeaningfulMarkdown(body);
-  const hasUnsavedWork = isDirty || uploadingImage;
+  const hasUnsavedWork = isDirty || uploadingImage || unclaimedAssetIds.length > 0;
 
   useEffect(() => onDirtyChange?.(hasUnsavedWork), [hasUnsavedWork, onDirtyChange]);
   useEffect(() => onCreatingChange?.(creating), [creating, onCreatingChange]);
   useEffect(() => onUploadingChange?.(uploadingImage), [uploadingImage, onUploadingChange]);
   useEffect(() => onAssetIdsChange?.(bodyAssetIds), [bodyAssetIds, onAssetIdsChange]);
+  useEffect(
+    () => onUnclaimedAssetIdsChange?.(unclaimedAssetIds),
+    [onUnclaimedAssetIdsChange, unclaimedAssetIds],
+  );
 
   useEffect(() => {
     if (creating) return;
@@ -199,11 +216,12 @@ export function DocumentCreateForm({
         tags,
         body,
         assetIds: [...bodyAssetIds],
+        assetExpiresAt: bodyAssetExpirations,
       });
       setDraftStatus(saved ? "saved" : "error");
     }, 300);
     return () => window.clearTimeout(timer);
-  }, [body, bodyAssetIds, collection, creating, domain, isDirty, summary, tags, title, type, vault]);
+  }, [body, bodyAssetExpirations, bodyAssetIds, collection, creating, domain, isDirty, summary, tags, title, type, vault]);
 
   useEffect(() => {
     const media = window.matchMedia("(min-width: 1024px)");
@@ -408,6 +426,8 @@ export function DocumentCreateForm({
                 ? "Uploading image…"
                 : draftStatus === "restored"
                   ? "Local draft restored"
+                  : draftStatus === "expired"
+                    ? "Draft expired — review attachments"
                   : draftStatus === "saving"
                     ? "Saving draft…"
                     : draftStatus === "saved"
@@ -559,6 +579,13 @@ export function DocumentCreateForm({
                       setServerConflict(null);
                       if (invalidField === "body") setInvalidField(null);
                     }}
+                    onAssetExpirationsChange={(expirations) => {
+                      setBodyAssetExpirations(expirations);
+                      onAssetExpirationsChange?.(expirations);
+                    }}
+                    onUnclaimedAssetIdsChange={(assetIds) => {
+                      setUnclaimedAssetIds(assetIds);
+                    }}
                     placeholder="Start with the idea, decision, or context worth keeping…"
                     ariaLabelledby="doc-body-label"
                     required
@@ -570,6 +597,7 @@ export function DocumentCreateForm({
                       if (uploading) setClaimedAssetIds(null);
                     }}
                     initialUnclaimedAssetIds={restoredDraft?.assetIds}
+                    initialUnclaimedAssetExpirations={restoredDraft?.assetExpiresAt}
                     preserveUploadsOnUnmount
                     claimedAssetIds={claimedAssetIds}
                   />

--- a/frontend/src/components/markdown-editor.tsx
+++ b/frontend/src/components/markdown-editor.tsx
@@ -96,8 +96,14 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { discardAsset, uploadAsset } from "@/lib/api";
-import { normalizeEditorLinkUrl } from "@/lib/editor-link";
+import { discardAsset } from "@/lib/api";
+import { isAkbResourceTarget, normalizeEditorLinkUrl } from "@/lib/editor-link";
+import {
+  canonicalAkbMarkdownTarget,
+  createAkbMarkdownAdapters,
+  extractAkbMarkdownLinkTargets,
+  type AkbMarkdownTargetResolution,
+} from "@/lib/markdown-adapters";
 import {
   assetIdFromUrl,
   classifyEditorImageUploadFailure,
@@ -161,14 +167,35 @@ function CodeLineElement(props: PlateElementProps) {
 
 function LinkElement(props: PlateElementProps) {
   const url = (props.element as { url?: string }).url;
-  const safe = sanitizeLinkUrl(url);
+  const targetUrl = url ?? "";
+  const canonicalTarget = canonicalAkbMarkdownTarget(targetUrl) ?? targetUrl;
+  const assetLifecycle = React.useContext(EditorAssetLifecycleContext);
+  const resolution = isAkbResourceTarget(canonicalTarget)
+    ? assetLifecycle?.targetResolutions.get(canonicalTarget)
+    : undefined;
+  const safe = isAkbResourceTarget(canonicalTarget)
+    ? resolution?.status === "available" && resolution.runtimeUrl
+      ? resolution.runtimeUrl
+      : "#"
+    : sanitizeLinkUrl(targetUrl);
   return (
     <PlateElement
       {...props}
       as="a"
       // href is read-only in the editor; opening links is handled outside the
       // editing surface (cmd-click). We still set href for serialization round-trip.
-      attributes={{ ...props.attributes, href: safe, rel: "noopener noreferrer" }}
+      attributes={{
+        ...props.attributes,
+        href: safe,
+        rel: "noopener noreferrer",
+        ...(isAkbResourceTarget(canonicalTarget)
+          ? {
+              "data-markdown-target": canonicalTarget,
+              "data-markdown-resolution": resolution?.status ?? "pending",
+              "aria-disabled": resolution?.status === "available" ? undefined : "true",
+            }
+          : {}),
+      }}
       className="text-link underline underline-offset-2 hover:no-underline"
     />
   );
@@ -401,9 +428,11 @@ interface EditorAssetLifecycle {
   readOnly?: boolean;
   focusEditor: () => void;
   requestImageReplacement: (path: number[]) => void;
+  targetResolutions: ReadonlyMap<string, AkbMarkdownTargetResolution>;
 }
 
 const EditorAssetLifecycleContext = React.createContext<EditorAssetLifecycle | null>(null);
+const EMPTY_TARGET_RESOLUTIONS: ReadonlyMap<string, AkbMarkdownTargetResolution> = new Map();
 
 function ImageElement(props: PlateElementProps) {
   const editor = useEditorRef();
@@ -459,6 +488,7 @@ function ImageElement(props: PlateElementProps) {
         <div className="relative mx-auto w-fit max-w-full">
           <AssetImage
             src={element.url}
+            canonicalTarget={element.url}
             alt={alt}
             assetContext={
               assetLifecycle
@@ -1199,6 +1229,12 @@ export interface MarkdownEditorProps {
   claimedAssetIds?: readonly string[] | null;
   /** Temporary image ids recovered with a locally saved new-document draft. */
   initialUnclaimedAssetIds?: readonly string[];
+  /** Server expiry metadata for recovered unclaimed attachments. */
+  initialUnclaimedAssetExpirations?: Readonly<Record<string, string>>;
+  /** Reports server-provided expiry metadata for current unclaimed uploads. */
+  onAssetExpirationsChange?: (expirations: Readonly<Record<string, string>>) => void;
+  /** Reports all unclaimed uploads, including nodes removed before unmount. */
+  onUnclaimedAssetIdsChange?: (assetIds: readonly string[]) => void;
 }
 
 export function MarkdownEditor({
@@ -1219,6 +1255,9 @@ export function MarkdownEditor({
   preserveUploadsOnUnmount = false,
   claimedAssetIds = null,
   initialUnclaimedAssetIds = [],
+  initialUnclaimedAssetExpirations = {},
+  onAssetExpirationsChange,
+  onUnclaimedAssetIdsChange,
 }: MarkdownEditorProps) {
   const [uploadingImage, setUploadingImage] = React.useState(false);
   const [uploadingName, setUploadingName] = React.useState("");
@@ -1236,10 +1275,32 @@ export function MarkdownEditor({
   const uploadInFlightRef = React.useRef(false);
   const deferredImageFilesRef = React.useRef<File[]>([]);
   const unclaimedAssetIdsRef = React.useRef(new Set(initialUnclaimedAssetIds));
+  const unclaimedAssetExpirationsRef = React.useRef(
+    new Map(Object.entries(initialUnclaimedAssetExpirations)),
+  );
   const discardingAssetIdsRef = React.useRef(new Set<string>());
   const mountedRef = React.useRef(true);
   const onUploadingChangeRef = React.useRef(onUploadingChange);
   const preserveUploadsOnUnmountRef = React.useRef(preserveUploadsOnUnmount);
+
+  const reportAssetExpirations = React.useCallback(() => {
+    onAssetExpirationsChange?.(
+      Object.fromEntries(unclaimedAssetExpirationsRef.current.entries()),
+    );
+  }, [onAssetExpirationsChange]);
+
+  const reportUnclaimedAssetIds = React.useCallback(() => {
+    onUnclaimedAssetIdsChange?.([...unclaimedAssetIdsRef.current]);
+  }, [onUnclaimedAssetIdsChange]);
+
+  const markdownAdapters = React.useMemo(
+    () => createAkbMarkdownAdapters({ vault, document, commit }),
+    [commit, document, vault],
+  );
+
+  React.useEffect(() => {
+    reportUnclaimedAssetIds();
+  }, [reportUnclaimedAssetIds]);
 
   const discardUnclaimedAsset = React.useCallback(
     (assetId: string) => {
@@ -1249,14 +1310,19 @@ export function MarkdownEditor({
       ) return;
       discardingAssetIdsRef.current.add(assetId);
       void discardAsset(vault, assetId)
-        .then(() => unclaimedAssetIdsRef.current.delete(assetId))
+        .then(() => {
+          unclaimedAssetIdsRef.current.delete(assetId);
+          unclaimedAssetExpirationsRef.current.delete(assetId);
+          reportAssetExpirations();
+          reportUnclaimedAssetIds();
+        })
         .catch(() => {
           // Retain the id for a later unmount retry. Server-side TTL cleanup is
           // the final backstop for an abrupt browser termination.
         })
         .finally(() => discardingAssetIdsRef.current.delete(assetId));
     },
-    [vault],
+    [reportAssetExpirations, reportUnclaimedAssetIds, vault],
   );
 
   const discardIfUnclaimed = React.useCallback(
@@ -1327,11 +1393,14 @@ export function MarkdownEditor({
     for (const assetId of unclaimedAssetIdsRef.current) {
       if (accepted.has(assetId)) {
         unclaimedAssetIdsRef.current.delete(assetId);
+        unclaimedAssetExpirationsRef.current.delete(assetId);
       } else {
         discardUnclaimedAsset(assetId);
       }
     }
-  }, [claimedAssetIds, discardUnclaimedAsset]);
+    reportAssetExpirations();
+    reportUnclaimedAssetIds();
+  }, [claimedAssetIds, discardUnclaimedAsset, reportAssetExpirations, reportUnclaimedAssetIds]);
 
   const uploadImages = React.useCallback(
     async (
@@ -1341,28 +1410,15 @@ export function MarkdownEditor({
     ) => {
       if (readOnly || uploadInFlightRef.current || files.length === 0) return;
 
-      for (const file of files) {
-        const validationMessage = validateEditorImage(file);
-        if (validationMessage) {
-          setUploadFailure({
-            // Validation is a preflight over the entire batch, so no earlier
-            // file has uploaded yet. Reject the batch explicitly instead of
-            // presenting a partial retry that silently omits valid files.
-            files: [],
-            message: `${file.name}: ${validationMessage} No images were uploaded.`,
-            retryable: false,
-            kind: "error",
-            replacementPath,
-          });
-          return;
-        }
-      }
-
       const controller = new AbortController();
       const insertionRef = insertionRange ? editor.api.rangeRef(insertionRange) : null;
       let currentFileIndex = 0;
       let restoredInsertion = false;
+      let insertedImageCount = 0;
       let failed = false;
+      const batchFailures: Array<{ file: File; message: string; retryable: boolean }> = [];
+      const cancelledFiles: File[] = [];
+      const retryableFiles: File[] = [];
       uploadControllerRef.current = controller;
       uploadInFlightRef.current = true;
       setUploadFailure(null);
@@ -1372,54 +1428,105 @@ export function MarkdownEditor({
       try {
         for (const [index, file] of files.entries()) {
           currentFileIndex = index;
-          setUploadingName(`Checking ${file.name}`);
-          const prepared = await prepareEditorImage(file);
-          setUploadingName(
-            prepared.optimized ? `Uploading optimized ${file.name}` : file.name,
-          );
-          const asset = await uploadAsset(vault, prepared.file, controller.signal);
-          const assetId = assetIdFromUrl(asset.url);
-          if (!assetId || assetId !== asset.id) {
-            throw new Error("The image upload returned an invalid asset URL.");
-          }
-          unclaimedAssetIdsRef.current.add(assetId);
-
-          if (controller.signal.aborted || !mountedRef.current) {
-            discardIfUnclaimed(asset.url);
-            throw new DOMException("Upload cancelled", "AbortError");
-          }
-
-          if (!restoredInsertion && insertionRef?.current) {
-            editor.tf.select(insertionRef.current);
-          }
-          restoredInsertion = true;
-          const alt = file.name.replace(/\.[^.]+$/, "") || "Image";
-          if (replacementPath && index === 0) {
-            const target = editor.api.node(replacementPath)?.[0] as {
-              type?: string;
-              url?: string;
-            } | undefined;
-            if (target?.type !== ImagePlugin.key) {
-              throw new Error("The image to replace is no longer available.");
+          try {
+            setUploadingName(`Checking ${file.name}`);
+            const validationMessage = validateEditorImage(file);
+            if (validationMessage) {
+              throw Object.assign(new Error(validationMessage), {
+                status: 415,
+                code: "invalid",
+              });
             }
-            const replacedUrl = target.url;
-            editor.tf.setNodes(
-              { url: asset.url, caption: [{ text: alt }] },
-              { at: replacementPath },
+            const prepared = await prepareEditorImage(file);
+            setUploadingName(
+              prepared.optimized ? `Uploading optimized ${file.name}` : file.name,
             );
-            editor.tf.select(replacementPath);
-            discardIfUnclaimed(replacedUrl);
-          } else {
-            editor.tf.insertNodes(
-              {
-                type: ImagePlugin.key,
-                url: asset.url,
-                caption: [{ text: alt }],
-                children: [{ text: "" }],
-              },
-              { select: true },
-            );
+            const asset = await markdownAdapters.upload.upload(prepared.file, {
+              vault,
+              document,
+              commit,
+              signal: controller.signal,
+            });
+            const target = asset.target;
+            const assetId = assetIdFromUrl(target);
+            if (!assetId || (asset.id && assetId !== asset.id)) {
+              throw new Error("The image upload returned an invalid asset URL.");
+            }
+            unclaimedAssetIdsRef.current.add(assetId);
+            if (asset.expiresAt) {
+              unclaimedAssetExpirationsRef.current.set(assetId, asset.expiresAt);
+              reportAssetExpirations();
+            }
+            reportUnclaimedAssetIds();
+
+            if (controller.signal.aborted || !mountedRef.current) {
+              discardIfUnclaimed(target);
+              throw new DOMException("Upload cancelled", "AbortError");
+            }
+
+            if (!restoredInsertion && insertionRef?.current) {
+              editor.tf.select(insertionRef.current);
+            }
+            restoredInsertion = true;
+            const alt = file.name.replace(/\.[^.]+$/, "") || "Image";
+            if (replacementPath && insertedImageCount === 0) {
+              const replacementTarget = editor.api.node(replacementPath)?.[0] as {
+                type?: string;
+                url?: string;
+              } | undefined;
+              if (replacementTarget?.type !== ImagePlugin.key) {
+                throw new Error("The image to replace is no longer available.");
+              }
+              const replacedUrl = replacementTarget.url;
+              editor.tf.setNodes(
+                { url: target, caption: [{ text: alt }] },
+                { at: replacementPath },
+              );
+              editor.tf.select(replacementPath);
+              discardIfUnclaimed(replacedUrl);
+            } else {
+              editor.tf.insertNodes(
+                {
+                  type: ImagePlugin.key,
+                  url: target,
+                  caption: [{ text: alt }],
+                  children: [{ text: "" }],
+                },
+                { select: true },
+              );
+            }
+            insertedImageCount += 1;
+          } catch (error) {
+            failed = true;
+            const aborted =
+              controller.signal.aborted ||
+              (error instanceof DOMException && error.name === "AbortError");
+            if (aborted) {
+              cancelledFiles.push(file, ...files.slice(index + 1));
+              break;
+            }
+
+            const failure = classifyEditorImageUploadFailure(error, file);
+            batchFailures.push({ file, message: failure.message, retryable: failure.retryable });
+            if (failure.retryable) retryableFiles.push(file);
           }
+        }
+        if (mountedRef.current && (batchFailures.length > 0 || cancelledFiles.length > 0)) {
+          const deferred = deferredImageFilesRef.current.splice(0);
+          const cancelledMessage = cancelledFiles.length > 0
+            ? `${cancelledFiles.length} image${cancelledFiles.length === 1 ? "" : "s"} cancelled.`
+            : "";
+          setUploadFailure({
+            files: [...retryableFiles, ...deferred],
+            message: [
+              ...batchFailures.map((failure) => failure.message),
+              cancelledMessage,
+              "Successful images remain in the draft.",
+            ].filter(Boolean).join(" "),
+            retryable: retryableFiles.length > 0 || deferred.length > 0,
+            kind: "error",
+            replacementPath,
+          });
         }
       } catch (error) {
         const aborted =
@@ -1471,7 +1578,52 @@ export function MarkdownEditor({
         }
       }
     },
-    [discardIfUnclaimed, editor, readOnly, vault],
+    [commit, discardIfUnclaimed, document, editor, markdownAdapters, readOnly, reportAssetExpirations, reportUnclaimedAssetIds, vault],
+  );
+
+  const targetResolver = React.useMemo(
+    () => markdownAdapters.targetResolver,
+    [markdownAdapters],
+  );
+  const targetStrings = React.useMemo(
+    () => extractAkbMarkdownLinkTargets(value),
+    [value],
+  );
+  const targetResolutionKey = React.useMemo(
+    () => [vault, document ?? "", commit ?? "", ...targetStrings].join("\u0000"),
+    [commit, document, targetStrings, vault],
+  );
+  const [targetResolutionState, setTargetResolutionState] = React.useState<{
+    key: string;
+    values: ReadonlyMap<string, AkbMarkdownTargetResolution>;
+  }>({ key: "", values: new Map() });
+
+  React.useEffect(() => {
+    if (targetStrings.length === 0) return;
+    const controller = new AbortController();
+    void Promise.all(
+      targetStrings.map(async (target) => [
+        target,
+        await targetResolver.resolve(target, {
+          vault,
+          document,
+          commit,
+          signal: controller.signal,
+        }),
+      ] as const),
+    ).then((entries) => {
+      if (!controller.signal.aborted) {
+        setTargetResolutionState({ key: targetResolutionKey, values: new Map(entries) });
+      }
+    });
+    return () => controller.abort();
+  }, [commit, document, targetResolutionKey, targetResolver, targetStrings, vault]);
+  const targetResolutions = React.useMemo(
+    () =>
+      targetResolutionState.key === targetResolutionKey
+        ? targetResolutionState.values
+        : EMPTY_TARGET_RESOLUTIONS,
+    [targetResolutionKey, targetResolutionState],
   );
 
   const assetLifecycle = React.useMemo(
@@ -1485,8 +1637,9 @@ export function MarkdownEditor({
         replacementPathRef.current = path;
         imageInputRef.current?.click();
       },
+      targetResolutions,
     }),
-    [commit, document, readOnly, vault],
+    [commit, document, readOnly, targetResolutions, vault],
   );
 
   const handleImageDragOver = React.useCallback(
@@ -1613,8 +1766,8 @@ export function MarkdownEditor({
           <div className="flex flex-wrap items-center justify-between gap-3">
             <span className="min-w-0 flex-1">
               {uploadFailure.message}
-              {uploadFailure.files.length > 1
-                ? ` ${uploadFailure.files.length} images remain in this batch.`
+              {uploadFailure.files.length > 0
+                ? ` ${uploadFailure.files.length} image${uploadFailure.files.length === 1 ? "" : "s"} remain in this batch.`
                 : ""}
             </span>
             <div className="flex flex-wrap items-center gap-1.5">

--- a/frontend/src/components/markdown-editor.tsx
+++ b/frontend/src/components/markdown-editor.tsx
@@ -101,7 +101,7 @@ import { isAkbResourceTarget, normalizeEditorLinkUrl } from "@/lib/editor-link";
 import {
   canonicalAkbMarkdownTarget,
   createAkbMarkdownAdapters,
-  extractAkbMarkdownLinkTargets,
+  useAkbMarkdownTargetResolutions,
   type AkbMarkdownTargetResolution,
 } from "@/lib/markdown-adapters";
 import {
@@ -432,7 +432,6 @@ interface EditorAssetLifecycle {
 }
 
 const EditorAssetLifecycleContext = React.createContext<EditorAssetLifecycle | null>(null);
-const EMPTY_TARGET_RESOLUTIONS: ReadonlyMap<string, AkbMarkdownTargetResolution> = new Map();
 
 function ImageElement(props: PlateElementProps) {
   const editor = useEditorRef();
@@ -1281,22 +1280,29 @@ export function MarkdownEditor({
   const discardingAssetIdsRef = React.useRef(new Set<string>());
   const mountedRef = React.useRef(true);
   const onUploadingChangeRef = React.useRef(onUploadingChange);
+  const onAssetExpirationsChangeRef = React.useRef(onAssetExpirationsChange);
+  const onUnclaimedAssetIdsChangeRef = React.useRef(onUnclaimedAssetIdsChange);
   const preserveUploadsOnUnmountRef = React.useRef(preserveUploadsOnUnmount);
 
   const reportAssetExpirations = React.useCallback(() => {
-    onAssetExpirationsChange?.(
+    onAssetExpirationsChangeRef.current?.(
       Object.fromEntries(unclaimedAssetExpirationsRef.current.entries()),
     );
-  }, [onAssetExpirationsChange]);
+  }, []);
 
   const reportUnclaimedAssetIds = React.useCallback(() => {
-    onUnclaimedAssetIdsChange?.([...unclaimedAssetIdsRef.current]);
-  }, [onUnclaimedAssetIdsChange]);
+    onUnclaimedAssetIdsChangeRef.current?.([...unclaimedAssetIdsRef.current]);
+  }, []);
 
   const markdownAdapters = React.useMemo(
     () => createAkbMarkdownAdapters({ vault, document, commit }),
     [commit, document, vault],
   );
+
+  React.useEffect(() => {
+    onAssetExpirationsChangeRef.current = onAssetExpirationsChange;
+    onUnclaimedAssetIdsChangeRef.current = onUnclaimedAssetIdsChange;
+  }, [onAssetExpirationsChange, onUnclaimedAssetIdsChange]);
 
   React.useEffect(() => {
     reportUnclaimedAssetIds();
@@ -1428,6 +1434,10 @@ export function MarkdownEditor({
       try {
         for (const [index, file] of files.entries()) {
           currentFileIndex = index;
+          if (controller.signal.aborted) {
+            cancelledFiles.push(file, ...files.slice(index + 1));
+            break;
+          }
           try {
             setUploadingName(`Checking ${file.name}`);
             const validationMessage = validateEditorImage(file);
@@ -1459,7 +1469,7 @@ export function MarkdownEditor({
             }
             reportUnclaimedAssetIds();
 
-            if (controller.signal.aborted || !mountedRef.current) {
+            if (!mountedRef.current) {
               discardIfUnclaimed(target);
               throw new DOMException("Upload cancelled", "AbortError");
             }
@@ -1496,6 +1506,10 @@ export function MarkdownEditor({
               );
             }
             insertedImageCount += 1;
+            if (controller.signal.aborted) {
+              cancelledFiles.push(...files.slice(index + 1));
+              break;
+            }
           } catch (error) {
             failed = true;
             const aborted =
@@ -1552,9 +1566,9 @@ export function MarkdownEditor({
           setUploadFailure({
             files: deferredImageFilesRef.current.splice(0),
             message: "The current upload was cancelled before the next batch started.",
-              retryable: true,
-              kind: "error",
-              replacementPath,
+            retryable: true,
+            kind: "error",
+            replacementPath,
           });
         }
       } finally {
@@ -1581,50 +1595,7 @@ export function MarkdownEditor({
     [commit, discardIfUnclaimed, document, editor, markdownAdapters, readOnly, reportAssetExpirations, reportUnclaimedAssetIds, vault],
   );
 
-  const targetResolver = React.useMemo(
-    () => markdownAdapters.targetResolver,
-    [markdownAdapters],
-  );
-  const targetStrings = React.useMemo(
-    () => extractAkbMarkdownLinkTargets(value),
-    [value],
-  );
-  const targetResolutionKey = React.useMemo(
-    () => [vault, document ?? "", commit ?? "", ...targetStrings].join("\u0000"),
-    [commit, document, targetStrings, vault],
-  );
-  const [targetResolutionState, setTargetResolutionState] = React.useState<{
-    key: string;
-    values: ReadonlyMap<string, AkbMarkdownTargetResolution>;
-  }>({ key: "", values: new Map() });
-
-  React.useEffect(() => {
-    if (targetStrings.length === 0) return;
-    const controller = new AbortController();
-    void Promise.all(
-      targetStrings.map(async (target) => [
-        target,
-        await targetResolver.resolve(target, {
-          vault,
-          document,
-          commit,
-          signal: controller.signal,
-        }),
-      ] as const),
-    ).then((entries) => {
-      if (!controller.signal.aborted) {
-        setTargetResolutionState({ key: targetResolutionKey, values: new Map(entries) });
-      }
-    });
-    return () => controller.abort();
-  }, [commit, document, targetResolutionKey, targetResolver, targetStrings, vault]);
-  const targetResolutions = React.useMemo(
-    () =>
-      targetResolutionState.key === targetResolutionKey
-        ? targetResolutionState.values
-        : EMPTY_TARGET_RESOLUTIONS,
-    [targetResolutionKey, targetResolutionState],
-  );
+  const targetResolutions = useAkbMarkdownTargetResolutions(value, { vault, document, commit });
 
   const assetLifecycle = React.useMemo(
     () => ({

--- a/frontend/src/components/markdown-render.tsx
+++ b/frontend/src/components/markdown-render.tsx
@@ -28,8 +28,8 @@
  *     as a soft rounded card. `\[..\]` / `\(..\)` pre-normalized to
  *     `$$` / `$`.
  */
-import React, { useCallback, useMemo, useState, type ComponentProps } from "react";
-import Markdown, { type Components, type ExtraProps } from "react-markdown";
+import React, { useCallback, useEffect, useMemo, useState, type ComponentProps } from "react";
+import Markdown, { defaultUrlTransform, type Components, type ExtraProps } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
@@ -48,6 +48,13 @@ import "katex/dist/katex.min.css";
 import { AssetImage, type AssetContext } from "@/components/asset-image";
 import { cn, sanitizeLinkUrl } from "@/lib/utils";
 import { parseHeadings, slugify, stripFrontmatter } from "@/lib/markdown";
+import {
+  canonicalAkbMarkdownTarget,
+  classifyAkbMarkdownTarget,
+  createAkbMarkdownTargetResolver,
+  extractAkbMarkdownLinkTargets,
+  type AkbMarkdownTargetResolution,
+} from "@/lib/markdown-adapters";
 
 /* ── LaTeX delimiter normalization ────────────────────────────────
    GPT-family models emit \[..\] / \(..\); remark-math only groks the
@@ -438,7 +445,11 @@ function flattenText(children: React.ReactNode): string {
 /* ── Build the full components map ───────────────────────────────── */
 type HeadingProps = ComponentProps<"h1"> & ExtraProps;
 
-function buildComponents(markdown: string, assetContext?: AssetContext): Components {
+function buildComponents(
+  markdown: string,
+  assetContext?: AssetContext,
+  targetResolutions: ReadonlyMap<string, AkbMarkdownTargetResolution> = new Map(),
+): Components {
   // Heading slugs in document order — matches parseHeadings() so the
   // outline's `#slug` anchors line up with the rendered `id`s. The
   // cursor advances once per heading element react-markdown renders,
@@ -575,11 +586,24 @@ function buildComponents(markdown: string, assetContext?: AssetContext): Compone
 
     /* ── Links + media ────────────────────────────────────────── */
     a: ({ node: _node, href, children, ...props }) => {
-      const safe = sanitizeLinkUrl(href);
+      const canonical = typeof href === "string" ? canonicalAkbMarkdownTarget(href) : null;
+      const resolution = canonical ? targetResolutions.get(canonical) : undefined;
+      const ownedTarget = canonical && classifyAkbMarkdownTarget(canonical);
+      const safe = ownedTarget
+        ? resolution?.status === "available" && resolution.runtimeUrl
+          ? resolution.runtimeUrl
+          : "#"
+        : sanitizeLinkUrl(href);
+      const unavailable =
+        !!ownedTarget && (!resolution || resolution.status === "unavailable");
       const external = /^https?:\/\//i.test(safe);
       return (
         <a
           href={safe}
+          data-markdown-target={ownedTarget ? canonical : undefined}
+          data-markdown-resolution={ownedTarget ? resolution?.status ?? "unavailable" : undefined}
+          aria-disabled={unavailable || undefined}
+          title={unavailable ? "Reference unavailable" : undefined}
           {...(external ? { rel: "noopener noreferrer", target: "_blank" } : {})}
           className="text-link underline decoration-link/40 underline-offset-[3px] decoration-1 hover:text-link-hover hover:decoration-link-hover transition-token break-words"
           {...props}
@@ -589,13 +613,24 @@ function buildComponents(markdown: string, assetContext?: AssetContext): Compone
       );
     },
     img: ({ node: _node, src, alt, ...props }) => (
-      <AssetImage
-        src={typeof src === "string" ? src : null}
-        alt={alt}
-        assetContext={assetContext}
-        className="block my-4 rounded-[var(--radius-lg)] border border-border max-w-full h-auto"
-        {...props}
-      />
+      (() => {
+        const rawTarget = typeof src === "string" ? src : "";
+        const canonical = canonicalAkbMarkdownTarget(rawTarget);
+        const resolution = canonical ? targetResolutions.get(canonical) : undefined;
+        return (
+          <AssetImage
+            src={canonical ?? rawTarget}
+            canonicalTarget={canonical ?? rawTarget}
+            runtimeSrc={resolution?.status === "available" ? resolution.runtimeUrl : null}
+            unavailable={resolution?.status === "unavailable"}
+            unavailableLabel="Reference unavailable"
+            alt={alt}
+            assetContext={assetContext}
+            className="block my-4 rounded-[var(--radius-lg)] border border-border max-w-full h-auto"
+            {...props}
+          />
+        );
+      })()
     ),
 
     /* ── Code (inline + fenced) ───────────────────────────────── */
@@ -694,6 +729,10 @@ function buildComponents(markdown: string, assetContext?: AssetContext): Compone
   };
 }
 
+function preserveCanonicalTargetUrl(url: string): string {
+  return canonicalAkbMarkdownTarget(url) ?? defaultUrlTransform(url);
+}
+
 const REMARK_PLUGINS = [remarkGfm, remarkMath];
 const REHYPE_PLUGINS = [rehypeKatex];
 
@@ -742,9 +781,54 @@ export function MarkdownRender({ markdown, className, assetContext }: MarkdownRe
     }
     return undefined;
   }, [assetCommit, assetDocument, assetMode, assetVault, publicationSlug]);
+  const targetResolver = useMemo(
+    () =>
+      assetMode === "authenticated" && assetVault
+        ? createAkbMarkdownTargetResolver({
+            vault: assetVault,
+            document: assetDocument,
+            commit: assetCommit,
+          })
+        : undefined,
+    [assetCommit, assetDocument, assetMode, assetVault],
+  );
+  const targetStrings = useMemo(() => extractAkbMarkdownLinkTargets(body), [body]);
+  const targetResolutionKey = useMemo(
+    () => [assetVault ?? "", assetDocument ?? "", assetCommit ?? "", ...targetStrings].join("\u0000"),
+    [assetCommit, assetDocument, assetVault, targetStrings],
+  );
+  const [targetResolutionState, setTargetResolutionState] = useState<{
+    key: string;
+    values: ReadonlyMap<string, AkbMarkdownTargetResolution>;
+  }>({ key: "", values: new Map() });
+
+  useEffect(() => {
+    if (!targetResolver || targetStrings.length === 0) return;
+    const controller = new AbortController();
+    void Promise.all(
+      targetStrings.map(async (target) => [
+        target,
+        await targetResolver.resolve(target, {
+          vault: assetVault,
+          document: assetDocument,
+          commit: assetCommit,
+          signal: controller.signal,
+        }),
+      ] as const),
+    ).then((entries) => {
+      if (!controller.signal.aborted) {
+        setTargetResolutionState({ key: targetResolutionKey, values: new Map(entries) });
+      }
+    });
+    return () => controller.abort();
+  }, [assetCommit, assetDocument, assetVault, targetResolutionKey, targetResolver, targetStrings]);
+  const targetResolutions =
+    targetResolver && targetResolutionState.key === targetResolutionKey
+      ? targetResolutionState.values
+      : undefined;
   const components = useMemo(
-    () => buildComponents(body, stableAssetContext),
-    [body, stableAssetContext],
+    () => buildComponents(body, stableAssetContext, targetResolutions),
+    [body, stableAssetContext, targetResolutions],
   );
 
   return (
@@ -752,6 +836,7 @@ export function MarkdownRender({ markdown, className, assetContext }: MarkdownRe
       <Markdown
         remarkPlugins={REMARK_PLUGINS}
         rehypePlugins={REHYPE_PLUGINS}
+        urlTransform={preserveCanonicalTargetUrl}
         components={components}
       >
         {normalized}

--- a/frontend/src/components/markdown-render.tsx
+++ b/frontend/src/components/markdown-render.tsx
@@ -28,7 +28,7 @@
  *     as a soft rounded card. `\[..\]` / `\(..\)` pre-normalized to
  *     `$$` / `$`.
  */
-import React, { useCallback, useEffect, useMemo, useState, type ComponentProps } from "react";
+import React, { useCallback, useMemo, useState, type ComponentProps } from "react";
 import Markdown, { defaultUrlTransform, type Components, type ExtraProps } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
@@ -51,8 +51,7 @@ import { parseHeadings, slugify, stripFrontmatter } from "@/lib/markdown";
 import {
   canonicalAkbMarkdownTarget,
   classifyAkbMarkdownTarget,
-  createAkbMarkdownTargetResolver,
-  extractAkbMarkdownLinkTargets,
+  useAkbMarkdownTargetResolutions,
   type AkbMarkdownTargetResolution,
 } from "@/lib/markdown-adapters";
 
@@ -781,51 +780,11 @@ export function MarkdownRender({ markdown, className, assetContext }: MarkdownRe
     }
     return undefined;
   }, [assetCommit, assetDocument, assetMode, assetVault, publicationSlug]);
-  const targetResolver = useMemo(
-    () =>
-      assetMode === "authenticated" && assetVault
-        ? createAkbMarkdownTargetResolver({
-            vault: assetVault,
-            document: assetDocument,
-            commit: assetCommit,
-          })
-        : undefined,
-    [assetCommit, assetDocument, assetMode, assetVault],
-  );
-  const targetStrings = useMemo(() => extractAkbMarkdownLinkTargets(body), [body]);
-  const targetResolutionKey = useMemo(
-    () => [assetVault ?? "", assetDocument ?? "", assetCommit ?? "", ...targetStrings].join("\u0000"),
-    [assetCommit, assetDocument, assetVault, targetStrings],
-  );
-  const [targetResolutionState, setTargetResolutionState] = useState<{
-    key: string;
-    values: ReadonlyMap<string, AkbMarkdownTargetResolution>;
-  }>({ key: "", values: new Map() });
-
-  useEffect(() => {
-    if (!targetResolver || targetStrings.length === 0) return;
-    const controller = new AbortController();
-    void Promise.all(
-      targetStrings.map(async (target) => [
-        target,
-        await targetResolver.resolve(target, {
-          vault: assetVault,
-          document: assetDocument,
-          commit: assetCommit,
-          signal: controller.signal,
-        }),
-      ] as const),
-    ).then((entries) => {
-      if (!controller.signal.aborted) {
-        setTargetResolutionState({ key: targetResolutionKey, values: new Map(entries) });
-      }
-    });
-    return () => controller.abort();
-  }, [assetCommit, assetDocument, assetVault, targetResolutionKey, targetResolver, targetStrings]);
-  const targetResolutions =
-    targetResolver && targetResolutionState.key === targetResolutionKey
-      ? targetResolutionState.values
-      : undefined;
+  const targetResolutions = useAkbMarkdownTargetResolutions(body, {
+    vault: assetVault,
+    document: assetDocument,
+    commit: assetCommit,
+  });
   const components = useMemo(
     () => buildComponents(body, stableAssetContext, targetResolutions),
     [body, stableAssetContext, targetResolutions],

--- a/frontend/src/lib/__tests__/api-assets.test.ts
+++ b/frontend/src/lib/__tests__/api-assets.test.ts
@@ -2,7 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   discardAsset,
   clearPrivateAssetCache,
+  copyFileToAttachment,
   configureAuthTransport,
+  getAttachmentMetadata,
+  getAttachmentRetentionPolicy,
   getAssetBlob,
   getPublication,
   publicationAssetUrl,
@@ -64,6 +67,65 @@ describe("editor image asset API", () => {
       "Content-Type": "image/png",
       Authorization: "Bearer test-token",
     });
+  });
+
+  it("keeps the canonical target and server expiry separate from runtime URLs", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        kind: "attachment",
+        id: ASSET_ID,
+        target: `/api/assets/${ASSET_ID}`,
+        url: `/api/assets/${ASSET_ID}`,
+        unclaimed_expires_at: "2026-09-10T00:00:00.000Z",
+      }),
+    );
+
+    const result = await uploadAsset(
+      "team vault",
+      new File(["image bytes"], "diagram.png", { type: "image/png" }),
+    );
+
+    expect(result.target).toBe(`/api/assets/${ASSET_ID}`);
+    expect(result.unclaimed_expires_at).toBe("2026-09-10T00:00:00.000Z");
+    expect(JSON.stringify(result)).not.toContain("signed");
+  });
+
+  it("reads attachment policy/metadata and exposes the File-copy action", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({
+        kind: "attachment_policy",
+        vault: "team",
+        server_time: "2026-09-09T00:00:00.000Z",
+        unclaimed_ttl_hours: 7,
+        revision_retention_days: 3,
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        kind: "attachment",
+        target: `/api/assets/${ASSET_ID}`,
+        status: "unclaimed",
+        unclaimed_expires_at: "2026-09-09T07:00:00.000Z",
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        kind: "attachment",
+        id: ASSET_ID,
+        target: `/api/assets/${ASSET_ID}`,
+        url: `/api/assets/${ASSET_ID}`,
+      }));
+
+    await expect(getAttachmentRetentionPolicy("team")).resolves.toMatchObject({
+      unclaimed_ttl_hours: 7,
+    });
+    await expect(getAttachmentMetadata("team", ASSET_ID)).resolves.toMatchObject({
+      status: "unclaimed",
+    });
+    await expect(copyFileToAttachment("team", ASSET_ID)).resolves.toMatchObject({
+      target: `/api/assets/${ASSET_ID}`,
+    });
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "/api/v1/assets/team/policy",
+      `/api/v1/assets/team/${ASSET_ID}/metadata`,
+      `/api/v1/assets/team/from-file/${ASSET_ID}`,
+    ]);
   });
 
   it("fetches private image bytes with Bearer auth", async () => {

--- a/frontend/src/lib/__tests__/document-edit-draft.test.ts
+++ b/frontend/src/lib/__tests__/document-edit-draft.test.ts
@@ -3,6 +3,8 @@ import {
   clearDocumentEditDraft,
   documentEditDraftStorageKey,
   loadDocumentEditDraft,
+  documentDraftStorageKey,
+  saveDocumentDraft,
   saveDocumentEditDraft,
   type DocumentEditDraftInput,
 } from "@/lib/document-draft";
@@ -10,6 +12,7 @@ import {
 const USER = "user-1";
 const VAULT = "team";
 const DOCUMENT = "akb://team/coll/notes/doc/hello.md";
+const ATTACHMENT_TARGET = "/api/assets/123e4567-e89b-42d3-a456-426614174000";
 
 function draft(overrides: Partial<DocumentEditDraftInput> = {}): DocumentEditDraftInput {
   return {
@@ -24,7 +27,8 @@ function draft(overrides: Partial<DocumentEditDraftInput> = {}): DocumentEditDra
     title: "Local title",
     body: "Local body",
     assetIds: ["asset-1"],
-    editorVersion: "0.1.0",
+    assetExpiresAt: { "asset-1": "2026-09-10T01:00:00.000Z" },
+    editorVersion: "0.2.0",
     markdownProfile: "preserve",
     ...overrides,
   };
@@ -66,7 +70,7 @@ describe("existing-document draft storage", () => {
   it("returns an expired draft for recovery without deleting its original text", () => {
     const stored = {
       ...draft(),
-      version: 1,
+      version: 2,
       kind: "document-edit",
       updatedAt: "2026-09-01T00:00:00.000Z",
       expiresAt: "2026-09-01T01:00:00.000Z",
@@ -85,6 +89,24 @@ describe("existing-document draft storage", () => {
     );
     expect(result).toMatchObject({ status: "expired", draft: { body: "Local body" } });
     expect(window.localStorage.getItem(documentEditDraftStorageKey(USER, VAULT, DOCUMENT, "tab-1", "draft-1"))).toContain("Local body");
+  });
+
+  it("bounds draft recovery by the earliest server-provided attachment expiry", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-09T00:00:00.000Z"));
+    try {
+      expect(saveDocumentEditDraft(draft({
+        assetExpiresAt: { "asset-1": "2026-09-09T00:30:00.000Z" },
+      }))).toBe(true);
+      const stored = JSON.parse(
+        window.localStorage.getItem(
+          documentEditDraftStorageKey(USER, VAULT, DOCUMENT, "tab-1", "draft-1"),
+        ) ?? "{}",
+      ) as { expiresAt?: string };
+      expect(stored.expiresAt).toBe("2026-09-09T00:30:00.000Z");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("preserves incompatible records for copying instead of migrating or discarding them", () => {
@@ -120,5 +142,30 @@ describe("existing-document draft storage", () => {
 
     expect(window.localStorage.getItem(documentEditDraftStorageKey(USER, VAULT, DOCUMENT, "tab-1", "draft-1"))).toBeNull();
     expect(window.localStorage.getItem(documentEditDraftStorageKey(USER, VAULT, DOCUMENT, "tab-2", "draft-2"))).not.toBeNull();
+  });
+
+  it("keeps a new-document draft expiry at the server attachment boundary", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-09T00:00:00.000Z"));
+    try {
+      expect(saveDocumentDraft({
+        vault: VAULT,
+        title: "New",
+        collection: "notes",
+        type: "note",
+        domain: "",
+        summary: "",
+        tags: [],
+        body: `![image](${ATTACHMENT_TARGET})`,
+        assetIds: ["asset-1"],
+        assetExpiresAt: { "asset-1": "2026-09-09T00:15:00.000Z" },
+      })).toBe(true);
+      const stored = JSON.parse(
+        window.localStorage.getItem(documentDraftStorageKey(VAULT)) ?? "{}",
+      ) as { expiresAt?: string };
+      expect(stored.expiresAt).toBe("2026-09-09T00:15:00.000Z");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/frontend/src/lib/__tests__/markdown-adapters.test.ts
+++ b/frontend/src/lib/__tests__/markdown-adapters.test.ts
@@ -57,6 +57,7 @@ describe("AKB Markdown target adapter", () => {
     apiMocks.getVaultFileDownloadUrl.mockResolvedValue({
       kind: "file",
       download_url: "https://signed.example/file?expires=60",
+      expires_in: 60,
     });
     apiMocks.getAttachmentMetadata.mockResolvedValue({
       kind: "attachment",
@@ -71,12 +72,14 @@ describe("AKB Markdown target adapter", () => {
       status: "available",
       runtimeUrl: "/vault/team/doc/notes%2Fguide.md",
     });
-    await expect(resolver.resolve(FILE)).resolves.toMatchObject({
+    const fileResolution = await resolver.resolve(FILE);
+    expect(fileResolution).toMatchObject({
       target: FILE,
       kind: "file",
       status: "available",
       runtimeUrl: "https://signed.example/file?expires=60",
     });
+    expect(fileResolution.status === "available" && fileResolution.expiresAt).toBeTruthy();
     await expect(resolver.resolve(ATTACHMENT)).resolves.toMatchObject({
       target: ATTACHMENT,
       kind: "attachment",

--- a/frontend/src/lib/__tests__/markdown-adapters.test.ts
+++ b/frontend/src/lib/__tests__/markdown-adapters.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiMocks = vi.hoisted(() => ({
+  copyFileToAttachment: vi.fn(),
+  getAssetBlob: vi.fn(),
+  getAttachmentMetadata: vi.fn(),
+  getDocument: vi.fn(),
+  getVaultFileDownloadUrl: vi.fn(),
+  searchDocs: vi.fn(),
+  uploadAsset: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => apiMocks);
+
+import {
+  canonicalAkbMarkdownTarget,
+  classifyAkbMarkdownTarget,
+  createAkbMarkdownAdapters,
+  createAkbMarkdownTargetResolver,
+  extractAkbMarkdownLinkTargets,
+} from "@/lib/markdown-adapters";
+
+const ATTACHMENT = "/api/assets/123e4567-e89b-42d3-a456-426614174000";
+const DOCUMENT = "akb://team/coll/notes/doc/guide.md";
+const FILE = "akb://team/coll/notes/file/123e4567-e89b-42d3-a456-426614174001";
+
+describe("AKB Markdown target adapter", () => {
+  beforeEach(() => {
+    Object.values(apiMocks).forEach((mock) => mock.mockReset());
+  });
+
+  it("classifies and canonicalizes the three durable target kinds", () => {
+    expect(classifyAkbMarkdownTarget(ATTACHMENT)).toBe("attachment");
+    expect(classifyAkbMarkdownTarget(DOCUMENT)).toBe("document");
+    expect(classifyAkbMarkdownTarget(FILE)).toBe("file");
+    expect(canonicalAkbMarkdownTarget(`${ATTACHMENT}/`)).toBe(ATTACHMENT);
+    expect(canonicalAkbMarkdownTarget(DOCUMENT)).toBe(DOCUMENT);
+    expect(canonicalAkbMarkdownTarget(FILE)).toBe(FILE);
+    expect(classifyAkbMarkdownTarget("javascript:alert(1)")).toBeNull();
+  });
+
+  it("finds reference-style links without resolving examples inside code", () => {
+    expect(extractAkbMarkdownLinkTargets([
+      "[Guide][guide]",
+      "",
+      `[guide]: ${DOCUMENT} "title"`,
+      "",
+      "[Shortcut]",
+      `[Shortcut]: ${FILE}`,
+      "",
+      "`[ignored](akb://other/doc/nope.md)`",
+    ].join("\n"))).toEqual([DOCUMENT, FILE]);
+  });
+
+  it("resolves only accessible same-vault targets and keeps runtime URLs ephemeral", async () => {
+    apiMocks.getDocument.mockResolvedValue({ path: "notes/guide.md" });
+    apiMocks.getVaultFileDownloadUrl.mockResolvedValue({
+      kind: "file",
+      download_url: "https://signed.example/file?expires=60",
+    });
+    apiMocks.getAttachmentMetadata.mockResolvedValue({
+      kind: "attachment",
+      target: ATTACHMENT,
+      status: "claimed",
+    });
+    const resolver = createAkbMarkdownTargetResolver({ vault: "team" });
+
+    await expect(resolver.resolve(DOCUMENT)).resolves.toMatchObject({
+      target: DOCUMENT,
+      kind: "document",
+      status: "available",
+      runtimeUrl: "/vault/team/doc/notes%2Fguide.md",
+    });
+    await expect(resolver.resolve(FILE)).resolves.toMatchObject({
+      target: FILE,
+      kind: "file",
+      status: "available",
+      runtimeUrl: "https://signed.example/file?expires=60",
+    });
+    await expect(resolver.resolve(ATTACHMENT)).resolves.toMatchObject({
+      target: ATTACHMENT,
+      kind: "attachment",
+      status: "available",
+    });
+    await expect(resolver.resolve("akb://other/doc/private.md")).resolves.toMatchObject({
+      target: "akb://other/doc/private.md",
+      status: "unavailable",
+    });
+    expect(apiMocks.getDocument).toHaveBeenCalledWith("team", "notes/guide.md", undefined);
+    expect(apiMocks.getAttachmentMetadata).toHaveBeenCalledWith("team", "123e4567-e89b-42d3-a456-426614174000", {
+      document: undefined,
+      commit: undefined,
+    });
+  });
+
+  it("returns canonical upload and search values without runtime URLs", async () => {
+    apiMocks.uploadAsset.mockResolvedValue({
+      id: "123e4567-e89b-42d3-a456-426614174000",
+      target: ATTACHMENT,
+      url: ATTACHMENT,
+      unclaimed_expires_at: "2026-09-10T00:00:00.000Z",
+    });
+    apiMocks.searchDocs.mockResolvedValue({
+      results: [
+        { uri: DOCUMENT, title: "Guide", matched_section: "body" },
+        { uri: "https://example.test/nope", title: "External" },
+      ],
+    });
+    const adapters = createAkbMarkdownAdapters({ vault: "team" });
+    const file = new File(["bytes"], "diagram.png", { type: "image/png" });
+
+    await expect(adapters.upload.upload(file)).resolves.toMatchObject({
+      kind: "attachment",
+      target: ATTACHMENT,
+      expiresAt: "2026-09-10T00:00:00.000Z",
+    });
+    await expect(adapters.search.search("guide")).resolves.toEqual([
+      {
+        id: DOCUMENT,
+        title: "Guide",
+        snippet: "body",
+        target: DOCUMENT,
+        kind: "document",
+      },
+    ]);
+    expect(apiMocks.uploadAsset.mock.calls[0]?.[0]).toBe("team");
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1394,11 +1394,17 @@ export const deleteDocument = (vault: string, id: string) =>
 
 // ── Editor image assets ──
 export interface AssetUploadResponse {
+  kind?: "attachment";
   id: string;
-  url: string;
+  /** Stable target persisted in document Markdown. */
+  target: string;
+  /** Same stable target for the existing editor wire shape; never a runtime URL. */
+  url?: string;
   name: string;
   mime_type: string;
   size_bytes: number;
+  unclaimed_expires_at?: string | null;
+  source_file_uri?: string;
 }
 
 /**
@@ -1423,6 +1429,51 @@ export async function uploadAsset(
   }
   return res.json();
 }
+
+export interface AttachmentRetentionPolicy {
+  kind: "attachment_policy";
+  vault: string;
+  server_time: string;
+  unclaimed_ttl_hours: number;
+  revision_retention_days: number;
+}
+
+/** Read the active server policy used to bound recoverable attachment drafts. */
+export const getAttachmentRetentionPolicy = (vault: string) =>
+  api<AttachmentRetentionPolicy>(
+    `/assets/${encodeURIComponent(vault)}/policy`,
+  );
+
+export interface AttachmentMetadata {
+  kind: "attachment";
+  target: string;
+  status: "unclaimed" | "claimed" | "expired";
+  unclaimed_expires_at?: string | null;
+}
+
+/** Resolve an attachment through the same document/user reachability boundary as its bytes. */
+export async function getAttachmentMetadata(
+  vault: string,
+  fileId: string,
+  source?: { document?: string; commit?: string },
+): Promise<AttachmentMetadata> {
+  const params = new URLSearchParams();
+  if (source?.document) params.set("document", source.document);
+  if (source?.commit) params.set("commit", source.commit);
+  const query = params.toString();
+  const response = await authenticatedFetch(
+    `${API_BASE}/assets/${encodeURIComponent(vault)}/${encodeURIComponent(fileId)}/metadata${query ? `?${query}` : ""}`,
+  );
+  if (!response.ok) await throwJsonApiError(response);
+  return response.json() as Promise<AttachmentMetadata>;
+}
+
+/** Copy a confirmed standalone image File into an independent Attachment. */
+export const copyFileToAttachment = (vault: string, fileId: string) =>
+  api<AssetUploadResponse>(
+    `/assets/${encodeURIComponent(vault)}/from-file/${encodeURIComponent(fileId)}`,
+    { method: "POST" },
+  );
 
 /** Fetch a private asset with the app's Bearer credential for blob rendering. */
 export async function getAssetBlob(
@@ -1602,6 +1653,29 @@ export async function uploadVaultFile(
     }
     throw error;
   }
+}
+
+export interface VaultFileDownloadResult {
+  kind: "file";
+  name?: string;
+  download_url: string;
+  mime_type?: string;
+  size_bytes?: number;
+  content_hash?: string;
+  version?: string | null;
+  expires_in?: number;
+}
+
+/** Resolve a standalone File to a short-lived download URL for viewing. */
+export async function getVaultFileDownloadUrl(
+  vault: string,
+  fileId: string,
+): Promise<VaultFileDownloadResult> {
+  const response = await authenticatedFetch(
+    `${API_BASE}/files/${encodeURIComponent(vault)}/${encodeURIComponent(fileId)}/download`,
+  );
+  if (!response.ok) await throwJsonApiError(response);
+  return response.json() as Promise<VaultFileDownloadResult>;
 }
 
 export const deleteVaultFile = (vault: string, fileId: string) =>

--- a/frontend/src/lib/document-draft.ts
+++ b/frontend/src/lib/document-draft.ts
@@ -80,11 +80,6 @@ export type DocumentEditDraftInput = Omit<
   "version" | "kind" | "updatedAt" | "expiresAt"
 >;
 
-export interface DocumentDraftSaveOptions {
-  /** Active server expiry boundary for this draft's unclaimed attachments. */
-  expiresAt?: string;
-}
-
 let fallbackTabId: string | null = null;
 
 function encodeKeyPart(value: string): string {
@@ -294,16 +289,10 @@ export function listDocumentEditDrafts(
   }
 }
 
-export function saveDocumentEditDraft(
-  draft: DocumentEditDraftInput,
-  options: DocumentDraftSaveOptions = {},
-): boolean {
+export function saveDocumentEditDraft(draft: DocumentEditDraftInput): boolean {
   const updatedAt = new Date();
-  const configuredExpiry = options.expiresAt ? Date.parse(options.expiresAt) : Number.NaN;
   const expiresAt = new Date(
-    Number.isFinite(configuredExpiry) && configuredExpiry > 0
-      ? configuredExpiry
-      : updatedAt.getTime() + DOCUMENT_EDIT_DRAFT_RETENTION_MS,
+    updatedAt.getTime() + DOCUMENT_EDIT_DRAFT_RETENTION_MS,
   );
   const assetExpiresAt = Object.fromEntries(
     Object.entries(draft.assetExpiresAt ?? {}).filter(

--- a/frontend/src/lib/document-draft.ts
+++ b/frontend/src/lib/document-draft.ts
@@ -1,6 +1,6 @@
 import { DOC_TYPES, type DocType } from "@/lib/doc-constants";
 
-const DRAFT_VERSION = 1;
+const DRAFT_VERSION = 2;
 const DRAFT_PREFIX = "akb:document-draft:";
 
 /**
@@ -9,11 +9,11 @@ const DRAFT_PREFIX = "akb:document-draft:";
  * rather than a private Plate schema: package semver + MarkdownProfile are
  * the durable compatibility boundary owned by the shared editor package.
  */
-const DOCUMENT_EDIT_DRAFT_VERSION = 1;
+const DOCUMENT_EDIT_DRAFT_VERSION = 2;
 const DOCUMENT_EDIT_DRAFT_KIND = "document-edit";
 const DOCUMENT_EDIT_DRAFT_PREFIX = "akb:document-edit-draft:";
 const DOCUMENT_EDIT_TAB_ID_KEY = "akb:document-edit-tab-id";
-export const DOCUMENT_EDIT_DRAFT_EDITOR_VERSION = "0.1.0";
+export const DOCUMENT_EDIT_DRAFT_EDITOR_VERSION = "0.2.0";
 export const DOCUMENT_EDIT_DRAFT_MARKDOWN_PROFILE = "preserve" as const;
 export const DOCUMENT_EDIT_DRAFT_RETENTION_HOURS = 24;
 const DOCUMENT_EDIT_DRAFT_RETENTION_MS =
@@ -30,7 +30,11 @@ export interface StoredDocumentDraft {
   tags: string[];
   body: string;
   assetIds: string[];
+  /** Server-provided expiry per unclaimed attachment, when available. */
+  assetExpiresAt?: Record<string, string>;
   updatedAt: string;
+  /** Earliest local/attachment recovery boundary. */
+  expiresAt?: string;
 }
 
 export interface StoredDocumentEditDraft {
@@ -47,6 +51,8 @@ export interface StoredDocumentEditDraft {
   title: string;
   body: string;
   assetIds: string[];
+  /** Server-provided expiry per unclaimed attachment, when available. */
+  assetExpiresAt?: Record<string, string>;
   editorVersion: typeof DOCUMENT_EDIT_DRAFT_EDITOR_VERSION;
   markdownProfile: typeof DOCUMENT_EDIT_DRAFT_MARKDOWN_PROFILE;
   updatedAt: string;
@@ -73,6 +79,11 @@ export type DocumentEditDraftInput = Omit<
   StoredDocumentEditDraft,
   "version" | "kind" | "updatedAt" | "expiresAt"
 >;
+
+export interface DocumentDraftSaveOptions {
+  /** Active server expiry boundary for this draft's unclaimed attachments. */
+  expiresAt?: string;
+}
 
 let fallbackTabId: string | null = null;
 
@@ -161,6 +172,14 @@ function recordLooksLikeEditDraft(value: unknown): value is StoredDocumentEditDr
     typeof draft.body === "string" &&
     Array.isArray(draft.assetIds) &&
     draft.assetIds.every((assetId) => typeof assetId === "string") &&
+    (draft.assetExpiresAt === undefined || (
+      !!draft.assetExpiresAt &&
+      typeof draft.assetExpiresAt === "object" &&
+      !Array.isArray(draft.assetExpiresAt) &&
+      Object.entries(draft.assetExpiresAt).every(
+        ([assetId, expiresAt]) => typeof assetId === "string" && typeof expiresAt === "string",
+      )
+    )) &&
     typeof draft.updatedAt === "string" &&
     typeof draft.expiresAt === "string"
   );
@@ -275,13 +294,29 @@ export function listDocumentEditDrafts(
   }
 }
 
-export function saveDocumentEditDraft(draft: DocumentEditDraftInput): boolean {
+export function saveDocumentEditDraft(
+  draft: DocumentEditDraftInput,
+  options: DocumentDraftSaveOptions = {},
+): boolean {
   const updatedAt = new Date();
+  const configuredExpiry = options.expiresAt ? Date.parse(options.expiresAt) : Number.NaN;
   const expiresAt = new Date(
-    updatedAt.getTime() + DOCUMENT_EDIT_DRAFT_RETENTION_MS,
+    Number.isFinite(configuredExpiry) && configuredExpiry > 0
+      ? configuredExpiry
+      : updatedAt.getTime() + DOCUMENT_EDIT_DRAFT_RETENTION_MS,
   );
+  const assetExpiresAt = Object.fromEntries(
+    Object.entries(draft.assetExpiresAt ?? {}).filter(
+      ([assetId, value]) =>
+        draft.assetIds.includes(assetId) && !Number.isNaN(Date.parse(value)),
+    ),
+  );
+  for (const value of Object.values(assetExpiresAt)) {
+    if (Date.parse(value) < expiresAt.getTime()) expiresAt.setTime(Date.parse(value));
+  }
   const stored: StoredDocumentEditDraft = {
     ...draft,
+    assetExpiresAt,
     version: DOCUMENT_EDIT_DRAFT_VERSION,
     kind: DOCUMENT_EDIT_DRAFT_KIND,
     updatedAt: updatedAt.toISOString(),
@@ -358,12 +393,27 @@ export function saveDocumentDraft(
   draft: Omit<StoredDocumentDraft, "version" | "updatedAt">,
 ): boolean {
   try {
+    const updatedAt = new Date();
+    const assetExpiresAt = Object.fromEntries(
+      Object.entries(draft.assetExpiresAt ?? {}).filter(
+        ([assetId, value]) =>
+          draft.assetIds.includes(assetId) && !Number.isNaN(Date.parse(value)),
+      ),
+    );
+    const expiresAt = new Date(
+      updatedAt.getTime() + DOCUMENT_EDIT_DRAFT_RETENTION_MS,
+    );
+    for (const value of Object.values(assetExpiresAt)) {
+      if (Date.parse(value) < expiresAt.getTime()) expiresAt.setTime(Date.parse(value));
+    }
     window.localStorage.setItem(
       documentDraftStorageKey(draft.vault),
       JSON.stringify({
         ...draft,
+        assetExpiresAt,
         version: DRAFT_VERSION,
-        updatedAt: new Date().toISOString(),
+        updatedAt: updatedAt.toISOString(),
+        expiresAt: expiresAt.toISOString(),
       } satisfies StoredDocumentDraft),
     );
     return true;

--- a/frontend/src/lib/editor-link.ts
+++ b/frontend/src/lib/editor-link.ts
@@ -1,8 +1,16 @@
 import { sanitizeLinkUrl } from "@/lib/utils";
+import { parseUri } from "@/lib/uri";
+import { canonicalAkbMarkdownTarget } from "@/lib/markdown-adapters";
+
+export function isAkbResourceTarget(raw: string | null | undefined): boolean {
+  const parsed = parseUri(raw?.trim() || "");
+  return parsed?.kind === "doc" || parsed?.kind === "file";
+}
 
 export function normalizeEditorLinkUrl(raw: string): string | null {
   const trimmed = raw.trim();
   if (!trimmed) return null;
+  if (isAkbResourceTarget(trimmed)) return canonicalAkbMarkdownTarget(trimmed) ?? trimmed;
   const withScheme = /^[\w.-]+\.[a-z]{2,}(?:[/:?#]|$)/i.test(trimmed)
     ? `https://${trimmed}`
     : trimmed;

--- a/frontend/src/lib/markdown-adapters.ts
+++ b/frontend/src/lib/markdown-adapters.ts
@@ -1,3 +1,4 @@
+import { useEffect, useMemo, useState } from "react";
 import {
   copyFileToAttachment,
   getAttachmentMetadata,
@@ -20,6 +21,7 @@ export type AkbMarkdownTargetResolution =
       status: "available";
       runtimeUrl: string;
       label?: string;
+      expiresAt?: string;
     }
   | {
       target: string;
@@ -150,7 +152,10 @@ export function createAkbMarkdownTargetResolver(
 
         if (kind === "file" && parsed?.kind === "file") {
           const access = await getVaultFileDownloadUrl(vault, parsed.id);
-          return { target, kind, status: "available", runtimeUrl: access.download_url };
+          const expiresAt = typeof access.expires_in === "number" && access.expires_in > 0
+            ? new Date(Date.now() + access.expires_in * 1000).toISOString()
+            : undefined;
+          return { target, kind, status: "available", runtimeUrl: access.download_url, expiresAt };
         }
 
         const attachmentId = assetIdFromUrl(target);
@@ -188,6 +193,77 @@ export function createAkbMarkdownTargetResolver(
       return unavailable(target, kind);
     },
   };
+}
+
+const EMPTY_TARGET_RESOLUTIONS: ReadonlyMap<string, AkbMarkdownTargetResolution> = new Map();
+
+/** Resolve editor/viewer links and refresh short-lived runtime URLs in place. */
+export function useAkbMarkdownTargetResolutions(
+  markdown: string,
+  defaults: Partial<AkbMarkdownUploadContext> = {},
+): ReadonlyMap<string, AkbMarkdownTargetResolution> {
+  const { commit, document, vault } = defaults;
+  const targetStrings = useMemo(
+    () => extractAkbMarkdownLinkTargets(markdown),
+    [markdown],
+  );
+  const targetResolver = useMemo(
+    () => (vault ? createAkbMarkdownTargetResolver({ vault, document, commit }) : undefined),
+    [commit, document, vault],
+  );
+  const targetResolutionKey = useMemo(
+    () => [vault ?? "", document ?? "", commit ?? "", ...targetStrings].join("\u0000"),
+    [commit, document, targetStrings, vault],
+  );
+  const [targetResolutionState, setTargetResolutionState] = useState<{
+    key: string;
+    values: ReadonlyMap<string, AkbMarkdownTargetResolution>;
+  }>({ key: "", values: EMPTY_TARGET_RESOLUTIONS });
+  const [refreshNonce, setRefreshNonce] = useState(0);
+
+  useEffect(() => {
+    if (!targetResolver || targetStrings.length === 0) return;
+    const controller = new AbortController();
+    void Promise.all(
+      targetStrings.map(async (target) => [
+        target,
+        await targetResolver.resolve(target, {
+          vault,
+          document,
+          commit,
+          signal: controller.signal,
+        }),
+      ] as const),
+    ).then((entries) => {
+      if (!controller.signal.aborted) {
+        setTargetResolutionState({ key: targetResolutionKey, values: new Map(entries) });
+      }
+    });
+    return () => controller.abort();
+  }, [commit, document, refreshNonce, targetResolutionKey, targetResolver, targetStrings, vault]);
+
+  const targetResolutions =
+    targetResolver && targetResolutionState.key === targetResolutionKey
+      ? targetResolutionState.values
+      : EMPTY_TARGET_RESOLUTIONS;
+  const nextRefreshAt = useMemo(() => {
+    let earliest = Number.POSITIVE_INFINITY;
+    for (const resolution of targetResolutions.values()) {
+      if (resolution.status !== "available" || !resolution.expiresAt) continue;
+      const timestamp = Date.parse(resolution.expiresAt);
+      if (Number.isFinite(timestamp)) earliest = Math.min(earliest, timestamp);
+    }
+    return Number.isFinite(earliest) ? earliest : null;
+  }, [targetResolutions]);
+
+  useEffect(() => {
+    if (nextRefreshAt === null) return;
+    const delay = Math.max(0, nextRefreshAt - Date.now() - 1_000);
+    const timer = window.setTimeout(() => setRefreshNonce((value) => value + 1), delay);
+    return () => window.clearTimeout(timer);
+  }, [nextRefreshAt]);
+
+  return targetResolutions;
 }
 
 export function createAkbMarkdownAdapters(defaults: AkbMarkdownUploadContext) {

--- a/frontend/src/lib/markdown-adapters.ts
+++ b/frontend/src/lib/markdown-adapters.ts
@@ -1,0 +1,241 @@
+import {
+  copyFileToAttachment,
+  getAttachmentMetadata,
+  getAttachmentRetentionPolicy,
+  getAssetBlob,
+  getDocument,
+  getVaultFileDownloadUrl,
+  searchDocs,
+  uploadAsset,
+} from "@/lib/api";
+import { assetIdFromUrl } from "@/lib/image-assets";
+import { docUri, fileUri, parseUri } from "@/lib/uri";
+
+export type AkbMarkdownTargetKind = "document" | "file" | "attachment";
+
+export type AkbMarkdownTargetResolution =
+  | {
+      target: string;
+      kind?: AkbMarkdownTargetKind;
+      status: "available";
+      runtimeUrl: string;
+      label?: string;
+    }
+  | {
+      target: string;
+      kind?: AkbMarkdownTargetKind;
+      status: "unavailable";
+      reason: "inaccessible" | "deleted" | "unsupported" | "cross-vault" | "expired" | "unknown";
+      label?: string;
+    };
+
+export interface AkbMarkdownUploadContext {
+  vault: string;
+  document?: string;
+  commit?: string;
+  draftId?: string;
+  signal?: AbortSignal;
+}
+
+function unavailable(
+  target: string,
+  kind?: AkbMarkdownTargetKind,
+  reason: "inaccessible" | "deleted" | "unsupported" | "cross-vault" | "expired" | "unknown" = "unknown",
+): AkbMarkdownTargetResolution {
+  return { target, kind, status: "unavailable", reason };
+}
+
+/** Classify only the three targets owned by the Markdown resource contract. */
+export function classifyAkbMarkdownTarget(target: string): AkbMarkdownTargetKind | null {
+  if (assetIdFromUrl(target)) return "attachment";
+  const parsed = parseUri(target);
+  if (parsed?.kind === "doc") return "document";
+  if (parsed?.kind === "file") return "file";
+  return null;
+}
+
+export function canonicalAkbMarkdownTarget(
+  target: string,
+  kind?: AkbMarkdownTargetKind,
+): string | null {
+  const attachmentId = assetIdFromUrl(target);
+  if (attachmentId && (!kind || kind === "attachment")) {
+    return `/api/assets/${attachmentId}`;
+  }
+  const parsed = parseUri(target);
+  if (!parsed || (kind && classifyAkbMarkdownTarget(target) !== kind)) return null;
+  if (parsed.kind === "doc") return docUri(parsed.vault, parsed.id);
+  if (parsed.kind === "file") return fileUri(parsed.vault, parsed.id, parsed.collection);
+  return null;
+}
+
+/** Extract only link targets that need a resource resolver; image attachments
+ * keep their own bounded byte loader and are intentionally not duplicated. */
+export function extractAkbMarkdownLinkTargets(markdown: string): string[] {
+  const targets: string[] = [];
+  const seen = new Set<string>();
+  const source = markdown.replace(/```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]*`/g, " ");
+  const normalizeReferenceLabel = (label: string) => label.trim().replace(/\s+/g, " ").toLowerCase();
+  const add = (raw: string) => {
+    const target = canonicalAkbMarkdownTarget(raw.trim());
+    if (!target || classifyAkbMarkdownTarget(target) === "attachment" || seen.has(target)) return;
+    seen.add(target);
+    targets.push(target);
+  };
+  const definitions = new Map<string, string>();
+  for (const match of source.matchAll(/^\s{0,3}\[([^\]]+)\]:\s*(<[^>]+>|[^\s]+).*$/gm)) {
+    definitions.set(normalizeReferenceLabel(match[1]), (match[2] ?? "").replace(/^<|>$/g, ""));
+  }
+
+  const pattern = /!?\[[^\]]*\]\(\s*(<[^>]+>|[^)\s]+)(?:\s+(?:"[^"]*"|'[^']*'))?\s*\)/g;
+  for (const match of source.matchAll(pattern)) {
+    const raw = (match[1] ?? "").replace(/^<|>$/g, "");
+    add(raw);
+  }
+  for (const match of source.matchAll(/!?\[([^\]]*)\]\[([^\]]*)\]/g)) {
+    const label = normalizeReferenceLabel(match[2] || match[1]);
+    const target = definitions.get(label);
+    if (target) add(target);
+  }
+  // CommonMark shortcut references use one bracket pair: `[Guide]`, with a
+  // matching `[Guide]: target` definition. Skip images, inline links, full /
+  // collapsed references, and the definition declaration itself.
+  for (const match of source.matchAll(/\[([^\]]+)\](?![ \t]*(?:\[|\(|:))/g)) {
+    const index = match.index ?? 0;
+    if (index > 0 && source[index - 1] === "!") continue;
+    const target = definitions.get(normalizeReferenceLabel(match[1]));
+    if (target) add(target);
+  }
+  return targets;
+}
+
+function documentRuntimeUrl(vault: string, path: string, commit?: string): string {
+  const query = commit ? `?commit=${encodeURIComponent(commit)}` : "";
+  return `/vault/${encodeURIComponent(vault)}/doc/${encodeURIComponent(path)}${query}`;
+}
+
+export function createAkbMarkdownTargetResolver(
+  defaults: Partial<AkbMarkdownUploadContext> = {},
+) {
+  return {
+    async resolve(
+      rawTarget: string,
+      context: Partial<AkbMarkdownUploadContext> = {},
+    ): Promise<AkbMarkdownTargetResolution> {
+      const target = canonicalAkbMarkdownTarget(rawTarget);
+      const kind = classifyAkbMarkdownTarget(rawTarget) ?? undefined;
+      if (!target || !kind) return unavailable(rawTarget, undefined, "unsupported");
+
+      const vault = context.vault ?? defaults.vault;
+      const parsed = parseUri(target);
+      if (!vault) return unavailable(target, kind, "unknown");
+      if (kind !== "attachment" && (!parsed || parsed.vault !== vault)) {
+        return unavailable(
+          target,
+          kind,
+          parsed && parsed.vault !== vault ? "cross-vault" : "unknown",
+        );
+      }
+
+      try {
+        if (kind === "document" && parsed?.kind === "doc") {
+          await getDocument(vault, parsed.id, context.commit ?? defaults.commit);
+          return {
+            target,
+            kind,
+            status: "available",
+            runtimeUrl: documentRuntimeUrl(vault, parsed.id, context.commit ?? defaults.commit),
+          };
+        }
+
+        if (kind === "file" && parsed?.kind === "file") {
+          const access = await getVaultFileDownloadUrl(vault, parsed.id);
+          return { target, kind, status: "available", runtimeUrl: access.download_url };
+        }
+
+        const attachmentId = assetIdFromUrl(target);
+        if (attachmentId) {
+          // The actual private-image request is made by AssetImage so it can
+          // retain its bounded blob cache and historical source identity.
+          // This resolver call verifies that the target has a usable runtime
+          // address without placing a signed/blob URL in Markdown.
+          const metadata = await getAttachmentMetadata(vault, attachmentId, {
+            document: context.document ?? defaults.document,
+            commit: context.commit ?? defaults.commit,
+          });
+          if (metadata.status === "expired") return unavailable(target, kind, "expired");
+          const query = new URLSearchParams({ vault });
+          if (context.document ?? defaults.document) {
+            query.set("document", context.document ?? defaults.document!);
+          }
+          if (context.commit ?? defaults.commit) {
+            query.set("commit", context.commit ?? defaults.commit!);
+          }
+          return {
+            target,
+            kind,
+            status: "available",
+            runtimeUrl: `/api/assets/${attachmentId}?${query}`,
+          };
+        }
+      } catch {
+        // The adapter deliberately collapses permission, absence, and remote
+        // failures into one unavailable result. Callers retain the canonical
+        // source text and therefore do not need an existence oracle.
+        return unavailable(target, kind);
+      }
+
+      return unavailable(target, kind);
+    },
+  };
+}
+
+export function createAkbMarkdownAdapters(defaults: AkbMarkdownUploadContext) {
+  const targetResolver = createAkbMarkdownTargetResolver(defaults);
+  return {
+    upload: {
+      async upload(file: Blob, context?: AkbMarkdownUploadContext) {
+        const vault = context?.vault ?? defaults.vault;
+        const isFile = typeof File !== "undefined" && file instanceof File;
+        const name = isFile ? (file as File).name : "attachment";
+        const uploadFile = isFile
+          ? (file as File)
+          : new File([file], name, { type: file.type || "application/octet-stream" });
+        const uploaded = await uploadAsset(vault, uploadFile, context?.signal);
+        return {
+          kind: "attachment" as const,
+          id: uploaded.id,
+          target: canonicalAkbMarkdownTarget(uploaded.target ?? uploaded.url, "attachment") ?? uploaded.url,
+          alt: name.replace(/\.[^.]+$/, "") || "Image",
+          expiresAt: uploaded.unclaimed_expires_at ?? undefined,
+        };
+      },
+    },
+    search: {
+      async search(query: string) {
+        const response = await searchDocs(query, defaults.vault, 20);
+        return response.results
+          .map((result) => {
+            const target = typeof result?.uri === "string" ? canonicalAkbMarkdownTarget(result.uri) : null;
+            if (!target) return null;
+            const kind = classifyAkbMarkdownTarget(target);
+            return {
+              id: target,
+              title: typeof result.title === "string" ? result.title : target,
+              snippet: typeof result.matched_section === "string" ? result.matched_section : undefined,
+              target,
+              kind: kind ?? undefined,
+            };
+          })
+          .filter((result): result is NonNullable<typeof result> => result !== null);
+      },
+    },
+    targetResolver,
+    /** Explicit action for embedding an existing standalone image File. */
+    copyFileToAttachment: (fileId: string) => copyFileToAttachment(defaults.vault, fileId),
+    getRetentionPolicy: () => getAttachmentRetentionPolicy(defaults.vault),
+    /** Kept as an adapter-level capability for consumers that need the bytes. */
+    getAttachmentBlob: (fileId: string, signal?: AbortSignal) =>
+      getAssetBlob(fileId, defaults.vault, signal),
+  };
+}

--- a/frontend/src/mocks/browser.ts
+++ b/frontend/src/mocks/browser.ts
@@ -52,7 +52,7 @@ type FixtureState = {
   refetch_generation?: number;
   expire_draft_generation?: number;
   faults?: { save?: number; upload?: number };
-  assets?: Array<{ id: string; filename: string; status: string }>;
+  assets?: Array<{ id: string; filename: string; status: string; expires_at?: string }>;
 };
 
 let fixtureState: FixtureState = {};
@@ -81,19 +81,42 @@ const baseDocument = {
   metadata_is_current: true,
 };
 
+const referenceDocument = {
+  ...baseDocument,
+  uri: "akb://fixture/coll/notes/doc/references.md",
+  path: "notes/references.md",
+  title: "Reference adapter fixture",
+  content: [
+    "# Reference adapter fixture",
+    "",
+    "[Available document](akb://fixture/doc/available.md)",
+    "",
+    "[Available file](akb://fixture/file/123e4567-e89b-42d3-a456-426614174001)",
+    "",
+    "[Unavailable file](akb://fixture/file/123e4567-e89b-42d3-a456-426614174099)",
+    "",
+    "![Fixture attachment](/api/assets/123e4567-e89b-42d3-a456-426614174000)",
+  ].join("\n"),
+};
+
 function documentForState(): typeof baseDocument {
   const remote = fixtureState.document;
+  const template = isReferenceScenario() ? referenceDocument : baseDocument;
   return remote
-    ? { ...baseDocument, ...remote }
-    : { ...baseDocument };
+    ? { ...template, ...remote }
+    : { ...template };
 }
 
 function isDocumentScenario(): boolean {
-  return activeScenario === "document-edit-recovery";
+  return activeScenario === "document-edit-recovery" || activeScenario === "markdown-reference-adapters";
+}
+
+function isReferenceScenario(): boolean {
+  return activeScenario === "markdown-reference-adapters";
 }
 
 function documentIdentity(): string {
-  return fixtureState.identity?.document_uri || baseDocument.uri;
+  return fixtureState.identity?.document_uri || documentForState().uri;
 }
 
 async function consumeFixtureFault(operation: "save" | "upload"): Promise<boolean> {
@@ -137,7 +160,10 @@ async function syncFixtureState(): Promise<FixtureState> {
       appliedRefetchGeneration = refetchGeneration;
       window.dispatchEvent(
         new CustomEvent("akb:mock-document-refetch", {
-          detail: { vault: "fixture", document: "notes/recovery.md" },
+          detail: {
+            vault: "fixture",
+            document: fixtureState.identity?.document_path || "notes/recovery.md",
+          },
         }),
       );
     }
@@ -243,7 +269,7 @@ const handlers = [
     await syncPublicReset();
     return HttpResponse.json({
       vaults: isDocumentScenario()
-        ? [{ name: "fixture", role: "owner", description: "Document recovery fixture" }]
+        ? [{ name: "fixture", role: "owner", description: isReferenceScenario() ? "Reference adapter fixture" : "Document recovery fixture" }]
         : [],
     });
   }),
@@ -251,7 +277,7 @@ const handlers = [
     await syncPublicReset();
     return HttpResponse.json({
       name: "fixture",
-      description: "Document recovery fixture",
+      description: isReferenceScenario() ? "Reference adapter fixture" : "Document recovery fixture",
       role: "owner",
       member_count: 1,
       owner_display_name: "JY Kim",
@@ -272,12 +298,25 @@ const handlers = [
       path: "",
       items: [
         { type: "collection", name: "notes", path: "notes", doc_count: 1 },
-        { type: "document", name: documentForState().title, path: "notes/recovery.md" },
+        { type: "document", name: documentForState().title, path: documentForState().path },
       ],
     });
   }),
-  http.get(/\/api\/v1\/documents\/fixture\/.+$/, async () => {
+  http.get(/\/api\/v1\/documents\/fixture\/.+$/, async ({ request }) => {
     await syncPublicReset();
+    if (isReferenceScenario()) {
+      const path = decodeURIComponent(new URL(request.url).pathname.split("/documents/fixture/")[1] || "");
+      if (path === "missing.md") return new HttpResponse(null, { status: 404 });
+      if (path === "available.md") {
+        return HttpResponse.json({
+          ...referenceDocument,
+          uri: "akb://fixture/doc/available.md",
+          path,
+          title: "Available document",
+          content: "Available reference",
+        });
+      }
+    }
     return HttpResponse.json(documentForState());
   }),
   http.patch(/\/api\/v1\/documents\/fixture\/.+$/, async ({ request }) => {
@@ -342,7 +381,7 @@ const handlers = [
   }),
   http.get(`${API}/relations`, async () => {
     await syncPublicReset();
-    return HttpResponse.json({ uri: baseDocument.uri, relations: [] });
+    return HttpResponse.json({ uri: documentForState().uri, relations: [] });
   }),
   http.post(`${API}/assets/fixture`, async ({ request }) => {
     await syncPublicReset();
@@ -355,21 +394,89 @@ const handlers = [
     const url = new URL(request.url);
     const filename = url.searchParams.get("filename") || "fixture.png";
     const id = `00000000-0000-4000-8000-${String(Date.now() % 1_000_000_000_000).padStart(12, "0")}`;
+    let uploadedState: { expires_at?: string };
     try {
-      await fetch("/__akb_mock__/fixture/upload", {
+      const uploaded = await fetch("/__akb_mock__/fixture/upload", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ id, filename }),
       });
+      uploadedState = await uploaded.json().catch(() => ({})) as { expires_at?: string };
     } catch {
       return HttpResponse.json({ error: "fixture_upload_failed" }, { status: 503 });
     }
     return HttpResponse.json({
+      kind: "attachment",
       id,
+      target: `/api/assets/${id}`,
       url: `/api/assets/${id}`,
       name: filename,
       mime_type: request.headers.get("content-type") || "image/png",
       size_bytes: Number(request.headers.get("content-length") || 0),
+      unclaimed_expires_at: uploadedState.expires_at ?? null,
+    });
+  }),
+  http.post(/\/api\/v1\/assets\/fixture\/from-file\/[^/]+$/, async ({ request }) => {
+    await syncPublicReset();
+    const sourceId = new URL(request.url).pathname.split("/").at(-1) || "";
+    if (sourceId !== "123e4567-e89b-42d3-a456-426614174001") {
+      return new HttpResponse(null, { status: 404 });
+    }
+    const id = `00000000-0000-4000-8000-${String(Date.now() % 1_000_000_000_000).padStart(12, "0")}`;
+    const uploaded = await fetch("/__akb_mock__/fixture/upload", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id, filename: "available.png" }),
+    });
+    const uploadedState = await uploaded.json().catch(() => ({})) as { expires_at?: string };
+    return HttpResponse.json({
+      kind: "attachment",
+      id,
+      target: `/api/assets/${id}`,
+      url: `/api/assets/${id}`,
+      name: "available.png",
+      mime_type: "image/png",
+      size_bytes: 10,
+      source_file_uri: `akb://fixture/file/${sourceId}`,
+      unclaimed_expires_at: uploadedState.expires_at ?? null,
+    }, { status: 201 });
+  }),
+  http.get(`${API}/assets/fixture/policy`, async () => {
+    await syncPublicReset();
+    return HttpResponse.json({
+      kind: "attachment_policy",
+      vault: "fixture",
+      server_time: new Date().toISOString(),
+      unclaimed_ttl_hours: 24,
+      revision_retention_days: 30,
+    });
+  }),
+  http.get(/\/api\/v1\/assets\/fixture\/[^/]+\/metadata$/, async ({ request }) => {
+    await syncPublicReset();
+    const id = new URL(request.url).pathname.split("/").at(-2) || "";
+    const asset = fixtureState.assets?.find((candidate) => candidate.id === id);
+    if (!asset || asset.status === "discarded") return new HttpResponse(null, { status: 404 });
+    return HttpResponse.json({
+      kind: "attachment",
+      target: `/api/assets/${asset.id}`,
+      status: asset.status,
+      unclaimed_expires_at: asset.expires_at ?? null,
+    });
+  }),
+  http.get(`${API}/files/fixture/123e4567-e89b-42d3-a456-426614174001/download`, async () => {
+    await syncPublicReset();
+    return HttpResponse.json({
+      kind: "file",
+      name: "available.png",
+      download_url: "/__akb_mock__/fixture/available-file.png",
+      mime_type: "image/png",
+      size_bytes: 5,
+    });
+  }),
+  http.get("/__akb_mock__/fixture/available-file.png", async () => {
+    await syncPublicReset();
+    return new HttpResponse(new Blob(["file-image"], { type: "image/png" }), {
+      headers: { "Content-Type": "image/png" },
     });
   }),
   http.delete(/\/api\/v1\/assets\/fixture\/.+$/, async ({ request }) => {

--- a/frontend/src/mocks/browser.ts
+++ b/frontend/src/mocks/browser.ts
@@ -13,6 +13,17 @@ import {
 
 const API = "/api/v1";
 const MOCK_TOKEN = "akb-mock-browser-token";
+const FIXTURE_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+
+function fixturePngBlob(): Blob {
+  const binary = atob(FIXTURE_PNG_BASE64);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return new Blob([bytes], { type: "image/png" });
+}
 
 type MockUser = typeof fixtureUser & { auth_method: "local" };
 
@@ -475,7 +486,7 @@ const handlers = [
   }),
   http.get("/__akb_mock__/fixture/available-file.png", async () => {
     await syncPublicReset();
-    return new HttpResponse(new Blob(["file-image"], { type: "image/png" }), {
+    return new HttpResponse(fixturePngBlob(), {
       headers: { "Content-Type": "image/png" },
     });
   }),
@@ -496,7 +507,7 @@ const handlers = [
     if (!asset || asset.status === "discarded") {
       return new HttpResponse(null, { status: 404 });
     }
-    return new HttpResponse(new Blob(["fixture-image"], { type: "image/png" }), {
+    return new HttpResponse(fixturePngBlob(), {
       headers: { "Content-Type": "image/png" },
     });
   }),

--- a/frontend/src/pages/document.tsx
+++ b/frontend/src/pages/document.tsx
@@ -212,6 +212,8 @@ export default function DocumentPage({
   const [editingContent, setEditingContent] = useState("");
   const [editingTitle, setEditingTitle] = useState("");
   const [editingAssetIds, setEditingAssetIds] = useState<readonly string[]>([]);
+  const [editingAssetExpirations, setEditingAssetExpirations] = useState<Readonly<Record<string, string>>>({});
+  const [unclaimedAssetIds, setUnclaimedAssetIds] = useState<readonly string[]>([]);
   const [originalContent, setOriginalContent] = useState("");
   const [originalTitle, setOriginalTitle] = useState("");
   const [titleTouched, setTitleTouched] = useState(false);
@@ -259,20 +261,22 @@ export default function DocumentPage({
     title: "",
     content: "",
     assetIds: [] as readonly string[],
+    assetExpirations: {} as Readonly<Record<string, string>>,
   });
   const contentChanged = editingContent !== originalContent;
   const normalizedEditingTitle = documentTitleKey(editingTitle);
   const titleChanged = normalizedEditingTitle !== documentTitleKey(originalTitle);
   const isDirty = contentChanged || titleChanged;
-  const hasUnsavedWork = isDirty || uploadingImage;
+  const hasUnsavedWork = isDirty || uploadingImage || unclaimedAssetIds.length > 0;
 
   useEffect(() => {
     editingSnapshotRef.current = {
       title: editingTitle,
       content: editingContent,
       assetIds: editingAssetIds,
+      assetExpirations: editingAssetExpirations,
     };
-  }, [editingAssetIds, editingContent, editingTitle]);
+  }, [editingAssetExpirations, editingAssetIds, editingContent, editingTitle]);
 
   useEffect(() => {
     // A real editor can emit one canonicalization event while mounting. The
@@ -302,12 +306,13 @@ export default function DocumentPage({
       title: string;
       body: string;
       assetIds: readonly string[];
+      assetExpiresAt: Readonly<Record<string, string>>;
     }> = {},
   ) {
     if (!currentUserId || !name || !doc?.path || !editBaseCommitRef.current) return null;
     if (!draftSessionRef.current) {
       draftSessionRef.current = {
-        version: 1,
+        version: 2,
         kind: "document-edit",
         draftId: createDocumentEditDraftId(),
         tabId: draftTabIdRef.current || documentEditDraftTabId(),
@@ -320,6 +325,7 @@ export default function DocumentPage({
         title: editingTitle,
         body: editingContent,
         assetIds: [...editingAssetIds],
+        assetExpiresAt: { ...editingAssetExpirations },
         editorVersion: DOCUMENT_EDIT_DRAFT_EDITOR_VERSION,
         markdownProfile: DOCUMENT_EDIT_DRAFT_MARKDOWN_PROFILE,
         updatedAt: new Date().toISOString(),
@@ -338,6 +344,9 @@ export default function DocumentPage({
       title: overrides.title ?? editingTitle,
       body: overrides.body ?? editingContent,
       assetIds: [...(overrides.assetIds ?? editingAssetIds)],
+      assetExpiresAt: {
+        ...(overrides.assetExpiresAt ?? editingAssetExpirations),
+      },
       tabId: draftTabIdRef.current || session.tabId,
     };
   }
@@ -643,6 +652,7 @@ export default function DocumentPage({
         draftStatus === "saving" ||
         draftStatus === "saved" ||
         draftStatus === "error" ||
+        draftStatus === "expired" ||
         saveConflict !== null);
 
     if (identityChanged) {
@@ -667,6 +677,8 @@ export default function DocumentPage({
       setOriginalTitle(d.title || "");
       setEditingTitle(d.title || "");
       setEditingAssetIds([]);
+      setEditingAssetExpirations({});
+      setUnclaimedAssetIds([]);
       setEditorInitialContent(d.content || "");
       editorHydrationModeRef.current = "server";
       hydratedKey.current = null;
@@ -687,6 +699,9 @@ export default function DocumentPage({
       setEditingContent(d.content || "");
       setOriginalTitle(d.title || "");
       setEditingTitle(d.title || "");
+      setEditingAssetIds([]);
+      setEditingAssetExpirations({});
+      setUnclaimedAssetIds([]);
       setEditorInitialContent(d.content || "");
       editorHydrationModeRef.current = "server";
       hydratedKey.current = null;
@@ -744,6 +759,8 @@ export default function DocumentPage({
       setEditingContent(stored.body);
       setEditingTitle(stored.title);
       setEditingAssetIds(stored.assetIds);
+      setEditingAssetExpirations(stored.assetExpiresAt ?? {});
+      setUnclaimedAssetIds(stored.assetIds);
       setEditorInitialContent(stored.body);
       editorHydrationModeRef.current = "draft";
       hydratedKey.current = null;
@@ -838,6 +855,7 @@ export default function DocumentPage({
   }, [
     currentUserId,
     doc?.path,
+    editingAssetExpirations,
     editingAssetIds,
     editingContent,
     editingTitle,
@@ -865,6 +883,7 @@ export default function DocumentPage({
   }, [
     currentUserId,
     doc?.path,
+    editingAssetExpirations,
     draftStatus,
     editingAssetIds,
     editingContent,
@@ -974,6 +993,7 @@ export default function DocumentPage({
         title: editingTitle,
         body: editingContent,
         assetIds: editingAssetIds,
+        assetExpiresAt: editingAssetExpirations,
       });
     } finally {
       setRebasing(false);
@@ -1071,6 +1091,7 @@ export default function DocumentPage({
           title: followup.title,
           body: followup.content,
           assetIds: followup.assetIds,
+          assetExpiresAt: followup.assetExpirations,
         });
       } else if (draftSessionRef.current) {
         clearDocumentEditDraft(draftSessionRef.current);
@@ -1078,6 +1099,7 @@ export default function DocumentPage({
         latestDraftInputRef.current = null;
         setDraftStatus("idle");
         setDraftNotice("");
+        setEditingAssetExpirations({});
       }
       // Sidebar refresh is best-effort — its failure must not leave the
       // user looking at a "still dirty" editor after a successful save.
@@ -1208,6 +1230,7 @@ export default function DocumentPage({
     const assets = new Set<string>([
       ...(draft?.assetIds || []),
       ...editingAssetIds,
+      ...unclaimedAssetIds,
     ]);
     if (draft) clearDocumentEditDraft(draft);
     if (draftRecovery?.status === "expired") {
@@ -1219,6 +1242,7 @@ export default function DocumentPage({
         .map((assetId) => discardAsset(name!, assetId)),
     );
     draftSessionRef.current = null;
+    setEditingAssetExpirations({});
     setDraftRecovery(null);
     setDraftStatus("idle");
     setDraftNotice("");
@@ -1710,6 +1734,7 @@ export default function DocumentPage({
                             title: editingTitle,
                             content: markdown,
                             assetIds: nextAssetIds,
+                            assetExpirations: editingAssetExpirations,
                           };
                           setEditingAssetIds(nextAssetIds);
                           setServerTitleConflict((current) =>
@@ -1725,6 +1750,10 @@ export default function DocumentPage({
                           }
                           setEditingContent(markdown);
                         }}
+                        onAssetExpirationsChange={(expirations) => {
+                          setEditingAssetExpirations(expirations);
+                        }}
+                        onUnclaimedAssetIdsChange={setUnclaimedAssetIds}
                         ariaLabel="Document body (markdown)"
                         autoFocus
                         readOnly={savingBody}
@@ -1745,6 +1774,7 @@ export default function DocumentPage({
                         }
                         claimedAssetIds={claimedAssetIds}
                         initialUnclaimedAssetIds={editingAssetIds}
+                        initialUnclaimedAssetExpirations={editingAssetExpirations}
                       />
                     </Suspense>
                     {draftNotice && (draftStatus === "restored" || draftStatus === "saved" || draftStatus === "error" || draftStatus === "unavailable") && (
@@ -2202,6 +2232,7 @@ export default function DocumentPage({
           setEditingContent(originalContent);
           setEditingTitle(originalTitle);
           setEditingAssetIds([]);
+          setUnclaimedAssetIds([]);
           setTitleTouched(false);
           setServerTitleConflict(null);
           if (existingPath) openExistingDocument(existingPath);
@@ -2227,6 +2258,7 @@ export default function DocumentPage({
           setEditorInitialContent(originalContent);
           setEditingTitle(originalTitle);
           setEditingAssetIds([]);
+          setUnclaimedAssetIds([]);
           setEditorKey((k) => k + 1);
           setBodyError("");
           setTitleTouched(false);

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,7 +9,7 @@ import path from "path";
 const target = process.env.AKB_FRONTEND_BACKEND_URL || "http://localhost:8000";
 const cacheDir = process.env.AKB_FRONTEND_CACHE_DIR;
 const isHttps = false;
-const requestedMockScenario = process.env.CRABBOX_RUNTIME_SCENARIO || "empty";
+const requestedMockScenario = process.env.AKB_FE_E2E_SCENARIO || "empty";
 const mockScenario = ["document-edit-recovery", "markdown-reference-adapters"].includes(requestedMockScenario)
   ? requestedMockScenario
   : "empty";

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,7 +10,7 @@ const target = process.env.AKB_FRONTEND_BACKEND_URL || "http://localhost:8000";
 const cacheDir = process.env.AKB_FRONTEND_CACHE_DIR;
 const isHttps = false;
 const requestedMockScenario = process.env.CRABBOX_RUNTIME_SCENARIO || "empty";
-const mockScenario = requestedMockScenario === "document-edit-recovery"
+const mockScenario = ["document-edit-recovery", "markdown-reference-adapters"].includes(requestedMockScenario)
   ? requestedMockScenario
   : "empty";
 let mockResetGeneration = 0;
@@ -26,6 +26,7 @@ type MockFixtureAsset = {
   id: string;
   filename: string;
   status: "unclaimed" | "claimed" | "discarded";
+  expires_at?: string;
 };
 
 type MockFixtureState = {
@@ -48,12 +49,20 @@ const BASE_FIXTURE_DOCUMENT: MockFixtureDocument = {
 let mockFixtureState: MockFixtureState = createMockFixtureState();
 
 function createMockFixtureState(): MockFixtureState {
+  const assets = mockScenario === "markdown-reference-adapters"
+    ? [{
+        id: "123e4567-e89b-42d3-a456-426614174000",
+        filename: "fixture.png",
+        status: "claimed" as const,
+        expires_at: "2099-01-01T00:00:00.000Z",
+      }]
+    : [];
   return {
     remote_document: null,
     refetch_generation: 0,
     expire_draft_generation: 0,
     faults: { save: 0, upload: 0 },
-    assets: [],
+    assets,
     asset_sequence: 0,
     commit_sequence: 1,
   };
@@ -64,20 +73,43 @@ function resetMockFixtureState() {
 }
 
 function currentFixtureDocument(): MockFixtureDocument {
-  return mockFixtureState.remote_document || BASE_FIXTURE_DOCUMENT;
+  if (mockFixtureState.remote_document) return mockFixtureState.remote_document;
+  if (mockScenario === "markdown-reference-adapters") {
+    return {
+      ...BASE_FIXTURE_DOCUMENT,
+      title: "Reference adapter fixture",
+      content: [
+        "# Reference adapter fixture",
+        "",
+        "[Available document](akb://fixture/doc/available.md)",
+        "",
+        "[Available file](akb://fixture/file/123e4567-e89b-42d3-a456-426614174001)",
+        "",
+        "[Unavailable file](akb://fixture/file/123e4567-e89b-42d3-a456-426614174099)",
+        "",
+        "![Fixture attachment](/api/assets/123e4567-e89b-42d3-a456-426614174000)",
+      ].join("\n"),
+    };
+  }
+  return BASE_FIXTURE_DOCUMENT;
 }
 
 function fixtureStateSnapshot() {
   const document = currentFixtureDocument();
+  const referenceScenario = mockScenario === "markdown-reference-adapters";
   return {
     scenario: mockScenario,
     reset_generation: mockResetGeneration,
     identity: {
       user_id: "u-jylkim",
       vault: "fixture",
-      document_path: "notes/recovery.md",
-      document_uri: "akb://fixture/coll/notes/doc/recovery.md",
-      start_url: "/vault/fixture/doc/notes%2Frecovery.md?view=edit",
+      document_path: referenceScenario ? "notes/references.md" : "notes/recovery.md",
+      document_uri: referenceScenario
+        ? "akb://fixture/coll/notes/doc/references.md"
+        : "akb://fixture/coll/notes/doc/recovery.md",
+      start_url: referenceScenario
+        ? "/vault/fixture/doc/notes%2Freferences.md"
+        : "/vault/fixture/doc/notes%2Frecovery.md?view=edit",
       actors: ["editor-a", "editor-b"],
     },
     document,
@@ -85,6 +117,10 @@ function fixtureStateSnapshot() {
     expire_draft_generation: mockFixtureState.expire_draft_generation,
     faults: mockFixtureState.faults,
     assets: mockFixtureState.assets,
+    attachment_policy: {
+      unclaimed_ttl_hours: 24,
+      revision_retention_days: 30,
+    },
   };
 }
 
@@ -156,7 +192,36 @@ function mockDescriptor(origin: string) {
           },
         },
       }
-    : null;
+    : mockScenario === "markdown-reference-adapters"
+      ? {
+          identity: {
+            user_id: "u-jylkim",
+            vault: "fixture",
+            document_path: "notes/references.md",
+            document_uri: "akb://fixture/coll/notes/doc/references.md",
+            start_url: `${origin}/vault/fixture/doc/notes%2Freferences.md`,
+            actors: ["reader-a", "writer-a"],
+          },
+          operations: {
+            state: { method: "GET", url: `${origin}/__akb_mock__/fixture/state` },
+            expire_attachment: {
+              method: "POST",
+              url: `${origin}/__akb_mock__/fixture/expire-attachment`,
+              body: { id: "123e4567-e89b-42d3-a456-426614174000" },
+            },
+            retryable_upload_failure: {
+              method: "POST",
+              url: `${origin}/__akb_mock__/fixture/failure`,
+              body: { operation: "upload", times: 1, status: 503 },
+            },
+            expire_draft: {
+              method: "POST",
+              url: `${origin}/__akb_mock__/fixture/expire-draft`,
+              body: {},
+            },
+          },
+        }
+      : null;
   return {
     schema_version: 2,
     status: "ready",
@@ -280,6 +345,15 @@ function mockControlPlugin(): Plugin {
           response.end(JSON.stringify({ status: "ready", expire_draft_generation: mockFixtureState.expire_draft_generation }));
           return;
         }
+        if (pathname === "/__akb_mock__/fixture/expire-attachment" && request.method === "POST") {
+          void readJsonBody(request).then((body) => {
+            const id = typeof body.id === "string" ? body.id : "";
+            const asset = mockFixtureState.assets.find((candidate) => candidate.id === id);
+            if (asset) asset.status = "discarded";
+            response.end(JSON.stringify({ status: "ready", id, expired: asset?.status === "discarded" }));
+          });
+          return;
+        }
         if (pathname === "/__akb_mock__/fixture/consume-fault" && request.method === "POST") {
           void readJsonBody(request).then((body) => {
             const operation = body.operation === "upload" ? "upload" : "save";
@@ -297,8 +371,13 @@ function mockControlPlugin(): Plugin {
               id,
               filename: typeof body.filename === "string" ? body.filename : "fixture.png",
               status: "unclaimed",
+              expires_at: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
             });
-            response.end(JSON.stringify({ status: "ready", id }));
+            response.end(JSON.stringify({
+              status: "ready",
+              id,
+              expires_at: mockFixtureState.assets.at(-1)?.expires_at,
+            }));
           });
           return;
         }
@@ -315,7 +394,7 @@ function mockControlPlugin(): Plugin {
               ? body.asset_ids.filter((assetId): assetId is string => typeof assetId === "string")
               : [];
             for (const asset of mockFixtureState.assets) {
-              if (asset.status === "unclaimed") asset.status = "claimed";
+              if (asset.status === "unclaimed" && assetIds.includes(asset.id)) asset.status = "claimed";
             }
             response.end(JSON.stringify({ status: "ready", document: currentFixtureDocument() }));
           });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,6 +13,10 @@ const requestedMockScenario = process.env.CRABBOX_RUNTIME_SCENARIO || "empty";
 const mockScenario = ["document-edit-recovery", "markdown-reference-adapters"].includes(requestedMockScenario)
   ? requestedMockScenario
   : "empty";
+const FIXTURE_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+  "base64",
+);
 let mockResetGeneration = 0;
 
 type MockFixtureDocument = {
@@ -285,6 +289,11 @@ function mockControlPlugin(): Plugin {
 
         const origin = `http://${request.headers.host || "127.0.0.1:4173"}`;
         response.setHeader("Content-Type", "application/json");
+        if (pathname === "/__akb_mock__/fixture/available-file.png" && request.method === "GET") {
+          response.setHeader("Content-Type", "image/png");
+          response.end(FIXTURE_PNG);
+          return;
+        }
         if (pathname === "/__akb_mock__/health" && request.method === "GET") {
           response.end(
             JSON.stringify({

--- a/packages/markdown-editor/CHANGELOG.md
+++ b/packages/markdown-editor/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.0
+
+- Preserve canonical document, standalone File, and document Attachment targets through image/link Markdown editing.
+- Add product-neutral upload batch outcomes and runtime-only target resolution for editor/viewer surfaces.
+
 ## 0.1.0
 
 - Add the shared Tiptap Markdown editor/viewer core and conformance contract.

--- a/packages/markdown-editor/README.md
+++ b/packages/markdown-editor/README.md
@@ -36,8 +36,37 @@ Use `profile="structured"` for CommonMark + GFM structure editing. The default `
 adds explicit raw HTML/MDX nodes while keeping math and Mermaid fences as semantic nodes. Both
 surfaces use the same extension set for a stable viewer/editor meaning model.
 
-Upload, search, and target resolution are adapter interfaces only. Products provide their own
-implementations when they integrate the package.
+Upload, search, and target resolution are adapter interfaces. A `MarkdownAsset` returns the
+canonical `target` that is safe to store in Markdown; `runtimeUrl` exists only on a resolver
+result and is never serialized. `uploadMarkdownBatch` keeps success, failure, and cancellation
+per file so a partial batch can be recovered without losing successful attachments.
+
+```ts
+import {
+  MarkdownViewer,
+  uploadMarkdownBatch,
+  type MarkdownTargetResolution,
+} from '@akb/markdown-editor'
+
+const result = await uploadMarkdownBatch(uploadAdapter, files, { vault: 'team' })
+// result.items contains one success/failed/cancelled outcome per file.
+
+const resolver = {
+  async resolve(target: string): Promise<MarkdownTargetResolution> {
+    return { target, status: 'available', runtimeUrl: await makeRuntimeUrl(target) }
+  },
+}
+
+<MarkdownViewer
+  markdown={markdown}
+  adapters={{ targetResolver: resolver }}
+  resolverContext={{ vault: 'team' }}
+/>
+```
+
+The viewer/editor apply resolver results to their rendered DOM only. The editor model and
+`getMarkdown()` continue to contain the original canonical target, including when a resource is
+unavailable.
 
 ## Contributor commands
 
@@ -55,7 +84,7 @@ with a physical OS IME.
 
 ## Versioning
 
-The initial public contract is `0.1.0`. Consumers should pin one exact package version, store the
+The `0.2.0` public contract adds canonical resource targets. Consumers should pin one exact package version, store the
 Markdown returned by `onChange` or `editor.getMarkdown()` as the canonical representation, and
 choose `profile="structured"` when unknown HTML/MDX should be rejected or the default `preserve`
 profile when those constructs must survive edit/serialize cycles. Changes to the exported schema,

--- a/packages/markdown-editor/package.json
+++ b/packages/markdown-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akb/markdown-editor",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Product-neutral Tiptap Markdown editor, viewer, and conformance contract for AKB and Reef.",
   "type": "module",
   "sideEffects": false,

--- a/packages/markdown-editor/src/adapters.ts
+++ b/packages/markdown-editor/src/adapters.ts
@@ -1,0 +1,201 @@
+import type {
+  MarkdownAdapterError,
+  MarkdownAsset,
+  MarkdownTarget,
+  MarkdownTargetResolution,
+  MarkdownTargetResolver,
+  MarkdownTargetResolverContext,
+  MarkdownUnavailableReason,
+  MarkdownUploadAdapter,
+  MarkdownUploadBatchResult,
+  MarkdownUploadContext,
+  MarkdownUploadItem,
+} from './types.js'
+
+function adapterError(error: unknown): MarkdownAdapterError {
+  if (error instanceof DOMException && error.name === 'AbortError') {
+    return {
+      code: 'cancelled',
+      message: 'Upload cancelled',
+      retryable: true,
+    }
+  }
+
+  if (error && typeof error === 'object') {
+    const candidate = error as {
+      code?: unknown
+      message?: unknown
+      retryable?: unknown
+    }
+    const code = candidate.code
+    if (
+      code === 'unavailable' ||
+      code === 'invalid' ||
+      code === 'conflict' ||
+      code === 'cancelled'
+    ) {
+      return {
+        code,
+        message:
+          typeof candidate.message === 'string' && candidate.message
+            ? candidate.message
+            : 'The upload could not be completed.',
+        retryable: candidate.retryable === true,
+      }
+    }
+    return {
+      code: 'unknown',
+      message:
+        typeof candidate.message === 'string' && candidate.message
+          ? candidate.message
+          : 'The upload could not be completed.',
+      retryable: candidate.retryable === true,
+    }
+  }
+
+  return {
+    code: 'unknown',
+    message: error instanceof Error ? error.message : 'The upload could not be completed.',
+    retryable: false,
+  }
+}
+
+function cancelledItem(file: Blob): MarkdownUploadItem {
+  return {
+    status: 'cancelled',
+    file,
+    error: adapterError(new DOMException('Upload cancelled', 'AbortError')),
+  }
+}
+
+/**
+ * Run independent file uploads through the one-file adapter contract while
+ * retaining every outcome. A failed item never erases a successful item, and
+ * cancellation marks the current/remaining files explicitly.
+ */
+export async function uploadMarkdownBatch(
+  adapter: MarkdownUploadAdapter,
+  files: readonly Blob[],
+  context: MarkdownUploadContext = {},
+): Promise<MarkdownUploadBatchResult> {
+  const items: MarkdownUploadItem[] = []
+
+  for (const file of files) {
+    if (context.signal?.aborted) {
+      items.push(cancelledItem(file))
+      continue
+    }
+
+    try {
+      const asset = await adapter.upload(file, context)
+      // An adapter may finish a remote upload after the caller aborts its
+      // signal. The returned asset is still real and must remain visible to
+      // the caller so it can be claimed or explicitly discarded. The signal
+      // gates the next file; it does not erase a completed result.
+      items.push({ status: 'success', file, asset })
+    } catch (error) {
+      const normalized = adapterError(error)
+      if (normalized.code === 'cancelled' || context.signal?.aborted) {
+        items.push({ status: 'cancelled', file, error: normalized })
+        continue
+      }
+      items.push({ status: 'failed', file, error: normalized })
+    }
+  }
+
+  const succeeded = items.filter(item => item.status === 'success').length
+  const failed = items.filter(item => item.status === 'failed').length
+  const cancelled = items.filter(item => item.status === 'cancelled').length
+
+  return {
+    items,
+    succeeded,
+    failed,
+    cancelled,
+    partial: items.length > 0 && succeeded > 0 && (failed > 0 || cancelled > 0),
+  }
+}
+
+/**
+ * Resolve each distinct canonical target once. Resolver failures become a
+ * coarse unavailable result so one broken resource cannot blank a document.
+ */
+export async function resolveMarkdownTargets(
+  resolver: MarkdownTargetResolver,
+  targets: readonly MarkdownTarget[] | readonly string[],
+  context: MarkdownTargetResolverContext = {},
+): Promise<ReadonlyMap<string, MarkdownTargetResolution>> {
+  const unique = new Map<string, MarkdownTarget>()
+  for (const value of targets) {
+    const target = typeof value === 'string' ? value : value.target
+    if (!unique.has(target)) {
+      unique.set(target, typeof value === 'string' ? { kind: 'document', target } : value)
+    }
+  }
+
+  const entries = await Promise.all(
+    [...unique.values()].map(async target => {
+      try {
+        return [
+          target.target,
+          await resolver.resolve(target.target, {
+            vault: context.vault,
+            document: context.document,
+            commit: context.commit,
+            signal: context.signal,
+          }),
+        ] as const
+      } catch {
+        return [
+          target.target,
+          {
+            target: target.target,
+            kind: target.kind,
+            status: 'unavailable',
+            reason: 'unknown',
+          } satisfies MarkdownTargetResolution,
+        ] as const
+      }
+    }),
+  )
+
+  return new Map(entries)
+}
+
+export function targetResolution(
+  target: MarkdownTarget,
+  runtimeUrl: string,
+  label?: string,
+): MarkdownTargetResolution {
+  return {
+    target: target.target,
+    kind: target.kind,
+    status: 'available',
+    runtimeUrl,
+    label,
+  }
+}
+
+export function unavailableTargetResolution(
+  target: MarkdownTarget,
+  reason: MarkdownUnavailableReason = 'unknown',
+  label?: string,
+): MarkdownTargetResolution {
+  return {
+    target: target.target,
+    kind: target.kind,
+    status: 'unavailable',
+    reason,
+    label,
+  }
+}
+
+export function isMarkdownAsset(value: unknown): value is MarkdownAsset {
+  if (!value || typeof value !== 'object') return false
+  const candidate = value as Partial<MarkdownAsset>
+  return (
+    (candidate.kind === 'file' || candidate.kind === 'attachment') &&
+    typeof candidate.target === 'string' &&
+    candidate.target.trim().length > 0
+  )
+}

--- a/packages/markdown-editor/src/adapters.ts
+++ b/packages/markdown-editor/src/adapters.ts
@@ -1,11 +1,9 @@
 import type {
   MarkdownAdapterError,
-  MarkdownAsset,
   MarkdownTarget,
   MarkdownTargetResolution,
   MarkdownTargetResolver,
   MarkdownTargetResolverContext,
-  MarkdownUnavailableReason,
   MarkdownUploadAdapter,
   MarkdownUploadBatchResult,
   MarkdownUploadContext,
@@ -160,42 +158,4 @@ export async function resolveMarkdownTargets(
   )
 
   return new Map(entries)
-}
-
-export function targetResolution(
-  target: MarkdownTarget,
-  runtimeUrl: string,
-  label?: string,
-): MarkdownTargetResolution {
-  return {
-    target: target.target,
-    kind: target.kind,
-    status: 'available',
-    runtimeUrl,
-    label,
-  }
-}
-
-export function unavailableTargetResolution(
-  target: MarkdownTarget,
-  reason: MarkdownUnavailableReason = 'unknown',
-  label?: string,
-): MarkdownTargetResolution {
-  return {
-    target: target.target,
-    kind: target.kind,
-    status: 'unavailable',
-    reason,
-    label,
-  }
-}
-
-export function isMarkdownAsset(value: unknown): value is MarkdownAsset {
-  if (!value || typeof value !== 'object') return false
-  const candidate = value as Partial<MarkdownAsset>
-  return (
-    (candidate.kind === 'file' || candidate.kind === 'attachment') &&
-    typeof candidate.target === 'string' &&
-    candidate.target.trim().length > 0
-  )
 }

--- a/packages/markdown-editor/src/core.ts
+++ b/packages/markdown-editor/src/core.ts
@@ -7,6 +7,8 @@ import type {
   MarkdownDocument,
   MarkdownEditorConfig,
   MarkdownParseOptions,
+  MarkdownTarget,
+  MarkdownTargetKind,
 } from './types.js'
 
 function managerFor(options: MarkdownParseOptions = {}): MarkdownManager {
@@ -37,6 +39,53 @@ export function canonicalizeMarkdown(
   return serializeMarkdown(parseMarkdown(markdown, options), options)
 }
 
+function inferTargetKind(target: string, nodeType: string): MarkdownTargetKind | null {
+  if (nodeType === 'image') {
+    return /^\/api\/assets\/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/?$/i.test(target)
+      ? 'attachment'
+      : null
+  }
+  if (!target.startsWith('akb://')) return null
+  if (/\/file\/[^/]+$/.test(target)) return 'file'
+  if (/\/doc\/[^/]+$/.test(target)) return 'document'
+  return null
+}
+
+/**
+ * Return the canonical resource targets represented by Markdown links and
+ * images. Code blocks/spans are absent from the parsed document and therefore
+ * cannot accidentally become runtime fetches.
+ */
+export function extractMarkdownTargets(markdown: string): MarkdownTarget[] {
+  const document = parseMarkdown(markdown)
+  const targets: MarkdownTarget[] = []
+  const seen = new Set<string>()
+
+  const visit = (node: JSONContent) => {
+    if (node.type === 'image') {
+      const target = typeof node.attrs?.target === 'string' ? node.attrs.target : ''
+      const kind = target ? inferTargetKind(target, 'image') : null
+      if (kind && !seen.has(target)) {
+        seen.add(target)
+        targets.push({ kind, target })
+      }
+    }
+    for (const mark of node.marks ?? []) {
+      if (mark.type !== 'link') continue
+      const target = typeof mark.attrs?.href === 'string' ? mark.attrs.href : ''
+      const kind = target ? inferTargetKind(target, 'link') : null
+      if (kind && !seen.has(target)) {
+        seen.add(target)
+        targets.push({ kind, target })
+      }
+    }
+    for (const child of node.content ?? []) visit(child)
+  }
+
+  for (const node of document.content ?? []) visit(node)
+  return targets
+}
+
 export function createMarkdownEditor(options: MarkdownEditorConfig = {}): Editor {
   const {
     initialMarkdown = '',
@@ -65,6 +114,11 @@ export function markdownCommands(editor: Editor): MarkdownCommands {
     setMarkdown: markdown => editor.commands.setContent(markdown, { contentType: 'markdown' }),
     insertMarkdown: markdown =>
       editor.commands.insertContent(markdown, { contentType: 'markdown' }),
+    insertImage: (target, alt = '', title) =>
+      editor.commands.insertContent({
+        type: 'image',
+        attrs: { target, alt, title: title ?? null },
+      }),
     toggleBold: () => editor.commands.toggleBold(),
     toggleItalic: () => editor.commands.toggleItalic(),
     toggleBulletList: () => editor.commands.toggleBulletList(),

--- a/packages/markdown-editor/src/extensions.ts
+++ b/packages/markdown-editor/src/extensions.ts
@@ -26,6 +26,73 @@ interface RawMarkdownToken extends MarkdownToken {
   kind?: RawMarkdownKind
 }
 
+interface MarkdownImageToken extends MarkdownToken {
+  href?: string
+  title?: string | null
+}
+
+function escapeImageLabel(value: string): string {
+  return value.replace(/([\\\]])/g, '\\$1')
+}
+
+function imageDestination(target: string): string {
+  return /[\s()]/.test(target) ? `<${target.replace(/[<>]/g, '')}>` : target
+}
+
+/**
+ * Image is intentionally part of the shared schema rather than a product
+ * renderer. Its `target` attribute is the canonical Markdown value; runtime
+ * adapters may change only the rendered DOM `src` and never this attribute.
+ */
+export const MarkdownImage = Node.create({
+  name: 'image',
+  inline: true,
+  group: 'inline',
+  atom: true,
+  selectable: true,
+  draggable: true,
+
+  addAttributes() {
+    return {
+      target: { default: '' },
+      alt: { default: '' },
+      title: { default: null },
+    }
+  },
+
+  parseHTML() {
+    return [{ tag: 'img[src]' }]
+  },
+
+  renderHTML({ node }) {
+    const target = String(node.attrs.target || node.attrs.src || '')
+    return [
+      'img',
+      {
+        src: target,
+        alt: String(node.attrs.alt ?? ''),
+        ...(node.attrs.title ? { title: String(node.attrs.title) } : {}),
+        'data-markdown-target': target,
+      },
+    ]
+  },
+
+  parseMarkdown: (token: MarkdownImageToken, helpers) =>
+    helpers.createNode('image', {
+      target: token.href ?? '',
+      alt: token.text ?? '',
+      title: token.title ?? null,
+    }),
+
+  renderMarkdown: node => {
+    const attrs = node.attrs ?? {}
+    const target = String(attrs.target || attrs.src || '')
+    const alt = String(attrs.alt ?? '')
+    const title = attrs.title ? ` "${String(attrs.title).replace(/"/g, '\\"')}"` : ''
+    return `![${escapeImageLabel(alt)}](${imageDestination(target)}${title})`
+  },
+})
+
 const rawBlockStart = /^(?:<!--|<!\[CDATA\[|<>|<\/?[A-Za-z][A-Za-z0-9:._-]*(?:[\s/>]|$))/
 const rawInlineStart = /^(?:<!--[\s\S]*?-->|<>|<\/>|<\/?[A-Za-z][A-Za-z0-9:._-]*(?:\s[^<>]*?)?\/?>)/
 
@@ -236,7 +303,13 @@ export function createMarkdownExtensions({
   onSlash,
 }: MarkdownExtensionsOptions = {}): AnyExtension[] {
   const extensions: AnyExtension[] = [
-    StarterKit,
+    StarterKit.configure({
+      // AKB/consumer adapters resolve these durable references to a runtime
+      // URL after parsing. `akb` is only accepted as a data scheme here; no
+      // adapter or network behavior belongs in the shared schema.
+      link: { protocols: ['akb'] },
+    }),
+    MarkdownImage,
     Table.configure({ resizable: false }),
     TableRow,
     TableHeader,

--- a/packages/markdown-editor/src/index.ts
+++ b/packages/markdown-editor/src/index.ts
@@ -1,4 +1,5 @@
 export * from './types.js'
+export * from './adapters.js'
 export * from './extensions.js'
 export * from './core.js'
 export * from './react/index.js'

--- a/packages/markdown-editor/src/react/index.tsx
+++ b/packages/markdown-editor/src/react/index.tsx
@@ -4,14 +4,20 @@ import { EditorContent, useEditor } from '@tiptap/react'
 import type { Editor } from '@tiptap/core'
 
 import { createMarkdownExtensions } from '../extensions.js'
-import { markdownCommands } from '../core.js'
+import { extractMarkdownTargets, markdownCommands } from '../core.js'
+import { resolveMarkdownTargets } from '../adapters.js'
 import type {
+  MarkdownAdapters,
   MarkdownCommands,
   MarkdownEditorConfig,
   MarkdownProfile,
   MarkdownSlashContext,
   MarkdownState,
+  MarkdownTargetResolution,
+  MarkdownTargetResolverContext,
 } from '../types.js'
+
+const EMPTY_RESOLUTIONS: ReadonlyMap<string, MarkdownTargetResolution> = new Map()
 
 export interface UseMarkdownEditorOptions {
   initialMarkdown?: string
@@ -51,6 +57,7 @@ export function useMarkdownCommands(editor: Editor | null): MarkdownCommands {
         : {
             setMarkdown: () => false,
             insertMarkdown: () => false,
+            insertImage: () => false,
             toggleBold: () => false,
             toggleItalic: () => false,
             toggleBulletList: () => false,
@@ -99,13 +106,120 @@ export function useMarkdownState(editor: Editor | null): MarkdownState | null {
   return editor ? state : null
 }
 
+/**
+ * Resolve canonical targets for presentation. The returned map is ephemeral;
+ * it is never fed back into the editor document or its Markdown serializer.
+ */
+export function useMarkdownTargetResolutions(
+  markdown: string,
+  resolver?: MarkdownAdapters['targetResolver'],
+  context: MarkdownTargetResolverContext = {},
+): ReadonlyMap<string, MarkdownTargetResolution> {
+  const { commit, document, vault } = context
+  const targets = useMemo(() => extractMarkdownTargets(markdown), [markdown])
+  const resolutionKey = useMemo(
+    () => [vault ?? '', document ?? '', commit ?? '', ...targets.map(target => target.target)].join('\u0000'),
+    [commit, document, targets, vault],
+  )
+  const [resolutionState, setResolutionState] = useState<{
+    key: string
+    resolutions: ReadonlyMap<string, MarkdownTargetResolution>
+  }>({ key: '', resolutions: EMPTY_RESOLUTIONS })
+
+  useEffect(() => {
+    if (!resolver || targets.length === 0) return
+
+    const controller = new AbortController()
+    void resolveMarkdownTargets(resolver, targets, {
+      vault,
+      document,
+      commit,
+      signal: controller.signal,
+    }).then(next => {
+      if (!controller.signal.aborted) setResolutionState({ key: resolutionKey, resolutions: next })
+    })
+
+    return () => controller.abort()
+  }, [commit, document, resolutionKey, resolver, targets, vault])
+
+  return resolver && targets.length > 0 && resolutionState.key === resolutionKey
+    ? resolutionState.resolutions
+    : EMPTY_RESOLUTIONS
+}
+
 interface MarkdownSurfaceProps extends Omit<ComponentPropsWithoutRef<'div'>, 'onChange'> {
   editor: Editor | null
   editable: boolean
+  resolutions?: ReadonlyMap<string, MarkdownTargetResolution>
+  resolvingTargets?: boolean
   children?: ReactNode
 }
 
-function MarkdownSurface({ editor, editable, children, ...props }: MarkdownSurfaceProps) {
+function MarkdownSurface({
+  editor,
+  editable,
+  resolutions = EMPTY_RESOLUTIONS,
+  resolvingTargets = false,
+  children,
+  ...props
+}: MarkdownSurfaceProps) {
+  useEffect(() => {
+    const root = editor?.view.dom
+    if (!root) return
+
+    const applyResolutions = () => {
+      root.querySelectorAll<HTMLElement>('img[data-markdown-target], a[href]').forEach(element => {
+        const target =
+          element.dataset.markdownTarget ??
+          (element.tagName === 'A' && element.getAttribute('href')?.startsWith('akb://')
+            ? element.getAttribute('href')
+            : null)
+        if (!target) return
+        element.dataset.markdownTarget = target
+        const resolution = resolutions.get(target)
+        const previousResolution = element.dataset.markdownResolution
+        if (!resolution) {
+          if (resolvingTargets) {
+            element.dataset.markdownResolution = 'pending'
+            element.setAttribute('aria-disabled', 'true')
+            if (element.tagName === 'IMG') element.removeAttribute('src')
+            else element.setAttribute('href', '#')
+            return
+          }
+          if (element.tagName === 'IMG') element.setAttribute('src', target)
+          else element.setAttribute('href', target)
+          if (previousResolution === 'unavailable') element.removeAttribute('aria-label')
+          element.removeAttribute('aria-disabled')
+          delete element.dataset.markdownResolution
+          return
+        }
+
+        if (resolution.status === 'available' && resolution.runtimeUrl) {
+          if (element.tagName === 'IMG') element.setAttribute('src', resolution.runtimeUrl)
+          else element.setAttribute('href', resolution.runtimeUrl)
+          element.dataset.markdownResolution = 'available'
+          if (previousResolution === 'unavailable') element.removeAttribute('aria-label')
+          element.removeAttribute('aria-disabled')
+          return
+        }
+
+        element.dataset.markdownResolution = 'unavailable'
+        element.setAttribute('aria-label', resolution.label ?? 'Reference unavailable')
+        if (element.tagName === 'IMG') element.removeAttribute('src')
+        else {
+          element.setAttribute('href', '#')
+          element.setAttribute('aria-disabled', 'true')
+        }
+      })
+    }
+
+    applyResolutions()
+    editor.on('transaction', applyResolutions)
+    return () => {
+      editor.off('transaction', applyResolutions)
+    }
+  }, [editor, resolvingTargets, resolutions])
+
   return (
     <div
       {...props}
@@ -122,6 +236,8 @@ export interface MarkdownEditorProps extends Omit<MarkdownSurfaceProps, 'editor'
   profile?: MarkdownProfile
   onChange?: MarkdownEditorConfig['onChange']
   onSlash?: (context: MarkdownSlashContext) => void
+  adapters?: MarkdownAdapters
+  resolverContext?: MarkdownTargetResolverContext
 }
 
 export function MarkdownEditor({
@@ -129,6 +245,8 @@ export function MarkdownEditor({
   profile = 'preserve',
   onChange,
   onSlash,
+  adapters,
+  resolverContext,
   ...props
 }: MarkdownEditorProps) {
   const editor = useMarkdownEditor({
@@ -138,6 +256,11 @@ export function MarkdownEditor({
     onChange,
     onSlash,
   })
+  const resolutions = useMarkdownTargetResolutions(
+    markdown,
+    adapters?.targetResolver,
+    resolverContext,
+  )
 
   useEffect(() => {
     if (!editor || editor.getMarkdown() === markdown) {
@@ -147,17 +270,29 @@ export function MarkdownEditor({
     editor.commands.setContent(markdown, { contentType: 'markdown' })
   }, [editor, markdown])
 
-  return <MarkdownSurface {...props} editor={editor} editable />
+  return (
+    <MarkdownSurface
+      {...props}
+      editor={editor}
+      editable
+      resolutions={resolutions}
+      resolvingTargets={Boolean(adapters?.targetResolver)}
+    />
+  )
 }
 
 export interface MarkdownViewerProps extends Omit<MarkdownSurfaceProps, 'editor' | 'editable'> {
   markdown: string
   profile?: MarkdownProfile
+  adapters?: MarkdownAdapters
+  resolverContext?: MarkdownTargetResolverContext
 }
 
 export function MarkdownViewer({
   markdown,
   profile = 'preserve',
+  adapters,
+  resolverContext,
   ...props
 }: MarkdownViewerProps) {
   const editor = useMarkdownEditor({
@@ -165,6 +300,11 @@ export function MarkdownViewer({
     profile,
     editable: false,
   })
+  const resolutions = useMarkdownTargetResolutions(
+    markdown,
+    adapters?.targetResolver,
+    resolverContext,
+  )
 
   useEffect(() => {
     if (!editor || editor.getMarkdown() === markdown) {
@@ -174,7 +314,15 @@ export function MarkdownViewer({
     editor.commands.setContent(markdown, { contentType: 'markdown' })
   }, [editor, markdown])
 
-  return <MarkdownSurface {...props} editor={editor} editable={false} />
+  return (
+    <MarkdownSurface
+      {...props}
+      editor={editor}
+      editable={false}
+      resolutions={resolutions}
+      resolvingTargets={Boolean(adapters?.targetResolver)}
+    />
+  )
 }
 
 export { EditorContent }

--- a/packages/markdown-editor/src/types.ts
+++ b/packages/markdown-editor/src/types.ts
@@ -3,39 +3,121 @@ import type { MarkdownExtensionOptions } from '@tiptap/markdown'
 
 export type MarkdownProfile = 'structured' | 'preserve'
 
+export type MarkdownTargetKind = 'document' | 'file' | 'attachment'
+
+/**
+ * A resource reference as it appears in canonical Markdown.  `target` is the
+ * durable value; a resolver's short-lived runtime URL is deliberately not a
+ * field on this type.
+ */
+export interface MarkdownTarget {
+  kind: MarkdownTargetKind
+  target: string
+}
+
+export type MarkdownUnavailableReason =
+  | 'inaccessible'
+  | 'deleted'
+  | 'unsupported'
+  | 'cross-vault'
+  | 'expired'
+  | 'unknown'
+
+export type MarkdownTargetResolution =
+  | {
+      target: string
+      kind?: MarkdownTargetKind
+      status: 'available'
+      /** Short-lived runtime URL; never serialized to Markdown. */
+      runtimeUrl: string
+      label?: string
+    }
+  | {
+      target: string
+      kind?: MarkdownTargetKind
+      status: 'unavailable'
+      reason: MarkdownUnavailableReason
+      label?: string
+    }
+
 export interface MarkdownParseOptions {
   profile?: MarkdownProfile
   markedOptions?: MarkdownExtensionOptions['markedOptions']
 }
 
 export interface MarkdownUploadContext {
+  vault?: string
   documentId?: string
+  draftId?: string
   target?: string
+  signal?: AbortSignal
 }
 
 export interface MarkdownAsset {
-  url: string
+  /** Opaque product identity used for draft handoff/cleanup, when provided. */
+  id?: string
+  /** Canonical target to write into Markdown. */
+  target: string
+  kind: 'file' | 'attachment'
   alt?: string
   title?: string
+  /** Server-provided expiry for an unclaimed upload, when applicable. */
+  expiresAt?: string
 }
 
 export interface MarkdownUploadAdapter {
   upload(file: Blob, context?: MarkdownUploadContext): Promise<MarkdownAsset>
 }
 
+export interface MarkdownAdapterError {
+  code: 'unavailable' | 'invalid' | 'conflict' | 'cancelled' | 'unknown'
+  message: string
+  retryable: boolean
+}
+
+export type MarkdownUploadItem =
+  | { status: 'success'; file: Blob; asset: MarkdownAsset }
+  | { status: 'failed'; file: Blob; error: MarkdownAdapterError }
+  | { status: 'cancelled'; file: Blob; error: MarkdownAdapterError }
+
+export interface MarkdownUploadBatchResult {
+  items: readonly MarkdownUploadItem[]
+  succeeded: number
+  failed: number
+  cancelled: number
+  partial: boolean
+}
+
 export interface MarkdownSearchResult {
   id: string
   title: string
   snippet?: string
-  target?: string
+  /** Canonical target to insert into Markdown; never a signed/runtime URL. */
+  target: string
+  kind?: MarkdownTargetKind
 }
 
 export interface MarkdownSearchAdapter {
-  search(query: string): Promise<readonly MarkdownSearchResult[]>
+  search(query: string, context?: MarkdownSearchContext): Promise<readonly MarkdownSearchResult[]>
+}
+
+export interface MarkdownSearchContext {
+  vault?: string
+  signal?: AbortSignal
 }
 
 export interface MarkdownTargetResolver {
-  resolve(target: string): Promise<string | null>
+  resolve(
+    target: string,
+    context?: MarkdownTargetResolverContext,
+  ): Promise<MarkdownTargetResolution>
+}
+
+export interface MarkdownTargetResolverContext {
+  vault?: string
+  document?: string
+  commit?: string
+  signal?: AbortSignal
 }
 
 export interface MarkdownAdapters {
@@ -53,6 +135,7 @@ export interface MarkdownEditorConfig extends MarkdownParseOptions {
   initialMarkdown?: string
   editable?: boolean
   element?: EditorOptions['element']
+  adapters?: MarkdownAdapters
   onChange?: (markdown: string, editor: Editor) => void
   onSlash?: (context: MarkdownSlashContext) => void
 }
@@ -60,6 +143,7 @@ export interface MarkdownEditorConfig extends MarkdownParseOptions {
 export interface MarkdownCommands {
   setMarkdown(markdown: string): boolean
   insertMarkdown(markdown: string): boolean
+  insertImage(target: string, alt?: string, title?: string): boolean
   toggleBold(): boolean
   toggleItalic(): boolean
   toggleBulletList(): boolean

--- a/packages/markdown-editor/test/core.test.ts
+++ b/packages/markdown-editor/test/core.test.ts
@@ -3,9 +3,11 @@ import { afterEach, describe, expect, it } from 'vitest'
 import {
   canonicalizeMarkdown,
   createMarkdownEditor,
+  extractMarkdownTargets,
   markdownCommands,
   parseMarkdown,
   serializeMarkdown,
+  uploadMarkdownBatch,
 } from '../src/index.js'
 import type { MarkdownAdapters } from '../src/index.js'
 
@@ -79,16 +81,83 @@ describe('Markdown conformance core', () => {
     expect(canonicalizeMarkdown(canonical)).toBe(canonical)
   })
 
+  it('keeps document, file, and attachment targets through image/link editing', () => {
+    const attachment = '/api/assets/00000000-0000-4000-8000-000000000001'
+    const document = 'akb://vault/coll/notes/doc/guide.md'
+    const file = 'akb://vault/file/00000000-0000-4000-8000-000000000002'
+    const markdown = [
+      `[Guide](${document})`,
+      `[Download](${file})`,
+      `![Diagram](${attachment})`,
+      '![Remote](https://example.com/remote.png)',
+      '`[ignored](akb://vault/doc/ignored.md)`',
+    ].join('\n\n')
+
+    expect(canonicalizeMarkdown(markdown)).toContain(`![Diagram](${attachment})`)
+    expect(extractMarkdownTargets(markdown)).toEqual([
+      { kind: 'document', target: document },
+      { kind: 'file', target: file },
+      { kind: 'attachment', target: attachment },
+    ])
+  })
+
+  it('retains every per-file upload outcome for a partial batch', async () => {
+    const files = [new Blob(['one']), new Blob(['two']), new Blob(['three'])]
+    const adapter = {
+      upload: async (file: Blob) => {
+        if (file === files[1]) throw Object.assign(new Error('busy'), { retryable: true })
+        return { kind: 'attachment' as const, target: `/api/assets/${file.size}` }
+      },
+    }
+
+    const result = await uploadMarkdownBatch(adapter, files)
+
+    expect(result).toMatchObject({ succeeded: 2, failed: 1, cancelled: 0, partial: true })
+    expect(result.items.map(item => item.status)).toEqual(['success', 'failed', 'success'])
+    expect(result.items[1]).toMatchObject({
+      status: 'failed',
+      error: { code: 'unknown', message: 'busy', retryable: true },
+    })
+  })
+
+  it('marks the remaining files cancelled once the batch signal is aborted', async () => {
+    const controller = new AbortController()
+    const files = [new Blob(['one']), new Blob(['two'])]
+    const adapter = {
+      upload: async (file: Blob) => {
+        if (file === files[0]) controller.abort()
+        return { kind: 'attachment' as const, target: `/api/assets/${file.size}` }
+      },
+    }
+
+    const result = await uploadMarkdownBatch(adapter, files, { signal: controller.signal })
+
+    expect(result.succeeded).toBe(1)
+    expect(result.cancelled).toBe(1)
+    expect(result.items.map(item => item.status)).toEqual(['success', 'cancelled'])
+  })
+
   it('exposes product-neutral adapter contracts without implementing product behavior', () => {
     const adapters: MarkdownAdapters = {
       upload: {
-        upload: async file => ({ url: `https://cdn.example/${file.size}` }),
+        upload: async file => ({
+          kind: 'attachment',
+          target: `/api/assets/${file.size}`,
+        }),
       },
       search: {
-        search: async query => [{ id: query, title: query }],
+        search: async query => [{
+          id: query,
+          title: query,
+          target: `akb://vault/doc/${query}.md`,
+        }],
       },
       targetResolver: {
-        resolve: async target => target,
+        resolve: async target => ({
+          target,
+          status: 'available',
+          runtimeUrl: `/runtime/${encodeURIComponent(target)}`,
+        }),
       },
     }
 

--- a/packages/markdown-editor/test/react.test.tsx
+++ b/packages/markdown-editor/test/react.test.tsx
@@ -84,4 +84,51 @@ describe('React surfaces', () => {
     await userEvent.setup().click(getByRole('button', { name: 'update' }))
     await waitFor(() => expect(container.querySelector('.ProseMirror')).toHaveTextContent('외부 갱신'))
   })
+
+  it('applies runtime URLs without changing the canonical image target', async () => {
+    const target = '/api/assets/00000000-0000-4000-8000-000000000001'
+    const resolver = {
+      resolve: async (value: string) => ({
+        target: value,
+        status: 'available' as const,
+        runtimeUrl: 'blob:runtime-image',
+      }),
+    }
+    const { container } = render(
+      <MarkdownEditor
+        markdown={`![diagram](${target})`}
+        adapters={{ targetResolver: resolver }}
+      />,
+    )
+
+    await waitFor(() => {
+      const image = container.querySelector('img[data-markdown-target]')
+      expect(image).toHaveAttribute('src', 'blob:runtime-image')
+      expect(image).toHaveAttribute('data-markdown-target', target)
+    })
+  })
+
+  it('renders an unavailable placeholder while preserving the source target', async () => {
+    const target = 'akb://vault/coll/notes/doc/missing.md'
+    const resolver = {
+      resolve: async (value: string) => ({
+        target: value,
+        status: 'unavailable' as const,
+        reason: 'unknown' as const,
+      }),
+    }
+    const { container } = render(
+      <MarkdownViewer
+        markdown={`[Missing](${target})`}
+        adapters={{ targetResolver: resolver }}
+      />,
+    )
+
+    await waitFor(() => {
+      const link = container.querySelector('a[data-markdown-target]')
+      expect(link).toHaveAttribute('data-markdown-resolution', 'unavailable')
+      expect(link).toHaveAttribute('href', '#')
+      expect(link).toHaveAttribute('data-markdown-target', target)
+    })
+  })
 })


### PR DESCRIPTION
## Why

AKB Markdown previously had no shared contract separating durable resource references from short-lived display URLs. That made Document, standalone File, and document Attachment links product-specific, and left partial uploads or expired draft attachments without consistent recovery behavior.

This change gives the shared editor a canonical target contract while keeping access-sensitive runtime URLs in the rendered session only.

## What changes

- Bump `@akb/markdown-editor` to `0.2.0` with product-neutral upload, search, target-resolution, and per-file batch outcome APIs.
- Preserve canonical Document, File, and Attachment targets in editor state and serialized Markdown while resolving temporary display URLs only in the viewer/editor DOM.
- Connect the AKB frontend to those adapters, including partial upload retry/removal, unavailable-resource treatment, and recoverable draft expiry/discard behavior.
- Add immutable standalone File-to-Attachment copy and expose unclaimed attachment expiry metadata from the asset API.
- Project canonical inline references into `links_to` without persisting signed, blob, or fixture-runtime URLs.
- Keep frontend fixture selection behind the AKB-owned `AKB_FE_E2E_SCENARIO` interface so external runner details do not enter the repository contract.

Tracking: `AKB-249`

## Reviewer focus

1. The canonical/runtime boundary in `packages/markdown-editor`: only canonical targets may reach Markdown; resolver URLs must remain render-only.
2. Attachment lifecycle behavior across upload, draft restoration, expiry, explicit discard, save/claim, and immutable File copy.
3. The intentional `0.2.0` public API change for `MarkdownAsset`, search results, and target resolvers.
4. Graph extraction of Document/File/Attachment references without changing unrelated Markdown links.

## Compatibility and risk

- This is an intentional `@akb/markdown-editor` `0.2.0` contract change: exact-pinned consumers must adopt canonical `target`/`kind` assets and structured resolver results instead of the `0.1.0` URL-shaped interfaces.
- Existing ordinary Markdown remains valid. Newly authored AKB resources use canonical `akb://...` or `/api/assets/...` targets; runtime download/blob URLs are never serialized.
- The highest-risk paths are partial upload recovery and draft attachment lifetime. The browser scenarios below cover retry, removal, reload restoration, expiry, explicit discard, and save/claim transitions.

## Validation

Exercised user scenarios:

- Document and File references resolve to usable routes while inaccessible resources receive a neutral unavailable state.
- A claimed Attachment renders normally, then becomes unavailable after expiry without losing its canonical target.
- A mixed upload batch keeps successful images, exposes the failed item, supports retry/removal, and saves only canonical attachment targets.
- Unsaved text and attachments restore after reload; expired drafts remain recoverable until explicit discard.

Project checks:

- `bash scripts/check.sh`
- Shared-package pack/install/typecheck/build smoke from a clean consumer
- [Static analysis](https://github.com/dnotitia/akb/actions/runs/34333256104), [backend and pgvector tests](https://github.com/dnotitia/akb/actions/runs/34333256221), and [frontend plus repository-runtime E2E](https://github.com/dnotitia/akb/actions/runs/34333256119)

## UI evidence

After an Attachment expires, the document presents a neutral unavailable state without exposing storage or provider details; the underlying canonical target remains intact.

![Unavailable attachment treatment](https://github.com/user-attachments/assets/75e5e07a-d4e7-446e-afb8-cd78fe33fd94)

After a reload, the editor restores the unsaved title and explicitly reports `Local draft restored`.

![Restored local draft after reload](https://github.com/user-attachments/assets/5deb6031-2dde-40d0-9c5e-dd03cae614a0)

## Pull Request Checklist

- [x] `bash scripts/check.sh` passes.
- [x] Relevant browser, backend, package, and graph scenarios pass.
- [x] Changes to the frontend E2E fixture/runtime path pass the repository's isolated E2E gate.
- [x] Static analysis includes secret detection; the diff contains no credentials, internal hosts, or personal data.
- [x] No backend configuration key was added, so `config/*.yaml.example` does not require a change.
- [x] User-facing behavior and the `@akb/markdown-editor` compatibility change are described above.
