### PR TITLE
fix(search): cross-process vault-filter readiness (akb#526)

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -7,6 +7,21 @@ specifically; the proxy has its own log in
 
 ## Unreleased
 
+### Vault-filter readiness visible to the serving tier (akb#526)
+
+`vault_backfill.is_ready()` was a process-local latch flipped only by the
+backfill runner, which lives in the worker tier — on a split api/worker
+deployment the serving process never ran it, so its copy stayed False for
+life and every native-arm query fell back to id enumeration (and the
+bounded-corpus refusal on large scopes), even with zero NULL `vault_id`
+rows. Search now calls `is_ready_async()`: the local latch on hit, else the
+store's own NULL count — state both tiers can see — with a 30s cache on
+negative outcomes so the hot path stays cheap. A True outcome latches
+locally and is never re-checked; a counter failure stays gated (fail
+closed). When the vault path is wanted but readiness is not established,
+search logs one line (`vault path disabled: readiness not established`)
+instead of surfacing only as an unrelated search refusal downstream.
+
 ### Write cap + source_uris hardening (bounded-corpus fix, part 3)
 
 The reference placement (`m1-reference-payload-v1`) enforces the same 10MiB

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -779,13 +779,21 @@ class SearchService:
         # AKB is purely per-vault, so this is correctness-equivalent. Otherwise
         # the existing SOURCE_IDS path runs UNCHANGED (flag off / other driver /
         # any doc-level filter present).
-        # `is_ready()` additionally gates on the auto-backfill: until every
-        # pre-upgrade pgvector point carries its vault_id, fall back to the
-        # source-id path so a user can't miss their own un-backfilled docs.
+        # Readiness is cross-process (akb#526): the backfill runner lives in the
+        # worker tier, so the serving tier must derive it from store state it
+        # can see (NULL-vault_id count, briefly cached) rather than from a
+        # process-local latch the worker flips in its own copy.
         from app.services import vault_backfill
-        use_vault_path = not (doc_types or source_type or scope != "all") and vault_path_eligible(
+        vault_path_wanted = not (doc_types or source_type or scope != "all") and vault_path_eligible(
             collection=collection, doc_type=doc_type, tags=tags, source_uris=source_uris,
-        ) and vault_backfill.is_ready()
+        )
+        vault_ready = vault_backfill.is_ready() or await vault_backfill.is_ready_async()
+        if vault_path_wanted and not vault_ready:
+            # One line on the serving side naming the disabled path (akb#526):
+            # without it this surfaces only as an unrelated search refusal
+            # downstream (bounded-corpus 422 on large scopes).
+            logger.info("vault path disabled: readiness not established")
+        use_vault_path = vault_path_wanted and vault_ready
 
         if use_vault_path:
             async with pool.acquire() as conn:

--- a/backend/app/services/vault_backfill.py
+++ b/backend/app/services/vault_backfill.py
@@ -27,6 +27,7 @@ vault and source paths, so they do NOT block readiness.
 from __future__ import annotations
 
 import logging
+import time
 
 from app.config import settings
 from app.db.postgres import get_pool
@@ -37,15 +38,71 @@ from app.services.vector_store.base import supports_vault_filter
 logger = logging.getLogger("akb.vault_backfill")
 
 _BATCH = 5000
-# Set once all live-source points carry vault_id. Increment A guarantees no NEW
-# nulls appear, so once True it stays True for the life of the process.
+# Process-local fast path for the search hot path. Set once THIS process has
+# established readiness (see is_ready_async); never cleared afterwards.
+# Increment A guarantees no NEW nulls appear, so once True it stays True for
+# the life of the process. It is deliberately NOT shared across processes —
+# cross-process visibility comes from the cached DB check in is_ready_async.
 _ready = False
+# Cached outcome of the last cross-process readiness check: (established_at,
+# value). A True value is latched into `_ready` above, so only False outcomes
+# are ever re-checked — and only after the TTL below.
+_last_check: tuple[float, bool] | None = None
+# How long a negative readiness outcome is trusted before re-checking the
+# store (akb#526). The check is one indexed COUNT(*) on the vector schema;
+# 30s keeps the hot path cheap while opening the vault path within half a
+# minute of the backfill completing anywhere (any process, any replica).
+_NEGATIVE_TTL_SECS = 30.0
 
 
 def is_ready() -> bool:
-    """True when the vault filter is safe to use (all live-source points have
-    vault_id). Read on the search hot path — must stay a cheap memory read."""
+    """Process-local fast path: True once THIS process has established
+    readiness. Kept for the worker loop (`_process_once` short-circuit) and
+    for tests. Search must call `is_ready_async()` instead — on a split
+    api/worker deployment the worker flips its own copy of this latch while
+    the serving process never runs the backfill runner, so a bare memory
+    read here is permanently False where search actually runs (akb#526)."""
     return _ready
+
+
+async def is_ready_async() -> bool:
+    """Cross-process readiness for the search hot path (akb#526).
+
+    Returns the process-local latch when set (zero cost). Otherwise asks the
+    store for its NULL-`vault_id` count — state every tier can see — and
+    caches a negative outcome for `_NEGATIVE_TTL_SECS`. A True outcome
+    latches process-locally and is never re-checked.
+    """
+    global _ready, _last_check
+    if _ready:
+        return True
+    now = time.monotonic()
+    if _last_check is not None:
+        checked_at, value = _last_check
+        if not value and now - checked_at < _NEGATIVE_TTL_SECS:
+            return False
+    store = get_vector_store()
+    if not supports_vault_filter(store):
+        _ready = True
+        _last_check = None
+        return True
+    fn = getattr(store, "vault_backfill_pending", None)
+    if fn is None:
+        # A capable driver that exposes no counter can't prove its existing
+        # points carry vault_id: stay gated (matches the worker branch below).
+        _last_check = (now, False)
+        return False
+    try:
+        pending = await fn()
+    except Exception:  # noqa: BLE001 — a counter failure must not open the path
+        _last_check = (now, False)
+        return False
+    if pending == 0:
+        _ready = True
+        _last_check = None
+        return True
+    _last_check = (now, False)
+    return False
 
 
 def _is_pgvector() -> bool:

--- a/backend/tests/test_vault_backfill.py
+++ b/backend/tests/test_vault_backfill.py
@@ -2,9 +2,14 @@
 
 The worker's job is to make the vault-filter path zero-touch: it backfills
 `vault_id` onto pre-upgrade pgvector points on startup, and search reads
-`is_ready()` to decide whether the vault path is safe yet. These tests lock the
+readiness to decide whether the vault path is safe yet. These tests lock the
 contract that gates that decision — the DB-backed `_process_once` join is
 exercised end-to-end in the e2e suite, not here.
+
+akb#526: readiness must be visible to the SERVING tier, which never runs the
+backfill runner on a split api/worker deployment. `is_ready()` is the
+process-local latch (worker loop + fast path); `is_ready_async()` derives it
+from store state both tiers can see, with a short negative-result cache.
 """
 from __future__ import annotations
 
@@ -15,8 +20,9 @@ from app.services import vault_backfill
 
 @pytest.fixture(autouse=True)
 def _reset_ready(monkeypatch):
-    # `_ready` is module state that latches True for the process; isolate each test.
+    # `_ready` / `_last_check` are module state; isolate each test.
     monkeypatch.setattr(vault_backfill, "_ready", False, raising=False)
+    monkeypatch.setattr(vault_backfill, "_last_check", None, raising=False)
 
 
 def test_is_ready_defaults_false_and_reflects_module_state(monkeypatch):
@@ -150,3 +156,98 @@ async def test_pending_stats_omits_count_for_drivers_without_counter(monkeypatch
     stats = await vault_backfill.pending_stats()
     assert "null_remaining" not in stats
     assert set(stats) == {"ready", "applicable", "vault_filter_supported"}
+
+
+# ── akb#526: cross-process readiness for the serving tier ──
+
+class _CountedStore:
+    """Driver stand-in with an observable NULL-vault_id count."""
+
+    vault_filter_supported = True
+
+    def __init__(self, pending: int, fail: bool = False):
+        self.pending = pending
+        self.fail = fail
+        self.calls = 0
+
+    async def vault_backfill_pending(self):
+        self.calls += 1
+        if self.fail:
+            raise RuntimeError("store unreachable")
+        return self.pending
+
+
+@pytest.mark.asyncio
+async def test_is_ready_async_opens_path_without_worker_latch(monkeypatch):
+    """The serving tier never runs the backfill runner, so its `_ready` is
+    False forever. A zero NULL count from the store must still open the path
+    (and latch the local fast path)."""
+    store = _CountedStore(pending=0)
+    monkeypatch.setattr(vault_backfill, "get_vector_store", lambda: store)
+    assert vault_backfill.is_ready() is False
+    assert await vault_backfill.is_ready_async() is True
+    assert vault_backfill.is_ready() is True
+    assert store.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_is_ready_async_caches_negative_outcome(monkeypatch):
+    """A nonzero count stays cached for the TTL: the hot path must not pay a
+    COUNT(*) per search while the backfill is still draining."""
+    store = _CountedStore(pending=5)
+    monkeypatch.setattr(vault_backfill, "get_vector_store", lambda: store)
+    assert await vault_backfill.is_ready_async() is False
+    assert await vault_backfill.is_ready_async() is False
+    assert store.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_is_ready_async_rechecks_after_ttl(monkeypatch):
+    """After the TTL the count is re-read, so the path opens within ~30s of
+    the backfill completing anywhere (any process, any replica)."""
+    store = _CountedStore(pending=5)
+    monkeypatch.setattr(vault_backfill, "get_vector_store", lambda: store)
+    assert await vault_backfill.is_ready_async() is False
+    assert store.calls == 1
+    monkeypatch.setattr(vault_backfill, "_NEGATIVE_TTL_SECS", 0)
+    store.pending = 0
+    assert await vault_backfill.is_ready_async() is True
+    assert store.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_is_ready_async_stays_gated_on_counter_failure(monkeypatch):
+    """A counter failure must not open the path — fail closed, stay cached."""
+    store = _CountedStore(pending=0, fail=True)
+    monkeypatch.setattr(vault_backfill, "get_vector_store", lambda: store)
+    assert await vault_backfill.is_ready_async() is False
+    assert await vault_backfill.is_ready_async() is False
+    assert vault_backfill.is_ready() is False
+    assert store.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_is_ready_async_without_counter_stays_gated(monkeypatch):
+    """A capable driver with no vault_backfill_pending can't prove its points
+    carry vault_id — same fail-closed rule as the worker branch."""
+
+    class _NoCounter:
+        vault_filter_supported = True
+
+    monkeypatch.setattr(vault_backfill, "get_vector_store", lambda: _NoCounter())
+    assert await vault_backfill.is_ready_async() is False
+    assert vault_backfill.is_ready() is False
+
+
+@pytest.mark.asyncio
+async def test_is_ready_async_non_capable_latches_immediately(monkeypatch):
+    """A driver without the vault filter never takes the vault path, so the
+    check is moot — same immediate-latch rule as the worker branch, no store
+    call needed."""
+
+    class _Plain:  # no vault_filter_supported attribute
+        pass
+
+    monkeypatch.setattr(vault_backfill, "get_vector_store", lambda: _Plain())
+    assert await vault_backfill.is_ready_async() is True
+    assert vault_backfill.is_ready() is True


### PR DESCRIPTION
Make vault-filter readiness visible to the serving tier.

## Problem

`vault_backfill.is_ready()` is a module-level boolean flipped only by the
backfill runner, which is composed by `start_workers()` — a serving process
with any role other than the combined one never runs it. On a split
api/worker deployment the worker flips its own copy of the latch ("vault_id
backfill complete" in the worker log) while the API's copy stays `False`
for the life of the process (the backfill runner is absent from the API
log). The search hot path reads it:

```python
use_vault_path = ... and vault_path_eligible(...) and vault_backfill.is_ready()
```

so `use_vault_path` is permanently `False` where search actually runs, and
every native-arm query falls back to enumerating candidate source ids —
carrying the bounded-corpus guard, so any scope above the ceiling is
refused outright. Measured on a split `postgres_native` + pgvector
deployment: `vault_path_eligible(...)` is `True`, the NULL-`vault_id` count
is zero (the guarded condition fully holds), small vaults search fine,
large vaults and unscoped search return the bounded-corpus refusal — before
and after a redeploy. Single-process (`role=all`) never shows this, which
is why verification there passed.

## Change

- New `vault_backfill.is_ready_async()`: the process-local latch on hit
  (zero cost), else the store's own `vault_backfill_pending()` NULL count —
  state both tiers can see — with a 30s cache on negative outcomes so the
  hot path stays cheap (one indexed `COUNT(*)` at most twice a minute per
  process while draining). A True outcome latches locally and is never
  re-checked. A counter failure, or a capable driver with no counter,
  stays gated (fail closed, same rule as the worker branch).
- Search calls `is_ready() or await is_ready_async()`: the sync latch first
  (worker tier / already-established processes pay nothing), the shared
  check only while unestablished.
- When the vault path is wanted but readiness is not established, search
  logs one line — `vault path disabled: readiness not established` — so
  this names itself instead of presenting as an unrelated search refusal
  downstream.
- `is_ready()` itself is unchanged (worker loop short-circuit + tests).

## Scope / non-goals

- No schema migration, no config change, no constant changes. The 30s
  negative TTL is a module constant next to the latch.
- Orphan points (NULL `vault_id`, no live source) are counted by the
  driver's counter but excluded by both search paths, matching the
  worker-side semantics discussion already on record.

## Verification

- `tests/test_vault_backfill.py`: 14 passed — the 8 pre-existing worker
  tests plus: opens path on zero count without the worker latch (and
  latches locally), negative-outcome caching (1 store call for 2 reads),
  re-check after TTL, fail-closed on counter failure and on
  counter-less capable drivers, immediate latch for non-capable drivers.
- Related search suites (`test_native_search_selection_unit`,
  `test_search_rerank_fusion`, `test_search_filter_contract_unit`,
  `test_search_multi_vault_unit`, `test_search_parent_context_unit`,
  `test_search_hit_chunk_identity_unit`): green.
- `ruff check` clean on all touched files.
