### PR TITLE
fix(cutover): accept a stepped File path at authority mint too

### DIFF
--- a/backend/app/services/native_revision_cutover.py
+++ b/backend/app/services/native_revision_cutover.py
@@ -733,7 +733,12 @@ class NativeRevisionCutover:
                 file.file_id,
                 "file",
                 "live",
-                file.logical_path,
+                # The path the File was published at. Same rule as
+                # `_verify_files`: `logical_path` unless that path was already
+                # live and the File stepped onto its own uuid. Comparing the
+                # frozen path here would reject every stepped File at authority
+                # mint, after verification had already accepted it.
+                file.applied_path or file.logical_path,
                 file.native_revision_id,
                 file.content_hash,
                 file.byte_size,

--- a/backend/tests/test_native_revision_cutover_pg.py
+++ b/backend/tests/test_native_revision_cutover_pg.py
@@ -2468,3 +2468,9 @@ async def test_apply_disambiguates_file_paths_that_are_already_live(tmp_path):
         assert (await cutover.apply(planned.cutover_id)).status == "verified"
         async with pool.acquire() as conn:
             assert await conn.fetchval("SELECT count(*) FROM native_resources") == before
+
+        # Authority mint runs its OWN File binding check, separate from the one
+        # verify runs. A stepped File has to survive both, or a cutover that
+        # verified clean still dies at the last gate.
+        authority = await cutover.commit(planned.cutover_id, identity=_identity("file-path-collision"))
+        assert authority.cutover_id == planned.cutover_id


### PR DESCRIPTION
Follow-up to #517.

## What #517 missed

#517 taught `_verify_files` that a File may be published somewhere other than its
frozen `logical_path`. Authority mint runs a **separate** File binding check —
`_require_native_file_bindings`, reached from `_revalidate_authority_catalog` —
and that one still compared the frozen path.

So a cutover verifies clean and then dies at the last gate:

```
revision_backend_cutover_failed: File <id> Native searchable projection drifted
```

By then every document and every file has already been published. The run is
`verified`, so there is nothing wrong with the data — only the last comparison
is asking the wrong question.

## Why one fixed site read as green

The regression test from #517 stopped at `verify`. The two phases do not share
this check, so a test that stops early cannot see the second site. This PR runs
the same test through `commit`, and reverting only the one-line hunk fails it.

## Scope check

All seven `logical_path` uses in the module were reviewed:

| site | describes | correct value |
| --- | --- | --- |
| `_file_inventory_fact` (plan digest) | legacy source row | `logical_path` — unchanged |
| `_resolve_free_file_path` (3 uses) | the path being resolved from | `logical_path` — unchanged |
| `_verify_files` `expected_source` | legacy source row | `logical_path` — unchanged |
| `_verify_files` `expected_native` | native `current_path` | published path — fixed in #517 |
| `_require_native_file_bindings` | native `current_path` | published path — **fixed here** |

Only comparisons against a native resource's `current_path` take the published
path. The two that describe the legacy source row must not.

## Verification

- Cutover suites: 32 passed, 1 skipped.
- `mypy --python-version 3.14` and `ruff check` clean on the changed file.
- Reverting only this hunk fails the extended regression test.
