### PR TITLE
fix(search): write cap + ANY-shaped source_uris + configurable URI cap

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -7,6 +7,24 @@ specifically; the proxy has its own log in
 
 ## Unreleased
 
+### Write cap + source_uris hardening (bounded-corpus fix, part 3)
+
+The reference placement (`m1-reference-payload-v1`) enforces the same 10MiB
+write cap the pg-bodystore placement already had (`max_text_bytes`). Without
+it, an unbounded body could enter the corpus and every read path had to assume
+the unbounded case; with it, hydration memory is statically bounded by
+`limit × 10MiB` and larger content has a directed home (File storage +
+projection, with the 413 pointing there).
+
+`source_uris` scope resolution collapses from one SQL OR-clause per URI to a
+single `= ANY(...)` predicate per dimension (vaults, paths-or-ids): request
+SQL text stays constant-size no matter how many URIs arrive. The caller-side
+cap moves from the `NATIVE_SEARCH_MAX_SOURCE_URIS` module constant to the
+`search_max_source_uris` setting (default 200, provisional — documented with
+its derivation path: per-driver IN-list measurement). Over-cap rejections now
+name the recovery (split the request or use a vault scope) instead of a bare
+refusal. The old constant stays as an untouched legacy alias.
+
 ### Native candidate filtering reads frontmatter slices, paginated (bounded-corpus fix, part 2)
 
 `_native_document_candidates` no longer selects full `canonical_bytes` rows to

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -744,6 +744,18 @@ class Settings(BaseModel):
     # caller (MCP, REST, internal) is bounded uniformly.
     search_limit_max: int = Field(default=50, ge=1)
 
+    # Cap on the caller-supplied `source_uris` scope list (workbench #1069,
+    # part 3). Each URI expands into SQL OR-clauses (candidate scope) and a
+    # vector-store IN-list entry, so an unbounded list lets one request grow
+    # the query text and the downstream filter payload without bound (the
+    # seahorse drivers have overflowed on giant IN lists before). 200 is a
+    # provisional value — large enough for the "previously found resources"
+    # agent loop, small enough to keep both expansions trivial. Revisit with
+    # a measured per-driver IN-list limit if callers ever need more; until
+    # then the error message tells them to split the request or use a vault
+    # scope instead.
+    search_max_source_uris: int = Field(default=200, ge=1)
+
     # Push the ACL filter down to VAULT granularity in the vector store (issue
     # #189 Phase 2). When True AND the driver is pgvector AND a search has no
     # doc-level filter (collection/doc_type/tags/source_uris), search filters by

--- a/backend/app/services/m1_reference_payload_store.py
+++ b/backend/app/services/m1_reference_payload_store.py
@@ -37,6 +37,13 @@ class M1ReferencePayloadStore:
 
     selected_placement = "m1-reference-payload-v1"
     verification_profile = "sha256-size-utf8-v1"
+    # Write-path byte cap (workbench #1069, part 3): the same 10MiB the
+    # pg-bodystore placement enforces (`M1_PG_TEXT_MAX_BYTES`). Without a cap
+    # here, an unbounded body can enter the corpus and every read path —
+    # candidate filtering, hydration, grep — must assume the unbounded case.
+    # Larger content belongs in File storage (S3/CAS + projection), not in a
+    # Document body row. Raised as ValidationError to match the sibling store.
+    max_text_bytes = 10 * 1024 * 1024
 
     def __init__(self, pool: asyncpg.Pool):
         self.pool = pool
@@ -49,11 +56,19 @@ class M1ReferencePayloadStore:
         expected_size: int | None = None,
     ) -> tuple[bytes, str]:
         if isinstance(payload, str):
+            if len(payload.encode("utf-8")) > M1ReferencePayloadStore.max_text_bytes:
+                raise ValidationError(
+                    "Reference text payload exceeds the 10 MiB limit; store larger content as a File, not a Document body"
+                )
             canonical = payload.encode("utf-8")
         elif isinstance(payload, bytes):
             canonical = payload
         else:
             raise ValidationError("Reference payload must be str or bytes")
+        if len(canonical) > M1ReferencePayloadStore.max_text_bytes:
+            raise ValidationError(
+                "Reference text payload exceeds the 10 MiB limit; store larger content as a File, not a Document body"
+            )
         try:
             canonical.decode("utf-8", errors="strict")
         except UnicodeDecodeError as exc:

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -48,6 +48,9 @@ NATIVE_DOCUMENT_SOURCE = "native_document"
 NATIVE_MEASUREMENT_DATABASE = "akb_revision_m1_measurement"
 NATIVE_SEARCH_MAX_CANDIDATE_RESOURCES = 10_000
 NATIVE_SEARCH_MAX_BODY_BYTES = 128 * 1024 * 1024
+# Legacy alias for the caller-supplied `source_uris` scope cap. The live limit
+# is `settings.search_max_source_uris` (configurable, documented there); this
+# constant stays so older imports keep resolving, but nothing reads it anymore.
 NATIVE_SEARCH_MAX_SOURCE_URIS = 200
 # Frontmatter slice for candidate filtering (workbench #1069, part 2): the
 # filter decision needs only the leading frontmatter envelope (`type`/`tags`/
@@ -562,23 +565,41 @@ class SearchService:
                 f"OR v.owner_id = ${index} OR v.public_access IN ('reader', 'writer'))"
             )
         if source_uris:
-            if len(source_uris) > NATIVE_SEARCH_MAX_SOURCE_URIS:
+            max_uris = settings.search_max_source_uris
+            if len(source_uris) > max_uris:
                 raise ValidationError(
-                    f"native search accepts at most {NATIVE_SEARCH_MAX_SOURCE_URIS} source URIs"
+                    f"native search accepts at most {max_uris} source URIs "
+                    f"(got {len(source_uris)}); split the request or use a "
+                    "vault scope instead"
                 )
-            source_clauses: list[str] = []
+            # Pairwise scope match via unnested (vault, identifier) rows: the SQL
+            # text stays constant-size no matter how many URIs arrive (only the
+            # bind arrays grow). Each pair matches exactly the way the old
+            # per-URI OR expansion did — vault AND (path OR id) PER PAIR — so
+            # no cross-pairing: vault A can never match vault B's identifier.
+            # (A naive `v.name = ANY($1) AND ident = ANY($2)` WOULD cross-match
+            # and pollute the scope across vaults.) Non-doc URIs are skipped,
+            # so every identifier here is a doc path-or-id by construction.
+            uri_pairs: list[tuple[str, str]] = []
             for uri in source_uris:
                 parsed = parse_uri(uri)
                 if parsed is None or parsed.kind != "doc" or not parsed.identifier:
                     continue
-                params.extend([parsed.vault, parsed.identifier])
-                source_clauses.append(
-                    f"(v.name = ${len(params) - 1} AND "
-                    f"(r.current_path = ${len(params)} OR r.resource_id::text = ${len(params)}))"
-                )
-            if not source_clauses:
+                uri_pairs.append((parsed.vault, parsed.identifier))
+            if not uri_pairs:
                 return [], {}
-            conditions.append("(" + " OR ".join(source_clauses) + ")")
+            params.extend([
+                [v for v, _ in uri_pairs],
+                [i for _, i in uri_pairs],
+            ])
+            pair_idx = len(params) - 1
+            ident_idx = len(params)
+            conditions.append(
+                f"((v.name, r.current_path) IN ("
+                f"SELECT * FROM unnest(${pair_idx}::text[], ${ident_idx}::text[])) OR "
+                f"(v.name, r.resource_id::text) IN ("
+                f"SELECT * FROM unnest(${pair_idx}::text[], ${ident_idx}::text[])))"
+            )
 
         joins = """
               FROM native_resources r
@@ -698,9 +719,11 @@ class SearchService:
         include_archived = scope != "unarchived"
         if mode != "hybrid":
             raise ValidationError("unsupported search mode")
-        if source_uris and len(source_uris) > NATIVE_SEARCH_MAX_SOURCE_URIS:
+        if source_uris and len(source_uris) > settings.search_max_source_uris:
             raise ValidationError(
-                f"search accepts at most {NATIVE_SEARCH_MAX_SOURCE_URIS} source URIs"
+                f"search accepts at most {settings.search_max_source_uris} source URIs "
+                f"(got {len(source_uris)}); split the request or use a "
+                "vault scope instead"
             )
 
         document_source = _configured_document_source_type()

--- a/backend/tests/test_native_search_selection_unit.py
+++ b/backend/tests/test_native_search_selection_unit.py
@@ -304,8 +304,137 @@ async def test_native_search_pushes_source_uri_into_bounded_sql_scope():
     assert candidates == []
     assert stats == {}
 
+    # Pairwise shape: one clause covering all URIs via unnested
+    # (vault, identifier) rows — not one OR per URI, and NOT two independent
+    # ANYs (which would cross-match vault A's identifier against vault B).
+    # The scope query (fetchrow) and the page query (fetch) both carry it.
+    # (" OR " still appears once — the path-OR-id alternation.)
     assert all("r.current_path" in sql and "r.resource_id::text" in sql for sql, _ in conn.queries)
-    assert conn.params == ("measure", "specs/guide.md")
+    assert all("unnest(" in sql for sql, _ in conn.queries)
+    assert conn.sql.count(" OR ") == 1
+    assert conn.params == (["measure"], ["specs/guide.md"])
+
+
+@pytest.mark.asyncio
+async def test_native_search_source_uris_share_one_pairwise_clause():
+    """N URIs produce one pairwise clause (constant-size SQL), not N OR
+    clauses — and pairs never cross-match (vault A + vault B's identifier)."""
+    conn = _CandidateConn()
+    uris = [f"akb://measure/doc/specs/guide-{i}.md" for i in range(5)]
+    candidates, stats = await SearchService()._native_document_candidates(
+        conn,
+        user_uuid=None,
+        is_admin=True,
+        vaults=None,
+        collection=None,
+        doc_type=None,
+        tags=None,
+        include_archived=False,
+        source_uris=uris,
+    )
+    assert candidates == []
+    assert stats == {}
+    assert conn.sql.count(" OR ") == 1  # only the path-OR-id alternation
+    assert "unnest(" in conn.sql
+    # Same vault repeated per pair (pairwise), NOT one vault list × one id
+    # list (which would cross-match across vaults).
+    assert conn.params == (["measure"] * 5, [f"specs/guide-{i}.md" for i in range(5)])
+
+
+@pytest.mark.asyncio
+async def test_native_search_source_uris_do_not_cross_match_vaults():
+    """Pairwise unnest keeps (vault, identifier) together: with URIs from two
+    vaults, the generated SQL cannot match vault A's name against vault B's
+    identifier. Verified by executing the scope predicate shape against a
+    fake conn that evaluates the pairing in Python."""
+
+    seen_sql: list[str] = []
+    seen_params: list[tuple] = []
+
+    class _PairCheckingConn(_CandidateConn):
+        async def fetch(self, sql, *params):
+            seen_sql.append(sql)
+            seen_params.append(params)
+            # Simulate rows from two vaults; the candidate loop then runs
+            # normally (empty body slices → plain-markdown defaults).
+            return [
+                {
+                    "resource_id": uuid.uuid4(),
+                    "current_path": "specs/guide.md",
+                    "vault_name": "vault-a",
+                    "byte_size": 20,
+                    "digest": "0" * 64,
+                    "encoding": "utf-8",
+                    "selected_placement": M1ReferencePayloadStore.selected_placement,
+                    "verification_profile": "sha256-size-utf8-v1",
+                    "body_slice": b"plain body\n",
+                },
+            ]
+
+    conn = _PairCheckingConn()
+    candidates, stats = await SearchService()._native_document_candidates(
+        conn,
+        user_uuid=None,
+        is_admin=True,
+        vaults=None,
+        collection=None,
+        doc_type=None,
+        tags=None,
+        include_archived=False,
+        source_uris=[
+            "akb://vault-a/doc/specs/guide.md",
+            "akb://vault-b/doc/other.md",
+        ],
+    )
+    assert candidates != []  # vault-a pair matches its own row
+    assert stats == {}
+    # The SQL carries both pairs positionally aligned: index i of the vault
+    # array belongs to index i of the identifier array.
+    vaults_param, idents_param = seen_params[-1][-2], seen_params[-1][-1]
+    assert vaults_param == ["vault-a", "vault-b"]
+    assert idents_param == ["specs/guide.md", "other.md"]
+    # And the predicate is a row-constructor IN (pairwise), not two ANYs.
+    assert "(v.name, r.current_path) IN (" in seen_sql[-1]
+    assert "v.name = ANY" not in seen_sql[-1]
+
+
+@pytest.mark.asyncio
+async def test_native_search_source_uri_cap_message_names_recovery():
+    """Over-cap rejection tells the caller how to recover (split / vault scope)."""
+    from app.config import settings
+    from app.services import search_service
+
+    conn = _CandidateConn()
+    over = ["akb://measure/doc/specs/guide.md"] * (settings.search_max_source_uris + 1)
+    with pytest.raises(ValidationError, match="split the request or use a vault scope"):
+        await SearchService()._native_document_candidates(
+            conn,
+            user_uuid=None,
+            is_admin=True,
+            vaults=None,
+            collection=None,
+            doc_type=None,
+            tags=None,
+            include_archived=False,
+            source_uris=over,
+        )
+    assert search_service.NATIVE_SEARCH_MAX_SOURCE_URIS == 200  # legacy alias intact
+
+
+@pytest.mark.asyncio
+async def test_reference_payload_write_cap_rejects_oversize_body():
+    """The reference placement enforces the same 10MiB write cap as the
+    pg-bodystore placement; larger content belongs in File storage."""
+    from app.exceptions import ValidationError as VE
+    from app.services.m1_reference_payload_store import M1ReferencePayloadStore
+
+    assert M1ReferencePayloadStore.max_text_bytes == 10 * 1024 * 1024
+    with pytest.raises(VE, match="10 MiB limit"):
+        M1ReferencePayloadStore._verified_bytes(b"x" * (10 * 1024 * 1024 + 1))
+    with pytest.raises(VE, match="10 MiB limit"):
+        M1ReferencePayloadStore._verified_bytes("y" * (10 * 1024 * 1024 + 1))
+    ok, _ = M1ReferencePayloadStore._verified_bytes(b"small body\n")
+    assert ok == b"small body\n"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Close the write/read bound loop and normalize the caller-supplied scope cap.

## Problem

Two remaining unbounded inputs in the native search path (workbench #1069
series, part 3 of 3):

1. The operating reference placement (`m1-reference-payload-v1`) had no byte
   cap — `M1_PG_TEXT_MAX_BYTES = 10MiB` existed only on the pg-bodystore
   placement. An unbounded body could enter the corpus, forcing every read
   path to assume the unbounded case.
2. Each `source_uris` entry expanded into its own SQL OR-clause, so request
   SQL text grew with the caller-supplied list. The 200 cap was a module
   constant with no derivation, and over-cap rejections named no recovery.

## Change

- `M1ReferencePayloadStore.max_text_bytes = 10MiB`, enforced in
  `_verified_bytes` for both `str` and `bytes` inputs (same shape and error
  class as the sibling store). Larger content is directed to File storage
  by the error message. Hydration memory is now statically bounded by
  `limit × 10MiB`.
- `source_uris` scope resolution matches (vault, identifier) pairs as row
  constructors against unnested arrays — one constant-size clause for any
  number of URIs, with exact per-URI semantics. Two independent ANYs would
  cross-match vault A's name against vault B's identifier and pollute the
  scope across vaults; the pairwise form cannot.
- The cap moves to `settings.search_max_source_uris` (default 200,
  provisional — the setting comment documents the derivation path:
  per-driver IN-list measurement). Over-cap errors name the recovery
  (split the request or use a vault scope). `NATIVE_SEARCH_MAX_SOURCE_URIS`
  stays as an untouched legacy alias.
- Part of the workbench #1069 bounded-corpus series (part 1: driver-side
  `source_types` predicate + native vault path; part 2: frontmatter-slice +
  paginated candidate filtering). Stacked on parts 1+2.

## Verification

- New: reference-placement write-cap rejection (`str` + `bytes`, boundary
  accept just under), pairwise unnest shape (single clause, positional pair
  alignment, no `v.name = ANY`, cross-vault non-match test), over-cap
  recovery message, legacy-alias intactness — in
  `tests/test_native_search_selection_unit.py`.
- Full related suite (`test_native_search_selection_unit`,
  `test_search_rerank_fusion`, `test_search_filter_contract_unit`,
  `test_native_payload_verification_unit`, `test_m1_pg_body_grep_unit`,
  `test_qdrant_vault_filter_unit`, `test_seahorse_vault_filter_unit`,
  `test_search_hit_chunk_identity_unit`, `test_search_parent_context_unit`,
  `test_search_multi_vault_unit`, `test_vault_backfill`): green.
  `ruff check` clean on all touched files.
