### PR TITLE
fix(cutover): let a File step aside instead of failing the whole cutover

### DIFF
--- a/backend/app/db/migrations/100_native_revision_cutover_file_applied_path.py
+++ b/backend/app/db/migrations/100_native_revision_cutover_file_applied_path.py
@@ -1,0 +1,52 @@
+"""Migration 100: record the native path a cutover File was actually published at.
+
+Legacy File names are not unique — the storage key is what
+`UNIQUE(vault_id, s3_key)` covers — and native paths are one authority namespace
+across Document and File Resources. So the path a File is published at can differ
+from the `logical_path` the plan froze, and both `apply` and `verify` need to
+agree on which one it was.
+
+The column is also what makes a retry safe: the publication fingerprint includes
+the path, so re-deriving it against live state after a partial apply would raise
+`Native idempotency key was reused with different input`. Writing the resolved
+path before publishing means a retry replays the same input.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("akb.migration.100")
+
+
+async def migrate(conn=None):
+    if conn is None:
+        from app.db.postgres import get_pool
+
+        pool = await get_pool()
+        async with pool.acquire() as new_conn:
+            await _run(new_conn)
+    else:
+        await _run(conn)
+
+
+async def _run(conn):
+    if await conn.fetchval("SELECT to_regclass('public.native_revision_cutover_files')") is None:
+        logger.info("Migration 100 skipped: cutover File inventory is absent")
+        return
+
+    async with conn.transaction():
+        await conn.execute(
+            """
+            ALTER TABLE native_revision_cutover_files
+                ADD COLUMN IF NOT EXISTS applied_path TEXT;
+
+            ALTER TABLE native_revision_cutover_files
+                DROP CONSTRAINT IF EXISTS native_revision_cutover_files_applied_path_shape;
+            ALTER TABLE native_revision_cutover_files
+                ADD CONSTRAINT native_revision_cutover_files_applied_path_shape
+                CHECK (applied_path IS NULL OR btrim(applied_path) <> '');
+            """
+        )
+
+    logger.info("Migration 100 recorded the published native path per cutover File")

--- a/backend/app/db/postgres.py
+++ b/backend/app/db/postgres.py
@@ -351,6 +351,7 @@ async def _apply_pending_migrations(conn, applied: set[str]) -> None:
         "097_native_revision_migration_inventory.py",  # one immutable fixed-ref inventory per run
         "098_native_revision_nul_payload.py",  # permit UTF-8 NUL bytes in Native text payloads while retaining DB validation
         "099_personal_notifications.py",  # independent durable personal inbox and watches
+        "100_native_revision_cutover_file_applied_path.py",  # record the native path each cutover File was published at
     ):
         if filename in applied:
             continue

--- a/backend/app/repositories/native_revision_cutover_repo.py
+++ b/backend/app/repositories/native_revision_cutover_repo.py
@@ -61,6 +61,7 @@ class CutoverFile:
     verification_digest: str | None
     applied_at: Any
     verified_at: Any
+    applied_path: str | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -147,7 +148,7 @@ class NativeRevisionCutoverRepository:
             SELECT cutover_id, namespace_id, file_id, logical_path, mime_type,
                    content_hash, byte_size, s3_key, etag, storage_version,
                    created_by, disposition, status, native_revision_id,
-                   verification_digest, applied_at, verified_at
+                   verification_digest, applied_at, verified_at, applied_path
               FROM native_revision_cutover_files
              WHERE cutover_id = $1
              ORDER BY namespace_id, file_id
@@ -396,6 +397,56 @@ class NativeRevisionCutoverRepository:
                     raise CutoverIntegrityError("cutover exclusion inventory drifted")
                 return _run(row)
 
+    async def set_file_applied_path(
+        self,
+        *,
+        cutover_id: uuid.UUID,
+        file_id: uuid.UUID,
+        applied_path: str,
+    ) -> CutoverFile:
+        """Claim the native path this File will be published at, before publishing.
+
+        The publication fingerprint includes the path, so a retry that re-derived
+        it against live state after a partial apply would be refused as an
+        idempotency-key reuse. Writing the claim first makes the retry replay the
+        same input. The first claim wins: a second call with a different path is
+        an integrity error, not an overwrite.
+        """
+        if not isinstance(applied_path, str) or not applied_path.strip():
+            raise ValueError("applied_path must be a non-empty path")
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                row = await conn.fetchrow(
+                    """
+                    SELECT applied_path
+                      FROM native_revision_cutover_files
+                     WHERE cutover_id = $1 AND file_id = $2
+                     FOR UPDATE
+                    """,
+                    cutover_id,
+                    file_id,
+                )
+                if row is None:
+                    raise CutoverIntegrityError("cutover File disappeared")
+                if row["applied_path"] is not None and row["applied_path"] != applied_path:
+                    raise CutoverIntegrityError("cutover File publication path drifted")
+                updated = await conn.fetchrow(
+                    """
+                    UPDATE native_revision_cutover_files
+                       SET applied_path = $3
+                     WHERE cutover_id = $1 AND file_id = $2
+                    RETURNING cutover_id, namespace_id, file_id, logical_path, mime_type,
+                              content_hash, byte_size, s3_key, etag, storage_version,
+                              created_by, disposition, status, native_revision_id,
+                              verification_digest, applied_at, verified_at, applied_path
+                    """,
+                    cutover_id,
+                    file_id,
+                    applied_path,
+                )
+                assert updated is not None
+                return _file(updated)
+
     async def set_file_status(
         self,
         *,
@@ -420,7 +471,7 @@ class NativeRevisionCutoverRepository:
                     SELECT cutover_id, namespace_id, file_id, logical_path, mime_type,
                            content_hash, byte_size, s3_key, etag, storage_version,
                            created_by, disposition, status, native_revision_id,
-                           verification_digest, applied_at, verified_at
+                           verification_digest, applied_at, verified_at, applied_path
                       FROM native_revision_cutover_files
                      WHERE cutover_id = $1 AND file_id = $2
                      FOR UPDATE
@@ -446,7 +497,7 @@ class NativeRevisionCutoverRepository:
                     RETURNING cutover_id, namespace_id, file_id, logical_path, mime_type,
                               content_hash, byte_size, s3_key, etag, storage_version,
                               created_by, disposition, status, native_revision_id,
-                              verification_digest, applied_at, verified_at
+                              verification_digest, applied_at, verified_at, applied_path
                     """,
                     cutover_id,
                     file_id,

--- a/backend/app/services/native_revision_cutover.py
+++ b/backend/app/services/native_revision_cutover.py
@@ -9,6 +9,7 @@ import uuid
 from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from contextlib import ExitStack, asynccontextmanager
 from dataclasses import dataclass
+from pathlib import PurePosixPath
 from typing import Any, Protocol
 
 import asyncpg
@@ -28,6 +29,7 @@ from app.repositories.native_revision_migration_repo import (
 )
 from app.services.native_revision_backfill import NativeRevisionBackfill
 from app.services.m1_pg_body_store import M1_PG_TEXT_MAX_BYTES, M1PgBodyStore
+from app.repositories.native_revision_repo import NativeRevisionRepository
 from app.services.native_revision_service import NativeRevisionService
 from app.services.adapters import s3_adapter
 from app.services.git_service import GitService
@@ -275,6 +277,7 @@ class NativeRevisionCutover:
                     verification_digest=None,
                     applied_at=None,
                     verified_at=None,
+                    applied_path=None,
                 )
             )
         return files
@@ -473,6 +476,49 @@ class NativeRevisionCutover:
             raise CutoverApplyError(f"File {file.file_id} is not eligible searchable text")
         return data.decode("utf-8", errors="strict")
 
+    @staticmethod
+    def _stepped_path(base_path: str, hex_slice: str) -> str:
+        """Insert a disambiguator ahead of the final suffix.
+
+        Mirrors `DocumentService._resolve_free_path`, which appends the same
+        slice before `.md`; generalizing over the suffix keeps attachments
+        (`.txt`, `.html`, `.pdf`, no suffix at all) readable and leaves the
+        Document case byte-identical to what Documents already produce.
+        """
+        suffix = PurePosixPath(base_path).suffix
+        stem = base_path[: len(base_path) - len(suffix)] if suffix else base_path
+        return f"{stem}-{hex_slice}{suffix}"
+
+    async def _resolve_free_file_path(self, file: CutoverFile) -> str:
+        """Return the native path this File should be published at.
+
+        Legacy File names are not unique — `UNIQUE(vault_id, s3_key)` covers the
+        storage key, and the partial UNIQUE on
+        `(vault, collection, name, content_hash)` does not apply to the historical
+        hash-less upload path at all — while native paths are one authority
+        namespace across Document and File Resources. So the frozen
+        `logical_path` may already be live, held by another attachment or by a
+        Document this same cutover just migrated.
+
+        Documents already answer this: keep the clean path if it is free, else
+        step onto progressively longer slices of the resource's OWN uuid
+        (8→12→16→full). Reusing that rule rather than inventing a second one is
+        the point — it preserves every byte, keeps `file_id`, and terminates
+        because the full hex is unique.
+        """
+        native_repo = NativeRevisionRepository(self.pool)
+        async with self.pool.acquire() as conn:
+            if await native_repo.find_live_path(conn, file.namespace_id, "file", file.logical_path) is None:
+                return file.logical_path
+            hexs = file.file_id.hex
+            for width in (8, 12, 16, len(hexs)):
+                candidate = self._stepped_path(file.logical_path, hexs[:width])
+                if await native_repo.find_live_path(conn, file.namespace_id, "file", candidate) is None:
+                    return candidate
+        # Unreachable in practice (the full uuid is unique); fall through and let
+        # the live-path UNIQUE surface any true clash rather than guess again.
+        return self._stepped_path(file.logical_path, file.file_id.hex)
+
     async def _apply_files(self, cutover_id: uuid.UUID) -> None:
         native = NativeRevisionService(
             self.pool,
@@ -491,10 +537,20 @@ class NativeRevisionCutover:
                 continue
             data = await asyncio.to_thread(self.file_reader, file.s3_key)
             self._validate_text_file(file, data)
+            # Claim the path before publishing: the fingerprint below includes it,
+            # so a retry that re-derived it would be refused as key reuse.
+            applied_path = file.applied_path
+            if applied_path is None:
+                applied_path = await self._resolve_free_file_path(file)
+                await self.repository.set_file_applied_path(
+                    cutover_id=cutover_id,
+                    file_id=file.file_id,
+                    applied_path=applied_path,
+                )
             result = await native.create_text(
                 namespace_id=file.namespace_id,
                 surface="file",
-                path=file.logical_path,
+                path=applied_path,
                 payload=data,
                 actor=file.created_by or "akb-native-revision-migration",
                 mutation_id=uuid.uuid5(
@@ -603,7 +659,9 @@ class NativeRevisionCutover:
                     file.file_id,
                     "file",
                     "live",
-                    file.logical_path,
+                    # The published path, which is the frozen `logical_path` unless
+                    # that path was already live and the File stepped aside.
+                    file.applied_path or file.logical_path,
                     file.native_revision_id,
                     file.content_hash,
                     file.byte_size,

--- a/backend/tests/test_native_revision_cutover_pg.py
+++ b/backend/tests/test_native_revision_cutover_pg.py
@@ -122,6 +122,7 @@ async def _fresh_schema(*, cutover_migrations: bool = True):
                     "094_native_revision_completed_reservation_transfer.py",
                     "096_native_revision_cutover_fence.py",
                     "097_native_revision_migration_inventory.py",
+                    "100_native_revision_cutover_file_applied_path.py",
                 ]
             )
         for filename in filenames:
@@ -1145,6 +1146,7 @@ async def test_plan_supersession_migration_releases_legacy_aborted_reservations(
                 "090_native_revision_vault_purge_fence.py",
                 "091_native_revision_committed_receipt_guard.py",
                 "097_native_revision_migration_inventory.py",
+                "100_native_revision_cutover_file_applied_path.py",
             ):
                 await _load(filename).migrate(conn=conn)
 
@@ -1210,6 +1212,7 @@ async def test_completed_reservation_transfer_migration_upgrades_aborted_applied
                 "092_native_revision_plan_supersession.py",
                 "093_external_git_retirement.py",
                 "097_native_revision_migration_inventory.py",
+                "100_native_revision_cutover_file_applied_path.py",
             ):
                 await _load(filename).migrate(conn=conn)
 
@@ -2371,3 +2374,97 @@ async def test_product_shadow_verifier_checks_real_git_and_native_reads(tmp_path
 
         assert verified.status == "verified"
         assert {vault.status for vault in verified.vaults} == {"verified"}
+
+
+async def test_apply_disambiguates_file_paths_that_are_already_live(tmp_path):
+    """Legacy File names are not unique; native paths are one authority namespace.
+
+    Two attachments can carry the same `logical_path` (the storage key, not the
+    name, is what the legacy UNIQUE covers), and an attachment can carry the path
+    of a Document in the same vault. The native side refuses a second live
+    resource on a path regardless of surface, so the cutover has to yield the way
+    Documents already do — keep the clean path for whoever holds it and step the
+    rest onto their own uuid — instead of failing the whole run.
+    """
+    async with _fresh_schema() as pool:
+        git = GitService(storage_path=str(tmp_path / "git"))
+        vault = await _manual_vault(pool, git, label="file-path-collision")
+        bodies: dict[str, bytes] = {}
+
+        async def _seed(label: str, data: bytes) -> uuid.UUID:
+            file_id, s3_key = await _confirmed_file(
+                pool,
+                namespace_id=vault.namespace_id,
+                label=label,
+                data=data,
+                mime_type="text/markdown",
+            )
+            bodies[s3_key] = data
+            return file_id
+
+        twin_a = await _seed("notes.md", b"first attachment\n")
+        twin_b = await _seed("notes.md", b"second attachment\n")
+        shadow = await _seed("document.md", b"an attachment named like the Document\n")
+
+        cutover = NativeRevisionCutover(
+            pool,
+            backfill=NativeRevisionBackfill(pool, git=git),
+            verifier=_FixtureVerifier(pool),
+            file_reader=lambda s3_key: bodies[s3_key],
+        )
+        planned = await cutover.plan(
+            vaults=[vault],
+            coverage_version="fixture-file-path-collision-v1",
+        )
+        assert sorted(item.logical_path for item in planned.files) == [
+            "document.md",
+            "notes.md",
+            "notes.md",
+        ]
+        assert {item.disposition for item in planned.files} == {"native_text"}
+
+        applied = await cutover.apply(planned.cutover_id)
+        assert applied.status == "applied"
+        assert {item.status for item in applied.files} == {"applied"}
+
+        async with pool.acquire() as conn:
+            live = {
+                row["resource_id"]: row["current_path"]
+                for row in await conn.fetch(
+                    """
+                    SELECT resource_id, current_path
+                      FROM native_resources
+                     WHERE namespace_id = $1 AND lifecycle = 'live'
+                    """,
+                    vault.namespace_id,
+                )
+            }
+
+        # The migrated Document keeps the path its owner chose.
+        assert "document.md" in live.values()
+        # Every File is published, and no two live resources share a path.
+        assert {twin_a, twin_b, shadow} <= set(live)
+        assert len(set(live.values())) == len(live)
+
+        # One twin keeps the clean path; the other steps onto its own uuid.
+        twin_paths = {live[twin_a], live[twin_b]}
+        assert "notes.md" in twin_paths
+        stepped = twin_b if live[twin_a] == "notes.md" else twin_a
+        assert live[stepped] == f"notes-{stepped.hex[:8]}.md"
+
+        # The attachment that shadowed the Document yields to it.
+        assert live[shadow] == f"document-{shadow.hex[:8]}.md"
+
+        # Verification reads the path that was actually published, not the
+        # colliding one the plan recorded.
+        verified = await cutover.verify(planned.cutover_id)
+        assert verified.status == "verified"
+        assert {item.status for item in verified.files} == {"verified"}
+
+        # Re-applying is a no-op: the resolved path is persisted, so the
+        # idempotency fingerprint cannot drift on a retry.
+        async with pool.acquire() as conn:
+            before = await conn.fetchval("SELECT count(*) FROM native_resources")
+        assert (await cutover.apply(planned.cutover_id)).status == "verified"
+        async with pool.acquire() as conn:
+            assert await conn.fetchval("SELECT count(*) FROM native_resources") == before


### PR DESCRIPTION
## What breaks today

`_apply_files` publishes every File at the `logical_path` the plan froze, and
lets `_publish_create` refuse when that path is already live. One taken path
ends the whole apply — including a run where the entire document inventory had
already migrated successfully.

## Why the collision is legitimate

Legacy File names carry no uniqueness guarantee:

- `UNIQUE(vault_id, s3_key)` covers the **storage key**, not the name.
- The partial unique index on `(vault, collection, name, content_hash)` does not
  apply to the historical upload path at all. Without a caller-supplied
  `content_hash` the key is random, which `file_service` documents as
  "re-uploading the same artifact always makes a new row".
- Even with a hash, two rows are permitted deliberately when the bytes differ.

So two attachments can share a name, and one of them can be several successive
revisions someone uploaded under a single name. Deleting or renaming at the
source would lose content, change `file_id`, and recur on the next hash-less
upload.

There is a second axis. Native paths are one authority namespace across Document
and File Resources — `find_live_path` accepts a `surface` and does
`del surface`, and the live-path unique index carries no surface column — so an
attachment can also collide with a Document at the same path.

## The fix reuses a rule this repo already has

`DocumentService._resolve_free_path` keeps the clean path when it is free and
otherwise steps onto progressively longer slices of the resource's own uuid
(8 -> 12 -> 16 -> full). This wires the same rule into the File surface. The
disambiguator was already being handed in as `resource_id`, so nothing new is
invented and no byte is discarded.

Only the suffix handling differs: Documents hardcode `.md`, while attachments
carry `.txt`, `.html`, `.pdf` or no suffix at all, so the slice is inserted ahead
of the final suffix. For `.md` the result is byte-identical to what Documents
already produce.

Apply migrates vault items before files, so the ordering is deterministic:
Documents keep the path their owner chose, attachments yield.

## Why the resolved path is persisted before publishing

The publication fingerprint includes the path. A retry that re-derived the path
against live state after a partial apply could land on a different one and be
refused as `Native idempotency key was reused with different input`. Writing the
claim first makes a retry replay the same input; the first claim wins, and a
second claim with a different path is an integrity error rather than an
overwrite. `_verify_files` compares against the published path for the same
reason.

## Verification

- New regression test fails on the pre-fix code with the same conflict error and
  passes after.
- Three mutations each fail it: neutering the resolver, reverting verify to
  `logical_path`, and dropping the path persistence.
- Cutover suites: 32 passed, 1 skipped.
- `mypy --python-version 3.14 app/ mcp_server/`: no issues in 365 files.
- `ruff check` clean on the changed files.
- Every other backend suite failure is present, identically, on a pristine
  `origin/main` checkout of the same commit.

## Migration

`100_native_revision_cutover_file_applied_path.py` adds a nullable
`applied_path` column and is registered in `_apply_migrations()`. Existing rows
keep `NULL`, which reads as "published at `logical_path`", so an in-flight
cutover planned before this change verifies unchanged.
