### PR TITLE
fix(search): driver-side source_type predicate + native vault path

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -7,6 +7,24 @@ specifically; the proxy has its own log in
 
 ## Unreleased
 
+### Native search takes the vault path (bounded-corpus fix, part 1)
+
+`hybrid_search` accepts an orthogonal `source_types` pre-filter on all five
+vector drivers (pgvector, qdrant, seahorse×3): it ANDs with whichever ACL
+filter (`vault_ids` / `source_ids`) is present and excludes stale points from
+the non-active Document arm driver-side, before the top-K cut. The native arm
+is therefore eligible for the vault-granularity path (`vault_path_eligible`),
+so vault-scoped native search no longer enumerates candidate ids through the
+10,000-resource / 128MiB bounded-corpus gate — the gate stays in place for the
+id-enumeration path only. `_hydrate_hits` keeps its arm-mismatch skip as
+defense in depth.
+
+Hydration drops are now counted by cause (`stale_arm`,
+`unknown_source_type`, `stale_native_file_path`, `hydration_miss`,
+`unuriable_source_type`) and surfaced as a `hydration_dropped:...`
+degradation reason, so `total_matches > 0, returned == 0` can never again
+read as a silent zero-match.
+
 ### Added a personal notification inbox and document watches
 
 Human browser sessions can view effective Vault-access changes and explicitly

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -368,15 +368,17 @@ def vault_path_eligible(
     Phase 2) instead of enumerating source ids. Requires: the flag on, a driver
     whose `vault_filter_supported` is True (it stores vault_id and filters on it),
     and NO doc-level narrowing filter (those still need per-resource source_ids).
-    When False, the existing source_ids path runs unchanged."""
+    When False, the existing source_ids path runs unchanged.
+
+    The vector-store vault filter now ALSO constrains source_type (workbench
+    #1069: the caller passes `source_types` alongside `vault_ids`), so the
+    native arm is eligible too — stale legacy Document points are excluded
+    driver-side before the top-K is cut and can no longer suppress valid
+    native hits. `_hydrate_hits` keeps its arm-mismatch skip as defense in
+    depth."""
     return (
         settings.vault_filter_enabled
         and supports_vault_filter(get_vector_store())
-        # The vector-store vault filter cannot yet constrain source_type.
-        # Under the native arm, stale legacy Document points could consume the
-        # complete top-K before hydration drops them, suppressing valid native
-        # hits. Use the source-id path until the driver accepts that predicate.
-        and _configured_document_source_type() == LEGACY_DOCUMENT_SOURCE
         and not (collection or doc_type or tags or source_uris)
     )
 
@@ -826,11 +828,17 @@ class SearchService:
 
         # Hybrid (dense + BM25 sparse) via the configured driver. Returns [] on any vector-store
         # failure — PG is the source of truth, the index is rebuildable.
+        #
+        # source_types (workbench #1069): constrain the driver-side pre-filter
+        # to the active Document arm (+ table/file, which have no second arm)
+        # so stale points from the non-active arm can never consume the top-K.
+        # `_hydrate_hits` keeps its arm-mismatch skip as defense in depth.
         hits, degraded_reason = await self._run_vector_search(
             query_text=query,
             query_embedding=query_embedding,
             candidate_source_ids=candidate_source_ids,
             candidate_vault_ids=candidate_vault_ids,
+            source_types=[document_source, "table", "file", SOURCE_NATIVE_FILE],
             limit=target_unique * 3,
         )
 
@@ -879,7 +887,16 @@ class SearchService:
         # Post-search metadata join — one fetch per source_type, merged back
         # in the driver-returned order. Keeps document results fully
         # backward-compatible (doc_id == source_id) while adding table/file.
-        results = await self._hydrate_hits(unique_hits)
+        # `dropped` counts hits lost between retrieval and hydration by cause
+        # (workbench #1069 G3): any non-empty drop set marks the response
+        # degraded so `total_matches > 0, returned == 0` can never again read
+        # as a silent zero-match.
+        results, dropped = await self._hydrate_hits(unique_hits)
+        hydrate_reason = (
+            f"hydration_dropped:{','.join(f'{k}={v}' for k, v in sorted(dropped.items()))}" if dropped else None
+        )
+        if hydrate_reason is not None and degraded_reason is None:
+            degraded_reason = hydrate_reason
         returned = len(results)
         hint = (
             "Prefetch pool was capped; the corpus may contain more matches than reported. "
@@ -1005,17 +1022,29 @@ class SearchService:
 
         return doc_ids, table_ids, file_ids
 
-    async def _hydrate_hits(self, hits: list) -> list[SearchResult]:
+    async def _hydrate_hits(self, hits: list) -> tuple[list[SearchResult], dict[str, int]]:
         from app.services.index_service import SOURCE_TYPES
         by_type: dict[str, list[str]] = {t: [] for t in SOURCE_TYPES}
         document_source = _configured_document_source_type()
         unknown_types: set[str] = set()
+        # Hydration-drop accounting (workbench #1069 G3): every hit that enters
+        # this method but leaves as no result is counted by cause, so a
+        # `total_matches > 0, returned == 0` response can say WHERE the hits
+        # went instead of reading as a silent zero-match. Keys are stable
+        # diagnostic strings (not user-facing copy).
+        dropped: dict[str, int] = {}
         for h in hits:
             if h.source_type in {LEGACY_DOCUMENT_SOURCE, NATIVE_DOCUMENT_SOURCE} and h.source_type != document_source:
                 # A selected backend has exactly one Document authority. Old
-                # vector points from the other arm are never hydrated.
+                # vector points from the other arm are never hydrated. With the
+                # driver-side `source_types` predicate (workbench #1069) these
+                # should no longer arrive; the skip stays as defense in depth
+                # and the counter proves it (stays zero when the predicate
+                # works, goes non-zero if a driver ignores it).
+                dropped["stale_arm"] = dropped.get("stale_arm", 0) + 1
                 continue
             if h.source_type not in by_type:
+                dropped["unknown_source_type"] = dropped.get("unknown_source_type", 0) + 1
                 unknown_types.add(h.source_type)
                 continue
             if h.source_id:
@@ -1212,6 +1241,7 @@ class SearchService:
                             "hydrate: stale native File path skipped for %s",
                             r["resource_id"],
                         )
+                        dropped["stale_native_file_path"] = dropped.get("stale_native_file_path", 0) + 1
                         continue
                     meta[(SOURCE_NATIVE_FILE, str(r["resource_id"]))] = {
                         "vault": r["vault_name"],
@@ -1350,6 +1380,12 @@ class SearchService:
             key = (h.source_type, h.source_id)
             m = meta.get(key)
             if not m:
+                # The hit survived retrieval but its source row is gone or stale
+                # (deleted between retrieval and hydration, or a derived chunk
+                # whose head moved). Count it — this is the workbench #1069
+                # `total_matches=30, returned=0` shape, and it must never again
+                # read as a silent zero-match.
+                dropped["hydration_miss"] = dropped.get("hydration_miss", 0) + 1
                 continue
             # Build the canonical 0.3.0 URI per resource type. Doc URIs
             # derive the collection from `path` automatically (path
@@ -1361,6 +1397,7 @@ class SearchService:
             elif h.source_type in {"file", SOURCE_NATIVE_FILE}:
                 uri = file_uri(m["vault"], h.source_id, collection=m.get("collection"))
             else:
+                dropped["unuriable_source_type"] = dropped.get("unuriable_source_type", 0) + 1
                 continue
             results.append(
                 SearchResult(
@@ -1393,7 +1430,9 @@ class SearchService:
                     chunk_index=_chunk_index_of(h, chunk_indexes),
                 )
             )
-        return results
+        if dropped:
+            logger.warning("hydrate: dropped %d hit(s): %s", sum(dropped.values()), dropped)
+        return results, dropped
 
     async def _apply_rerank(self, query: str, hits: list) -> list:
         """Rescore `hits` with the configured reranker. On any rerank
@@ -1419,6 +1458,7 @@ class SearchService:
         query_embedding: list[float] | None,
         candidate_source_ids: list[str] | None,
         candidate_vault_ids: list[str] | None = None,
+        source_types: list[str] | None = None,
         limit: int,
     ) -> tuple[list, str | None]:
         """Hybrid search over the vector store.
@@ -1470,6 +1510,7 @@ class SearchService:
                 query_sparse_values=sparse_vals,
                 source_ids=candidate_source_ids,
                 vault_ids=candidate_vault_ids,
+                source_types=source_types,
                 limit=limit,
                 prefetch_per_leg=prefetch_per_leg,
             )

--- a/backend/app/services/vector_store/_seahorse_common.py
+++ b/backend/app/services/vector_store/_seahorse_common.py
@@ -69,25 +69,51 @@ def validate_uuid_for_sql(s: str) -> str:
     return s
 
 
+def validate_source_type_for_sql(s: str) -> str:
+    """Reject anything that isn't a known `source_type` discriminator before
+    interpolating into a SQL WHERE clause (workbench #1069). Values are
+    driver-owned (`SOURCE_TYPES`), never user input — this is purely defense
+    in depth against any caller mistake."""
+    from app.services.index_service import SOURCE_TYPES
+    if s not in SOURCE_TYPES:
+        raise ValueError(f"unknown source_type filter: {s!r}")
+    return s
+
+
 def vault_filter_sql(
     vault_ids: list[str] | None,
     source_ids: list[str] | None,
     *,
     vault_col: str = "vault_id",
     source_col: str = "source_id",
+    source_types: list[str] | None = None,
+    source_type_col: str = "source_type",
 ) -> str | None:
     """The ACL pre-filter as a Coral SQL WHERE clause (issue #189 Phase 2):
     vault_ids (per-VAULT) wins when present, else source_ids (per-resource),
     else None (no filter). Mirrors the pgvector/qdrant exactly-one contract — the
     caller sends one or the other, never both. Both id kinds are UUIDs, validated
-    before interpolation (defense in depth; the IN list is otherwise trusted)."""
+    before interpolation (defense in depth; the IN list is otherwise trusted).
+
+    `source_types` (workbench #1069) ANDs an additional `source_type IN (...)`
+    predicate — orthogonal to the ACL filter, so it combines with either branch
+    (or stands alone when both id lists are absent)."""
     assert not (vault_ids and source_ids), \
         "vault_filter_sql got both vault_ids and source_ids; expected exactly one"
+    clauses: list[str] = []
     if vault_ids:
         col, ids = vault_col, vault_ids
+        quoted = ", ".join(f"'{validate_uuid_for_sql(str(s))}'" for s in ids)
+        clauses.append(f"{col} IN ({quoted})")
     elif source_ids:
         col, ids = source_col, source_ids
-    else:
+        quoted = ", ".join(f"'{validate_uuid_for_sql(str(s))}'" for s in ids)
+        clauses.append(f"{col} IN ({quoted})")
+    if source_types:
+        quoted_types = ", ".join(
+            f"'{validate_source_type_for_sql(str(t))}'" for t in source_types
+        )
+        clauses.append(f"{source_type_col} IN ({quoted_types})")
+    if not clauses:
         return None
-    quoted = ", ".join(f"'{validate_uuid_for_sql(str(s))}'" for s in ids)
-    return f"{col} IN ({quoted})"
+    return " AND ".join(clauses)

--- a/backend/app/services/vector_store/base.py
+++ b/backend/app/services/vector_store/base.py
@@ -275,6 +275,7 @@ class VectorStore(Protocol):
         limit: int,
         prefetch_per_leg: int,
         vault_ids: list[str] | None = None,
+        source_types: list[str] | None = None,
     ) -> list[VectorHit]:
         """Dense + sparse search, RRF-fused.
 
@@ -294,6 +295,14 @@ class VectorStore(Protocol):
           caller's `vault_path_eligible` gate is False for them) and keep
           filtering by `source_ids`. The caller sends EXACTLY ONE of the two,
           never both — capable drivers assert this.
+        - `source_types` is an orthogonal resource-kind filter (workbench
+          #1069): the caller passes the active Document arm (e.g. exactly one
+          of `document` / `native_document`) so stale points from the other arm
+          can never consume the top-K before hydration drops them. It ANDs
+          with whichever of `vault_ids` / `source_ids` is present. `None`
+          means no constraint (legacy behaviour, unchanged). Values are
+          driver-owned discriminator strings (`SOURCE_TYPES`), never user
+          input — drivers validate against the known set and reject unknown.
         - `prefetch_per_leg` caps each leg's candidate pool before
           fusion. Caller decides — typically `max(limit * 3, 50)`.
         """

--- a/backend/app/services/vector_store/pgvector.py
+++ b/backend/app/services/vector_store/pgvector.py
@@ -601,6 +601,7 @@ class PgvectorStore:
         limit: int,
         prefetch_per_leg: int,
         vault_ids: list[str] | None = None,
+        source_types: list[str] | None = None,
     ) -> list[VectorHit]:
         del query_text  # debug-only on this driver; keep signature parity
         await self.ensure_collection()
@@ -631,6 +632,18 @@ class PgvectorStore:
         else:
             filter_uuids = None
             filter_col = "source_id"  # unused when filter_uuids is None
+        # source_types (workbench #1069) is orthogonal to the ACL filter: it
+        # ANDs with whichever of vault_ids / source_ids is present (or with no
+        # filter at all). Values are driver-owned discriminators, never user
+        # input — validate against the known set so a caller typo fails loud
+        # instead of silently matching nothing.
+        source_type_values: list[str] | None = None
+        if source_types is not None:
+            from app.services.index_service import SOURCE_TYPES
+            unknown = [t for t in source_types if t not in SOURCE_TYPES]
+            if unknown:
+                raise ValueError(f"unknown source_type filter: {unknown!r}")
+            source_type_values = list(source_types)
         pool = await self._pool()
 
         async def _dense_leg() -> list[str]:
@@ -640,6 +653,7 @@ class PgvectorStore:
                 return await self._search_dense(
                     c, query_dense=query_dense,
                     filter_uuids=filter_uuids, filter_col=filter_col,
+                    source_type_values=source_type_values,
                     limit=prefetch_per_leg,
                 )
 
@@ -650,6 +664,7 @@ class PgvectorStore:
                     c, terms=list(query_sparse_indices),
                     weights=list(query_sparse_values),
                     filter_uuids=filter_uuids, filter_col=filter_col,
+                    source_type_values=source_type_values,
                     limit=prefetch_per_leg,
                 )
 
@@ -700,6 +715,7 @@ class PgvectorStore:
         query_dense: list[float],
         filter_uuids: list[uuid.UUID] | None,
         filter_col: str,
+        source_type_values: list[str] | None = None,
         limit: int,
     ) -> list[str]:
         # Binary codec → list[float] passes through directly.
@@ -707,6 +723,16 @@ class PgvectorStore:
         # sparse-only points (embed API was down when they were indexed)
         # contribute only to the sparse leg, never to the dense KNN.
         # `filter_col` is "source_id" or "vault_id" (literal — see hybrid_search).
+        # `source_type_values`, when present, ANDs an additional
+        # `source_type = ANY(...)` predicate (workbench #1069). The bind slot
+        # is always $4 in the filtered branch and $3 in the unfiltered branch
+        # (params: dense, [uuids,] limit, types) so planner shapes stay stable.
+        type_suffix_filtered = (
+            " AND source_type = ANY($4::text[])" if source_type_values else ""
+        )
+        type_suffix_unfiltered = (
+            " AND source_type = ANY($3::text[])" if source_type_values else ""
+        )
         if filter_uuids:
             # HNSW post-filters: it walks the graph for ~`ef_search` GLOBAL
             # nearest, THEN drops the ones failing the WHERE. With a selective
@@ -728,22 +754,24 @@ class PgvectorStore:
                     f"""
                     SELECT chunk_id::text AS chunk_id
                     FROM "{self._schema}".chunks
-                    WHERE {filter_col} = ANY($2::uuid[]) AND dense IS NOT NULL
+                    WHERE {filter_col} = ANY($2::uuid[]) AND dense IS NOT NULL{type_suffix_filtered}
                     ORDER BY dense <=> $1
                     LIMIT $3
                     """,
                     list(query_dense), filter_uuids, int(limit),
+                    *([source_type_values] if source_type_values else []),
                 )
         else:
             rows = await conn.fetch(
                 f"""
                 SELECT chunk_id::text AS chunk_id
                 FROM "{self._schema}".chunks
-                WHERE dense IS NOT NULL
+                WHERE dense IS NOT NULL{type_suffix_unfiltered}
                 ORDER BY dense <=> $1
                 LIMIT $2
                 """,
                 list(query_dense), int(limit),
+                *([source_type_values] if source_type_values else []),
             )
         return [r["chunk_id"] for r in rows]
 
@@ -755,40 +783,94 @@ class PgvectorStore:
         weights: list[float],
         filter_uuids: list[uuid.UUID] | None,
         filter_col: str,
+        source_type_values: list[str] | None = None,
         limit: int,
     ) -> list[str]:
         if not terms:
             return []
 
+        # source_type predicate (workbench #1069), orthogonal to the ACL
+        # filter. In filtered branches it ANDs onto the existing WHERE; in
+        # unfiltered branches it becomes the WHERE. Each branch below spells
+        # its own bind numbering. Values are driver-owned discriminators
+        # (validated in hybrid_search), never user input.
         if self._sparse_shape == "arrays":
             # Two query branches (with/without filter) keep the planner honest —
             # a single SQL with `WHERE $3 IS NULL OR <col> = ANY($3)` confuses
             # ANY-cardinality estimation. `filter_col` is "source_id"/"vault_id"
             # (literal — see hybrid_search), so the interpolation is safe.
             if filter_uuids:
+                if source_type_values:
+                    sql = f"""
+                        WITH q AS (
+                          SELECT unnest($1::bigint[]) AS tid,
+                                 unnest($2::real[])   AS w
+                        ),
+                        cand AS (
+                          SELECT chunk_id, sparse_terms, sparse_weights
+                          FROM "{self._schema}".chunks
+                          WHERE {filter_col} = ANY($3::uuid[])
+                            AND source_type = ANY($5::text[])
+                        )
+                        SELECT c.chunk_id::text AS chunk_id,
+                               SUM(q.w * t.weight) AS score
+                        FROM cand c
+                        CROSS JOIN LATERAL unnest(c.sparse_terms, c.sparse_weights)
+                            AS t(tid, weight)
+                        JOIN q ON q.tid = t.tid
+                        GROUP BY c.chunk_id
+                        ORDER BY score DESC
+                        LIMIT $4
+                    """
+                    rows = await conn.fetch(
+                        sql, list(terms), [float(w) for w in weights],
+                        filter_uuids, int(limit), source_type_values,
+                    )
+                else:
+                    sql = f"""
+                        WITH q AS (
+                          SELECT unnest($1::bigint[]) AS tid,
+                                 unnest($2::real[])   AS w
+                        ),
+                        cand AS (
+                          SELECT chunk_id, sparse_terms, sparse_weights
+                          FROM "{self._schema}".chunks
+                          WHERE {filter_col} = ANY($3::uuid[])
+                        )
+                        SELECT c.chunk_id::text AS chunk_id,
+                               SUM(q.w * t.weight) AS score
+                        FROM cand c
+                        CROSS JOIN LATERAL unnest(c.sparse_terms, c.sparse_weights)
+                            AS t(tid, weight)
+                        JOIN q ON q.tid = t.tid
+                        GROUP BY c.chunk_id
+                        ORDER BY score DESC
+                        LIMIT $4
+                    """
+                    rows = await conn.fetch(
+                        sql, list(terms), [float(w) for w in weights],
+                        filter_uuids, int(limit),
+                    )
+            elif source_type_values:
                 sql = f"""
                     WITH q AS (
                       SELECT unnest($1::bigint[]) AS tid,
                              unnest($2::real[])   AS w
-                    ),
-                    cand AS (
-                      SELECT chunk_id, sparse_terms, sparse_weights
-                      FROM "{self._schema}".chunks
-                      WHERE {filter_col} = ANY($3::uuid[])
                     )
                     SELECT c.chunk_id::text AS chunk_id,
                            SUM(q.w * t.weight) AS score
-                    FROM cand c
+                    FROM "{self._schema}".chunks c
                     CROSS JOIN LATERAL unnest(c.sparse_terms, c.sparse_weights)
                         AS t(tid, weight)
                     JOIN q ON q.tid = t.tid
+                    WHERE c.source_type = ANY($4::text[])
                     GROUP BY c.chunk_id
                     ORDER BY score DESC
-                    LIMIT $4
+                    LIMIT $3
                 """
                 rows = await conn.fetch(
-                    sql, list(terms), [float(w) for w in weights],
-                    filter_uuids, int(limit),
+                    sql, list(terms), [float(w) for w in weights], int(limit),
+                    source_type_values,
                 )
             else:
                 sql = f"""
@@ -811,6 +893,48 @@ class PgvectorStore:
                 )
         else:  # posting
             if filter_uuids:
+                if source_type_values:
+                    sql = f"""
+                        WITH q AS (
+                          SELECT unnest($1::bigint[]) AS tid,
+                                 unnest($2::real[])   AS w
+                        )
+                        SELECT p.chunk_id::text AS chunk_id,
+                               SUM(q.w * p.weight) AS score
+                        FROM "{self._schema}".posting p
+                        JOIN q ON q.tid = p.term_id
+                        JOIN "{self._schema}".chunks c ON c.chunk_id = p.chunk_id
+                        WHERE c.{filter_col} = ANY($3::uuid[])
+                          AND c.source_type = ANY($5::text[])
+                        GROUP BY p.chunk_id
+                        ORDER BY score DESC
+                        LIMIT $4
+                    """
+                    rows = await conn.fetch(
+                        sql, list(terms), [float(w) for w in weights],
+                        filter_uuids, int(limit), source_type_values,
+                    )
+                else:
+                    sql = f"""
+                        WITH q AS (
+                          SELECT unnest($1::bigint[]) AS tid,
+                                 unnest($2::real[])   AS w
+                        )
+                        SELECT p.chunk_id::text AS chunk_id,
+                               SUM(q.w * p.weight) AS score
+                        FROM "{self._schema}".posting p
+                        JOIN q ON q.tid = p.term_id
+                        JOIN "{self._schema}".chunks c ON c.chunk_id = p.chunk_id
+                        WHERE c.{filter_col} = ANY($3::uuid[])
+                        GROUP BY p.chunk_id
+                        ORDER BY score DESC
+                        LIMIT $4
+                    """
+                    rows = await conn.fetch(
+                        sql, list(terms), [float(w) for w in weights],
+                        filter_uuids, int(limit),
+                    )
+            elif source_type_values:
                 sql = f"""
                     WITH q AS (
                       SELECT unnest($1::bigint[]) AS tid,
@@ -821,14 +945,14 @@ class PgvectorStore:
                     FROM "{self._schema}".posting p
                     JOIN q ON q.tid = p.term_id
                     JOIN "{self._schema}".chunks c ON c.chunk_id = p.chunk_id
-                    WHERE c.{filter_col} = ANY($3::uuid[])
+                    WHERE c.source_type = ANY($4::text[])
                     GROUP BY p.chunk_id
                     ORDER BY score DESC
-                    LIMIT $4
+                    LIMIT $3
                 """
                 rows = await conn.fetch(
-                    sql, list(terms), [float(w) for w in weights],
-                    filter_uuids, int(limit),
+                    sql, list(terms), [float(w) for w in weights], int(limit),
+                    source_type_values,
                 )
             else:
                 sql = f"""

--- a/backend/app/services/vector_store/qdrant.py
+++ b/backend/app/services/vector_store/qdrant.py
@@ -249,6 +249,7 @@ class QdrantStore:
         limit: int,
         prefetch_per_leg: int,
         vault_ids: list[str] | None = None,
+        source_types: list[str] | None = None,
     ) -> list[VectorHit]:
         await self.ensure_collection()
         client = self._get_client()
@@ -263,7 +264,10 @@ class QdrantStore:
         if not has_dense and not has_sparse:
             return []
 
-        flt = _acl_filter(vault_ids=vault_ids, source_ids=source_ids)
+        flt = _acl_filter(
+            vault_ids=vault_ids, source_ids=source_ids,
+            source_types=_validated_source_types(source_types),
+        )
 
         if has_dense and has_sparse:
             prefetch = [
@@ -339,20 +343,50 @@ async def _qdrant_errors(op: str):
         raise VectorStoreUnavailable(f"qdrant {op}: {e}") from e
 
 
-def _acl_filter(*, vault_ids: list[str] | None, source_ids: list[str] | None):
+def _validated_source_types(source_types: list[str] | None) -> list[str] | None:
+    """Validate the driver-owned `source_type` discriminator filter (workbench
+    #1069). Returns the list unchanged (None stays None = no constraint); an
+    unknown value is a caller bug and fails loud instead of silently matching
+    nothing."""
+    if source_types is None:
+        return None
+    from app.services.index_service import SOURCE_TYPES
+    unknown = [t for t in source_types if t not in SOURCE_TYPES]
+    if unknown:
+        raise ValueError(f"unknown source_type filter: {unknown!r}")
+    return list(source_types)
+
+
+def _acl_filter(
+    *,
+    vault_ids: list[str] | None,
+    source_ids: list[str] | None,
+    source_types: list[str] | None = None,
+):
     """The ACL pre-filter: vault_ids (per-vault, issue #189 Phase 2) wins when
     present, else source_ids (per-resource), else no filter. The qdrant analogue
     of pgvector's `WHERE {vault_id|source_id} = ANY(...)`. vault_id is stored as
-    UUID text (like source_id), so MatchAny over the keyword index is exact."""
+    UUID text (like source_id), so MatchAny over the keyword index is exact.
+
+    `source_types` (workbench #1069) ANDs an additional `source_type` MatchAny
+    onto the `must` list — stale points from the non-active Document arm can
+    never consume the top-K. Orthogonal to the ACL filter, so it combines with
+    either branch (or with no ACL filter at all)."""
+    must = []
     if vault_ids:
         key, vals = PAYLOAD_VAULT_ID, vault_ids
+        must.append(qm.FieldCondition(key=key, match=qm.MatchAny(any=[str(v) for v in vals])))
     elif source_ids:
         key, vals = PAYLOAD_SOURCE_ID, source_ids
-    else:
+        must.append(qm.FieldCondition(key=key, match=qm.MatchAny(any=[str(v) for v in vals])))
+    if source_types:
+        must.append(qm.FieldCondition(
+            key=PAYLOAD_SOURCE_TYPE,
+            match=qm.MatchAny(any=[str(t) for t in source_types]),
+        ))
+    if not must:
         return None
-    return qm.Filter(
-        must=[qm.FieldCondition(key=key, match=qm.MatchAny(any=[str(v) for v in vals]))],
-    )
+    return qm.Filter(must=must)
 
 
 def _to_hit(point) -> VectorHit:

--- a/backend/app/services/vector_store/qdrant.py
+++ b/backend/app/services/vector_store/qdrant.py
@@ -109,24 +109,34 @@ class QdrantStore:
         # for the same reason as source_id. Created OUTSIDE the `if not exists`
         # block (idempotent server-side) so an ALREADY-deployed collection
         # — created before vault_id existed — also gets the index on first ensure.
+        # source_type joins them as a driver-side pre-filter (workbench #1069):
+        # same treatment — every search carrying `source_types` filters on it.
         # Best-effort (non-fatal) — but a TypeError/ValueError is a programming
         # bug, not a transient index hiccup, so let it surface.
-        try:
-            await client.create_payload_index(
-                collection_name=self._collection,
-                field_name=PAYLOAD_VAULT_ID,
-                field_schema=qm.PayloadSchemaType.KEYWORD,
-            )
-        except (TypeError, ValueError):
-            raise
-        except Exception as e:  # noqa: BLE001
-            # Non-fatal: a missing index doesn't break correctness (the readiness
-            # gate keys off the NULL-vault_id count, not the index), but every
-            # vault-filtered search then does a full payload scan. Log at ERROR,
-            # not WARNING, so a PERSISTENT failure (e.g. a managed cluster
-            # rejecting the schema) leaves a standing, greppable signal — this
-            # fires once per process since `_ensured_collection` latches below.
-            logger.error("qdrant vault_id payload index ensure failed (non-fatal, search falls back to full scan): %s", e)
+        for _key, _label in (
+            (PAYLOAD_VAULT_ID, "vault_id"),
+            (PAYLOAD_SOURCE_TYPE, "source_type"),
+        ):
+            try:
+                await client.create_payload_index(
+                    collection_name=self._collection,
+                    field_name=_key,
+                    field_schema=qm.PayloadSchemaType.KEYWORD,
+                )
+            except (TypeError, ValueError):
+                raise
+            except Exception as e:  # noqa: BLE001
+                # Non-fatal: a missing index doesn't break correctness (the readiness
+                # gate keys off the NULL-vault_id count, not the index), but every
+                # filtered search then does a full payload scan. Log at ERROR,
+                # not WARNING, so a PERSISTENT failure (e.g. a managed cluster
+                # rejecting the schema) leaves a standing, greppable signal — this
+                # fires once per process since `_ensured_collection` latches below.
+                logger.error(
+                    "qdrant %s payload index ensure failed (non-fatal, search falls back to full scan): %s",
+                    _label,
+                    e,
+                )
         self._ensured_collection = True
 
     async def health(self) -> bool:

--- a/backend/app/services/vector_store/seahorse_cloud.py
+++ b/backend/app/services/vector_store/seahorse_cloud.py
@@ -382,6 +382,7 @@ class SeahorseCloudStore:
         limit: int,
         prefetch_per_leg: int,
         vault_ids: list[str] | None = None,
+        source_types: list[str] | None = None,
     ) -> list[VectorHit]:
         # Seahorse runs its own RRF prefetch internally; the caller's
         # prefetch_per_leg hint isn't surfaced as an API knob.
@@ -433,8 +434,11 @@ class SeahorseCloudStore:
             body["fusion"] = {"type": "rrf", "parameters": {"k": RRF_K}}
         # ACL pre-filter (issue #189 Phase 2): exactly one of vault_ids /
         # source_ids; vault_filter_sql asserts that + UUID-validates each id.
+        # source_types (workbench #1069) ANDs a source_type predicate onto the
+        # same filter — the column is stored on every point (COL_SOURCE_TYPE).
         acl = _vault_filter_sql(
             vault_ids, source_ids, vault_col=COL_VAULT_ID, source_col=COL_SOURCE_ID,
+            source_types=source_types, source_type_col=COL_SOURCE_TYPE,
         )
         if acl is not None:
             body["filter"] = acl

--- a/backend/app/services/vector_store/seahorse_db.py
+++ b/backend/app/services/vector_store/seahorse_db.py
@@ -483,6 +483,7 @@ class SeahorseDbStore:
         limit: int,
         prefetch_per_leg: int,
         vault_ids: list[str] | None = None,
+        source_types: list[str] | None = None,
     ) -> list[VectorHit]:
         """Coral's hybrid search takes:
 
@@ -585,7 +586,9 @@ class SeahorseDbStore:
         # ACL pre-filter as a Coral SQL WHERE clause (issue #189 Phase 2): the
         # caller sends EXACTLY ONE of vault_ids (per-vault) / source_ids (per-
         # resource). vault_filter_sql asserts that and UUID-validates each id.
-        acl = _vault_filter_sql(vault_ids, source_ids)
+        # source_types (workbench #1069) ANDs a source_type predicate onto the
+        # same filter — the column is stored on every point (schema below).
+        acl = _vault_filter_sql(vault_ids, source_ids, source_types=source_types)
         if acl is not None:
             payload["filter"] = acl
 

--- a/backend/app/services/vector_store/seahorse_db_grpc.py
+++ b/backend/app/services/vector_store/seahorse_db_grpc.py
@@ -372,6 +372,7 @@ class SeahorseDbGrpcStore:
         limit: int,
         prefetch_per_leg: int,
         vault_ids: list[str] | None = None,
+        source_types: list[str] | None = None,
     ) -> list[VectorHit]:
         """Server-streaming search. Each ``ResultStreamEvent`` carries
         one of ``header`` / ``chunk`` / ``result_set_boundary`` /
@@ -448,7 +449,9 @@ class SeahorseDbGrpcStore:
         )
         # ACL pre-filter (issue #189 Phase 2): exactly one of vault_ids /
         # source_ids; vault_filter_sql asserts that + UUID-validates each id.
-        acl = _vault_filter_sql(vault_ids, source_ids)
+        # source_types (workbench #1069) ANDs a source_type predicate onto the
+        # same filter — the column is stored on every point (schema below).
+        acl = _vault_filter_sql(vault_ids, source_ids, source_types=source_types)
         if acl is not None:
             request.filter = acl
 

--- a/backend/tests/test_indexable_e2e.py
+++ b/backend/tests/test_indexable_e2e.py
@@ -329,7 +329,9 @@ async def t14_nonexistent_source_ids():
         chunk_id="fake", source_type="document", source_id=str(uuid.uuid4()),
         section_path="", content="x", score=0.5,
     )
-    results = await svc._hydrate_hits([fake])
+    results, dropped = await svc._hydrate_hits([fake])
+    if dropped.get("hydration_miss") != 1:
+        fail(f"hydrator did not count the bogus source_id as hydration_miss: {dropped}")
     if results:
         fail(f"hydrator returned {len(results)} results for bogus source_id")
     else:

--- a/backend/tests/test_native_search_selection_unit.py
+++ b/backend/tests/test_native_search_selection_unit.py
@@ -451,7 +451,7 @@ async def test_native_hydration_verification_and_decode_run_off_event_loop(monke
         return original_verify(candidate)
 
     monkeypatch.setattr(store, "_verify_row", staticmethod(guarded_verify))
-    results = await SearchService()._hydrate_hits(
+    results, dropped = await SearchService()._hydrate_hits(
         [
             VectorHit(
                 chunk_id=str(chunk_id),
@@ -465,6 +465,7 @@ async def test_native_hydration_verification_and_decode_run_off_event_loop(monke
     )
 
     assert results[0].title == "Hydrated"
+    assert dropped == {}
     assert verify_threads
 
 
@@ -516,7 +517,7 @@ async def test_native_file_hydration_preserves_public_file_identity(monkeypatch)
         return original_verify(candidate)
 
     monkeypatch.setattr(M1PgBodyStore, "_verify_row", staticmethod(guarded_verify))
-    results = await SearchService()._hydrate_hits(
+    results, dropped = await SearchService()._hydrate_hits(
         [
             VectorHit(
                 chunk_id=str(chunk_id),
@@ -529,6 +530,7 @@ async def test_native_file_hydration_preserves_public_file_identity(monkeypatch)
         ]
     )
 
+    assert dropped == {}
     assert len(results) == 1
     assert results[0].source_type == "file"
     assert results[0].uri == f"akb://measure/coll/files/file/{resource_id}"

--- a/backend/tests/test_qdrant_vault_filter_unit.py
+++ b/backend/tests/test_qdrant_vault_filter_unit.py
@@ -141,6 +141,18 @@ async def test_ensure_collection_indexes_vault_id():
     assert PAYLOAD_VAULT_ID in fake.indexes
 
 
+async def test_ensure_collection_indexes_source_type():
+    """`source_type` is a per-search pre-filter (workbench #1069) — it needs
+    the same keyword index as the ACL keys, on new AND pre-existing
+    collections (ensure runs outside the create branch)."""
+    from app.services.vector_store.qdrant import PAYLOAD_SOURCE_TYPE
+    fake = _FakeClient()
+    store = QdrantStore(url="http://x", api_key=None, collection="chunks", dense_dim=4)
+    store._client = fake
+    await store.ensure_collection()
+    assert PAYLOAD_SOURCE_TYPE in fake.indexes
+
+
 # ── #207: client errors → VectorStoreUnavailable (write + search paths) ──
 
 from app.services.vector_store.base import VectorStoreUnavailable

--- a/backend/tests/test_qdrant_vault_filter_unit.py
+++ b/backend/tests/test_qdrant_vault_filter_unit.py
@@ -12,6 +12,7 @@ from app.services.vector_store.qdrant import (
     PAYLOAD_SOURCE_ID,
     PAYLOAD_VAULT_ID,
     _acl_filter,
+    _validated_source_types,
 )
 
 
@@ -276,3 +277,44 @@ async def test_ensure_collection_vault_index_programming_error_propagates(exc):
     store._client = _VaultIndexBoom(exc)
     with pytest.raises(type(exc)):
         await store.ensure_collection()
+
+
+# ── workbench #1069: driver-side source_type predicate ──
+
+def test_source_type_filter_ands_onto_acl_branches():
+    from app.services.vector_store.qdrant import PAYLOAD_SOURCE_TYPE
+    fv = _acl_filter(vault_ids=["v1"], source_ids=None, source_types=["native_document"])
+    assert [c.key for c in fv.must] == [PAYLOAD_VAULT_ID, PAYLOAD_SOURCE_TYPE]
+    assert fv.must[1].match.any == ["native_document"]
+    fs = _acl_filter(vault_ids=None, source_ids=["s1"], source_types=["document", "table"])
+    assert [c.key for c in fs.must] == [PAYLOAD_SOURCE_ID, PAYLOAD_SOURCE_TYPE]
+    # No ACL filter + source_types alone still constrains (unscoped admin path).
+    fn = _acl_filter(vault_ids=None, source_ids=None, source_types=["native_document"])
+    assert [c.key for c in fn.must] == [PAYLOAD_SOURCE_TYPE]
+    # Legacy default unchanged.
+    assert _acl_filter(vault_ids=None, source_ids=None) is None
+
+
+def test_source_type_filter_rejects_unknown_discriminator():
+    with pytest.raises(ValueError, match="unknown source_type"):
+        _validated_source_types(["docu ment'] OR '1'='1"])
+
+
+@pytest.mark.asyncio
+async def test_hybrid_search_passes_source_types_to_both_prefetch_legs():
+    from app.services.vector_store.qdrant import PAYLOAD_SOURCE_TYPE
+    fake = _FakeClient()
+    store = _store_with(fake)
+    await store.hybrid_search(
+        query_text="q", query_dense=[0.1, 0.2, 0.3, 0.4],
+        query_sparse_indices=[1, 2], query_sparse_values=[0.5, 0.5],
+        source_ids=None, vault_ids=["v1"], source_types=["native_document", "table"],
+        limit=10, prefetch_per_leg=50,
+    )
+    prefetch = store._client.last_query["prefetch"]
+    assert len(prefetch) == 2
+    for leg in prefetch:
+        keys = [c.key for c in leg.filter.must]
+        assert keys[0] == PAYLOAD_VAULT_ID
+        assert keys[1] == PAYLOAD_SOURCE_TYPE
+        assert leg.filter.must[1].match.any == ["native_document", "table"]

--- a/backend/tests/test_seahorse_vault_filter_unit.py
+++ b/backend/tests/test_seahorse_vault_filter_unit.py
@@ -183,3 +183,68 @@ async def test_cloud_hybrid_search_filter_uses_vault_col_override():
         source_ids=None, vault_ids=[_UUID], limit=5, prefetch_per_leg=10,
     )
     assert s._client.calls[-1]["json"]["filter"] == f"{COL_VAULT_ID} IN ('{_UUID}')"
+
+
+# ── workbench #1069: source_types ANDs onto the Coral WHERE clause ──
+
+def test_vault_filter_sql_source_types_ands_onto_either_branch():
+    assert vault_filter_sql([_UUID], None, source_types=["native_document"]) == (
+        f"vault_id IN ('{_UUID}') AND source_type IN ('native_document')"
+    )
+    assert vault_filter_sql(None, [_UUID], source_types=["document", "table"]) == (
+        f"source_id IN ('{_UUID}') AND source_type IN ('document', 'table')"
+    )
+    # No id filter + source_types alone still constrains.
+    assert vault_filter_sql(None, None, source_types=["native_document"]) == (
+        "source_type IN ('native_document')"
+    )
+    # Legacy default unchanged.
+    assert vault_filter_sql(None, None) is None
+
+
+def test_vault_filter_sql_rejects_unknown_source_type():
+    with pytest.raises(ValueError, match="unknown source_type"):
+        vault_filter_sql([_UUID], None, source_types=["x'; DROP TABLE chunks; --"])
+
+
+@pytest.mark.asyncio
+async def test_db_hybrid_search_source_types_reach_filter(monkeypatch):
+    """source_types must reach the Coral request `filter` ANDed with the ACL
+    branch — otherwise stale legacy points consume the top-K (workbench #1069)."""
+    from unittest.mock import AsyncMock
+    monkeypatch.setattr("app.services.sparse_encoder.load_stats", AsyncMock(return_value={}))
+
+    s = SeahorseDbStore(coordinator_url="http://x", table_name="chunks", dense_dim=4)
+    s._ensured_collection = True
+    s._client = _FakeHttp(_Resp(200, {"data": {"data": [[]]}}))
+    await s.hybrid_search(
+        query_text="q", query_dense=_DENSE, query_sparse_indices=[], query_sparse_values=[],
+        source_ids=None, vault_ids=[_UUID], source_types=["native_document", "table", "file", "native_file"],
+        limit=5, prefetch_per_leg=10,
+    )
+    assert s._client.calls[-1]["json"]["filter"] == (
+        f"vault_id IN ('{_UUID}') AND source_type IN "
+        "('native_document', 'table', 'file', 'native_file')"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cloud_hybrid_search_source_types_use_source_type_col():
+    """seahorse_cloud passes its own column constants — the source_type column
+    override must be the cloud `source_type` key, not a default-literal drift."""
+    from app.services.vector_store.seahorse_cloud import COL_SOURCE_TYPE
+    s = SeahorseCloudStore(
+        management_url="http://x", token="t", tenant_uuid="ten", table_name="chunks",
+        dense_dim=4,
+    )
+    s._ensured = True
+    s._table_host = "http://host"
+    s._client = _FakeHttp(_Resp(200, {"data": {"data": [[]]}}))
+    await s.hybrid_search(
+        query_text="q", query_dense=_DENSE, query_sparse_indices=[], query_sparse_values=[],
+        source_ids=None, vault_ids=[_UUID], source_types=["native_document"],
+        limit=5, prefetch_per_leg=10,
+    )
+    assert s._client.calls[-1]["json"]["filter"] == (
+        f"{COL_VAULT_ID} IN ('{_UUID}') AND {COL_SOURCE_TYPE} IN ('native_document')"
+    )

--- a/backend/tests/test_search_hit_chunk_identity_unit.py
+++ b/backend/tests/test_search_hit_chunk_identity_unit.py
@@ -104,8 +104,9 @@ async def test_hit_carries_the_matched_chunk_section_and_ordinal(monkeypatch):
     connection = _Connection(doc_id, [{"chunk_id": chunk_id, "chunk_index": 4}])
     service = _configure(monkeypatch, connection)
 
-    (result,) = await service._hydrate_hits([_hit(chunk_id, doc_id)])
+    (result,), dropped = await service._hydrate_hits([_hit(chunk_id, doc_id)])
 
+    assert dropped == {}
     assert result.section_path == "# Collector > ## Product-API seam"
     assert result.chunk_index == 4
     # Everything the hit carried before is still there and unchanged.
@@ -132,8 +133,9 @@ async def test_a_missing_chunk_row_leaves_the_ordinal_null(monkeypatch):
     connection = _Connection(doc_id, [])
     service = _configure(monkeypatch, connection)
 
-    (result,) = await service._hydrate_hits([_hit(chunk_id, doc_id)])
+    (result,), dropped = await service._hydrate_hits([_hit(chunk_id, doc_id)])
 
+    assert dropped == {}
     assert result.chunk_index is None
     assert result.section_path == "# Collector > ## Product-API seam"
     assert result.matched_section == "Requests carry an Idempotency-Key."
@@ -144,7 +146,7 @@ async def test_a_driver_chunk_id_that_is_not_a_uuid_is_skipped(monkeypatch):
     connection = _Connection(doc_id, [])
     service = _configure(monkeypatch, connection)
 
-    (result,) = await service._hydrate_hits([_hit("not-a-uuid", doc_id)])
+    (result,), _ = await service._hydrate_hits([_hit("not-a-uuid", doc_id)])
 
     assert result.chunk_index is None
     # No chunk lookup was attempted for an id the query could not cast.
@@ -169,7 +171,7 @@ async def test_the_excerpt_drops_the_heading_context_line(monkeypatch):
         f"[{hit.section_path}]\n{body}"
     )
 
-    (result,) = await service._hydrate_hits([hit])
+    (result,), _ = await service._hydrate_hits([hit])
 
     assert result.matched_section == body[:500]
     assert result.section_path == "# Collector > ## Product-API seam"
@@ -184,7 +186,7 @@ async def test_a_bracketed_body_line_survives_in_the_excerpt(monkeypatch):
     hit = _hit(chunk_id, doc_id)
     hit.content = "[# Some other heading]\nBody text."
 
-    (result,) = await service._hydrate_hits([hit])
+    (result,), _ = await service._hydrate_hits([hit])
 
     assert result.matched_section == "[# Some other heading]\nBody text."
 
@@ -198,7 +200,7 @@ async def test_an_uppercase_driver_chunk_id_still_matches(monkeypatch):
     connection = _Connection(doc_id, [{"chunk_id": str(chunk_id), "chunk_index": 7}])
     service = _configure(monkeypatch, connection)
 
-    (result,) = await service._hydrate_hits([_hit(str(chunk_id).upper(), doc_id)])
+    (result,), _ = await service._hydrate_hits([_hit(str(chunk_id).upper(), doc_id)])
 
     assert result.chunk_index == 7
 
@@ -209,7 +211,7 @@ async def test_a_brace_wrapped_driver_chunk_id_still_matches(monkeypatch):
     connection = _Connection(doc_id, [{"chunk_id": str(chunk_id), "chunk_index": 2}])
     service = _configure(monkeypatch, connection)
 
-    (result,) = await service._hydrate_hits([_hit("{" + str(chunk_id) + "}", doc_id)])
+    (result,), _ = await service._hydrate_hits([_hit("{" + str(chunk_id) + "}", doc_id)])
 
     assert result.chunk_index == 2
 
@@ -223,7 +225,7 @@ async def test_an_empty_section_path_is_reported_as_null(monkeypatch):
     hit = _hit(chunk_id, doc_id)
     hit.section_path = ""
 
-    (result,) = await service._hydrate_hits([hit])
+    (result,), _ = await service._hydrate_hits([hit])
 
     assert result.section_path is None
     assert result.chunk_index == 0

--- a/backend/tests/test_search_parent_context_unit.py
+++ b/backend/tests/test_search_parent_context_unit.py
@@ -68,7 +68,7 @@ async def test_search_hydration_adds_parent_context_without_changing_score(monke
     monkeypatch.setattr(search_service, "get_pool", get_test_pool)
     monkeypatch.setattr(search_service, "_configured_document_source_type", lambda: "document")
 
-    results = await SearchService()._hydrate_hits([
+    results, dropped = await SearchService()._hydrate_hits([
         VectorHit(
             chunk_id=str(uuid.uuid4()),
             source_type="document",
@@ -79,6 +79,7 @@ async def test_search_hydration_adds_parent_context_without_changing_score(monke
         )
     ])
 
+    assert dropped == {}
     assert len(results) == 1
     assert results[0].collection == "research"
     assert results[0].collection_summary == "Technical comparisons and AKB recommendations"

--- a/backend/tests/test_search_rerank_fusion.py
+++ b/backend/tests/test_search_rerank_fusion.py
@@ -160,9 +160,12 @@ def test_vault_path_eligible(monkeypatch):
     assert call() is False
 
 
-def test_native_document_search_disables_vault_only_vector_filter(monkeypatch):
-    """Without a source_type vector predicate, legacy points must not consume
-    the native arm's top-K; native mode therefore uses exact source ids."""
+def test_native_document_search_uses_vault_path_with_source_type_predicate(monkeypatch):
+    """With the driver-side source_type predicate (workbench #1069), the native
+    arm takes the vault path too: stale legacy points are excluded driver-side
+    before the top-K cut, so they can no longer suppress valid native hits.
+    `source_types` is what carries the active-arm constraint (asserted in
+    test_run_vector_search_forwards_source_types_to_driver)."""
     from app.config import settings
     from app.services import search_service
 
@@ -170,9 +173,9 @@ def test_native_document_search_disables_vault_only_vector_filter(monkeypatch):
         vault_filter_supported = True
 
     monkeypatch.setattr(settings, "vault_filter_enabled", True, raising=False)
-    monkeypatch.setattr(settings, "document_revision_backend", "native_ledger_m1")
-    monkeypatch.setattr(settings, "native_revision_m1_measurement_only", True)
-    monkeypatch.setattr(settings, "db_name", "akb_revision_m1_measurement")
+    monkeypatch.setattr(settings, "document_revision_backend", "postgres_native")
+    monkeypatch.setattr(settings, "native_revision_m1_measurement_only", False)
+    monkeypatch.setattr(settings, "db_name", "akb")
     monkeypatch.setattr(search_service, "get_vector_store", lambda: _Capable())
 
     assert vault_path_eligible(
@@ -180,7 +183,7 @@ def test_native_document_search_disables_vault_only_vector_filter(monkeypatch):
         doc_type=None,
         tags=None,
         source_uris=None,
-    ) is False
+    ) is True
 
 
 @pytest.mark.asyncio
@@ -319,3 +322,40 @@ async def test_search_requires_vault_or_user_id():
         pytest.fail("Should not raise ValidationError when vault is set")
     except Exception:
         pass  # downstream (DB / embedding) is fine to fail; we only assert the guard
+
+
+@pytest.mark.asyncio
+async def test_run_vector_search_forwards_source_types_to_driver(monkeypatch):
+    """`source_types` (workbench #1069) threads into the driver's hybrid_search
+    so stale points from the non-active Document arm are excluded driver-side
+    before the top-K cut. None (legacy callers) stays None = no constraint."""
+    import app.services.search_service as ss
+
+    svc = ss.SearchService()
+    captured = {}
+
+    async def encode_ok(_q):
+        return [1], [1.0]
+
+    class _Store:
+        async def hybrid_search(self, **kw):
+            captured.update(kw)
+            return []
+
+    monkeypatch.setattr(ss.sparse_encoder, "encode_query", encode_ok)
+    monkeypatch.setattr(ss, "get_vector_store", lambda: _Store())
+
+    await svc._run_vector_search(
+        query_text="q", query_embedding=[0.1, 0.2],
+        candidate_source_ids=["s1"], source_types=["native_document", "table"],
+        limit=10,
+    )
+    assert captured["source_types"] == ["native_document", "table"]
+    assert captured["source_ids"] == ["s1"]
+
+    captured.clear()
+    await svc._run_vector_search(
+        query_text="q", query_embedding=[0.1, 0.2],
+        candidate_source_ids=["s1"], limit=10,
+    )
+    assert captured["source_types"] is None


### PR DESCRIPTION
Fix native search on large corpora where vault-scoped queries are rejected
by the bounded-corpus gate even though retrieval itself is top-K.

## Problem

After the A->B cutover to `document_revision_backend: postgres_native`,
search broke at our corpus scale (136,183 resources total; the largest
vault holds 50,850):

- Unscoped search, `vault=gdn-policies` (50,850), `vault=legalize-appended-kr-ro`
  (22,096): HTTP 422 `native search scope exceeds the bounded candidate corpus`.
- `vault=agent-notes` (2,985): HTTP 200 with `total_matches: 30, returned: 0,
  results: []` and `degraded: false` — a silent zero-match.

Root causes:

1. The native arm was ineligible for the vault-granularity vector path
   (`vault_path_eligible` excluded it), so every native query enumerated
   candidate ids through `_native_document_candidates`, whose 10,000-resource /
   128MiB gate rejects any vault larger than the bound. The gate guards
   full-body materialization during candidate filtering — but a vault alone
   can exceed it, so the vault is unsearchable by any query.
2. The reason the native arm was excluded: the vector vault filter could not
   constrain `source_type`, so stale legacy `document` points could consume
   the top-K before hydration dropped them.
3. Hydration drops were uncounted: hits lost between retrieval and hydration
   vanished without a signal (`degraded: false`).

## Change

- `hybrid_search` accepts an orthogonal `source_types` pre-filter on all five
  vector drivers (pgvector, qdrant, seahorse REST/gRPC/Cloud). It ANDs with
  whichever ACL filter (`vault_ids` / `source_ids`) is present and excludes
  stale points from the non-active Document arm driver-side, before the
  top-K cut. Unknown discriminator values fail loud (`ValueError`), never
  silently match nothing.
- The native arm is now eligible for the vault path. Vault-scoped native
  search (no doc-level narrowing filter) no longer enumerates candidate ids,
  so the bounded-corpus gate is not consulted; the gate stays in place for
  the id-enumeration path (source_uris / collection / doc_type / tags).
- The caller passes `[active document arm, table, file, native_file]`;
  `_hydrate_hits` keeps its arm-mismatch skip as defense in depth.
- `_hydrate_hits` returns `(results, dropped)` with per-cause drop counts
  (`stale_arm`, `unknown_source_type`, `stale_native_file_path`,
  `hydration_miss`, `unuriable_source_type`). Any non-empty drop set marks
  the response `degraded` with a `hydration_dropped:k=v,...` reason, so
  `total_matches > 0, returned == 0` can never again read as a silent
  zero-match.
- qdrant `ensure_collection` also creates the `source_type` keyword payload
  index (same best-effort pattern as `vault_id`), so the new pre-filter
  does not fall back to a payload scan.

## Scope / non-goals

- No schema migration. No driver replacement. No constant value changes
  (`MAX_CANDIDATE_RESOURCES`, `MAX_BODY_BYTES`, `MAX_SOURCE_URIS` untouched).
- Candidate-filtering body materialization (frontmatter slice + pagination)
  and write-path byte caps follow as separate PRs.

## Verification

- `tests/test_qdrant_vault_filter_unit.py`, `tests/test_seahorse_vault_filter_unit.py`
  (incl. new `source_types` AND-shape + unknown-value rejection),
  `tests/test_search_rerank_fusion.py` (vault-path eligibility incl. native arm,
  `source_types` forwarding), `tests/test_native_search_selection_unit.py`,
  `tests/test_search_hit_chunk_identity_unit.py`,
  `tests/test_search_parent_context_unit.py`, `tests/test_seahorse_db_grpc_unit.py`,
  `tests/test_search_filter_contract_unit.py`, `tests/test_search_multi_vault_unit.py`,
  `tests/test_vault_backfill.py`: green.
- `ruff check` clean on all touched files.
