### PR TITLE
fix(counters): every document counter follows the active authority (akb#525)

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -7,6 +7,46 @@ specifically; the proxy has its own log in
 
 ## Unreleased
 
+### Every document counter follows the active authority (akb#525)
+
+`GET /vaults/{vault}/info` learned to read the native ledger on
+`postgres_native`, but it was not the only counter answering from a table the
+native write path never touches, and the other two do not read `documents` at
+all — a grep for the query in the issue does not find them.
+
+`akb_browse` reports each collection's `doc_count` and `last_updated` from the
+denormalised `collections` columns, which only `DocumentRepository.increment_count`
+/ `decrement_count` bump — legacy-write-path-only. On a native installation the
+browse payload therefore carried a frozen count directly above the documents
+contradicting it. Measured on one installation: 25 of 10,344 collections already
+disagreed with the live ledger — 16 reporting documents they no longer hold, one
+reporting zero while holding documents.
+
+The operator corpus inventory (`app/stats`) counted `documents` across the whole
+installation, so it reported the pre-cutover total permanently. Same
+installation: 136,183 catalog rows against 136,188 live native documents, the
+gap widening with every write.
+
+Both now read the authority that holds the documents, alongside the vault-info
+counters, through one `document_counters` module rather than three copies of the
+same branch. The legacy arm is unchanged on all three, and pays no query at all
+— the authority is resolved before the pool is touched. Browsing into a subtree
+scopes the recount to that subtree, since only its collections are rendered
+(unscoped on the 50,850-document vault: 118 ms).
+
+Vault last activity also stops sorting `native_revisions.occurred_at`, which made
+the planner scan the entire append-only revision ledger — every vault's history,
+not the one being asked about. It orders the vault's own resources instead and
+reads the actor off the head revision, which `set_head` keeps in step by writing
+`updated_at` and `head_revision_id` in one statement (verified: 136,188 of
+136,188 live document resources had a head whose `occurred_at` equalled
+`updated_at` and was that resource's newest revision). For a 50,850-document
+vault: 93.7 ms to 60.9 ms, and no longer growing with unrelated vaults' history.
+
+Counting is unchanged in meaning on both arms: archived documents still count
+(native `lifecycle` records deletion, not archival), and a collection's count is
+still its direct children.
+
 ### Default archive scope no longer disqualifies the vault path (akb#530)
 
 `archive_scope` defaults to `unarchived`, and the vault-path gate demanded

--- a/backend/app/services/access_service.py
+++ b/backend/app/services/access_service.py
@@ -35,6 +35,7 @@ from app.services.access_contributions import (
 )
 from app.services.account_markers import is_retired_recovery_admin_password
 from app.services.account_service import presented_issuer_or_none
+from app.services import document_counters
 from app.services.edge_boundary import edge_scope_sql, vault_uri_prefix
 from app.services.role_sync import get_role_sync
 from app.services.uri_service import vault_uri
@@ -909,41 +910,6 @@ async def list_accessible_vaults(user_id: str) -> list[dict]:
 
 # ── Vault info ───────────────────────────────────────────────
 
-# Native document counters (akb#525): on `postgres_native` the `documents`
-# catalog table is never written by the native document path, so the legacy
-# `COUNT(*) FROM documents` / latest-`updated_at` queries under-report from
-# the cutover onward (fresh vaults read 0/NULL; old vaults freeze at their
-# pre-cutover numbers). Count live native document resources instead, and
-# take last activity from the newest native revision touching them.
-_NATIVE_DOC_COUNT_SQL = (
-    "SELECT COUNT(*) FROM native_resources WHERE namespace_id = $1 AND surface = 'document' AND lifecycle = 'live'"
-)
-_NATIVE_DOC_LAST_SQL = (
-    "SELECT nr.occurred_at AS updated_at, nr.actor AS created_by "
-    "FROM native_revisions nr "
-    "JOIN native_resources r ON r.resource_id = nr.resource_id "
-    "WHERE r.namespace_id = $1 AND r.surface = 'document' AND r.lifecycle = 'live' "
-    "ORDER BY nr.occurred_at DESC LIMIT 1"
-)
-
-
-def _native_document_source_selected() -> bool:
-    """True when native documents are the authority (akb#525).
-
-    Local import avoids a module cycle: search_service owns the selector and
-    does not import this module, so importing it here is one-directional.
-    """
-    from app.services.search_service import _configured_document_source_type
-
-    try:
-        from app.services.search_service import NATIVE_DOCUMENT_SOURCE
-
-        return _configured_document_source_type() == NATIVE_DOCUMENT_SOURCE
-    except RuntimeError:
-        # Partial native guard (measurement-only mismatch etc.): fail closed
-        # to the legacy catalog rather than raising out of a read path.
-        return False
-
 async def get_vault_info(user_id: str, vault_name: str) -> dict:
     """Get detailed vault info. Requires reader access. Includes the caller's
     effective role and the lifecycle/public-access/external-mirror flags the
@@ -969,17 +935,12 @@ async def get_vault_info(user_id: str, vault_name: str) -> dict:
     vid = vault["id"]
     # akb#525: document counters follow the active authority. Legacy `documents`
     # rows freeze at cutover (native writes never touch that table), so on
-    # `postgres_native` count live native resources and take last activity
-    # from native revisions instead. Tables/files/collections/edges are
+    # `postgres_native` both queries read the native ledger instead. The SQL
+    # lives in `document_counters` with every other counter that had to make
+    # the same choice. Tables/files/collections/edges are
     # authority-independent and keep their existing queries.
-    native_docs = _native_document_source_selected()
-    doc_count_sql = _NATIVE_DOC_COUNT_SQL if native_docs else "SELECT COUNT(*) FROM documents WHERE vault_id = $1"
-    doc_last_sql = (
-        _NATIVE_DOC_LAST_SQL
-        if native_docs
-        else "SELECT updated_at, created_by FROM documents WHERE vault_id = $1 "
-        "ORDER BY updated_at DESC LIMIT 1"
-    )
+    doc_count_sql = document_counters.vault_document_count_sql()
+    doc_last_sql = document_counters.vault_last_activity_sql()
     if (
         role_source in ("system_admin", "write_policy_admin_bypass")
         and vault["owner_id"] != uuid.UUID(user_id)

--- a/backend/app/services/document_counters.py
+++ b/backend/app/services/document_counters.py
@@ -1,0 +1,196 @@
+"""Document counts and freshness timestamps, resolved against the active authority.
+
+akb#525. The legacy `documents` catalog is written only by the bare-Git
+document path. On `postgres_native` the native path writes
+`native_resources` / `native_revisions` and never touches `documents`, so
+every count or "when was this last written" question answered from the
+catalog freezes at the cutover: a vault created afterwards reads 0/NULL, and
+a vault that predates it keeps a believable but motionless number.
+
+The catalog is not the only frozen surface. `collections.doc_count` and
+`collections.last_updated` are denormalised counters maintained by
+`DocumentRepository.increment_count` / `decrement_count`, which only the
+legacy write path calls — so `akb_browse` shows the same stall one level
+down, and a grep for `FROM documents` does not find it.
+
+This module is the single place that decides which authority answers such a
+question, so a new counter surface has one import to reach instead of its own
+copy of the branch. It answers only the counting/freshness questions; the
+identity, body and path questions each backend already owns are not here.
+
+Three shapes, because the call sites differ:
+
+* SQL constants for callers that fan a query out themselves
+  (`access_service.get_vault_info` gathers eight counts in parallel;
+  `app/stats/sampler` runs its counts inside one repeatable-read snapshot).
+* `collection_document_totals`, which executes, because the browse view needs
+  a map keyed by collection path rather than one scalar.
+
+Native semantics, and how they line up with the legacy ones:
+
+* A document is a `native_resources` row with `surface = 'document'` and
+  `lifecycle = 'live'`. Deleting removes the legacy row and flips the native
+  lifecycle, so both authorities count the same population. `lifecycle` does
+  NOT encode archival — an archived document keeps `status: archived` in its
+  frontmatter and stays live here, matching the legacy catalog, which counts
+  archived rows too.
+* Last activity comes from the head revision. `NativeRevisionRepository.set_head`
+  writes `native_resources.updated_at = <the head revision's occurred_at>` in
+  the same statement that advances `head_revision_id`, so ordering resources by
+  `updated_at` and reading the actor off the head revision returns one
+  consistent (time, actor) pair. Measured on one installation: 136,188 of
+  136,188 live document resources had a non-null head whose `occurred_at`
+  equalled `updated_at` and was the newest revision of that resource.
+
+  Ordering on the resource side is also what keeps the query bounded by the
+  vault. Sorting `native_revisions.occurred_at` across a namespace's live
+  resources makes the planner scan the WHOLE revision ledger — every vault's
+  history, append-only and never pruned. Measured on the same installation,
+  for a 50,850-document vault: 93.7 ms scanning all 137,658 revisions, against
+  60.9 ms for the form below, which touches only this vault's resources. (The
+  legacy query it replaces was 938 ms — a bitmap heap scan over the wide
+  catalog rows. Neither native form is a regression against it.)
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+# ── vault document count ─────────────────────────────────────
+
+_VAULT_COUNT_LEGACY = "SELECT COUNT(*) FROM documents WHERE vault_id = $1"
+_VAULT_COUNT_NATIVE = (
+    "SELECT COUNT(*) FROM native_resources "
+    "WHERE namespace_id = $1 AND surface = 'document' AND lifecycle = 'live'"
+)
+
+# ── vault last activity ──────────────────────────────────────
+#
+# Both arms return `updated_at` / `created_by` under those names so the
+# response shape of every consumer stays byte-identical across the switch.
+
+_VAULT_LAST_ACTIVITY_LEGACY = (
+    "SELECT updated_at, created_by FROM documents WHERE vault_id = $1 "
+    "ORDER BY updated_at DESC LIMIT 1"
+)
+_VAULT_LAST_ACTIVITY_NATIVE = (
+    "SELECT r.updated_at AS updated_at, nr.actor AS created_by "
+    "FROM native_resources r "
+    "JOIN native_revisions nr "
+    "  ON nr.resource_id = r.resource_id AND nr.revision_id = r.head_revision_id "
+    "WHERE r.namespace_id = $1 AND r.surface = 'document' AND r.lifecycle = 'live' "
+    "ORDER BY r.updated_at DESC LIMIT 1"
+)
+
+# ── instance-wide corpus count ───────────────────────────────
+
+_INSTANCE_COUNT_LEGACY = "SELECT COUNT(*) FROM documents"
+_INSTANCE_COUNT_NATIVE = (
+    "SELECT COUNT(*) FROM native_resources "
+    "WHERE surface = 'document' AND lifecycle = 'live'"
+)
+
+# ── per-collection totals ────────────────────────────────────
+#
+# `collections.doc_count` counts a collection's DIRECT children only
+# (`increment_count` is called with the document's own `collection_id`), so
+# this reproduces that and not a subtree total. The parent path is cut off
+# each resource path rather than matched with `LIKE c.path || '/%'`: one
+# grouped index scan instead of a per-collection predicate, and no LIKE
+# metacharacter to escape — `_` is a wildcard and is ordinary in a path.
+# A vault-root document has no separator and no collection, and is excluded.
+
+_COLLECTION_TOTALS_NATIVE = """
+    SELECT substring(
+               r.current_path from 1
+               for length(r.current_path) - position('/' in reverse(r.current_path))
+           ) AS collection_path,
+           COUNT(*) AS doc_count,
+           MAX(r.updated_at) AS last_updated
+      FROM native_resources r
+     WHERE r.namespace_id = $1
+       AND r.surface = 'document'
+       AND r.lifecycle = 'live'
+       AND position('/' in r.current_path) > 0
+"""
+# Browsing into a subtree only renders the collections under it, so scope the
+# scan the same way rather than grouping the whole vault every time. Measured
+# on one installation, unscoped on a 50,850-document vault: 118 ms.
+_COLLECTION_TOTALS_PREFIX_CLAUSE = "       AND r.current_path LIKE $2 ESCAPE '\\'\n"
+_COLLECTION_TOTALS_GROUP_BY = "     GROUP BY 1\n"
+
+
+def native_documents_are_authoritative() -> bool:
+    """True when the native ledger, not the legacy catalog, holds documents.
+
+    Local import avoids a module cycle: `search_service` owns the selector and
+    does not import the counter consumers, so importing it here is
+    one-directional. This is the same selector the search hydration path uses
+    to decide which arm a hit belongs to, so a counter can never disagree with
+    what a search over the same corpus returns.
+    """
+    from app.services.search_service import _configured_document_source_type
+
+    try:
+        from app.services.search_service import NATIVE_DOCUMENT_SOURCE
+
+        return _configured_document_source_type() == NATIVE_DOCUMENT_SOURCE
+    except RuntimeError:
+        # Partial native guard (measurement-only mismatch etc.): fail closed
+        # to the legacy catalog rather than raising out of a read path.
+        return False
+
+
+def vault_document_count_sql() -> str:
+    """`COUNT(*)` of a vault's live documents, bound to `$1 = vault id`."""
+    return _VAULT_COUNT_NATIVE if native_documents_are_authoritative() else _VAULT_COUNT_LEGACY
+
+
+def vault_last_activity_sql() -> str:
+    """Newest `(updated_at, created_by)` in a vault, bound to `$1 = vault id`."""
+    return (
+        _VAULT_LAST_ACTIVITY_NATIVE
+        if native_documents_are_authoritative()
+        else _VAULT_LAST_ACTIVITY_LEGACY
+    )
+
+
+def instance_document_count_sql() -> str:
+    """`COUNT(*)` of every live document in the installation. No parameters."""
+    return (
+        _INSTANCE_COUNT_NATIVE
+        if native_documents_are_authoritative()
+        else _INSTANCE_COUNT_LEGACY
+    )
+
+
+async def collection_document_totals(
+    pool, vault_id: uuid.UUID, *, prefix: str = "",
+) -> dict[str, tuple[int, datetime | None]] | None:
+    """Per-collection `(doc_count, last_updated)` from the native authority.
+
+    Returns ``None`` on a legacy installation, where the stored
+    `collections.doc_count` / `collections.last_updated` columns are the
+    authority and the caller should keep reading them. The authority is
+    resolved before the pool is touched, so the legacy arm costs no
+    connection and no round-trip.
+
+    A collection absent from the map holds no live native document directly,
+    which is a real zero rather than missing data — callers must render it as
+    zero and not fall back to the stored column, since the stored column is
+    exactly the frozen number this exists to replace.
+    """
+    if not native_documents_are_authoritative():
+        return None
+    sql = _COLLECTION_TOTALS_NATIVE
+    params: list = [vault_id]
+    if prefix:
+        from app.util.text import like_escape
+
+        params.append(like_escape(prefix) + "/%")
+        sql += _COLLECTION_TOTALS_PREFIX_CLAUSE
+    sql += _COLLECTION_TOTALS_GROUP_BY
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(sql, *params)
+    return {r["collection_path"]: (int(r["doc_count"]), r["last_updated"]) for r in rows}

--- a/backend/app/services/native_document_service.py
+++ b/backend/app/services/native_document_service.py
@@ -50,7 +50,7 @@ from app.repositories.native_revision_repo import (
     NativeRevisionSelectorAmbiguousError,
 )
 from app.repositories.vault_repo import VaultRepository
-from app.services import skill_policy
+from app.services import document_counters, skill_policy
 from app.services.document_service import (
     EditError,
     DocumentService,
@@ -1313,9 +1313,23 @@ class NativeDocumentService(DocumentService):
 
         items: list[BrowseItem] = []
         if show_docs:
+            # akb#525: `collections.doc_count` / `.last_updated` are
+            # denormalised counters bumped by the LEGACY write path only
+            # (`DocumentRepository.increment_count`). Reading them here put a
+            # frozen count beside the very documents it was contradicting —
+            # both in one browse payload. Recount from the authority that
+            # actually holds the documents; a collection missing from the map
+            # holds none directly, which is a true zero, so it must not fall
+            # back to the stored column.
+            native_totals = await document_counters.collection_document_totals(
+                pool, vault_id, prefix=prefix,
+            )
             for row in await collection_repo.list_by_vault(vault_id):
                 if prefix and not row["path"].startswith(prefix + "/"):
                     continue
+                doc_count, last_updated = row["doc_count"], row["last_updated"]
+                if native_totals is not None:
+                    doc_count, last_updated = native_totals.get(row["path"], (0, None))
                 items.append(
                     BrowseItem(
                         name=row["name"],
@@ -1323,8 +1337,8 @@ class NativeDocumentService(DocumentService):
                         type="collection",
                         uri=coll_uri(vault, row["path"]),
                         summary=row["summary"],
-                        doc_count=row["doc_count"],
-                        last_updated=row["last_updated"],
+                        doc_count=doc_count,
+                        last_updated=last_updated,
                     )
                 )
             items.extend(

--- a/backend/app/stats/sampler.py
+++ b/backend/app/stats/sampler.py
@@ -35,7 +35,7 @@ from typing import Any
 
 from app.config import settings
 from app.db.postgres import get_pool
-from app.services import tool_usage
+from app.services import document_counters, tool_usage
 from app.services._backfill import BackfillRunner
 
 logger = logging.getLogger("akb.stats_sampler")
@@ -333,12 +333,20 @@ async def _read_corpus(conn) -> dict[str, Any]:
     several statements later (which `distilled_doc_count` will require) cannot
     quietly reintroduce a torn read where a subset count exceeds its superset.
     """
+    # akb#525: documents are counted from whichever authority holds them.
+    # On `postgres_native` the legacy catalog stops growing at the cutover, so
+    # a plain `COUNT(*) FROM documents` reports the pre-cutover total forever
+    # — a believable, motionless number in an operator inventory. The
+    # subquery keeps both arms inside the one snapshot below; archived
+    # documents stay counted on both, because `lifecycle` records deletion,
+    # not archival.
+    doc_count_sql = document_counters.instance_document_count_sql()
     async with conn.transaction(isolation="repeatable_read", readonly=True):
         row = await conn.fetchrow(
-            """
+            f"""
             SELECT (SELECT COUNT(*) FROM vaults)      AS vault_count,
                    (SELECT COUNT(*) FROM collections) AS collection_count,
-                   (SELECT COUNT(*) FROM documents)   AS doc_count,
+                   ({doc_count_sql})                  AS doc_count,
                    -- Chunks that are actually present in the vector index.
                    -- `chunks` is the source of truth and always holds more
                    -- during indexing; the difference is the backlog, which is

--- a/backend/tests/test_document_counters_pg.py
+++ b/backend/tests/test_document_counters_pg.py
@@ -1,0 +1,419 @@
+"""Every document counter follows the active authority (akb#525).
+
+`test_vault_info_counters_pg.py` pins `GET /vaults/{vault}/info`. This file
+pins the counter surfaces that endpoint does NOT cover, and the half of the
+property the issue does not state: that an UPDATE through the ordinary write
+path moves the numbers, not only a create.
+
+Two of the three surfaces here never read `documents` at all, which is why
+grepping for the query in the issue does not find them:
+
+* `akb_browse` reports each collection's `doc_count` / `last_updated` from
+  the denormalised `collections` columns, which only the LEGACY write path
+  bumps (`DocumentRepository.increment_count`). On a native installation the
+  browse payload therefore shows a frozen count directly above the documents
+  that contradict it.
+* The operator corpus inventory (`app/stats/sampler`) counts the legacy
+  catalog installation-wide, so it reports the pre-cutover total forever.
+
+The writes go through `NativeRevisionService.create_text` / `replace_text`,
+the real native write primitives, rather than hand-built rows: the
+last-activity query relies on `set_head` keeping
+`native_resources.updated_at` equal to the head revision's `occurred_at`, and
+a fixture that stamped that column itself would be asserting its own
+arithmetic. Real Postgres, fresh database per test, self-skips if
+unreachable — the same convention as the neighbouring `*_pg.py` files.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import uuid
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import asyncpg
+import pytest
+
+from app.services import access_service
+from app.services.native_document_service import NativeDocumentService
+from app.services.native_revision_service import NativeRevisionService
+
+
+pytestmark = pytest.mark.asyncio
+
+_BACKEND = Path(__file__).resolve().parents[1]
+_INIT_SQL = (_BACKEND / "app" / "db" / "init.sql").read_text(encoding="utf-8")
+_MIGRATIONS = _BACKEND / "app" / "db" / "migrations"
+_DSN = os.environ.get(
+    "AKB_TEST_DSN",
+    "postgresql://akb:akb@localhost:5433/akb",  # pragma: allowlist secret
+)
+
+# A believable, motionless number: what a cutover leaves behind in the
+# denormalised columns, and what every assertion below must refuse to echo.
+_FROZEN_COUNT = 41
+_FROZEN_AT = datetime(2026, 5, 14, 9, 44, 12, tzinfo=timezone.utc)
+
+
+async def _reachable() -> bool:
+    try:
+        conn = await asyncpg.connect(_DSN, timeout=2)
+    except (OSError, asyncpg.PostgresError):
+        return False
+    await conn.close()
+    return True
+
+
+def _database_dsn(name: str) -> str:
+    return f"{_DSN.rsplit('/', 1)[0]}/{name}"
+
+
+def _load(filename: str):
+    path = _MIGRATIONS / filename
+    spec = importlib.util.spec_from_file_location(f"counters_migration_{filename}", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@asynccontextmanager
+async def _fresh_database(monkeypatch):
+    """A vault with an owner, on a database carrying the native core."""
+    if not await _reachable():
+        pytest.skip(f"Postgres not reachable at {_DSN}")
+
+    name = f"akb_document_counters_{uuid.uuid4().hex[:12]}"
+    admin = await asyncpg.connect(_DSN)
+    conn = None
+    pool = None
+    try:
+        await admin.execute(f'CREATE DATABASE "{name}"')
+        conn = await asyncpg.connect(_database_dsn(name))
+        await conn.execute(_INIT_SQL)
+        for filename in (
+            "010_external_git_mirror.py",
+            "015_events_outbox.py",
+            "044_vault_write_policy.py",
+            "045_vault_write_grant_actions.py",
+            "048_native_revision_core.py",
+        ):
+            await _load(filename).migrate(conn=conn)
+        await conn.close()
+        conn = None
+        pool = await asyncpg.create_pool(_database_dsn(name), min_size=1, max_size=4)
+
+        suffix = uuid.uuid4().hex[:12]
+        vault_name = f"dc-vault-{suffix}"
+        async with pool.acquire() as seeded:
+            owner_id = await seeded.fetchval(
+                "INSERT INTO users (username, email, password_hash) "
+                "VALUES ($1, $2, 'x') RETURNING id",
+                f"dc-{suffix}",
+                f"dc-{suffix}@example.com",
+            )
+            vault_id = await seeded.fetchval(
+                "INSERT INTO vaults (name, git_path, owner_id) VALUES ($1, $2, $3) RETURNING id",
+                vault_name,
+                f"/tmp/dc-{suffix}-unused.git",
+                owner_id,
+            )
+
+        from app.repositories import vault_write_policy_repo
+        from app.services import auth_service, table_service
+
+        async def _get_pool():
+            return pool
+
+        monkeypatch.setattr(auth_service, "get_pool", _get_pool)
+        monkeypatch.setattr(vault_write_policy_repo, "get_pool", _get_pool)
+        monkeypatch.setattr(access_service, "get_pool", _get_pool)
+        monkeypatch.setattr(table_service, "get_pool", _get_pool)
+
+        yield pool, vault_id, vault_name, owner_id
+    finally:
+        if pool is not None:
+            await pool.close()
+        if conn is not None and not conn.is_closed():
+            await conn.close()
+        await admin.execute(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
+        await admin.close()
+
+
+def _native_backend(monkeypatch) -> None:
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "document_revision_backend", "postgres_native", raising=False)
+    monkeypatch.setattr(settings, "native_revision_m1_measurement_only", False, raising=False)
+    monkeypatch.setattr(settings, "db_name", "akb", raising=False)
+
+
+def _legacy_backend(monkeypatch) -> None:
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "document_revision_backend", "bare_git", raising=False)
+
+
+async def _write_native_doc(pool, vault_id, path: str, *, actor: str, body: str):
+    return await NativeRevisionService(pool).create_text(
+        namespace_id=vault_id,
+        surface="document",
+        path=path,
+        payload=body,
+        actor=actor,
+        mutation_id=uuid.uuid4(),
+        resource_id=uuid.uuid4(),
+    )
+
+
+async def _freeze_collection(pool, vault_id, path: str, name: str) -> None:
+    """A collection row as the cutover leaves it: real row, stale counters."""
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO collections (vault_id, path, name, doc_count, last_updated) "
+            "VALUES ($1, $2, $3, $4, $5)",
+            vault_id,
+            path,
+            name,
+            _FROZEN_COUNT,
+            _FROZEN_AT,
+        )
+
+
+async def _freeze_legacy_document(pool, vault_id, path: str) -> None:
+    """One retained pre-cutover catalog row, the kind the projection kept."""
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO documents (vault_id, path, title, content_hash, updated_at, created_by) "
+            "VALUES ($1, $2, $3, 'x', $4, 'pre-cutover-author')",
+            vault_id,
+            path,
+            path.rsplit("/", 1)[-1],
+            _FROZEN_AT,
+        )
+
+
+# ── akb_browse ───────────────────────────────────────────────
+
+
+async def test_browse_collection_counters_read_the_native_authority(monkeypatch):
+    """A collection lists the documents it really holds, and when they landed.
+
+    The frozen `collections.doc_count` is the number a cutover leaves behind;
+    browse must report 2 and a timestamp from today, next to the two document
+    items in the very same payload.
+    """
+    _native_backend(monkeypatch)
+    async with _fresh_database(monkeypatch) as (pool, vault_id, vault_name, _owner):
+        await _freeze_collection(pool, vault_id, "notes", "notes")
+        await _write_native_doc(pool, vault_id, "notes/a.md", actor="writer", body="alpha\n")
+        await _write_native_doc(pool, vault_id, "notes/b.md", actor="writer", body="beta\n")
+
+        response = await NativeDocumentService(pool=pool).browse(
+            vault_name, content_type="documents",
+        )
+
+    collections = [i for i in response.items if i.type == "collection"]
+    documents = [i for i in response.items if i.type == "document"]
+    assert len(collections) == 1
+    assert len(documents) == 2, "the documents the count is meant to describe"
+    assert collections[0].doc_count == 2
+    assert collections[0].last_updated is not None
+    assert collections[0].last_updated > _FROZEN_AT
+
+
+async def test_browse_collection_with_no_live_documents_reads_zero(monkeypatch):
+    """An emptied collection reads 0, never the frozen number.
+
+    This is the shape the issue calls dangerous in reverse: a stale non-zero
+    beside nothing is as wrong as a stale zero beside documents, and only one
+    of the two can be caught by looking for a suspicious zero.
+    """
+    _native_backend(monkeypatch)
+    async with _fresh_database(monkeypatch) as (pool, vault_id, vault_name, _owner):
+        await _freeze_collection(pool, vault_id, "emptied", "emptied")
+
+        response = await NativeDocumentService(pool=pool).browse(
+            vault_name, content_type="documents",
+        )
+
+    collections = [i for i in response.items if i.type == "collection"]
+    assert len(collections) == 1
+    assert collections[0].doc_count == 0
+    assert collections[0].last_updated is None
+
+
+async def test_browse_counts_direct_children_not_the_subtree(monkeypatch):
+    """`doc_count` keeps its legacy meaning: documents directly inside.
+
+    `increment_count` is called with the document's own `collection_id`, so a
+    nested document belongs to the nested collection. Recounting from the
+    native ledger must not quietly turn this into a subtree total.
+    """
+    _native_backend(monkeypatch)
+    async with _fresh_database(monkeypatch) as (pool, vault_id, vault_name, _owner):
+        await _freeze_collection(pool, vault_id, "outer", "outer")
+        await _freeze_collection(pool, vault_id, "outer/inner", "inner")
+        await _write_native_doc(pool, vault_id, "outer/top.md", actor="writer", body="top\n")
+        await _write_native_doc(pool, vault_id, "outer/inner/deep.md", actor="writer", body="deep\n")
+
+        response = await NativeDocumentService(pool=pool).browse(
+            vault_name, content_type="documents", depth=-1,
+        )
+
+    counts = {i.path: i.doc_count for i in response.items if i.type == "collection"}
+    assert counts == {"outer": 1, "outer/inner": 1}
+
+
+async def test_browse_into_a_subtree_counts_that_subtree(monkeypatch):
+    """Browsing into a collection scopes the scan and still counts right.
+
+    The scan is narrowed to the prefix because only collections under it are
+    rendered. A narrowing that dropped a nested collection, or that matched
+    a sibling because `_` is a LIKE wildcard, would show up here.
+    """
+    _native_backend(monkeypatch)
+    async with _fresh_database(monkeypatch) as (pool, vault_id, vault_name, _owner):
+        await _freeze_collection(pool, vault_id, "team_notes", "team_notes")
+        await _freeze_collection(pool, vault_id, "team_notes/drafts", "drafts")
+        await _freeze_collection(pool, vault_id, "teamXnotes", "teamXnotes")
+        await _write_native_doc(pool, vault_id, "team_notes/drafts/a.md", actor="w", body="a\n")
+        await _write_native_doc(pool, vault_id, "team_notes/drafts/b.md", actor="w", body="b\n")
+        await _write_native_doc(pool, vault_id, "teamXnotes/sibling.md", actor="w", body="s\n")
+
+        response = await NativeDocumentService(pool=pool).browse(
+            vault_name, collection="team_notes", content_type="documents", depth=-1,
+        )
+
+    counts = {i.path: i.doc_count for i in response.items if i.type == "collection"}
+    assert counts == {"team_notes/drafts": 2}
+
+
+async def test_browse_on_bare_git_keeps_the_stored_columns(monkeypatch):
+    """The legacy arm is untouched: the stored counters are its authority,
+    and a native resource must not leak into them."""
+    _legacy_backend(monkeypatch)
+    async with _fresh_database(monkeypatch) as (pool, vault_id, vault_name, _owner):
+        await _freeze_collection(pool, vault_id, "notes", "notes")
+        await _write_native_doc(pool, vault_id, "notes/a.md", actor="writer", body="alpha\n")
+
+        response = await NativeDocumentService(pool=pool).browse(
+            vault_name, content_type="documents",
+        )
+
+    collections = [i for i in response.items if i.type == "collection"]
+    assert collections[0].doc_count == _FROZEN_COUNT
+    assert collections[0].last_updated == _FROZEN_AT
+
+
+# ── vault info: updates, not only creates ────────────────────
+
+
+async def test_vault_last_activity_follows_an_update(monkeypatch):
+    """`last_activity` moves when a document is EDITED, not only created.
+
+    Measured on one installation before this arc: three documents repaired
+    through the ordinary update route carried native revisions stamped that
+    day and `documents.updated_at` values four months old. The vault's
+    reported last activity was the stale one. Nothing in the retained catalog
+    row moves, so the assertion is that the reported time comes from the
+    edit and the reported user is whoever made it.
+    """
+    _native_backend(monkeypatch)
+    async with _fresh_database(monkeypatch) as (pool, vault_id, vault_name, owner_id):
+        await _freeze_legacy_document(pool, vault_id, "notes/a.md")
+        created = await _write_native_doc(
+            pool, vault_id, "notes/a.md", actor="original-author", body="first\n",
+        )
+        await NativeRevisionService(pool).replace_text(
+            namespace_id=vault_id,
+            surface="document",
+            path="notes/a.md",
+            payload="second\n",
+            actor="repairing-editor",
+            mutation_id=uuid.uuid4(),
+            expected_revision_id=created.revision_id,
+        )
+
+        info = await access_service.get_vault_info(str(owner_id), vault_name)
+
+        async with pool.acquire() as conn:
+            head_at = await conn.fetchval(
+                "SELECT nr.occurred_at FROM native_resources r "
+                "JOIN native_revisions nr ON nr.revision_id = r.head_revision_id "
+                "WHERE r.namespace_id = $1 AND r.current_path = 'notes/a.md'",
+                vault_id,
+            )
+
+    assert info["document_count"] == 1
+    assert info["last_active_user"] == "repairing-editor"
+    assert info["last_activity"] == head_at.isoformat()
+    assert head_at > _FROZEN_AT + timedelta(days=1), "not the retained catalog timestamp"
+
+
+async def test_vault_last_activity_picks_the_newest_of_several_documents(monkeypatch):
+    """Ordering runs over resources; the actor must come from the same row.
+
+    The reported timestamp and the reported user are read from two different
+    tables, so a form that ordered one and joined the other loosely could
+    return a time from one document and a name from another.
+    """
+    _native_backend(monkeypatch)
+    async with _fresh_database(monkeypatch) as (pool, vault_id, vault_name, owner_id):
+        await _write_native_doc(pool, vault_id, "notes/old.md", actor="earlier", body="old\n")
+        await _write_native_doc(pool, vault_id, "notes/new.md", actor="later", body="new\n")
+
+        info = await access_service.get_vault_info(str(owner_id), vault_name)
+
+        async with pool.acquire() as conn:
+            newest = await conn.fetchval(
+                "SELECT r.updated_at FROM native_resources r "
+                "WHERE r.namespace_id = $1 AND r.current_path = 'notes/new.md'",
+                vault_id,
+            )
+
+    assert info["last_active_user"] == "later"
+    assert info["last_activity"] == newest.isoformat()
+
+
+# ── operator corpus inventory ────────────────────────────────
+
+
+async def test_instance_corpus_count_reads_the_native_authority(monkeypatch):
+    """The installation-wide document total counts what exists now.
+
+    The retained catalog row is the pre-cutover population; the native
+    resources are the real one. Counting the catalog reports a total that
+    stopped moving at the cutover.
+    """
+    _native_backend(monkeypatch)
+    from app.stats import sampler
+
+    async with _fresh_database(monkeypatch) as (pool, vault_id, _vault_name, _owner):
+        await _freeze_legacy_document(pool, vault_id, "notes/retained.md")
+        await _write_native_doc(pool, vault_id, "notes/a.md", actor="writer", body="alpha\n")
+        await _write_native_doc(pool, vault_id, "notes/b.md", actor="writer", body="beta\n")
+        await _write_native_doc(pool, vault_id, "notes/c.md", actor="writer", body="gamma\n")
+
+        async with pool.acquire() as conn:
+            corpus = await sampler._read_corpus(conn)
+
+    assert corpus["doc_count"] == 3
+
+
+async def test_instance_corpus_count_on_bare_git_reads_the_catalog(monkeypatch):
+    """The legacy arm still counts `documents`, with no native leak."""
+    _legacy_backend(monkeypatch)
+    from app.stats import sampler
+
+    async with _fresh_database(monkeypatch) as (pool, vault_id, _vault_name, _owner):
+        await _freeze_legacy_document(pool, vault_id, "notes/retained.md")
+        await _write_native_doc(pool, vault_id, "notes/a.md", actor="writer", body="alpha\n")
+
+        async with pool.acquire() as conn:
+            corpus = await sampler._read_corpus(conn)
+
+    assert corpus["doc_count"] == 1


### PR DESCRIPTION
Completes akb#525. `GET /vaults/{vault}/info` was fixed in #534; it was not
the only counter reading a table the native document path never writes, and
the other two do not read `documents` at all — so a grep for the queries in
the issue does not find them.

## What else was stale, and why grepping missed it

`akb_browse` reports each collection's `doc_count` and `last_updated` from the
denormalised `collections` columns. Those are maintained by
`DocumentRepository.increment_count` / `decrement_count`, which only the
legacy write path calls. On a native installation the browse payload
therefore carried a frozen count directly above the documents contradicting
it — both in one response, which is a sharper contradiction than `/info`,
where the reader cannot see the documents at the same time.

Measured on one installation, with the query this change ships: 25 of 10,344
collections already disagreed with the live ledger — 16 reporting documents
they no longer hold, one reporting zero while holding documents. The count
drifts further on every native write.

The operator corpus inventory (`app/stats`) counted `documents` across the
whole installation, so it reported the pre-cutover total permanently. Same
installation: 136,183 catalog rows against 136,188 live native documents.

## Direction, and why not the other one

The issue names two: the native write path maintains the catalog rows, or the
counters move to the native side. #534 chose the second for `/info`; this
extends that choice to the rest, and the collections finding is what decided
it.

Direction one is not one table. The native path would have to maintain
`documents` *and* `collections.doc_count` / `.last_updated` — the second
denormalised projection the same legacy write path feeds — consistently under
create, update, move, delete and archive. Each is an independent drift
surface, and the browse defect is evidence the drift already happened
silently in a projection nobody thought to check: the issue was found by
reading a zero on one endpoint, and the collection counters had been wrong
the whole time without being noticed.

The native ledger already holds the data in the right shape, with a lifecycle
column, and `search_service`'s hydration already branches on the same
selector these counters now use — so a count can never disagree with what a
search over the same corpus returns.

Leaving the residue unfixed was the worse option specifically because #534
had already moved `/info`: a browse payload whose collection said 0 beside a
vault card that said 2 is a new inconsistency, not a surviving old one.

## Everything that answers "how many" or "how recent" about documents

| surface | reads | state |
| --- | --- | --- |
| `get_vault_info` | `documents` count + latest `updated_at` | branched in #534; moved here into the shared module, query re-shaped (below) |
| `browse` collection items | `collections.doc_count` / `.last_updated` | **fixed here** |
| corpus inventory (`app/stats`) | `COUNT(*) FROM documents` | **fixed here** |
| `/recent` recent changes | `documents` ordered by `updated_at` | already correct — the native revision backend implements `recent_changes` over resource heads |
| `/activity` | git log | already correct — the native backend implements `vault_activity` |
| legacy `DocumentService.browse` | `collections.doc_count` | correct as-is: on a native installation the composition root returns the native document service, so this arm never serves one |
| legacy `create_vault` rollback guard | `COUNT(*) FROM documents` | correct as-is, same reason — the native arm has its own `create_vault` |

All three fixed surfaces now go through one `document_counters` module rather
than three copies of the same branch, so the next counter has one import to
reach instead of its own decision to make. The legacy arm is unchanged on all
three, pays no query at all (the authority is resolved before the pool is
touched), and is pinned by tests.

Two things outside counters, reported separately rather than widened into
this change: `CollectionService.delete` judges emptiness from `documents`,
and the agent-memory reads are legacy-only. Neither is a counter, and both
need their own design.

## Vault last activity: same answer, bounded by the vault

#534's query sorts `native_revisions.occurred_at` across a namespace's live
resources, which makes the planner scan the entire revision ledger — every
vault's history, append-only and never pruned — to answer a question about
one vault. It now orders that vault's own resources and reads the actor off
the head revision.

The two are equivalent because `set_head` writes
`native_resources.updated_at = <the head revision's occurred_at>` in the same
statement that advances `head_revision_id`. Verified on one installation:
136,188 of 136,188 live document resources had a non-null head whose
`occurred_at` equalled `updated_at` and was that resource's newest revision.

For a 50,850-document vault on that installation, `EXPLAIN ANALYZE`:

| form | time | plan |
| --- | --- | --- |
| legacy catalog (pre-#534) | 938 ms | bitmap heap scan over 50,850 wide catalog rows |
| #534 | 93.7 ms | parallel seq scan of all 137,658 revisions + hash join |
| this change | 60.9 ms | index scan of this vault's resources + one head lookup |

Neither native form was a regression against legacy; this one additionally
stops growing with unrelated vaults' history.

The browse recount is a new query where the stored column was free, so it is
scoped the way the render is: browsing into a subtree groups only that
subtree. Unscoped on the same vault it is 118 ms — one grouped index scan,
alongside a collection listing that was already vault-wide.

## The property, and a test that fails without the change

An operator reading a vault's document count and last activity must get
numbers that reflect what the vault contains and when it was last written —
for documents created *and updated* after the cutover, through the ordinary
routes.

The update half is not in the issue, which was written from black-box
measurement of creation. It diverges too: on one installation, documents
repaired through the ordinary update route carried native revisions stamped
that day and catalog `updated_at` values four months old, and the vault
reported the four-month-old date.

`tests/test_document_counters_pg.py` — 9 tests, real Postgres, fresh database
per test, self-skips if unreachable. Writes go through
`NativeRevisionService.create_text` / `replace_text`, the real native write
primitives, not hand-built rows: the last-activity query depends on what
`set_head` maintains, and a fixture that stamped that column itself would be
asserting its own arithmetic.

Against `main` (`f6d39dd9`), 5 fail and 4 pass:

- fail — browse reports the real count and a fresh timestamp; an emptied
  collection reads 0 and not the frozen number; the count stays direct
  children and does not become a subtree total; browsing into a subtree
  counts that subtree (and does not catch a sibling through `_`, which is a
  LIKE wildcard and ordinary in a path); the corpus inventory counts what
  exists (`assert 1 == 3`, the retained catalog row against three live native
  documents).
- pass — the two legacy-arm tests, which must not change, and the two
  vault-info tests. The vault-info pair is a guard for the query re-shape
  above, not evidence of a defect: #534 already satisfies them. Stated
  plainly because a test that passes before the change proves nothing about
  the change.

A cutover-time equality assertion (the issue's suggestion) is deliberately
not added: after the cutover the two totals are *supposed* to diverge, so it
can only be a one-shot check at migration time, not a standing invariant, and
it belongs with the migration rather than with the readers.

## Verification

Run locally, with the baseline established on a pristine checkout of the base
commit (`f6d39dd9`) in a separate worktree.

**`scripts/check.sh`** — green on this branch: E2E suite manifest, agent
roles, ruff, mypy (366 files), bandit, eslint, tsc, `@akb/client` build +
typecheck + vitest + generated-type drift + packed-SDK consumer proof,
`@akb/markdown-editor` build + typecheck + lint + vitest, stdio proxy + MCP
Inspector contract (5/5), frontend vitest (818 passed, 116 files),
detect-secrets. `.secrets.baseline` untouched.

One environment note, since it costs a run to rediscover: with the backend's
runtime dependencies importable, mypy additionally reports a pre-existing
`list` invariance error in the qdrant vector store, on a line this change does
not touch. It reproduces identically on the pristine baseline, and CI cannot
see it by construction — the check workflow installs only the four analyzers,
so `qdrant_client` is missing and `ignore_missing_imports` makes the argument
`Any`. The green run above uses exactly CI's analyzer set at CI's pins.

**Backend suite** (`pytest tests`, real Postgres reachable so the `*_pg.py`
files run rather than skip):

| | passed | failed | errors | skipped |
| --- | --- | --- | --- | --- |
| baseline `f6d39dd9` | 3490 | 63 | 40 | 48 |
| this branch | 3499 | 63 | 40 | 48 |

Identical failure and error counts, and identical per-file breakdown —
`test_git_service.py` 39, `test_external_git_runner.py` 14, the external-git
cascade/capability files 6, `concurrency/test_ensure_collection_race_unit.py`
3, `test_vault_table_name_collision_unit.py` 1; errors are
`test_access_contributions_postgres.py` 23 and `mcp_e2e/*` 17. None is
touched by this change. The +9 passed is exactly the new file.

No schema migration, no config change, no response-shape change.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ch9b6uWnJh17gTYnBWHNQp
