### PR TITLE
fix(search): slice + paginate native candidate filtering

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -7,6 +7,23 @@ specifically; the proxy has its own log in
 
 ## Unreleased
 
+### Native candidate filtering reads frontmatter slices, paginated (bounded-corpus fix, part 2)
+
+`_native_document_candidates` no longer selects full `canonical_bytes` rows to
+decide `type`/`tags`/`status` filters. It fetches an 8KiB leading-body slice
+per row (`substring(canonical_bytes ...)`, the same shape the native grep path
+already uses) and parses only the frontmatter envelope — per-resource memory
+is slice-sized regardless of body size. Rows are keyset-paginated by
+`resource_id` (2,000/page, ids only accumulate), so peak memory is page-sized
+rather than scope-sized.
+
+A resource whose envelope opens but never closes inside the slice is excluded
+from candidates AND counted (`unparseable_envelope`, logged as a warning) —
+never filtered on defaults. The aggregate `COUNT(*)` / `SUM(byte_size)` guard
+still runs first on manifest numbers (no body bytes touched), and hydration
+still re-verifies the winners, so the per-row verify step is gone from this
+path without losing integrity.
+
 ### Native search takes the vault path (bounded-corpus fix, part 1)
 
 `hybrid_search` accepts an orthogonal `source_types` pre-filter on all five

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -482,18 +482,44 @@ def _filtered_native_metadata(row) -> dict | None:
     fields may lie beyond the slice, so the caller must exclude + count the
     resource rather than filter it on defaults. A body with no leading `---`
     parses normally (plain Markdown: defaults apply).
+
+    The slice is byte-cut (`substring(bytes ...)`), so it can end mid-codepoint
+    on multibyte text. The trailing incomplete sequence (at most 3 bytes for
+    UTF-8) is trimmed before decoding — only a cut inside the first 8KiB+1
+    bytes triggers this, and dropping ≤3 tail bytes cannot hide a complete
+    envelope close. A body that is genuinely non-UTF-8 still returns None.
     """
     from app.services.document_service import _parse_markdown
 
     raw = bytes(row["body_slice"])
-    try:
-        text = raw.decode("utf-8", errors="strict")
-    except UnicodeDecodeError:
+    text = _decode_slice_prefix(raw)
+    if text is None:
         return None
     if not _slice_has_complete_frontmatter(text):
         return None
     metadata, _ = _parse_markdown(text)
     return metadata
+
+
+def _decode_slice_prefix(raw: bytes) -> str | None:
+    """Decode a byte-cut slice, trimming a trailing partial codepoint.
+
+    Tries strict decode first (the common case: cut landed on a character
+    boundary). On failure, drops up to 3 trailing bytes (the max length of an
+    incomplete UTF-8 sequence) and retries — progressively, so a body ending
+    in genuinely invalid bytes still returns None instead of silently
+    decoding past the corruption.
+    """
+    try:
+        return raw.decode("utf-8", errors="strict")
+    except UnicodeDecodeError:
+        pass
+    for cut in (1, 2, 3):
+        try:
+            return raw[:-cut].decode("utf-8", errors="strict")
+        except UnicodeDecodeError:
+            continue
+    return None
 
 
 class SearchService:

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -49,6 +49,16 @@ NATIVE_MEASUREMENT_DATABASE = "akb_revision_m1_measurement"
 NATIVE_SEARCH_MAX_CANDIDATE_RESOURCES = 10_000
 NATIVE_SEARCH_MAX_BODY_BYTES = 128 * 1024 * 1024
 NATIVE_SEARCH_MAX_SOURCE_URIS = 200
+# Frontmatter slice for candidate filtering (workbench #1069, part 2): the
+# filter decision needs only the leading frontmatter envelope (`type`/`tags`/
+# `status`), never the body. Reading the first 8KiB bounds per-resource memory
+# regardless of body size; a resource whose envelope does not close inside the
+# slice is classified "unparseable" (counted, never silently dropped).
+NATIVE_CANDIDATE_FRONTMATTER_SLICE_BYTES = 8 * 1024
+# Candidate pagination: filter loop pages through scope rows keyset-ordered by
+# resource_id, so peak memory is page-sized, not scope-sized. Page of 2,000 ×
+# 8KiB slices ≈ 16MiB worst case per page, GC'd before the next page.
+NATIVE_CANDIDATE_PAGE_SIZE = 2_000
 
 
 def active_document_source_type(
@@ -436,11 +446,54 @@ def _verified_native_metadata(row) -> dict:
     return metadata
 
 
+# Matches a complete leading frontmatter envelope: an opening `---` line, then
+# a closing `---` line. `re.DOTALL` so the envelope may span lines; `\Z`-safe
+# via `$` with MULTILINE. Only the envelope presence is tested here — full
+# YAML parsing still goes through `_parse_markdown` on the slice.
+_FRONTMATTER_ENVELOPE_RE = re.compile(r"\A---[ \t]*\r?\n.*?\r?\n---[ \t]*(?:\r?\n|\Z)", re.DOTALL)
+
+
+def _slice_has_complete_frontmatter(slice_text: str) -> bool:
+    """Whether a body slice contains a complete leading frontmatter envelope.
+
+    A body without a leading `---` line has no envelope to complete (plain
+    Markdown: metadata defaults apply). Only a body that OPENS an envelope
+    but never closes it inside the slice is "incomplete" — its filter fields
+    may lie beyond the slice, so the caller must count it as unparseable
+    rather than filter it on defaults.
+    """
+    if not slice_text.startswith("---"):
+        return True
+    return _FRONTMATTER_ENVELOPE_RE.match(slice_text) is not None
+
+
 def _verify_native_body(row) -> None:
     """Verify one native body without interpreting File bytes as Markdown."""
     from app.services.native_payload_verification import verify_native_head_body
 
     verify_native_head_body(row)
+
+
+def _filtered_native_metadata(row) -> dict | None:
+    """Parse filter metadata from a frontmatter slice on a worker thread.
+
+    Returns the metadata dict, or None when the slice holds an INCOMPLETE
+    envelope (opens `---` but never closes inside the slice): the filter
+    fields may lie beyond the slice, so the caller must exclude + count the
+    resource rather than filter it on defaults. A body with no leading `---`
+    parses normally (plain Markdown: defaults apply).
+    """
+    from app.services.document_service import _parse_markdown
+
+    raw = bytes(row["body_slice"])
+    try:
+        text = raw.decode("utf-8", errors="strict")
+    except UnicodeDecodeError:
+        return None
+    if not _slice_has_complete_frontmatter(text):
+        return None
+    metadata, _ = _parse_markdown(text)
+    return metadata
 
 
 class SearchService:
@@ -459,7 +512,7 @@ class SearchService:
         archive_scope: ArchiveScope | None = None,
         source_uris: list[str] | None,
         doc_types: list[str] | None = None,
-    ) -> list[str]:
+    ) -> tuple[list[str], dict[str, int]]:
         conditions = ["r.surface = 'document'", "r.lifecycle = 'live'"]
         params: list = []
         if vaults:
@@ -498,7 +551,7 @@ class SearchService:
                     f"(r.current_path = ${len(params)} OR r.resource_id::text = ${len(params)}))"
                 )
             if not source_clauses:
-                return []
+                return [], {}
             conditions.append("(" + " OR ".join(source_clauses) + ")")
 
         joins = """
@@ -506,12 +559,15 @@ class SearchService:
               JOIN vaults v ON v.id = r.namespace_id
               JOIN native_revisions nr
                 ON nr.resource_id = r.resource_id
-               AND nr.revision_id = r.head_revision_id
+                AND nr.revision_id = r.head_revision_id
               JOIN native_payload_manifests pm
                 ON pm.payload_manifest_id = nr.payload_manifest_id
               JOIN m1_reference_payloads p ON p.payload_id = pm.private_locator
         """
         where_sql = " AND ".join(conditions)
+        # The aggregate guard reads manifest numbers only — no body bytes are
+        # touched, so an oversized scope is rejected before asyncpg
+        # materializes anything (same shape as the grep guard).
         async with conn.transaction(isolation="repeatable_read", readonly=True):
             scope = await conn.fetchrow(
                 f"""
@@ -529,27 +585,64 @@ class SearchService:
                 raise ValidationError(
                     "native search scope exceeds the bounded candidate corpus"
                 )
-            rows = await conn.fetch(
-                f"""
-            SELECT r.resource_id, r.current_path, v.name AS vault_name,
-                   p.payload_id, p.namespace_id, p.content_profile, p.digest,
-                   p.byte_size, p.encoding, p.selected_placement,
-                   p.verification_profile, p.canonical_bytes
-              {joins}
-             WHERE {where_sql}
-             ORDER BY r.resource_id
-                """,
-                *params,
+            # Slice + paginate (workbench #1069, part 2): filter 판정 needs only
+            # the leading frontmatter envelope, so fetch an 8KiB prefix per row
+            # instead of the full body, keyset-paged by resource_id so peak
+            # memory is page-sized rather than scope-sized. `byte_size` still
+            # comes along so the per-row slice can be sanity-checked.
+            candidates: list[str] = []
+            filter_stats: dict[str, int] = {}
+            last_seen: str | None = None
+            while True:
+                page_params = list(params)
+                page_where = where_sql
+                if last_seen is not None:
+                    page_params.append(last_seen)
+                    page_where = f"{where_sql} AND r.resource_id > ${len(page_params)}::uuid"
+                rows = await conn.fetch(
+                    f"""
+                SELECT r.resource_id, r.current_path, v.name AS vault_name,
+                       p.byte_size, p.digest, p.encoding,
+                       p.selected_placement, p.verification_profile,
+                       substring(
+                           p.canonical_bytes FROM 1
+                           FOR {NATIVE_CANDIDATE_FRONTMATTER_SLICE_BYTES + 1}
+                       ) AS body_slice
+                  {joins}
+                 WHERE {page_where}
+                 ORDER BY r.resource_id
+                 LIMIT {NATIVE_CANDIDATE_PAGE_SIZE}
+                    """,
+                    *page_params,
+                )
+                if not rows:
+                    break
+                for row in rows:
+                    last_seen = str(row["resource_id"])
+                    metadata = await asyncio.to_thread(
+                        _filtered_native_metadata, row
+                    )
+                    if metadata is None:
+                        # Envelope opens but never closes inside the slice:
+                        # filter fields may lie beyond it. Exclude + count,
+                        # never filter on defaults.
+                        filter_stats["unparseable_envelope"] = (
+                            filter_stats.get("unparseable_envelope", 0) + 1
+                        )
+                        continue
+                    if doc_type and (metadata.get("type") or "note") != doc_type:
+                        continue
+                    if not metadata_matches(metadata, doc_types, tags, include_archived, archive_scope):
+                        continue
+                    candidates.append(str(row["resource_id"]))
+                if len(rows) < NATIVE_CANDIDATE_PAGE_SIZE:
+                    break
+        if filter_stats:
+            logger.warning(
+                "native candidates: %d unparseable envelope(s) excluded: %s",
+                sum(filter_stats.values()), filter_stats,
             )
-        candidates: list[str] = []
-        for row in rows:
-            metadata = await asyncio.to_thread(_verified_native_metadata, row)
-            if doc_type and (metadata.get("type") or "note") != doc_type:
-                continue
-            if not metadata_matches(metadata, doc_types, tags, include_archived, archive_scope):
-                continue
-            candidates.append(str(row["resource_id"]))
-        return candidates
+        return candidates, filter_stats
 
     async def search(
         self,
@@ -739,7 +832,7 @@ class SearchService:
                 if source_type in {"file", "table"}:
                     candidate_source_ids = []
                 elif document_source == NATIVE_DOCUMENT_SOURCE:
-                    candidate_source_ids = await self._native_document_candidates(
+                    candidate_source_ids, _filter_stats = await self._native_document_candidates(
                         conn,
                         user_uuid=user_uuid,
                         is_admin=is_admin,

--- a/backend/tests/test_native_search_selection_unit.py
+++ b/backend/tests/test_native_search_selection_unit.py
@@ -215,6 +215,8 @@ class _CandidateConn:
         self.resource_count = resource_count
         self.body_bytes = body_bytes
         self.rows = rows or []
+        for r in self.rows:
+            r.setdefault("body_slice", r.get("canonical_bytes", b""))
 
     class _Transaction:
         async def __aenter__(self):
@@ -248,7 +250,7 @@ class _CandidateConn:
 async def test_native_search_collection_is_exact_descendant_boundary_and_escaped(collection, escaped):
     conn = _CandidateConn()
 
-    await SearchService()._native_document_candidates(
+    candidates, stats = await SearchService()._native_document_candidates(
         conn,
         user_uuid=None,
         is_admin=True,
@@ -260,6 +262,8 @@ async def test_native_search_collection_is_exact_descendant_boundary_and_escaped
         source_uris=None,
     )
 
+    assert candidates == []
+    assert stats == {}
     assert "r.current_path =" in conn.sql
     assert "ESCAPE '\\'" in conn.sql
     assert conn.params == (collection, escaped)
@@ -267,23 +271,26 @@ async def test_native_search_collection_is_exact_descendant_boundary_and_escaped
 
 @pytest.mark.asyncio
 async def test_native_archived_candidates_use_current_metadata_before_ranking(monkeypatch):
-    from app.services import search_service as module
-
     conn = _CandidateConn()
-    conn.rows = [{"resource_id": uuid.UUID(int=i + 1), "status": status}
-                 for i, status in enumerate(["draft", "active", "archived"])]
-    monkeypatch.setattr(module, "_verified_native_metadata", lambda row: {"status": row["status"]})
-    candidates = await SearchService()._native_document_candidates(
+    conn.rows = [
+        {
+            "resource_id": uuid.UUID(int=i + 1),
+            "body_slice": f"---\nstatus: {status}\n---\nbody\n".encode(),
+        }
+        for i, status in enumerate(["draft", "active", "archived"])
+    ]
+    candidates, stats = await SearchService()._native_document_candidates(
         conn, user_uuid=None, is_admin=True, vaults=["mine"], collection=None,
         doc_type=None, tags=None, include_archived=False, archive_scope="archived", source_uris=None,
     )
     assert candidates == [str(uuid.UUID(int=3))]
+    assert stats == {}
 
 
 @pytest.mark.asyncio
 async def test_native_search_pushes_source_uri_into_bounded_sql_scope():
     conn = _CandidateConn()
-    await SearchService()._native_document_candidates(
+    candidates, stats = await SearchService()._native_document_candidates(
         conn,
         user_uuid=None,
         is_admin=True,
@@ -294,6 +301,8 @@ async def test_native_search_pushes_source_uri_into_bounded_sql_scope():
         include_archived=False,
         source_uris=["akb://measure/doc/specs/guide.md"],
     )
+    assert candidates == []
+    assert stats == {}
 
     assert all("r.current_path" in sql and "r.resource_id::text" in sql for sql, _ in conn.queries)
     assert conn.params == ("measure", "specs/guide.md")
@@ -323,39 +332,43 @@ async def test_native_search_rejects_corpus_before_fetching_bodies():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "store",
-    (M1ReferencePayloadStore, M1PgBodyStore),
-)
-async def test_native_candidate_verification_and_decode_run_off_event_loop(monkeypatch, store):
-    body = b"---\ntitle: Worker\n---\nbody\n"
+async def test_native_candidate_slice_parse_runs_off_event_loop(monkeypatch):
+    """The slice path parses the frontmatter envelope off the loop and never
+    touches the payload stores (no per-row verify: the aggregate guard already
+    ran on manifest numbers, and hydration re-verifies the winners)."""
+    body = b"---\ntitle: Worker\ntype: note\n---\nbody\n"
     row = {
         "resource_id": uuid.uuid4(),
         "current_path": "worker.md",
         "vault_name": "measure",
-        "payload_id": uuid.uuid4(),
-        "namespace_id": uuid.uuid4(),
-        "content_profile": "text",
-        "digest": hashlib.sha256(body).hexdigest(),
         "byte_size": len(body),
+        "digest": hashlib.sha256(body).hexdigest(),
         "encoding": "utf-8",
-        "selected_placement": store.selected_placement,
+        "selected_placement": M1ReferencePayloadStore.selected_placement,
         "verification_profile": "sha256-size-utf8-v1",
-        "canonical_bytes": body,
+        "body_slice": body,
     }
     conn = _CandidateConn(resource_count=1, body_bytes=len(body), rows=[row])
     loop_thread = threading.get_ident()
-    verify_threads = []
-    original_verify = store._verify_row
+    parse_threads = []
 
-    def guarded_verify(candidate):
-        verify_threads.append(threading.get_ident())
+    import app.services.document_service as docs
+
+    original_parse = docs._parse_markdown
+
+    def guarded_parse(content, **kw):
+        parse_threads.append(threading.get_ident())
         assert threading.get_ident() != loop_thread
-        return original_verify(candidate)
+        return original_parse(content, **kw)
 
-    monkeypatch.setattr(store, "_verify_row", staticmethod(guarded_verify))
+    monkeypatch.setattr(docs, "_parse_markdown", guarded_parse)
+    for store in (M1ReferencePayloadStore, M1PgBodyStore):
+        monkeypatch.setattr(
+            store, "_verify_row", staticmethod(lambda candidate: (_ for _ in ()).throw(
+                AssertionError("slice path must not verify per-row")))
+        )
 
-    candidates = await SearchService()._native_document_candidates(
+    candidates, stats = await SearchService()._native_document_candidates(
         conn,
         user_uuid=None,
         is_admin=True,
@@ -368,7 +381,77 @@ async def test_native_candidate_verification_and_decode_run_off_event_loop(monke
     )
 
     assert candidates == [str(row["resource_id"])]
-    assert verify_threads
+    assert stats == {}
+    assert parse_threads
+
+
+@pytest.mark.asyncio
+async def test_native_candidate_slice_never_selects_full_body():
+    """The candidate SELECT must not fetch `canonical_bytes`: with a 10MiB body
+    behind a small envelope, the bytes crossing the wire stay slice-sized."""
+    body = b"---\ntitle: Big\n---\n" + b"x" * (10 * 1024 * 1024)
+    row = {
+        "resource_id": uuid.uuid4(),
+        "current_path": "big.md",
+        "vault_name": "measure",
+        "byte_size": len(body),
+        "digest": hashlib.sha256(body).hexdigest(),
+        "encoding": "utf-8",
+        "selected_placement": M1ReferencePayloadStore.selected_placement,
+        "verification_profile": "sha256-size-utf8-v1",
+        # The fake conn hands back only what the SELECT asked for: a slice.
+        "body_slice": body[:8192 + 1],
+    }
+    conn = _CandidateConn(resource_count=1, body_bytes=len(body), rows=[row])
+    candidates, stats = await SearchService()._native_document_candidates(
+        conn,
+        user_uuid=None,
+        is_admin=True,
+        vaults=None,
+        collection=None,
+        doc_type=None,
+        tags=None,
+        include_archived=False,
+        source_uris=None,
+    )
+    assert candidates == [str(row["resource_id"])]
+    assert stats == {}
+    # The only occurrence of the column name is inside substring(...): the full
+    # body is never selected.
+    assert conn.sql.count("canonical_bytes") == 1
+    assert "substring(" in conn.sql
+
+
+@pytest.mark.asyncio
+async def test_native_candidate_unparseable_envelope_is_counted_not_dropped_silently():
+    """An envelope that opens but never closes inside the slice is excluded
+    from candidates AND reported in stats (never filtered on defaults)."""
+    row = {
+        # Opens --- but the closing --- lies beyond the 8KiB slice.
+        "resource_id": uuid.uuid4(),
+        "current_path": "huge-frontmatter.md",
+        "vault_name": "measure",
+        "byte_size": 20000,
+        "digest": "0" * 64,
+        "encoding": "utf-8",
+        "selected_placement": M1ReferencePayloadStore.selected_placement,
+        "verification_profile": "sha256-size-utf8-v1",
+        "body_slice": b"---\ntitle: " + b"y" * 8100,
+    }
+    conn = _CandidateConn(resource_count=1, body_bytes=20000, rows=[row])
+    candidates, stats = await SearchService()._native_document_candidates(
+        conn,
+        user_uuid=None,
+        is_admin=True,
+        vaults=None,
+        collection=None,
+        doc_type=None,
+        tags=None,
+        include_archived=False,
+        source_uris=None,
+    )
+    assert candidates == []
+    assert stats == {"unparseable_envelope": 1}
 
 
 class _HydrationConn:

--- a/backend/tests/test_native_search_selection_unit.py
+++ b/backend/tests/test_native_search_selection_unit.py
@@ -454,6 +454,47 @@ async def test_native_candidate_unparseable_envelope_is_counted_not_dropped_sile
     assert stats == {"unparseable_envelope": 1}
 
 
+@pytest.mark.asyncio
+async def test_native_candidate_slice_cut_mid_codepoint_still_filters():
+    """A byte-cut slice ending inside a multibyte character decodes after
+    trimming the partial tail — the envelope is still parsed, not counted
+    as unparseable. Only genuinely invalid bytes stay unparseable."""
+    from app.services.search_service import _decode_slice_prefix
+
+    # '가' = 3 bytes in UTF-8; cut after the first byte.
+    full = "---\ntitle: 가\n---\nbody\n".encode("utf-8")
+    cut = full[:len("---\ntitle: ".encode("utf-8")) + 1]
+    assert _decode_slice_prefix(cut) == "---\ntitle: "
+    # Genuinely invalid bytes (not a cut tail) stay None.
+    assert _decode_slice_prefix(b"---\ntitle: \xff\xfe\n---\n") is None
+
+    row = {
+        "resource_id": uuid.uuid4(),
+        "current_path": "korean.md",
+        "vault_name": "measure",
+        "byte_size": len(full),
+        "digest": "0" * 64,
+        "encoding": "utf-8",
+        "selected_placement": M1ReferencePayloadStore.selected_placement,
+        "verification_profile": "sha256-size-utf8-v1",
+        "body_slice": full,
+    }
+    conn = _CandidateConn(resource_count=1, body_bytes=len(full), rows=[row])
+    candidates, stats = await SearchService()._native_document_candidates(
+        conn,
+        user_uuid=None,
+        is_admin=True,
+        vaults=None,
+        collection=None,
+        doc_type=None,
+        tags=None,
+        include_archived=False,
+        source_uris=None,
+    )
+    assert candidates == [str(row["resource_id"])]
+    assert stats == {}
+
+
 class _HydrationConn:
     def __init__(self, row):
         self.row = row


### PR DESCRIPTION
Slice native candidate filtering to the frontmatter envelope and paginate it.

## Problem

`_native_document_candidates` selected full `canonical_bytes` rows to decide
`type`/`tags`/`status` filters, so candidate-filtering memory scaled with
scope body bytes. The 10,000-resource / 128MiB bounded-corpus gate guards
this, but any vault larger than the bound is unsearchable by filtered
queries even after part 1 opened the vault path (doc-level filters still
take the id-enumeration path).

## Change

- Fetch an 8KiB leading-body slice per row
  (`substring(canonical_bytes FROM 1 FOR 8193)`, the same shape the native
  grep path already uses) and parse only the frontmatter envelope.
  Per-resource memory is slice-sized regardless of body size. A byte-cut
  slice can end mid-codepoint on multibyte text — the trailing partial
  sequence (≤3 bytes) is trimmed before decoding; genuinely invalid bytes
  stay unparseable.
- Keyset-paginate by `resource_id` (2,000 rows/page, ids only accumulate),
  so peak memory is page-sized rather than scope-sized.
- A resource whose envelope opens (`---`) but never closes inside the slice
  is excluded from candidates AND counted (`unparseable_envelope`, logged
  as a warning) — never filtered on defaults.
- The aggregate `COUNT(*)` / `SUM(byte_size)` guard still runs first on
  manifest numbers (no body bytes touched); hydration still re-verifies the
  winners, so the per-row verify step is gone from this path without losing
  integrity. Returns `(candidates, filter_stats)`.
- Part of the workbench #1069 bounded-corpus series (part 1: driver-side
  `source_types` predicate + native vault path). Stacked on part 1.

## Verification

- `tests/test_native_search_selection_unit.py` (slice shape —
  `canonical_bytes` appears only inside `substring(...)`; off-event-loop
  slice parse with stores asserting no per-row verify; unparseable-envelope
  counting; mid-codepoint cut tolerance; pagination covered via multi-page
  fake conn in follow-ups), plus the part-1 suite
  (`test_qdrant_vault_filter_unit`, `test_seahorse_vault_filter_unit`,
  `test_search_rerank_fusion`, `test_search_hit_chunk_identity_unit`,
  `test_search_parent_context_unit`, `test_search_filter_contract_unit`,
  `test_search_multi_vault_unit`): all green.
- `ruff check` clean on all touched files.
