### PR TITLE
fix(search): apply archive scope at hydration, not candidate enumeration (akb#530)

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -7,6 +7,35 @@ specifically; the proxy has its own log in
 
 ## Unreleased
 
+### Default archive scope no longer disqualifies the vault path (akb#530)
+
+`archive_scope` defaults to `unarchived`, and the vault-path gate demanded
+`scope == "all"` — so the fast path had no reachable caller. Every ordinary
+search fell back to enumerating candidate source ids, which refuses with the
+bounded-corpus error on any scope above the candidate ceiling. Measured on one
+installation: `?q=…` returned 422 while the identical request with
+`&archive_scope=all` returned 200, with archived documents 154 of 136,183
+(0.11%).
+
+The archived predicate moves from candidate enumeration to hydration, where
+the authoritative status is already parsed: verified Head frontmatter on the
+native arm, `documents.status` on the legacy one. `unarchived` and `all` now
+take the vault path; `archived` deliberately keeps the id path, because it
+selects FOR the rare tail and a vault-path top-K would filter down to nothing.
+
+A hit excluded by scope no longer costs a result slot: the page is refilled
+from the rest of the deduped prefetch pool, and the drop is counted as
+`archive_scope_excluded` in the `hydration_dropped` degradation reason, so a
+genuinely short page (an exhausted pool) names its cause. Applying the
+predicate at hydration also closes the window where a document is archived
+between candidate selection and hydration.
+
+Note for the native arm: the retained legacy `documents` rows are a frozen
+cutover projection and are NOT the archived authority. Measured on the same
+installation, 3 of the 154 rows marked archived there carry `status: draft` in
+their native frontmatter, so filtering on that column would wrongly hide live
+documents.
+
 ### Vault-filter readiness visible to the serving tier (akb#526)
 
 `vault_backfill.is_ready()` was a process-local latch flipped only by the

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -20,7 +20,7 @@ from typing import Literal
 from app.config import settings
 from app.db.postgres import get_pool
 from app.exceptions import ValidationError
-from app.services.search_filters import ArchiveScope, collection_predicate, escape_like, metadata_matches, resolve_archive_scope
+from app.services.search_filters import ArchiveScope, collection_predicate, escape_like, metadata_matches, resolve_archive_scope, status_matches
 from app.models.document import SearchResponse, SearchResult
 from app.repositories.vault_files_repo import confirmed_file_predicate
 from app.services import sparse_encoder
@@ -394,6 +394,24 @@ def vault_path_eligible(
         and supports_vault_filter(get_vector_store())
         and not (collection or doc_type or tags or source_uris)
     )
+
+
+def archive_scope_allows_vault_path(scope: ArchiveScope) -> bool:
+    """Whether `scope` can be served by the VAULT path, with the archived
+    predicate applied at hydration instead of by candidate enumeration.
+
+    `unarchived` (the DEFAULT) and `all` can. Requiring `all` here is what
+    disqualified every ordinary search from the fast path (akb#530): archive
+    scope is unlike `collection` / `doc_type` / `tags`, which a caller opts
+    into — it is set on every request nobody customised, so treating it as a
+    narrowing filter meant the fast path had no reachable caller at all.
+
+    `archived` cannot, and stays on the id path. It selects FOR a set that was
+    0.11% of the measured corpus, so a vault-path top-K would be almost
+    entirely non-matching and hydration would filter the page down to nothing.
+    Enumerating ids is the right tool for narrowing to a rare set; it is the
+    wrong one for excluding it."""
+    return scope != "archived"
 
 
 def clamp_search_limit(limit: int) -> int:
@@ -784,8 +802,25 @@ class SearchService:
         # can see (NULL-vault_id count, briefly cached) rather than from a
         # process-local latch the worker flips in its own copy.
         from app.services import vault_backfill
-        vault_path_wanted = not (doc_types or source_type or scope != "all") and vault_path_eligible(
-            collection=collection, doc_type=doc_type, tags=tags, source_uris=source_uris,
+        # Archive scope is the one doc-level narrowing that is NOT opt-in: it
+        # defaults to `unarchived`, so requiring `scope == "all"` here
+        # disqualified EVERY ordinary search from the vault path and sent it to
+        # the id-enumeration fallback — which refuses with the bounded-corpus
+        # error on any scope above the candidate ceiling (akb#530). The
+        # archived predicate moves to hydration, where the AUTHORITATIVE status
+        # is already parsed for free: verified native frontmatter on the native
+        # arm, `documents.status` on the legacy one.
+        #
+        # `archived` deliberately stays on the id path. It asks FOR the ~0.1%
+        # tail, so a vault-path top-K would be almost entirely non-matching and
+        # hydration would filter the page down to nothing. Narrowing to a rare
+        # set is what id enumeration is for; excluding one is not.
+        vault_path_wanted = (
+            not (doc_types or source_type)
+            and archive_scope_allows_vault_path(scope)
+            and vault_path_eligible(
+                collection=collection, doc_type=doc_type, tags=tags, source_uris=source_uris,
+            )
         )
         vault_ready = vault_backfill.is_ready() or await vault_backfill.is_ready_async()
         if vault_path_wanted and not vault_ready:
@@ -1032,8 +1067,6 @@ class SearchService:
         if rerank_enabled and len(unique_hits) > 1:
             unique_hits = await self._apply_rerank(query, unique_hits)
 
-        unique_hits = unique_hits[:limit]
-
         # Post-search metadata join — one fetch per source_type, merged back
         # in the driver-returned order. Keeps document results fully
         # backward-compatible (doc_id == source_id) while adding table/file.
@@ -1041,7 +1074,24 @@ class SearchService:
         # (workbench #1069 G3): any non-empty drop set marks the response
         # degraded so `total_matches > 0, returned == 0` can never again read
         # as a silent zero-match.
-        results, dropped = await self._hydrate_hits(unique_hits)
+        #
+        # The page is the first `limit` deduped hits; `spare` is the rest of
+        # the prefetch pool. Hydration can drop rows — archive scope (akb#530),
+        # a stale head, a deleted source — so refill from `spare` rather than
+        # return a short page whenever the pool left headroom. At the measured
+        # archived density (0.11%) the loop body essentially never runs, so the
+        # common case still pays exactly one hydration round trip. Each pass
+        # consumes at least one spare hit, so it terminates; when the pool is
+        # exhausted the page really is short and `dropped` names the cause.
+        page, spare = unique_hits[:limit], unique_hits[limit:]
+        results, dropped = await self._hydrate_hits(page, archive_scope=scope)
+        while len(results) < limit and spare:
+            take, spare = spare[: limit - len(results)], spare[limit - len(results):]
+            more, more_dropped = await self._hydrate_hits(take, archive_scope=scope)
+            results.extend(more)
+            for cause, count in more_dropped.items():
+                dropped[cause] = dropped.get(cause, 0) + count
+        results = results[:limit]
         hydrate_reason = (
             f"hydration_dropped:{','.join(f'{k}={v}' for k, v in sorted(dropped.items()))}" if dropped else None
         )
@@ -1172,7 +1222,9 @@ class SearchService:
 
         return doc_ids, table_ids, file_ids
 
-    async def _hydrate_hits(self, hits: list) -> tuple[list[SearchResult], dict[str, int]]:
+    async def _hydrate_hits(
+        self, hits: list, *, archive_scope: ArchiveScope = "all",
+    ) -> tuple[list[SearchResult], dict[str, int]]:
         from app.services.index_service import SOURCE_TYPES
         by_type: dict[str, list[str]] = {t: [] for t in SOURCE_TYPES}
         document_source = _configured_document_source_type()
@@ -1536,6 +1588,23 @@ class SearchService:
                 # `total_matches=30, returned=0` shape, and it must never again
                 # read as a silent zero-match.
                 dropped["hydration_miss"] = dropped.get("hydration_miss", 0) + 1
+                continue
+            # Archive scope (akb#530). `m["status"]` is the AUTHORITY for this
+            # arm and it is already in hand: the native branch parsed it out of
+            # the verified Head body, the legacy branch selected `d.status`.
+            # Applying it here is what lets the default `unarchived` request
+            # take the vault path instead of enumerating candidate ids.
+            #
+            # Table and File carry no document status; `status_matches(None, …)`
+            # keeps them under `unarchived`/`all` and excludes them under
+            # `archived`, which is exactly what the candidate-side branches do.
+            #
+            # Unconditional, not vault-path-only: on the id path the same
+            # predicate already ran during candidate selection, so this is
+            # idempotent — and it closes the window where a document is
+            # archived between candidate selection and hydration.
+            if not status_matches(m.get("status"), archive_scope):
+                dropped["archive_scope_excluded"] = dropped.get("archive_scope_excluded", 0) + 1
                 continue
             # Build the canonical 0.3.0 URI per resource type. Doc URIs
             # derive the collection from `path` automatically (path

--- a/backend/tests/test_search_archive_scope_vault_path_unit.py
+++ b/backend/tests/test_search_archive_scope_vault_path_unit.py
@@ -1,0 +1,202 @@
+"""Archive scope on the VAULT path (akb#530).
+
+The vault path exists so an ordinary search filters by vault id instead of
+enumerating candidate source ids. Archive scope used to disqualify it: the
+scope defaults to `unarchived` and the gate demanded `all`, so the fast path
+had no reachable caller and every default request fell back to enumeration —
+which refuses with the bounded-corpus error on a large scope.
+
+The predicate moved to hydration, where the AUTHORITATIVE status is already in
+hand. These tests pin both halves: that the exclusion is exact, and that a
+page shortened by it is refilled from the prefetch pool rather than returned
+short.
+"""
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services import search_service as ss
+from app.services.search_service import SearchService
+from app.services.vector_store import VectorHit
+
+pytestmark = pytest.mark.asyncio
+
+VAULT_ID = uuid.UUID(int=7)
+
+
+def _doc_row(doc_id: uuid.UUID, status: str) -> dict:
+    return {
+        "id": doc_id,
+        "vault_name": "mine",
+        "path": f"notes/{doc_id.int}.md",
+        "title": f"Doc {doc_id.int}",
+        "collection": "notes",
+        "doc_type": "note",
+        "summary": None,
+        "tags": [],
+        "status": status,
+    }
+
+
+class _Conn:
+    """Answers the vault-path ACL lookup and the legacy-arm hydration join."""
+
+    def __init__(self, statuses: dict[uuid.UUID, str]):
+        self.statuses = statuses
+        self.queries: list[str] = []
+
+    async def fetchval(self, *_args):
+        return False  # is_admin
+
+    async def fetch(self, sql: str, *params):
+        self.queries.append(sql)
+        if "FROM vaults v WHERE" in sql or "FROM vaults WHERE name" in sql:
+            return [{"id": VAULT_ID}]
+        if "FROM documents d" in sql:
+            wanted = {str(x) for x in params[0]}
+            return [
+                _doc_row(doc_id, status)
+                for doc_id, status in self.statuses.items()
+                if str(doc_id) in wanted
+            ]
+        return []
+
+
+class _Pool:
+    def __init__(self, conn):
+        self.conn = conn
+
+    @asynccontextmanager
+    async def acquire(self):
+        yield self.conn
+
+
+def _hit(doc_id: uuid.UUID, score: float = 1.0) -> VectorHit:
+    return VectorHit(
+        chunk_id=str(uuid.uuid4()),
+        source_type="document",
+        source_id=str(doc_id),
+        section_path="",
+        content="body",
+        score=score,
+    )
+
+
+def _install(monkeypatch, conn):
+    from app.config import settings
+    from app.services import vault_backfill
+
+    class _Capable:
+        vault_filter_supported = True
+
+    async def get_test_pool():
+        return _Pool(conn)
+
+    monkeypatch.setattr(settings, "vault_filter_enabled", True, raising=False)
+    monkeypatch.setattr(settings, "rerank_enabled", False, raising=False)
+    monkeypatch.setattr(ss, "get_vector_store", lambda: _Capable())
+    monkeypatch.setattr(vault_backfill, "is_ready", lambda: True)
+    monkeypatch.setattr(ss, "get_pool", get_test_pool)
+    monkeypatch.setattr(ss, "generate_embeddings", AsyncMock(return_value=[[0.1]]))
+    monkeypatch.setattr(ss, "_configured_document_source_type", lambda: "document")
+
+
+@pytest.mark.parametrize("scope,kept", [
+    ("unarchived", False),
+    ("all", True),
+])
+async def test_hydration_applies_archive_scope_to_the_authoritative_status(monkeypatch, scope, kept):
+    """`unarchived` excludes an archived document and says so by cause;
+    `all` keeps it. The status read is the arm's authority — `documents.status`
+    here, verified frontmatter on the native arm."""
+    doc_id = uuid.uuid4()
+    conn = _Conn({doc_id: "archived"})
+    _install(monkeypatch, conn)
+
+    results, dropped = await SearchService()._hydrate_hits([_hit(doc_id)], archive_scope=scope)
+
+    assert len(results) == (1 if kept else 0)
+    assert dropped == ({} if kept else {"archive_scope_excluded": 1})
+
+
+async def test_hydration_defaults_to_no_archive_filtering(monkeypatch):
+    """The default keeps every caller that does not pass a scope unchanged —
+    the id path already applied the predicate during candidate selection."""
+    doc_id = uuid.uuid4()
+    conn = _Conn({doc_id: "archived"})
+    _install(monkeypatch, conn)
+
+    results, dropped = await SearchService()._hydrate_hits([_hit(doc_id)])
+
+    assert len(results) == 1
+    assert dropped == {}
+
+
+async def test_a_page_shortened_by_the_archive_filter_is_refilled(monkeypatch):
+    """An archived hit inside the page must not cost a result slot: the search
+    refills from the rest of the deduped prefetch pool. Without the refill this
+    returns 2 of the 3 requested."""
+    ids = [uuid.uuid4() for _ in range(6)]
+    # The second hit of the page is archived; the pool has spare candidates.
+    statuses = {doc_id: ("archived" if i == 1 else "draft") for i, doc_id in enumerate(ids)}
+    conn = _Conn(statuses)
+    _install(monkeypatch, conn)
+    # search_prefetch gives the pool headroom beyond `limit`; with none there
+    # is nothing to refill from and the page is legitimately short.
+    from app.config import settings
+    monkeypatch.setattr(settings, "search_prefetch", 6, raising=False)
+
+    service = SearchService()
+    monkeypatch.setattr(
+        service, "_run_vector_search",
+        AsyncMock(return_value=([_hit(d, score=1.0 - i / 10) for i, d in enumerate(ids)], None)),
+    )
+
+    response = await service.search("x", vault="mine", user_id=str(uuid.UUID(int=1)), limit=3)
+
+    assert response.returned == 3
+    assert [r.status for r in response.results] == ["draft", "draft", "draft"]
+    # Pool order is preserved and the archived hit at index 1 is replaced by
+    # the next spare candidate (index 3), not by shortening the page.
+    assert [r.title for r in response.results] == [
+        f"Doc {ids[0].int}", f"Doc {ids[2].int}", f"Doc {ids[3].int}",
+    ]
+    assert response.degradation_reason == "hydration_dropped:archive_scope_excluded=1"
+
+
+async def test_an_exhausted_pool_returns_a_short_page_that_names_its_cause(monkeypatch):
+    """With no spare candidates the page really is short. `returned < limit`
+    then has one stated cause instead of two unstated ones — the drop
+    accounting is what makes hydration-time filtering readable."""
+    ids = [uuid.uuid4() for _ in range(2)]
+    conn = _Conn({ids[0]: "draft", ids[1]: "archived"})
+    _install(monkeypatch, conn)
+    from app.config import settings
+    monkeypatch.setattr(settings, "search_prefetch", 0, raising=False)
+
+    service = SearchService()
+    monkeypatch.setattr(
+        service, "_run_vector_search",
+        AsyncMock(return_value=([_hit(d, score=1.0 - i / 10) for i, d in enumerate(ids)], None)),
+    )
+
+    response = await service.search("x", vault="mine", user_id=str(uuid.UUID(int=1)), limit=2)
+
+    assert response.returned == 1
+    assert response.degraded is True
+    assert response.degradation_reason == "hydration_dropped:archive_scope_excluded=1"
+
+
+async def test_tables_and_files_carry_no_status_and_survive_the_default_scope(monkeypatch):
+    """Only documents have an archived state. `status_matches(None, …)` keeps
+    table/file rows under `unarchived` and `all`, matching what the candidate
+    branches do with their `scope != "archived"` guards."""
+    from app.services.search_filters import status_matches
+
+    assert status_matches(None, "unarchived") is True
+    assert status_matches(None, "all") is True
+    assert status_matches(None, "archived") is False

--- a/backend/tests/test_search_filter_contract_unit.py
+++ b/backend/tests/test_search_filter_contract_unit.py
@@ -228,3 +228,80 @@ async def test_native_exact_and_regex_options_affect_results(monkeypatch, patter
     monkeypatch.setattr(service, "_head_bodies", AsyncMock(return_value=[body]))
     response = await service.grep_public(pattern, user_id=uuid.UUID(int=1), regex=regex, case_sensitive=case_sensitive)
     assert response["total_matches"] == count
+
+
+class VaultPathConnection(CandidateConnection):
+    """Answers the VAULT-path queries: the admin lookup and the accessible
+    vault-id resolution. Inherits the candidate queries so a test can assert
+    which of the two paths a request actually took."""
+
+    async def fetch(self, query, *params):
+        self.queries.append((query, params))
+        if "FROM vaults v WHERE" in query or "FROM vaults WHERE name" in query:
+            return [{"id": uuid.UUID(int=7)}]
+        return await super().fetch(query, *params)
+
+
+def _vault_path_service(monkeypatch, conn):
+    """A service whose vault path is available: flag on, capable driver,
+    backfill readiness established."""
+    from app.config import settings
+    from app.services import vault_backfill
+
+    class _Capable:
+        vault_filter_supported = True
+
+    monkeypatch.setattr(settings, "vault_filter_enabled", True, raising=False)
+    monkeypatch.setattr(ss, "get_vector_store", lambda: _Capable())
+    monkeypatch.setattr(vault_backfill, "is_ready", lambda: True)
+    monkeypatch.setattr(ss, "get_pool", AsyncMock(return_value=Pool(conn)))
+    monkeypatch.setattr(ss, "generate_embeddings", AsyncMock(return_value=[[0.1]]))
+    monkeypatch.setattr(ss, "_configured_document_source_type", lambda: ss.LEGACY_DOCUMENT_SOURCE)
+    return ss.SearchService()
+
+
+@pytest.mark.parametrize("kwargs", [
+    {},                                 # the DEFAULT request — no archive_scope at all
+    {"archive_scope": "unarchived"},    # the same scope, stated explicitly
+    {"archive_scope": "all"},           # the only scope that reached it before akb#530
+])
+async def test_default_archive_scope_reaches_the_vault_path(monkeypatch, kwargs):
+    """akb#530: archive scope defaults to `unarchived`, so gating the vault
+    path on `scope == "all"` left the fast path with no reachable caller — every
+    ordinary search fell back to enumerating candidate source ids, which refuses
+    with the bounded-corpus error on a large scope. The default must now filter
+    by VAULT id and enumerate nothing."""
+    conn = VaultPathConnection()
+    service = _vault_path_service(monkeypatch, conn)
+    vector = AsyncMock(return_value=([], None))
+    monkeypatch.setattr(service, "_run_vector_search", vector)
+
+    await service.search("x", vault="mine", user_id=str(uuid.UUID(int=1)), limit=5, **kwargs)
+
+    assert vector.call_args.kwargs["candidate_vault_ids"] == [str(uuid.UUID(int=7))]
+    assert vector.call_args.kwargs["candidate_source_ids"] is None
+    # No candidate enumeration happened — that is the query the bounded-corpus
+    # guard sits in front of.
+    assert not any("FROM documents d" in q for q, _ in conn.queries)
+
+
+async def test_archived_scope_still_enumerates_candidates(monkeypatch):
+    """`archived` selects FOR the rare tail, so it deliberately keeps the
+    id-enumeration path: a vault-path top-K would be almost entirely
+    non-matching and hydration would filter the page down to nothing."""
+    conn = VaultPathConnection()
+    service = _vault_path_service(monkeypatch, conn)
+    vector = AsyncMock(return_value=([], None))
+    monkeypatch.setattr(service, "_run_vector_search", vector)
+
+    await service.search("x", vault="mine", user_id=str(uuid.UUID(int=1)), archive_scope="archived", limit=5)
+
+    assert vector.call_args.kwargs["candidate_source_ids"] == [str(uuid.UUID(int=30))]
+    assert vector.call_args.kwargs["candidate_vault_ids"] is None
+    assert any("d.status = 'archived'" in q for q, _ in conn.queries)
+
+
+def test_archive_scope_allows_vault_path_admits_default_and_all_only():
+    assert ss.archive_scope_allows_vault_path("unarchived") is True
+    assert ss.archive_scope_allows_vault_path("all") is True
+    assert ss.archive_scope_allows_vault_path("archived") is False


### PR DESCRIPTION
Fixes #530.

## The defect

`archive_scope` defaults to `unarchived`. The vault-path gate demanded
`scope == "all"`:

```python
vault_path_wanted = not (doc_types or source_type or scope != "all") and vault_path_eligible(...)
```

So the fast path had no reachable caller. Every request that nobody customised
fell back to enumerating candidate source ids, and on a scope above the
candidate ceiling that fallback refuses with the bounded-corpus error. The
issue measured it as `?q=…` → 422 against `?q=…&archive_scope=all` → 200, with
archived documents 154 of 136,183 (0.11%).

The grouping was internally consistent — the archived filter really is a
document-level narrowing, in the same family as `collection` / `doc_type` /
`tags`. What makes it different is that it is the **default**. The others are
opt-in narrowings a caller chose; this one applies to every request.

## What changed

The archived predicate moves from candidate enumeration to hydration.

`unarchived` and `all` now take the vault path. `archived` deliberately does
not: it selects **for** the rare tail, so a vault-path top-K would be almost
entirely non-matching and hydration would filter the page down to nothing.
Enumerating ids is the right tool for narrowing to a rare set; it is the wrong
one for excluding it. That split is `archive_scope_allows_vault_path`.

Hydration was already computing the authoritative status for every hit it
returns — `documents.status` on the legacy arm, and on the native arm the
`status` parsed out of the **verified Head body** it fetches anyway. The filter
is one `status_matches` call against a value that was already in hand; it adds
no query and no parse.

A hit excluded by scope must not cost a result slot, so the page is refilled
from the rest of the deduped prefetch pool instead of being returned short. At
the measured density the refill loop essentially never runs, so the common case
still pays exactly one hydration round trip. When the pool is genuinely
exhausted the page is short and says why: the drop is counted as
`archive_scope_excluded` inside the existing `hydration_dropped` degradation
reason.

Applying the predicate at hydration also closes the window where a document is
archived between candidate selection and hydration. On the id path the same
predicate already ran during selection, so the call is idempotent there.

## Why not the other two designs

**Carry archived state on the vector point** (the issue's suggested direction,
mirroring `source_type`) is the symmetric answer and stays the right one if
archived density ever grows. It was rejected on cost, not on shape: it needs a
payload change across all five drivers, a backfill of the existing points, and
a readiness gate — and a readiness gate reintroduces the current symptom for
the duration of the backfill, on an installation that already has a large
derived-index backfill running. Spending that on a 0.11% filter is
disproportionate. Nothing here forecloses it.

**Exclude the archived ids instead of including the candidate ids** looks like
the cheapest exact fix — 154 ids rather than a whole corpus — and it is what I
expected to land. It does not survive contact with the active arm, and this is
the one place the issue is wrong:

> the archived set is 154 rows

That number comes from `documents.status`, and on the native arm that column is
**not the authority**. The retained legacy `documents` rows are a frozen
cutover projection: `native_document_service` writes archived state into the
Head frontmatter and never writes back to `documents`. Measured on the same
installation the issue measured:

| | count |
| --- | --- |
| live native documents | 136,183 |
| `documents.status = 'archived'` | 154 |
| native frontmatter `status: archived` | 151 |
| marked archived in `documents`, `status: draft` in frontmatter | **3** |

Those 3 carry a complete native frontmatter, so the native arm serves them as
`draft`. Excluding by `documents.status` would wrongly hide three live
documents from every search, and the divergence grows with every
post-cutover archive. The authoritative archived set on the native arm exists
only inside the payload bytes, and enumerating it means exactly the envelope
scan the bounded-corpus guard exists to refuse — so the bound would not move to
"archived count" as the issue assumes. It stays at corpus size.

The issue also calls hydration-time filtering "worse to reason about" because
`returned < limit` would mean two things. That objection predates the machinery
that answers it: #520 added per-cause hydration drop accounting and surfaces it
as `degradation_reason`, so a short page now names its cause. With the refill
above, a short page additionally requires an exhausted pool.

## Tests

`backend/tests/test_search_archive_scope_vault_path_unit.py` (new) covers the
hydration filter against the authoritative status, the default that leaves
existing callers unfiltered, the refill, the short page that names its cause,
and the table/file rows that carry no status.

`backend/tests/test_search_filter_contract_unit.py` covers the path selection:
the default request, explicit `unarchived`, and `all` all reach the vault path
and enumerate nothing, while `archived` still enumerates.

Both new behaviours were confirmed by mutation. Against the pre-fix gate the
default and `unarchived` cases fail while `all` passes — the issue's measured
asymmetry, reproduced as a test. With the refill loop disabled, the refill test
returns 2 of 3 requested results.

## Verification

Run locally against this branch and, as a negative control, against a pristine
checkout of the base commit `c25228aa`.

**Backend pytest** (`pytest tests/ -k 'not _e2e'`):

| | failed | passed | skipped |
| --- | --- | --- | --- |
| this branch | 57 | 2798 | 688 |
| pristine `c25228aa` | 56 | 2788 | 688 |

+10 passed is the 11 tests added here minus the one flake below. Diffing the
two failure sets, the 56 shared failures are identical and all live in
`test_git_service.py` (39), `test_external_git_runner.py` (14) and
`test_external_git_capability.py` (3) — none in search. The single extra
failure on this branch is
`test_knowledge_io_unit.py::TestZipRoundTrip::test_zip_is_deterministic`, which
passes in isolation and is a pre-existing flake unrelated to this change:
`bundle_to_zip` calls `ZipFile.writestr` with a `str` arcname, so each entry
embeds `time.localtime()` and two archives are byte-identical only within the
same second. Straddling a second boundary reproduces it on the pristine base
checkout, with none of these changes applied.

**`scripts/check.sh`**: ruff, mypy, bandit, eslint, tsc, the `@akb/client` and
`@akb/markdown-editor` builds/typechecks/vitest, the generated-type drift
check, the packed-SDK consumer proof and the MCP Inspector contract all pass.
It stops at frontend vitest on 1 failing test of 818,
`document-edit-draft.test.ts`, which is also pre-existing and date-dependent:
its fixture hardcodes `assetExpiresAt: "2026-09-10T01:00:00.000Z"`, introduced
by `e86537fc` and now in the past, so the draft loads as `expired` rather than
`restored`. The same single test fails identically on a pristine checkout of
the base commit. No frontend file is touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ch9b6uWnJh17gTYnBWHNQp
