### PR TITLE
ci: stop scanning a file whose line numbers a baseline cannot survive

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -306,7 +306,14 @@ if command -v detect-secrets-hook >/dev/null 2>&1; then
   # The generated MSW worker also carries an integrity checksum.
   # All pnpm-lock.yaml files are excluded because package integrity hashes
   # (sha512-… base64) are expected high-entropy data, not secrets.
-  git ls-files -z -- . ':!frontend/pnpm-lock.yaml' ':!packages/akb-client/pnpm-lock.yaml' ':!packages/markdown-editor/pnpm-lock.yaml' ':!frontend/public/mockServiceWorker.js' |
+  # backend/CHANGELOG.md is excluded because a baseline entry cannot survive it:
+  # a changelog grows at the TOP, so every release shifts the recorded
+  # line_number and the next run demands the baseline be regenerated. Its one
+  # finding is the local test DSN this repo documents everywhere
+  # (backend/tests/** carry the same string by design), quoted inside a fenced
+  # block that shows how to run a suite. Rewriting a published release note to
+  # satisfy the scanner would be the wrong trade.
+  git ls-files -z -- . ':!frontend/pnpm-lock.yaml' ':!packages/akb-client/pnpm-lock.yaml' ':!packages/markdown-editor/pnpm-lock.yaml' ':!frontend/public/mockServiceWorker.js' ':!backend/CHANGELOG.md' |
     xargs -0 detect-secrets-hook --baseline .secrets.baseline
 else
   echo "  ! detect-secrets not installed — pipx install detect-secrets" >&2


### PR DESCRIPTION
Closes #537.

`detect-secrets` fails on `main` asking for `.secrets.baseline` to be
regenerated. The entry for `backend/CHANGELOG.md` records `line_number: 3758`;
the string it pins now sits at 3867. A changelog grows at the **top**, so every
release shifts it — refreshing the baseline buys exactly one merge's worth of
green, and two merges landed in that file today.

## Why it surfaced now

`check.sh` stops at its first violation. `main` has been dying earlier — at
`vitest (frontend)`, from an expired date in a test fixture (#533) — and never
reaching this step. Fixing that moved the stopping point here. A red check hides
the next red check; this is the one that was queued behind it.

## Why exclusion rather than the alternatives

The finding is the local test DSN this repository documents everywhere —
`backend/tests/**` carry the same string by design — quoted inside a fenced
block in a historical release note that shows how to run a suite. It is not a
secret, and it is not going to become one.

- **Rewriting the release note** would edit published history to satisfy a
  scanner, for one instance of a string that appears throughout the test tree.
- **Refreshing the baseline** restores green until the next backend merge, and
  then the same failure returns. It treats the symptom and reschedules it.
- **Excluding the file** matches what is already there: `pnpm-lock.yaml`
  integrity hashes and the generated MSW worker's checksum are excluded for the
  same class of reason — expected data that a secret scanner cannot usefully
  judge. The rationale is written next to theirs.

## Verification

By mutation, not by a green run — a green run today would also be produced by
simply regenerating the baseline:

| | exit | `.secrets.baseline` |
| --- | --- | --- |
| exclusion removed | **123** | rewritten by the hook |
| exclusion present | **0** | untouched |

One file changed: `scripts/check.sh`.

## What is deliberately not in this change

`.secrets.baseline` is untouched. Three open pull requests already carry changes
to it (#514, #496, #343) and a fourth concurrent editor would mostly produce
conflicts. The `backend/CHANGELOG.md` entry is now inert — the file is never
scanned, so nothing compares against it — and can be dropped whenever one of
those lands or in a later tidy-up.

The other four baseline entries point at ordinary source files, which grow in
the middle rather than at the top, so they are far less exposed to this. Worth a
look eventually; not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ch9b6uWnJh17gTYnBWHNQp
