### PR TITLE
fix(health): report abandoned derived-index intents (akb#527)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -471,8 +471,24 @@ async def health(user: AuthenticatedUser | None = Depends(get_optional_user)):
     in one atomic worker), so backfill stats live under
     `vector_store.backfill` and `embed_backfill` is gone — they were
     reporting the same `chunks.vector_indexed_at IS NULL` count.
+
+    Every indexing queue reported here carries its own terminal-failure count
+    beside its progress, and that adjacency is the point: a queue that gave up
+    on an item drains to `pending: 0` exactly like one that finished, so
+    progress alone reads as complete while documents are missing from ranked
+    search. `native_derived` is the document/File-level queue — one intent per
+    Resource revision, and `abandoned` there is a count of Resources that will
+    never be chunked or embedded; `vector_store.backfill.upsert` is the
+    chunk-level one below it; `native_file_projection` is the S3-to-Native
+    admission ahead of both.
     """
-    from app.services import native_file_projection, queue_rescuer, sparse_encoder, vault_backfill
+    from app.services import (
+        native_derived_worker,
+        native_file_projection,
+        queue_rescuer,
+        sparse_encoder,
+        vault_backfill,
+    )
 
     store = get_vector_store()
     vs_info: dict = {"reachable": await store.health()}
@@ -510,6 +526,7 @@ async def health(user: AuthenticatedUser | None = Depends(get_optional_user)):
         "events": await _safe(events_publisher.pending_stats),
         "notifications": await _safe(notification_worker.pending_stats),
         "native_file_projection": await _safe(native_file_projection.pending_stats),
+        "native_derived": await _safe(native_derived_worker.pending_stats),
         "vector_store": vs_info,
     }
 

--- a/backend/app/services/health.py
+++ b/backend/app/services/health.py
@@ -12,18 +12,30 @@ from __future__ import annotations
 
 import uuid
 
-from app.services import embed_worker, metadata_worker, native_file_projection
+from app.services import (
+    embed_worker,
+    metadata_worker,
+    native_derived_worker,
+    native_file_projection,
+)
 
 
 async def vault_health(vault_id: uuid.UUID) -> dict:
     """Return per-vault pending counts. Sequential awaits — the queries
     are sub-millisecond on indexed columns; gather() saves ~1-2ms but
-    adds task-scheduling overhead."""
+    adds task-scheduling overhead.
+
+    `native_derived` is the vault-scoped answer to the question the global
+    counters can only raise: it reports the derived-index intents this vault
+    gave up on, so an operator who sees a non-zero `abandoned` on `/health`
+    can find where the loss is without reading an internal queue table."""
     backfill = await embed_worker.pending_stats(vault_id)
     metadata = await metadata_worker.pending_stats(vault_id)
     projection = await native_file_projection.pending_stats(vault_id)
+    derived = await native_derived_worker.pending_stats(vault_id)
     return {
         "metadata_backfill": metadata,
         "vector_store":      {"backfill": backfill},
         "native_file_projection": projection,
+        "native_derived": derived,
     }

--- a/backend/app/services/native_derived_worker.py
+++ b/backend/app/services/native_derived_worker.py
@@ -30,6 +30,7 @@ from datetime import UTC, datetime, timedelta
 
 import asyncpg
 
+from app.db.postgres import get_pool
 from app.services import delete_worker
 from app.services._backfill import MAX_RETRIES, next_attempt_delay
 from app.services.document_service import _parse_markdown
@@ -119,6 +120,79 @@ def build_native_file_chunks(
         size_bytes=len(canonical_text.encode("utf-8")),
     )
     return chunk_text_body(canonical_text, metadata_header=header)
+
+
+async def _pending_stats(
+    pool: asyncpg.Pool,
+    namespace_id: uuid.UUID | None = None,
+) -> dict[str, int | str]:
+    """Return the durable derived-indexing queue state for an operator.
+
+    ``abandoned`` is the count that matters and the reason this is reported at
+    all: each one is a Resource revision that spent its whole retry budget and
+    will never be chunked, embedded, or returned by ranked search.  Nothing
+    else says so — the Resource stays readable and greppable, and ``pending``
+    drains to zero exactly as it would have if the work had succeeded.  So
+    ``status`` refuses to say ``ok`` while it is non-zero, even with an empty
+    queue: a backfill that reached 100% having dropped documents is not a
+    finished backfill.
+
+    ``exhausted`` is deliberately separate from terminal ``abandoned``: it is
+    the final claimed attempt while its lease is still in force.  The claim
+    query skips ``retry_count >= MAX_RETRIES``, so a process killed exactly
+    there leaves a row nothing will pick up until ``queue_rescuer`` stamps it
+    terminal — visible here rather than counted as ordinary retrying work.
+    """
+    params: list[object] = [MAX_RETRIES]
+    scope = ""
+    if namespace_id is not None:
+        params.append(namespace_id)
+        scope = "AND namespace_id = $2"
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            f"""
+            SELECT COUNT(*) FILTER (WHERE completed_at IS NULL)::int AS pending,
+                   COUNT(*) FILTER (
+                       WHERE completed_at IS NULL
+                         AND retry_count > 0
+                         AND retry_count < $1
+                   )::int AS retrying,
+                   COUNT(*) FILTER (
+                       WHERE completed_at IS NULL
+                         AND retry_count >= $1
+                   )::int AS exhausted,
+                   COUNT(*) FILTER (WHERE delivery_outcome = 'abandoned')::int AS abandoned,
+                   COUNT(*) FILTER (WHERE delivery_outcome = 'applied')::int AS applied,
+                   COUNT(*) FILTER (WHERE delivery_outcome = 'superseded')::int AS superseded,
+                   COUNT(*) FILTER (WHERE delivery_outcome = 'deleted')::int AS deleted,
+                   -- Pre-parity rows only; nothing produces 'direct_grep'
+                   -- since text Files took the document-parity path. The
+                   -- counter stays so history is reported, not rewritten.
+                   COUNT(*) FILTER (WHERE delivery_outcome = 'direct_grep')::int AS direct_grep
+              FROM native_invalidation_intents
+             WHERE TRUE {scope}
+            """,
+            *params,
+        )
+    pending = int(row["pending"])
+    exhausted = int(row["exhausted"])
+    abandoned = int(row["abandoned"])
+    return {
+        "pending": pending,
+        "retrying": int(row["retrying"]),
+        "exhausted": exhausted,
+        "abandoned": abandoned,
+        "applied": int(row["applied"]),
+        "superseded": int(row["superseded"]),
+        "deleted": int(row["deleted"]),
+        "direct_grep": int(row["direct_grep"]),
+        "status": "degraded" if exhausted or abandoned else "reconciling" if pending else "ok",
+    }
+
+
+async def pending_stats(namespace_id: uuid.UUID | None = None) -> dict[str, int | str]:
+    """Operator-facing derived-index queue state for the health surfaces."""
+    return await _pending_stats(await get_pool(), namespace_id)
 
 
 class NativeDerivedWorker:
@@ -219,8 +293,9 @@ class NativeDerivedWorker:
         attempt_count = int(intent["retry_count"])
         delay = next_attempt_delay(max(0, attempt_count - 1))
         next_at = datetime.now(UTC) + timedelta(seconds=delay)
+        terminal = attempt_count >= MAX_RETRIES
         async with self.pool.acquire() as conn:
-            if attempt_count >= MAX_RETRIES:
+            if terminal:
                 await conn.execute(
                     """
                     UPDATE native_invalidation_intents
@@ -244,6 +319,56 @@ class NativeDerivedWorker:
                     next_at,
                     type(error).__name__,
                 )
+        if terminal:
+            await self._log_abandonment(intent, error, attempt_count)
+
+    async def _log_abandonment(
+        self, intent: dict, error: Exception, attempts: int,
+    ) -> None:
+        """Say once, loudly, which Resource just stopped being retried.
+
+        ``process_once`` logs the same line for attempt 1 and attempt
+        ``MAX_RETRIES``, so the moment a Resource is given up on reads in a log
+        exactly like the transient failures before it.  The counters on the
+        health surfaces say how MANY were lost; this says WHICH, because a
+        count tells an operator that something is wrong and only the path tells
+        them what to fix.
+
+        Best effort on purpose: the row is already stamped terminal before this
+        runs, so a failed lookup costs a name in a message, never the state.
+        Only the exception CLASS is reported, as in ``last_error`` — an
+        exception message can quote the body that failed to store.
+        """
+        vault_name: str | None = None
+        path: str | None = None
+        try:
+            async with self.pool.acquire() as conn:
+                located = await conn.fetchrow(
+                    """
+                    SELECT v.name AS vault_name, r.current_path
+                      FROM native_resources r
+                      JOIN vaults v ON v.id = r.namespace_id
+                     WHERE r.resource_id = $1
+                    """,
+                    intent["resource_id"],
+                )
+            if located is not None:
+                vault_name = located["vault_name"]
+                path = located["current_path"]
+        except Exception:  # noqa: BLE001 — diagnostics must not mask the failure
+            logger.debug("could not name the abandoned resource", exc_info=True)
+        logger.error(
+            "native derived delivery ABANDONED after %d attempts: this %s will not be "
+            "indexed and ranked search will not return it until a new revision "
+            "supersedes it. vault=%s path=%s resource_id=%s revision_id=%s error=%s",
+            attempts,
+            intent["surface"],
+            vault_name or "<unresolved>",
+            path or "<unresolved>",
+            intent["resource_id"],
+            intent["revision_id"],
+            type(error).__name__,
+        )
 
     async def _head(self, resource_id: uuid.UUID) -> dict | None:
         async with self.pool.acquire() as conn:
@@ -472,33 +597,9 @@ class NativeDerivedWorker:
             logger.warning("native derived delivery failed: %s", type(exc).__name__)
             return 0
 
-    async def pending_stats(self, namespace_id: uuid.UUID | None = None) -> dict[str, int]:
-        params: list[object] = []
-        where = ""
-        if namespace_id is not None:
-            params.append(namespace_id)
-            where = "AND namespace_id = $1"
-        async with self.pool.acquire() as conn:
-            row = await conn.fetchrow(
-                f"""
-                SELECT COUNT(*) FILTER (WHERE completed_at IS NULL)::int AS pending,
-                       COUNT(*) FILTER (WHERE delivery_outcome = 'applied')::int AS applied,
-                       COUNT(*) FILTER (WHERE delivery_outcome = 'superseded')::int AS superseded,
-                       COUNT(*) FILTER (WHERE delivery_outcome = 'deleted')::int AS deleted,
-                       -- Pre-parity rows only; nothing produces 'direct_grep'
-                       -- since text Files took the document-parity path. The
-                       -- counter stays so history is reported, not rewritten.
-                       COUNT(*) FILTER (WHERE delivery_outcome = 'direct_grep')::int AS direct_grep,
-                       COUNT(*) FILTER (WHERE delivery_outcome = 'abandoned')::int AS abandoned,
-                       COUNT(*) FILTER (
-                           WHERE completed_at IS NULL AND retry_count > 0
-                       )::int AS retrying
-                  FROM native_invalidation_intents
-                 WHERE TRUE {where}
-                """,
-                *params,
-            )
-        return dict(row)
+    async def pending_stats(self, namespace_id: uuid.UUID | None = None) -> dict[str, int | str]:
+        """Return queue diagnostics using this worker's pool (tests/operators)."""
+        return await _pending_stats(self.pool, namespace_id)
 
     async def settle(
         self,
@@ -506,7 +607,7 @@ class NativeDerivedWorker:
         namespace_id: uuid.UUID,
         timeout_seconds: float,
         poll_interval_seconds: float = 0.05,
-    ) -> dict[str, int | float]:
+    ) -> dict[str, int | float | str]:
         started = asyncio.get_running_loop().time()
         polls = 0
         while True:

--- a/backend/tests/concurrency/test_native_derived_pipeline.py
+++ b/backend/tests/concurrency/test_native_derived_pipeline.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import importlib.util
+import logging
 import os
 import uuid
 from contextlib import asynccontextmanager
@@ -15,6 +16,7 @@ from app.config import settings
 from app.services import embed_worker, sparse_encoder
 from app.services.m1_pg_body_store import M1PgBodyStore
 from app.services.m1_native_grep_service import M1NativeGrepService
+from app.services import native_derived_worker
 from app.services._backfill import MAX_RETRIES
 from app.services.native_derived_worker import (
     NATIVE_FILE_SOURCE,
@@ -440,12 +442,18 @@ async def test_native_file_chunks_are_claimed_and_upserted_by_the_embed_worker(m
             ) == 0
 
 
-async def _create_document(pool, vault_id, *, path: str = "retry.md"):
+async def _create_document(
+    pool,
+    vault_id,
+    *,
+    path: str = "retry.md",
+    payload: str = "---\ntitle: Retry\n---\n# Retry\nsearchable\n",
+):
     return await NativeRevisionService(pool, payload_store=M1PgBodyStore(pool)).create_text(
         namespace_id=vault_id,
         surface="document",
         path=path,
-        payload="---\ntitle: Retry\n---\n# Retry\nsearchable\n",
+        payload=payload,
         actor="derived-test",
         mutation_id=uuid.uuid4(),
     )
@@ -538,6 +546,86 @@ async def test_retry_exhaustion_is_terminal_abandoned_and_settlement_reports_it(
             assert terminal["delivery_outcome"] == "abandoned"
             assert terminal["next_attempt_at"] is None
             assert terminal["last_error"] == "RuntimeError"
+
+
+async def test_a_body_the_derived_index_cannot_store_is_lost_but_counted(monkeypatch, caplog):
+    """akb#527, reproduced through the real substrate rather than a fake.
+
+    A `0x00` sits where a space belongs — what the PDF extractor emitted. The
+    payload store accepts it (its UTF-8 check is NUL-tolerant by construction,
+    migration 048), and `chunks.content` is `text`, which cannot hold one. So
+    nothing about the Resource changes between attempts and every attempt fails
+    identically until the budget is gone.
+
+    The Resource is then permanently absent from the derived index while
+    staying readable and greppable, and — this is the defect — `pending` has
+    drained to zero exactly as it would have on success. An operator watching
+    progress sees a finished backfill. What must stop that from being the whole
+    story is asserted here: the queue counts what it dropped, refuses to call
+    itself `ok` with an empty queue, and names the Resource once in a log.
+    """
+    async with _fresh_database() as pool:
+        async with pool.acquire() as conn:
+            vault_id = await conn.fetchval(
+                "INSERT INTO vaults (name, git_path) VALUES ($1, '/tmp/unused.git') RETURNING id",
+                f"extracted-{uuid.uuid4().hex}",
+            )
+        created = await _create_document(
+            pool,
+            vault_id,
+            path="ops/extracted.md",
+            payload="---\ntitle: Extracted\n---\n# Extracted\nword\x00word\x00word\n",
+        )
+        worker = NativeDerivedWorker(pool)
+        caplog.set_level(logging.ERROR, logger="akb.native_derived_worker")
+
+        for attempt in range(MAX_RETRIES):
+            assert await worker.process_once() == 0
+            if attempt + 1 < MAX_RETRIES:
+                async with pool.acquire() as conn:
+                    await conn.execute(
+                        "UPDATE native_invalidation_intents SET next_attempt_at = NOW() WHERE revision_id = $1",
+                        created.revision_id,
+                    )
+
+        async with pool.acquire() as conn:
+            terminal = await conn.fetchrow(
+                """
+                SELECT retry_count, delivery_outcome, completed_at, last_error
+                  FROM native_invalidation_intents WHERE revision_id = $1
+                """,
+                created.revision_id,
+            )
+            assert terminal["retry_count"] == MAX_RETRIES
+            assert terminal["completed_at"] is not None
+            assert terminal["delivery_outcome"] == "abandoned"
+            # The class, never the message — the message quotes the body.
+            assert terminal["last_error"] == "CharacterNotInRepertoireError"
+            # Absent from the derived index: no chunk, so nothing to embed and
+            # nothing for ranked search to return.
+            assert await conn.fetchval(
+                "SELECT COUNT(*) FROM chunks WHERE source_id = $1", created.resource_id,
+            ) == 0
+
+        stats = await worker.pending_stats(vault_id)
+        assert stats["pending"] == 0        # progress says the backfill finished …
+        assert stats["abandoned"] == 1      # … and a document is missing from the index
+        assert stats["exhausted"] == 0
+        assert stats["status"] == "degraded"
+
+        # The same numbers through the module-level entry point `/health` and
+        # `/health/vault/{name}` call, so the endpoint test above is wired to
+        # this table and not merely to a shape.
+        async def _fixture_pool():
+            return pool
+
+        monkeypatch.setattr(native_derived_worker, "get_pool", _fixture_pool)
+        assert await native_derived_worker.pending_stats(vault_id) == stats
+
+        abandonment = next(r for r in caplog.records if r.levelno == logging.ERROR).getMessage()
+        assert "ABANDONED" in abandonment
+        assert "path=ops/extracted.md" in abandonment
+        assert "error=CharacterNotInRepertoireError" in abandonment
 
 
 async def test_multiworker_skip_locked_claims_intent_once():

--- a/backend/tests/test_native_derived_worker_unit.py
+++ b/backend/tests/test_native_derived_worker_unit.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import uuid
+from contextlib import asynccontextmanager
 
 import pytest
 
+from app.services import native_derived_worker
+from app.services._backfill import MAX_RETRIES
 from app.services.index_service import MAX_CHUNK_SIZE, SOURCE_TYPES
 from app.services.m1_pg_body_store import M1PgBodyStore
 from app.services.m1_reference_payload_store import M1ReferencePayloadStore
@@ -17,6 +21,7 @@ from app.services.native_derived_worker import (
     NATIVE_DOCUMENT_SOURCE,
     NATIVE_FILE_SOURCE,
     SELECTED_DELIVERY,
+    NativeDerivedWorker,
     build_native_document_chunks,
     build_native_file_chunks,
     source_type_for_surface,
@@ -210,3 +215,186 @@ def test_native_head_body_verification_rejects_a_mismatched_placement_profile(pl
                 "verification_profile": "mismatched-profile-v1",
             }
         )
+
+
+# ── terminal delivery must be countable and named ─────────────────────
+#
+# The failure these cover lost three documents from ranked search and was
+# noticed only because someone happened to be watching `last_error` on an
+# internal queue table during a migration (#527).  Both halves of the fix are
+# asserted here without a database, because the queue state and the log line
+# are what an operator has and neither of them is a query they should have to
+# know to write.
+
+
+class _StatsConn:
+    """One row of `native_invalidation_intents` aggregates."""
+
+    def __init__(self, row):
+        self.row = row
+        self.queries: list[str] = []
+
+    async def fetchrow(self, query, *args):
+        self.queries.append(query)
+        self.args = args
+        return self.row
+
+
+def _stats_pool(row):
+    conn = _StatsConn(row)
+
+    class _Pool:
+        def acquire(self):
+            @asynccontextmanager
+            async def _acquire():
+                yield conn
+
+            return _acquire()
+
+    return _Pool(), conn
+
+
+def _counts(**overrides):
+    row = {
+        "pending": 0,
+        "retrying": 0,
+        "exhausted": 0,
+        "abandoned": 0,
+        "applied": 0,
+        "superseded": 0,
+        "deleted": 0,
+        "direct_grep": 0,
+    }
+    row.update(overrides)
+    return row
+
+
+async def test_an_abandoned_intent_is_reported_even_though_the_queue_drained():
+    """The bug in one assertion: progress at 100%, a document gone.
+
+    `pending` is 0 and `applied` says the rest of the backfill succeeded, which
+    is exactly what an operator watching progress sees when a Resource has been
+    given up on. The count and the status are the only things that say so.
+    """
+    pool, _ = _stats_pool(_counts(applied=41, abandoned=1))
+
+    stats = await native_derived_worker._pending_stats(pool)
+
+    assert stats["pending"] == 0
+    assert stats["abandoned"] == 1
+    assert stats["status"] == "degraded"
+
+
+async def test_a_drained_queue_with_nothing_lost_is_ok():
+    pool, _ = _stats_pool(_counts(applied=42))
+
+    assert (await native_derived_worker._pending_stats(pool))["status"] == "ok"
+
+
+async def test_work_still_in_flight_is_reconciling_not_ok():
+    """`ok` must mean settled, or a poller stops waiting while work remains."""
+    pool, _ = _stats_pool(_counts(pending=3, retrying=1))
+
+    assert (await native_derived_worker._pending_stats(pool))["status"] == "reconciling"
+
+
+async def test_a_claim_killed_on_its_final_attempt_is_exhausted_not_retrying():
+    """The pre-terminal state `queue_rescuer` exists to close.
+
+    The claim query skips `retry_count >= MAX_RETRIES`, so nothing will pick
+    this row up again on its own. Counting it as ordinary retrying work would
+    describe a stalled queue as a busy one.
+    """
+    pool, _ = _stats_pool(_counts(pending=1, exhausted=1))
+
+    stats = await native_derived_worker._pending_stats(pool)
+
+    assert stats["exhausted"] == 1
+    assert stats["status"] == "degraded"
+
+
+async def test_vault_scoped_stats_are_narrowed_by_namespace():
+    namespace_id = uuid.uuid4()
+    pool, conn = _stats_pool(_counts())
+
+    await native_derived_worker._pending_stats(pool, namespace_id)
+
+    assert "AND namespace_id = $2" in conn.queries[0]
+    assert conn.args == (MAX_RETRIES, namespace_id)
+
+
+class _FailureConn:
+    def __init__(self, located):
+        self._located = located
+        self.statements: list[str] = []
+
+    async def execute(self, query, *args):
+        self.statements.append(query)
+
+    async def fetchrow(self, _query, *_args):
+        return self._located
+
+
+def _failure_worker(located):
+    conn = _FailureConn(located)
+
+    class _Pool:
+        def acquire(self):
+            @asynccontextmanager
+            async def _acquire():
+                yield conn
+
+            return _acquire()
+
+    return NativeDerivedWorker(_Pool()), conn
+
+
+def _intent(retry_count):
+    return {
+        "intent_id": uuid.uuid4(),
+        "resource_id": uuid.uuid4(),
+        "revision_id": uuid.uuid4(),
+        "retry_count": retry_count,
+        "surface": "document",
+    }
+
+
+async def test_the_final_failure_names_the_resource_it_just_gave_up_on(caplog):
+    """A count says something was lost; only a path says what to fix."""
+    worker, conn = _failure_worker({"vault_name": "handbook", "current_path": "ops/extracted.md"})
+    caplog.set_level(logging.ERROR, logger="akb.native_derived_worker")
+
+    await worker._failure(_intent(MAX_RETRIES), ValueError("body bytes must not be logged"))
+
+    assert "delivery_outcome = 'abandoned'" in conn.statements[0]
+    record = next(r for r in caplog.records if r.levelno == logging.ERROR)
+    message = record.getMessage()
+    assert "ABANDONED" in message
+    assert "vault=handbook" in message
+    assert "path=ops/extracted.md" in message
+    assert "error=ValueError" in message
+    # The class, never the message: an exception can quote the body that
+    # failed to store, exactly as `last_error` refuses to.
+    assert "body bytes must not be logged" not in message
+
+
+async def test_a_retryable_failure_stays_quiet_about_abandonment(caplog):
+    """Attempt 1 of 8 is not a loss, and must not read as one."""
+    worker, _ = _failure_worker({"vault_name": "handbook", "current_path": "ops/extracted.md"})
+    caplog.set_level(logging.ERROR, logger="akb.native_derived_worker")
+
+    await worker._failure(_intent(1), ValueError("transient"))
+
+    assert [r for r in caplog.records if r.levelno == logging.ERROR] == []
+
+
+async def test_an_unnameable_resource_still_reports_the_abandonment(caplog):
+    """Diagnostics are best effort; the row is already terminal when this runs."""
+    worker, _ = _failure_worker(None)
+    caplog.set_level(logging.ERROR, logger="akb.native_derived_worker")
+
+    await worker._failure(_intent(MAX_RETRIES), ValueError("boom"))
+
+    message = next(r for r in caplog.records if r.levelno == logging.ERROR).getMessage()
+    assert "ABANDONED" in message
+    assert "vault=<unresolved>" in message

--- a/backend/tests/test_stats_endpoint_unit.py
+++ b/backend/tests/test_stats_endpoint_unit.py
@@ -663,6 +663,7 @@ def health_app(monkeypatch, tmp_path):
         events_publisher,
         external_git_poller,
         metadata_worker,
+        native_derived_worker,
         native_file_projection,
         queue_rescuer,
         sparse_encoder,
@@ -679,6 +680,7 @@ def health_app(monkeypatch, tmp_path):
     monkeypatch.setattr(vault_backfill, "pending_stats", _async_return({}))
     monkeypatch.setattr(sparse_encoder, "stats_snapshot", _async_return({}))
     monkeypatch.setattr(native_file_projection, "pending_stats", _async_return({}))
+    monkeypatch.setattr(native_derived_worker, "pending_stats", _async_return({}))
     for module in (external_git_poller, asset_gc_worker, metadata_worker, events_publisher):
         monkeypatch.setattr(module, "pending_stats", _async_return({}))
     return main
@@ -733,7 +735,13 @@ async def test_health_surfaces_native_file_projection_exhaustion_as_degraded(hea
 
 
 async def test_vault_health_surfaces_native_file_projection_diagnostics(monkeypatch):
-    from app.services import embed_worker, health as health_service, metadata_worker, native_file_projection
+    from app.services import (
+        embed_worker,
+        health as health_service,
+        metadata_worker,
+        native_derived_worker,
+        native_file_projection,
+    )
 
     vault_id = uuid.uuid4()
     diagnostic = {
@@ -746,10 +754,80 @@ async def test_vault_health_surfaces_native_file_projection_diagnostics(monkeypa
     monkeypatch.setattr(embed_worker, "pending_stats", _async_return({"upsert": {}}))
     monkeypatch.setattr(metadata_worker, "pending_stats", _async_return({}))
     monkeypatch.setattr(native_file_projection, "pending_stats", _async_return(diagnostic))
+    monkeypatch.setattr(native_derived_worker, "pending_stats", _async_return({}))
 
     result = await health_service.vault_health(vault_id)
 
     assert result["native_file_projection"] == diagnostic
+
+
+async def test_health_reports_a_derived_index_abandonment_beside_the_progress(health_app, monkeypatch):
+    """A Resource the indexer gave up on must be countable from `/health`.
+
+    This is the whole of akb#527's second defect. The derived-index queue is
+    the document-level one — one intent per Resource revision — and when it
+    abandons an intent that Resource is permanently absent from ranked search
+    while staying readable and greppable, so nothing else signals the loss.
+    Until this key existed the only trace was `last_error` on a row of an
+    internal queue table, which is how three documents were nearly lost
+    silently: `pending` drains to zero either way, so progress alone reaches
+    100% with documents missing.
+    """
+    from app.services import native_derived_worker
+
+    diagnostic = {
+        "pending": 0,
+        "retrying": 0,
+        "exhausted": 0,
+        "abandoned": 3,
+        "applied": 2_838,
+        "superseded": 0,
+        "deleted": 0,
+        "direct_grep": 0,
+        "status": "degraded",
+    }
+    monkeypatch.setattr(native_derived_worker, "pending_stats", _async_return(diagnostic))
+
+    result = await health_app.health(user=None)
+
+    assert result["native_derived"] == diagnostic
+    # Unauthenticated, like every other backlog counter beside it: an operator
+    # watching indexing progress is the audience, and the count names no vault
+    # and no path — `/health/vault/{name}` is where the scope narrows, behind
+    # the reader gate that already guards vault existence.
+    assert "audit" not in result
+
+
+async def test_vault_health_narrows_the_derived_index_abandonment_to_one_vault(monkeypatch):
+    """The global count raises the question; this is where it gets answered."""
+    from app.services import (
+        embed_worker,
+        health as health_service,
+        metadata_worker,
+        native_derived_worker,
+        native_file_projection,
+    )
+
+    vault_id = uuid.uuid4()
+    diagnostic = {
+        "pending": 0,
+        "retrying": 0,
+        "exhausted": 0,
+        "abandoned": 3,
+        "applied": 41,
+        "superseded": 0,
+        "deleted": 0,
+        "direct_grep": 0,
+        "status": "degraded",
+    }
+    monkeypatch.setattr(embed_worker, "pending_stats", _async_return({"upsert": {}}))
+    monkeypatch.setattr(metadata_worker, "pending_stats", _async_return({}))
+    monkeypatch.setattr(native_file_projection, "pending_stats", _async_return({}))
+    monkeypatch.setattr(native_derived_worker, "pending_stats", _async_return(diagnostic))
+
+    result = await health_service.vault_health(vault_id)
+
+    assert result["native_derived"] == diagnostic
 
 
 # ── the socket itself ────────────────────────────────────────────────────


### PR DESCRIPTION
Addresses the visibility half of #527 — the half that is still broken. The
three documents were already repaired through the API. Deliberately not
`Closes`: the other defect that issue names is untouched here, and there is an
observation about it at the end.

## What was invisible

`NativeDerivedWorker` records an exception on the intent, increments
`retry_count`, and schedules another attempt. At `MAX_RETRIES` it stamps
`delivery_outcome = 'abandoned'` and stops. The Resource is then permanently
absent from the derived index — never chunked, never embedded, never returned
by ranked search — while staying readable and greppable, so nothing else
signals the loss.

Two things kept that from reaching anyone:

- The worker already computed an `abandoned` count, but
  `NativeDerivedWorker.pending_stats` was reachable only from tests and
  `settle()`. Every other queue in this service reports its terminal-failure
  count on `/health` — `vector_store.backfill.upsert.abandoned`,
  `native_file_projection.abandoned`, the delete outbox. The one queue that
  drops whole documents did not.
- `process_once` logs the same `WARNING` for attempt 1 and attempt 8, so the
  moment a Resource is given up on is indistinguishable in a log from the
  transient failures before it.

The consequence is the defect worth naming: `pending` drains to zero whether
the work succeeded or was abandoned, so indexing progress alone reaches 100%
with documents missing from search.

## Counted, beside the progress it contradicts

`native_derived_worker` gains the module-level `pending_stats()` that the other
queue reporters have, returning `pending / retrying / exhausted / abandoned /
applied / superseded / deleted / direct_grep` and a `status`. It is wired into
`/health` as `native_derived` and into `/health/vault/{name}` through
`vault_health()`.

`status` is `degraded` whenever `abandoned` or `exhausted` is non-zero **even
with an empty queue**: a backfill that reached 100% having dropped documents is
not a finished backfill, and the section that reports the progress is the one
that has to say so. This is the shape `native_file_projection` already uses for
the same class of failure, so the two native queues now read alike.

`exhausted` is the separate, pre-terminal state, matching that sibling: the
final claimed attempt while its lease is still in force. The claim query skips
`retry_count >= MAX_RETRIES`, so a process killed exactly there leaves a row
nothing will pick up again until `queue_rescuer` stamps it terminal — a stalled
queue that would otherwise be counted as busy. `retrying` is narrowed to
`0 < retry_count < MAX_RETRIES` for the same reason.

## Named, once, where names already go

The terminal branch of `_failure` now logs an `ERROR` carrying the vault, path,
surface, resource id, revision id, and the exception class. A count tells an
operator that something is wrong; the path tells them what to fix.

It is best effort by construction — the row is stamped terminal before the
lookup runs, so a failed lookup costs a name in a message and never the state —
and it reports the exception **class** only, exactly as `last_error` does,
because an exception message can quote the body that failed to store.

## What this deliberately does not do

- **The intent stays terminal.** #527 raises leaving it claimable instead. For
  this failure class that is worse, not safer: the payload store admits a body
  the derived `chunks.content` column cannot hold, so the intent can never
  succeed and would retry forever. It would also leave `pending` permanently
  non-zero, which destroys the progress signal for every other item in the
  queue. Terminal is the right state; loud is what was missing. Recovery is
  what the issue's own repair did — write a new revision, which supersedes the
  intent and queues a fresh one.
- **No resource names on the world-readable surface.** `/health` is
  unauthenticated, and `/health/vault/{name}` exists because vault existence is
  itself something the access model gates. So the global surface carries counts
  and no identifiers; the per-vault surface narrows the same counts behind the
  reader gate; the identity of the lost Resource lives in the server log, which
  already carries document paths at INFO.
- **The top-level `/health` `status` still reads `ok`.** Making it `degraded`
  would be the loudest possible signal, and it would also change what every
  unauthenticated uptime poller sees. That is an owner's call about an existing
  contract, not a side effect of this fix.

## Tests

Eleven new tests. Ten of them fail against the parent commit; the eleventh is
the guard against over-reporting, and passes there because the parent logs
nothing.

- `test_a_body_the_derived_index_cannot_store_is_lost_but_counted` reproduces
  the real failure against Postgres rather than a stubbed exception: a document
  body carrying one `0x00` where a space belongs, driven through all eight
  attempts. It asserts the durable terminal row
  (`last_error = 'CharacterNotInRepertoireError'`), that no chunk exists for
  the Resource, that `pending` is 0 while `abandoned` is 1 and `status` is
  `degraded`, that the module-level entry point the endpoints call reports the
  same numbers from the same table, and that the log names the path.
- Five unit tests pin the status derivation with no database: abandoned with a
  drained queue is `degraded`, a genuinely clean drain is `ok`, in-flight work
  is `reconciling`, a claim killed on its final attempt is `exhausted` rather
  than `retrying`, and the vault-scoped form narrows by namespace.
- Three unit tests pin the log: the terminal failure names vault and path and
  omits the exception message, a retryable failure stays quiet, and an
  unresolvable Resource still reports the abandonment.
- Two endpoint tests assert `native_derived` reaches `/health` and
  `/health/vault/{name}`.

## Verification

`scripts/check.sh` and the backend suite were both run locally, and both were
already red on the parent commit for unrelated reasons, so the comparison is
against that measured baseline rather than against green.

`scripts/check.sh` — identical on parent and branch: every backend step passes
(ruff clean, mypy `Success: no issues found in 365 source files`, bandit 0 files
skipped) and the run stops at the frontend vitest step with 1 failed
and 817 passed of 818, the single failure being `document-edit-draft.test.ts`,
which is #533 and is being fixed separately. This change touches no frontend
file.

Backend `pytest tests/ -k 'not _e2e'` against a `pgvector/pgvector:pg16`
instance, parent measured on a pristine checkout of `c25228aa`:

| | parent `c25228aa` | this branch |
| --- | --- | --- |
| passed | 3410 | 3421 |
| failed | 60 | 60 |
| errors | 23 | 23 |
| skipped | 39 | 39 |

The failing and erroring sets are byte-identical between the two runs, and all
pre-existing: 39 failures in `test_git_service.py`, 14 in
`test_external_git_runner.py`, 3 in `test_external_git_cascade_unit.py`, 3 in
`test_external_git_capability.py`, 1 in
`test_vault_table_name_collision_unit.py`, and all 23 errors in
`test_access_contributions_postgres.py`. The difference between the runs is
exactly the eleven additional passes.

## One observation about the other half of #527

Not fixed here, and noted because it says why this failure class will recur:
the payload store this write path uses has no NUL check, while
`M1ReferencePayloadStore` rejects `b"\x00"` on both write and verified open,
`native_file_projection.validate_native_text_file` rejects it for text Files,
and the cutover and file-measurement paths reject it too. The `CHECK`
constraint on the payload table is NUL-tolerant by construction, so the byte
has one admitted route in and several closed ones. The PG test added here is
also the evidence for that statement: it gets a NUL body into the store
through the ordinary revision service and watches the derived index fail on
it eight times.

Whether the answer is to reject the write, to sanitise it, or to make the
derived chunk path tolerate a byte the body may legitimately hold, is a
product decision and belongs in #527 rather than in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ch9b6uWnJh17gTYnBWHNQp
