### PR TITLE
test(frontend): pin the clock in the document-edit-draft fixtures (akb#533)

### DIFF
--- a/frontend/src/lib/__tests__/document-edit-draft.test.ts
+++ b/frontend/src/lib/__tests__/document-edit-draft.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearDocumentEditDraft,
   documentEditDraftStorageKey,
@@ -14,6 +14,22 @@ const VAULT = "team";
 const DOCUMENT = "akb://team/coll/notes/doc/hello.md";
 const ATTACHMENT_TARGET = "/api/assets/123e4567-e89b-42d3-a456-426614174000";
 
+// Draft recovery is time-relative: saveDocumentEditDraft clamps a draft's
+// expiry down to the earliest attachment expiry, and loadDocumentEditDraft
+// compares that against `now`. So pin "now" to a fixed instant and build every
+// date as an offset from it, the way time-ago.test.ts does.
+//
+// Naming instants on the calendar instead is what made this file fail on every
+// branch from 2026-09-10: the fixture's attachment expiry became a past
+// instant, the draft was then correctly classified `expired`, and every
+// `restored` assertion here broke at once. A fixture that says "an hour from
+// now" cannot rot; one that says "2026-09-10T01:00Z" always eventually does.
+const NOW = Date.UTC(2026, 8, 11, 12, 0, 0); // 2026-09-11T12:00:00Z
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+const at = (offsetMs: number) => new Date(NOW + offsetMs).toISOString();
+
 function draft(overrides: Partial<DocumentEditDraftInput> = {}): DocumentEditDraftInput {
   return {
     draftId: "draft-1",
@@ -27,14 +43,20 @@ function draft(overrides: Partial<DocumentEditDraftInput> = {}): DocumentEditDra
     title: "Local title",
     body: "Local body",
     assetIds: ["asset-1"],
-    assetExpiresAt: { "asset-1": "2026-09-10T01:00:00.000Z" },
+    assetExpiresAt: { "asset-1": at(HOUR) },
     editorVersion: "0.2.0",
     markdownProfile: "preserve",
     ...overrides,
   };
 }
 
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
 afterEach(() => {
+  vi.useRealTimers();
   window.localStorage.clear();
   vi.restoreAllMocks();
 });
@@ -72,8 +94,8 @@ describe("existing-document draft storage", () => {
       ...draft(),
       version: 2,
       kind: "document-edit",
-      updatedAt: "2026-09-01T00:00:00.000Z",
-      expiresAt: "2026-09-01T01:00:00.000Z",
+      updatedAt: at(-DAY),
+      expiresAt: at(-DAY + HOUR),
     };
     window.localStorage.setItem(
       documentEditDraftStorageKey(USER, VAULT, DOCUMENT, "tab-1", "draft-1"),
@@ -85,28 +107,22 @@ describe("existing-document draft storage", () => {
       VAULT,
       DOCUMENT,
       "tab-1",
-      new Date("2026-09-02T00:00:00.000Z"),
+      new Date(NOW),
     );
     expect(result).toMatchObject({ status: "expired", draft: { body: "Local body" } });
     expect(window.localStorage.getItem(documentEditDraftStorageKey(USER, VAULT, DOCUMENT, "tab-1", "draft-1"))).toContain("Local body");
   });
 
   it("bounds draft recovery by the earliest server-provided attachment expiry", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-09-09T00:00:00.000Z"));
-    try {
-      expect(saveDocumentEditDraft(draft({
-        assetExpiresAt: { "asset-1": "2026-09-09T00:30:00.000Z" },
-      }))).toBe(true);
-      const stored = JSON.parse(
-        window.localStorage.getItem(
-          documentEditDraftStorageKey(USER, VAULT, DOCUMENT, "tab-1", "draft-1"),
-        ) ?? "{}",
-      ) as { expiresAt?: string };
-      expect(stored.expiresAt).toBe("2026-09-09T00:30:00.000Z");
-    } finally {
-      vi.useRealTimers();
-    }
+    expect(saveDocumentEditDraft(draft({
+      assetExpiresAt: { "asset-1": at(30 * MINUTE) },
+    }))).toBe(true);
+    const stored = JSON.parse(
+      window.localStorage.getItem(
+        documentEditDraftStorageKey(USER, VAULT, DOCUMENT, "tab-1", "draft-1"),
+      ) ?? "{}",
+    ) as { expiresAt?: string };
+    expect(stored.expiresAt).toBe(at(30 * MINUTE));
   });
 
   it("preserves incompatible records for copying instead of migrating or discarding them", () => {
@@ -145,27 +161,21 @@ describe("existing-document draft storage", () => {
   });
 
   it("keeps a new-document draft expiry at the server attachment boundary", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-09-09T00:00:00.000Z"));
-    try {
-      expect(saveDocumentDraft({
-        vault: VAULT,
-        title: "New",
-        collection: "notes",
-        type: "note",
-        domain: "",
-        summary: "",
-        tags: [],
-        body: `![image](${ATTACHMENT_TARGET})`,
-        assetIds: ["asset-1"],
-        assetExpiresAt: { "asset-1": "2026-09-09T00:15:00.000Z" },
-      })).toBe(true);
-      const stored = JSON.parse(
-        window.localStorage.getItem(documentDraftStorageKey(VAULT)) ?? "{}",
-      ) as { expiresAt?: string };
-      expect(stored.expiresAt).toBe("2026-09-09T00:15:00.000Z");
-    } finally {
-      vi.useRealTimers();
-    }
+    expect(saveDocumentDraft({
+      vault: VAULT,
+      title: "New",
+      collection: "notes",
+      type: "note",
+      domain: "",
+      summary: "",
+      tags: [],
+      body: `![image](${ATTACHMENT_TARGET})`,
+      assetIds: ["asset-1"],
+      assetExpiresAt: { "asset-1": at(15 * MINUTE) },
+    })).toBe(true);
+    const stored = JSON.parse(
+      window.localStorage.getItem(documentDraftStorageKey(VAULT)) ?? "{}",
+    ) as { expiresAt?: string };
+    expect(stored.expiresAt).toBe(at(15 * MINUTE));
   });
 });


### PR DESCRIPTION
Fixes #533.

## What was broken

`frontend/src/lib/__tests__/document-edit-draft.test.ts` built its fixture with
an absolute instant:

```ts
assetExpiresAt: { "asset-1": "2026-09-10T01:00:00.000Z" },
```

`saveDocumentEditDraft` clamps a draft's expiry down to the earliest attachment
expiry, and `loadDocumentEditDraft` compares that against `now`. So once the
wall clock walked past that instant the draft was *correctly* classified
`expired`, and the file's `restored` assertions all broke at once.

That is not flaky. It is one test failing on every branch, on every run, from
that date onward — which is how a required-looking check stops being a signal:
the next change that genuinely breaks ruff, tsc, secrets scanning or any of the
other 817 frontend tests presents identically, and nobody can tell them apart
without opening the log.

## The change

Pin `now` for the whole file with fake timers and build every date as an offset
from it:

```ts
const NOW = Date.UTC(2026, 8, 11, 12, 0, 0);
const at = (offsetMs: number) => new Date(NOW + offsetMs).toISOString();

beforeEach(() => {
  vi.useFakeTimers();
  vi.setSystemTime(NOW);
});
```

This is the existing convention, not a new one. `time-ago.test.ts` states it in
a header comment — "pin 'now' to a fixed instant and build each input as an
offset back from it" — and `recent-searches.test.ts` and
`recent-document-views.test.ts` use the same idiom. `document-edit-draft.test.ts`
was the one time-sensitive test in `src/lib/__tests__` that had adopted it only
halfway: two of its eight tests froze the clock locally, and the other six rode
the wall clock. The bug fell through exactly that gap.

Consequences of adopting it for the whole file:

- The fixture default becomes `at(HOUR)` — "an attachment that has not expired
  yet", stated as a relationship rather than a calendar position.
- The two tests that managed their own timers now share the suite-level pin, so
  the file has one way of pinning time instead of two.
- The other two absolute dates (`2026-09-01T00:00Z` / `2026-09-02T00:00Z` in the
  expired-recovery test) become `at(-DAY)` and `at(-DAY + HOUR)`, preserving the
  exact relationship they encoded: written a day ago, expired an hour after it
  was written. Those two could not actually rot — that test passes its own `now`
  as the fifth argument to `loadDocumentEditDraft`, so its three constants were
  only ever compared against each other — but they are now expressed the same
  way as everything else in the file.

Under a pinned clock an absolute date cannot drift out from under an assertion,
so this removes the failure mode for the file rather than for the one instance.

## Proving it, rather than showing a green run

A passing suite today is not evidence: it would pass with the bug removed *or*
with the date merely pushed forward. So the property under test is "the file no
longer depends on the wall clock", and the way to test that is to move the wall
clock.

The test realm's `Date` was shifted forward by a throwaway local vitest setup
file (a `Date` subclass whose zero-argument constructor and `now()` add a fixed
offset, installed via `setupFiles` ahead of `src/test-setup.ts`). A probe test
confirmed the shift reaches the tests: `new Date()` reported `2036-09-11` under
a +10-year shift against a real clock of `2026-09-11`.

| | real clock | clock +10y |
| --- | --- | --- |
| base (`main`) | **1 failed** / 817 passed | — |
| counterfeit fix — date pushed forward to `2026-12-31` | 8 passed | **1 failed** / 7 passed |
| this branch | 818 passed | 818 passed |

The middle row is the control that matters: pushing the date forward looks
exactly like a fix today and is still caught once the clock moves. This branch
is not. The whole suite was also run at +100 years (`2126`): 116 files, 818
passed.

The clock-shift harness is deliberately not part of this PR — it is a few lines,
reproducible from the description above, and wiring a second vitest config into
the gate is a separate decision.

## Sweep

Every tracked test-like file under `frontend/` (124 files: `__tests__/`,
`*.test.*`, `*.spec.*`, `e2e/`, `mocks/`) was scanned for date literals. On
`main` that is 84 literals across 30 files — and **zero of them are in the
future**.

That is the finding, not an absence of one. The signature of this class of bug
is not "a date in the future"; it is "a date that *was* in the future and has
since become past". A grep for future dates would have found nothing here and
missed the live failure entirely. (Extending the same scan to `packages/`
illustrates it from the other side: the only two future dates it finds are a
deliberately-invalid `2099-01-01` MCP protocol version, used to assert the
server does *not* echo an unknown version. A naive sweep flags that
and misses the real one.)

So the files were classified by shape — does a date literal reach a comparison
against the ambient clock that an assertion depends on?

- `time-ago.test.ts`, `recent-searches.test.ts`, `recent-document-views.test.ts`
  — time-relative, and all three pin the clock with `vi.setSystemTime`. Immune.
- `api-assets.test.ts` — `unclaimed_expires_at` / `server_time` are asserted by
  round-trip identity against the mocked response. Never compared to a clock.
- The remaining 25 files — dates are payload fields (`changed_at`,
  `created_at`, `last_activity`, revision dates) that no assertion reads a
  freshness verdict from.
- `document-edit-draft.test.ts` — the one instance. Fixed here.

The +10y and +100y full-suite runs are the empirical half of that sweep: any
test the static reading misclassified would have failed there. None did.

## Verification

`scripts/check.sh` run locally at this branch's head. Every step passes —
preflight, E2E suite manifest, agent roles, ruff, mypy, bandit, eslint, tsc,
`@akb/client` (6 files / 60 tests), `@akb/markdown-editor` (2 / 14), the stdio
proxy contract, and the frontend suite — except the final `detect-secrets` step,
covered in the next section.

Frontend suite before and after:

- base: `Test Files 1 failed | 115 passed (116)` · `Tests 1 failed | 817 passed (818)`
- this branch: `Test Files 116 passed (116)` · `Tests 818 passed (818)`

Same 818 tests — none added, removed or skipped to get there. The "before" run
matches the last `check` run on `main` line for line.

Scope: this PR touches one test file. No backend or source changes.

## One more failure is queued behind this one

`scripts/check.sh` stops at the first violation, so `check` on `main` has been
dying at `vitest (frontend)` and never reaching its last step. With this branch
that step passes and the run gets one step further — to `detect-secrets`, which
then fails:

```
The baseline file was updated.
Probably to keep line numbers of secrets up-to-date.
Please `git add .secrets.baseline`, thank you.
```

That is not introduced here, and it is not a secret. It reproduces identically
on a pristine checkout of `main` with nothing applied: the baseline's single
entry for `backend/CHANGELOG.md` records a line number that the string has since
moved past. The entry is a false positive — a local development database URL
inside a fenced example block — and it lives in a file that grows at the top with
every release, so its line number shifts on essentially every backend merge and
the baseline goes stale again right after it is refreshed.

Not fixed here on purpose: different defect, different cause, and
`.secrets.baseline` is already claimed by three other open pull requests. It
wants its own change, and probably a look at whether that entry should be an
exclusion rather than a line-numbered baseline row. Flagged so that a still-red
`check` on this branch is not read as this change not having worked.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ch9b6uWnJh17gTYnBWHNQp
