### PR TITLE
fix(frontend): provider-type selector with refuse-not-substitute + explicit discovery URL (akb#522)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3758
+        "line_number": 3867
       }
     ],
     "backend/mcp_server/help.py": [
@@ -6987,5 +6987,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-08T15:42:03Z"
+  "generated_at": "2026-09-11T17:08:21Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "backend/CHANGELOG.md",
         "hashed_secret": "5315196a87449ee7110cd2cce3695bdcf505e55f",
         "is_verified": false,
-        "line_number": 3867
+        "line_number": 3758
       }
     ],
     "backend/mcp_server/help.py": [
@@ -6987,5 +6987,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-11T17:08:21Z"
+  "generated_at": "2026-09-08T15:42:03Z"
 }

--- a/frontend/src/pages/__tests__/admin-auth-page.test.tsx
+++ b/frontend/src/pages/__tests__/admin-auth-page.test.tsx
@@ -259,6 +259,8 @@ describe("AdminPage mode boundary", () => {
     await user.clear(await screen.findByLabelText("Alias"));
     await user.type(screen.getByLabelText("Alias"), "partners");
     await user.type(screen.getByLabelText("Button label"), "Partner SSO");
+    await user.click(screen.getByLabelText("Provider type"));
+    await user.click(await screen.findByRole("menuitemradio", { name: /keycloak-oidc/ }));
     await user.type(screen.getByLabelText("Upstream issuer"), "https://id.example.com/realms/partners/");
     await user.type(screen.getByLabelText("Client ID"), "akb-partners");
     await user.type(screen.getByLabelText("Client secret"), "one-time-input");
@@ -266,12 +268,80 @@ describe("AdminPage mode boundary", () => {
 
     await waitFor(() => {
       expect(configureAdminSsoProvider).toHaveBeenCalledWith("partners", {
-        provider_type: "oidc",
+        provider_type: "keycloak-oidc",
         display_name: "Partner SSO",
         issuer: "https://id.example.com/realms/partners",
         discovery_url: "https://id.example.com/realms/partners/.well-known/openid-configuration",
         client_id: "akb-partners",
         client_secret: "one-time-input", // pragma: allowlist secret
+      });
+    });
+  });
+
+  it("refuses to save when no supported provider type is chosen", async () => {
+    vi.mocked(getAdminAuthConfig).mockResolvedValue(ssoConfig);
+    vi.mocked(getAdminSession).mockResolvedValue({
+      schema_version: 1,
+      auth_mode: "sso",
+      user: {
+        id: "11111111-1111-1111-1111-111111111111",
+        username: "admin",
+        email: "admin@example.com",
+        display_name: "Admin",
+        is_admin: true,
+      },
+    });
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(await screen.findByLabelText("Alias"), "unsupported-kind");
+    await user.type(screen.getByLabelText("Button label"), "Unsupported Kind");
+    await user.type(screen.getByLabelText("Upstream issuer"), "https://id.example.com/realms/unsupported");
+    await user.type(screen.getByLabelText("Client ID"), "akb-unsupported");
+    await user.click(screen.getByRole("button", { name: /Save disabled configuration/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /Choose a provider type this installation supports/,
+    );
+    expect(configureAdminSsoProvider).not.toHaveBeenCalled();
+  });
+
+  it("sends an explicit discovery URL when the upstream document lives elsewhere", async () => {
+    vi.mocked(getAdminAuthConfig).mockResolvedValue(ssoConfig);
+    vi.mocked(getAdminSession).mockResolvedValue({
+      schema_version: 1,
+      auth_mode: "sso",
+      user: {
+        id: "11111111-1111-1111-1111-111111111111",
+        username: "admin",
+        email: "admin@example.com",
+        display_name: "Admin",
+        is_admin: true,
+      },
+    });
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(await screen.findByLabelText("Alias"), "custom-discovery");
+    await user.type(screen.getByLabelText("Button label"), "Custom Discovery");
+    await user.click(screen.getByLabelText("Provider type"));
+    await user.click(await screen.findByRole("menuitemradio", { name: /^oidc/ }));
+    await user.type(screen.getByLabelText("Upstream issuer"), "https://id.example.com/tenant");
+    await user.click(screen.getByText("Advanced: discovery URL"));
+    await user.type(
+      screen.getByLabelText("Discovery URL"),
+      "https://discovery.example.com/tenant/.well-known/openid-configuration",
+    );
+    await user.type(screen.getByLabelText("Client ID"), "akb-custom");
+    await user.click(screen.getByRole("button", { name: /Save disabled configuration/i }));
+
+    await waitFor(() => {
+      expect(configureAdminSsoProvider).toHaveBeenCalledWith("custom-discovery", {
+        provider_type: "oidc",
+        display_name: "Custom Discovery",
+        issuer: "https://id.example.com/tenant",
+        discovery_url: "https://discovery.example.com/tenant/.well-known/openid-configuration",
+        client_id: "akb-custom",
       });
     });
   });
@@ -294,6 +364,8 @@ describe("AdminPage mode boundary", () => {
 
     await user.type(await screen.findByLabelText("Alias"), "entra-dn");
     await user.type(screen.getByLabelText("Button label"), "Microsoft Teams");
+    await user.click(screen.getByLabelText("Provider type"));
+    await user.click(await screen.findByRole("menuitemradio", { name: /^oidc/ }));
     await user.type(
       screen.getByLabelText("Upstream issuer"),
       "https://login.microsoftonline.com/ade9ac17-851e-48d0-ba36-ed99a8d8c07e/v2.0",

--- a/frontend/src/pages/admin.tsx
+++ b/frontend/src/pages/admin.tsx
@@ -6,7 +6,9 @@ import { Alert } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Panel, PanelHeader } from "@/components/ui/panel";
+import { SelectMenu } from "@/components/ui/select-menu";
 import { Logo } from "@/components/logo";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { LoadingState } from "@/components/ui/loading-state";
@@ -193,13 +195,19 @@ export default function AdminPage() {
 }
 
 const EMPTY_PROVIDER_FORM = {
-  providerType: "oidc",
+  providerType: "",
   alias: "",
   displayName: "",
   issuer: "",
+  discoveryUrl: "",
   clientId: "",
   clientSecret: "",
 };
+
+function derivedDiscoveryUrl(issuer: string): string {
+  const normalized = issuer.trim().replace(/\/+$/, "");
+  return normalized ? `${normalized}/.well-known/openid-configuration` : "";
+}
 
 function providerBadge(state: AdminSsoProvider["state"]) {
   if (state === "enabled") return <Badge variant="success">Enabled</Badge>;
@@ -232,6 +240,7 @@ function SsoProviderControl() {
       alias: provider.alias,
       displayName: provider.display_name,
       issuer: provider.issuer || "",
+      discoveryUrl: "",
       clientId: provider.client_id || "",
       clientSecret: "",
     });
@@ -245,15 +254,27 @@ function SsoProviderControl() {
     setNotice("");
     setSubmitting(true);
     const issuer = form.issuer.trim().replace(/\/+$/, "");
-    const providerType = catalog?.supported_provider_types.includes(form.providerType)
-      ? form.providerType
-      : catalog?.supported_provider_types[0] || form.providerType;
+    const providerType = form.providerType.trim();
+    // Refuse rather than substitute: silently saving a provider as a different
+    // kind (akb#522) produced a discovery-endpoint refusal that named the wrong
+    // cause. The type list is already loaded in this component.
+    if (!providerType || !catalog?.supported_provider_types.includes(providerType)) {
+      setError("Choose a provider type this installation supports before saving.");
+      setSubmitting(false);
+      return;
+    }
+    const discoveryUrl = form.discoveryUrl.trim() || derivedDiscoveryUrl(issuer);
+    if (!discoveryUrl) {
+      setError("Enter an upstream issuer or an explicit discovery URL.");
+      setSubmitting(false);
+      return;
+    }
     try {
       await configureAdminSsoProvider(form.alias.trim(), {
         provider_type: providerType,
         display_name: form.displayName.trim(),
         issuer,
-        discovery_url: `${issuer}/.well-known/openid-configuration`,
+        discovery_url: discoveryUrl,
         client_id: form.clientId.trim(),
         ...(form.clientSecret ? { client_secret: form.clientSecret } : {}),
       });
@@ -296,6 +317,11 @@ function SsoProviderControl() {
       </Alert>
     );
   }
+
+  const selectedProvider = catalog.providers.find(
+    (provider) => provider.provider_type === form.providerType,
+  );
+  const selectedCapabilities = selectedProvider?.capabilities;
 
   return (
     <div className="space-y-4" aria-labelledby="sso-providers-heading">
@@ -358,14 +384,70 @@ function SsoProviderControl() {
           <AdminField label="Alias" id="sso-alias" value={form.alias} onChange={(value) => setField("alias", value)} pattern="[a-z0-9][a-z0-9._-]{0,62}" autoComplete="off" required />
           <AdminField label="Button label" id="sso-display-name" value={form.displayName} onChange={(value) => setField("displayName", value)} maxLength={80} autoComplete="organization" required />
           <div className="sm:col-span-2">
+            <Label htmlFor="sso-provider-type">Provider type</Label>
+            <SelectMenu
+              id="sso-provider-type"
+              aria-label="Provider type"
+              value={form.providerType}
+              onValueChange={(value) => setField("providerType", value)}
+              className="mt-1.5"
+              placeholder="Choose a provider type…"
+              options={catalog.supported_provider_types.map((type) => {
+                const capabilities = catalog.providers.find(
+                  (provider) => provider.provider_type === type,
+                )?.capabilities;
+                return {
+                  value: type,
+                  label: type,
+                  hint: capabilities
+                    ? [
+                        capabilities.supports_logout ? "logout" : "no logout",
+                        capabilities.supports_identity_migration ? "identity migration" : "no identity migration",
+                      ].join(" · ")
+                    : undefined,
+                };
+              })}
+            />
+            {selectedCapabilities ? (
+              <p className="mt-2 text-xs leading-5 text-foreground-muted">
+                Capabilities: {selectedCapabilities.supports_logout ? "logout" : "no logout"} · {selectedCapabilities.supports_identity_migration ? "identity migration" : "no identity migration"}.
+              </p>
+            ) : (
+              <p className="mt-2 text-xs leading-5 text-foreground-muted">
+                The installation supports {catalog.supported_provider_types.join(", ")}.
+              </p>
+            )}
+          </div>
+          <div className="sm:col-span-2">
             <AdminField label="Upstream issuer" id="sso-issuer" type="url" value={form.issuer} onChange={(value) => setField("issuer", value)} placeholder="https://id.example.com/realms/workforce" autoComplete="url" required />
           </div>
           <AdminField label="Client ID" id="sso-client-id" value={form.clientId} onChange={(value) => setField("clientId", value)} autoComplete="off" required />
           <AdminField label="Client secret" id="sso-client-secret" type="password" value={form.clientSecret} onChange={(value) => setField("clientSecret", value)} placeholder="Required for a new provider" autoComplete="new-password" />
           <div className="sm:col-span-2">
+            <details className="group rounded-[var(--radius-md)] border border-border bg-surface-2/60 px-3">
+              <summary className="flex min-h-10 cursor-pointer list-none items-center gap-2 text-sm font-medium text-foreground transition-token hover:text-link focus:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+                Advanced: discovery URL
+              </summary>
+              <div className="pb-3">
+                <AdminField
+                  label="Discovery URL"
+                  id="sso-discovery-url"
+                  type="url"
+                  value={form.discoveryUrl}
+                  onChange={(value) => setField("discoveryUrl", value)}
+                  placeholder={derivedDiscoveryUrl(form.issuer) || "https://id.example.com/realms/workforce/.well-known/openid-configuration"}
+                  autoComplete="url"
+                />
+                <p className="mt-2 text-xs leading-5 text-foreground-muted">
+                  Defaults to the issuer&apos;s standard .well-known endpoint. Set it only when the upstream publishes its discovery document elsewhere.
+                </p>
+              </div>
+            </details>
+          </div>
+          <div className="sm:col-span-2">
             <Button type="submit" loading={submitting}>Save disabled configuration</Button>
             <p className="mt-2 text-xs leading-5 text-foreground-muted">
-              Discovery uses the issuer&apos;s standard .well-known endpoint. Secrets are write-only.
+              Secrets are write-only.
             </p>
           </div>
         </form>


### PR DESCRIPTION
## Fix: admin SSO provider form can choose a provider type, refuses instead of substituting, accepts an explicit discovery URL (akb#522)

Public-safe summary, no internal details.

### Problem

The admin SSO provider form (`frontend/src/pages/admin.tsx`) derived the provider
type from a hardcoded initial value instead of letting the administrator choose
one. The only other writer was the Edit button, so the set of creatable types was
exactly one. When the form value was not in the catalog's
`supported_provider_types`, the submit path silently substituted the
alphabetically first supported type rather than refusing — so a wrong *kind* of
provider surfaced later as a discovery-document field error naming the wrong
cause. The form also derived `discovery_url` unconditionally as
`<issuer>/.well-known/openid-configuration`, so an upstream publishing its
document elsewhere could not be configured through the UI.

### Change

- Render a provider-type selector over the already-loaded catalog
  `supported_provider_types`, with per-type capabilities
  (`supports_logout`, `supports_identity_migration`) shown next to it, taken
  from the matching configured provider when present.
- Refuse with a form-level error when no supported type is chosen instead of
  substituting another kind. No request is sent in that case.
- Add a collapsed "Advanced: discovery URL" field that defaults to the standard
  derivation and sends an explicit value when the upstream document lives
  elsewhere. Edit keeps the type from the provider being edited and leaves the
  override blank (derivation) by default.

### Verification

- `frontend`: full vitest suite 116 files / 820 tests pass, including 3 new
  RTL cases (refuse-without-type, explicit discovery URL, keycloak type
  selection); `tsc --noEmit`, `eslint`, `design:check` clean.
- `backend`: SSO unit files (routes, response models, both provider contracts,
  keycloak admin) 133 passed. Full `scripts/check.sh` stops at a pre-existing
  `mypy` error in `backend/app/services/vector_store/qdrant.py:399`
  (qdrant-client `Filter(must=...)` invariance, introduced by #520) — reproduced
  on the pristine file with the change stashed, unrelated to this fix.
